### PR TITLE
fix: fix mysql-cdc case sensitive

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/ChunkSplitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/ChunkSplitter.java
@@ -260,13 +260,13 @@ class ChunkSplitter {
         }
         boolean compare;
         if (isCaseSensitive) {
-            compare = (ObjectUtils.compare(chunkEnd, max) <= 0);
+            compare = (ObjectUtils.compare(chunkEnd, max) >= 0);
         } else {
             String endId = String.valueOf(chunkEnd);
             String maxId = String.valueOf(max);
-            compare = (ObjectUtils.compare(endId.toLowerCase(), maxId.toLowerCase()) <= 0);
+            compare = (ObjectUtils.compare(endId.toLowerCase(), maxId.toLowerCase()) >= 0);
         }
-        if (!compare) {
+        if (compare) {
             return null;
         } else {
             return chunkEnd;

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/ChunkSplitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/ChunkSplitter.java
@@ -160,7 +160,8 @@ class ChunkSplitter {
                         jdbc, tableId, splitColumnName, min, max, chunkSize, true);
             }
         } else {
-            return splitUnevenlySizedChunks(jdbc, tableId, splitColumnName, min, max, chunkSize, false);
+            return splitUnevenlySizedChunks(
+                    jdbc, tableId, splitColumnName, min, max, chunkSize, false);
         }
     }
 
@@ -205,8 +206,10 @@ class ChunkSplitter {
             throws SQLException {
         LOG.info(
                 "Use unevenly-sized chunks for table {}, the chunk size is {}", tableId, chunkSize);
-        // If the primary key passed in is a Int, follow the original logic. Otherwise, judge whether it is case sensitive
-        boolean isCaseSensitive = evenlyColumn ? true : queryCaseSensitive(jdbc, tableId, splitColumnName);
+        // If the primary key passed in is a Int, follow the original logic. Otherwise, judge
+        // whether it is case sensitive
+        boolean isCaseSensitive =
+                evenlyColumn ? true : queryCaseSensitive(jdbc, tableId, splitColumnName);
         final List<ChunkRange> splits = new ArrayList<>();
         Object chunkStart = null;
         Object chunkEnd =
@@ -286,8 +289,8 @@ class ChunkSplitter {
             Object chunkStart,
             Object chunkEnd) {
         // currently, we only support single split column
-        Object[] splitStart = chunkStart == null ? null : new Object[]{chunkStart};
-        Object[] splitEnd = chunkEnd == null ? null : new Object[]{chunkEnd};
+        Object[] splitStart = chunkStart == null ? null : new Object[] {chunkStart};
+        Object[] splitEnd = chunkEnd == null ? null : new Object[] {chunkEnd};
         Map<TableId, TableChange> schema = new HashMap<>();
         schema.put(tableId, mySqlSchema.getTableSchema(jdbc, tableId));
         return new MySqlSnapshotSplit(
@@ -302,9 +305,7 @@ class ChunkSplitter {
 
     // ------------------------------------------------------------------------------------------
 
-    /**
-     * Checks whether split column is evenly distributed across its range.
-     */
+    /** Checks whether split column is evenly distributed across its range. */
     private static boolean isEvenlySplitColumn(Column splitColumn) {
         DataType flinkType = MySqlTypeUtils.fromDbzColumn(splitColumn);
         LogicalTypeRoot typeRoot = flinkType.getLogicalType().getTypeRoot();
@@ -316,9 +317,7 @@ class ChunkSplitter {
                 || typeRoot == LogicalTypeRoot.DECIMAL;
     }
 
-    /**
-     * Returns the distribution factor of the given table.
-     */
+    /** Returns the distribution factor of the given table. */
     private double calculateDistributionFactor(
             TableId tableId, Object min, Object max, long approximateRowCnt) {
 


### PR DESCRIPTION
修复 mysql-cdc 因为大小写敏感导致 非自增型主键 chunks 分配大小不均匀问题。

修复逻辑：
   1、mysqlcdc  非自增型主键方法均会走splitUnevenlySizedChunks 方法。
   2、在splitUnevenlySizedChunks方法中在chunks之前判断主键collation 是否大小写敏感
   3、mysql中字段类型 collation 为null 以及是以_ci 结尾的都是大小写不敏感的
   4、如果主键大小写敏感，则走原逻辑。如果主键大小写不敏感则统一将字符转换为小写字符串 再进行ObjectUtils.compare比较
