### PR TITLE
optimize the update operation in binlog events

### DIFF
--- a/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/flink-connector-debezium/src/main/java/com/alibaba/ververica/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -90,7 +90,7 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
 	 */
 	private final boolean captureUnchangedUpdates;
 
-	public RowDataDebeziumDeserializeSchema(RowType rowType, TypeInformation<RowData> resultTypeInfo, ValueValidator validator, ZoneId serverTimeZone, boolean captureUnchangedUpdates) {
+	private RowDataDebeziumDeserializeSchema(RowType rowType, TypeInformation<RowData> resultTypeInfo, ValueValidator validator, ZoneId serverTimeZone, boolean captureUnchangedUpdates) {
 		this.runtimeConverter = createConverter(rowType);
 		this.resultTypeInfo = resultTypeInfo;
 		this.validator = validator;

--- a/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/mysql/table/MySQLTableSourceFactoryTest.java
@@ -77,7 +77,8 @@ public class MySQLTableSourceFactoryTest {
 			MY_PASSWORD,
 			ZoneId.of("UTC"),
 			PROPERTIES,
-			null
+			null,
+			true
 		);
 		assertEquals(expectedSource, actualSource);
 	}
@@ -89,6 +90,7 @@ public class MySQLTableSourceFactoryTest {
 		options.put("server-id", "4321");
 		options.put("server-time-zone", "Asia/Shanghai");
 		options.put("debezium.snapshot.mode", "never");
+		options.put("capture-unchanged-updates", "false");
 
 		DynamicTableSource actualSource = createTableSource(options);
 		Properties dbzProperties = new Properties();
@@ -103,7 +105,8 @@ public class MySQLTableSourceFactoryTest {
 			MY_PASSWORD,
 			ZoneId.of("Asia/Shanghai"),
 			dbzProperties,
-			4321
+			4321,
+			false
 		);
 		assertEquals(expectedSource, actualSource);
 	}

--- a/flink-connector-postgres-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
+++ b/flink-connector-postgres-cdc/src/test/java/com/alibaba/ververica/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
@@ -77,7 +77,8 @@ public class PostgreSQLTableFactoryTest {
 			MY_USERNAME,
 			MY_PASSWORD,
 			"decoderbufs",
-			PROPERTIES);
+			PROPERTIES,
+			true);
 		assertEquals(expectedSource, actualSource);
 	}
 
@@ -87,6 +88,7 @@ public class PostgreSQLTableFactoryTest {
 		options.put("port", "5444");
 		options.put("decoding.plugin.name", "wal2json");
 		options.put("debezium.snapshot.mode", "never");
+		options.put("capture-unchanged-updates", "false");
 
 		DynamicTableSource actualSource = createTableSource(options);
 		Properties dbzProperties = new Properties();
@@ -101,7 +103,8 @@ public class PostgreSQLTableFactoryTest {
 			MY_USERNAME,
 			MY_PASSWORD,
 			"wal2json",
-			dbzProperties);
+			dbzProperties,
+			false);
 		assertEquals(expectedSource, actualSource);
 	}
 

--- a/flink-connector-postgres-cdc/src/test/resources/ddl/inventory.sql
+++ b/flink-connector-postgres-cdc/src/test/resources/ddl/inventory.sql
@@ -38,3 +38,20 @@ VALUES (default,'scooter','Small 2-wheel scooter',3.14),
        (default,'rocks','box of assorted rocks',5.3),
        (default,'jacket','water resistent black wind breaker',0.1),
        (default,'spare tire','24 inch spare tire',22.2);
+
+-- Create some customers ...
+CREATE TABLE customers (
+  id SERIAL NOT NULL PRIMARY KEY,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL
+);
+
+ALTER SEQUENCE customers_id_seq RESTART WITH 1001;
+ALTER TABLE customers REPLICA IDENTITY FULL;
+
+INSERT INTO customers
+VALUES (default,'Sally','Thomas','sally.thomas@acme.com'),
+       (default,'George','Bailey','gbailey@foobar.com'),
+       (default,'Edward','Walker','ed@walker.com'),
+       (default,'Anne','Kretchmar','annek@noanswer.org');


### PR DESCRIPTION
Fixes #40：
Add optional flag `capture-unchanged-updates` whether to capture the updates if that have no change or not. default true, false to disable, just simply equals the before and after RowData before assigining RowKind.,when `before` and `afte`r are equal, no update is performed.
