### PR TITLE
[PostgreSQL] Add DeserializationConverterFactory for PostGIS schemas

### DIFF
--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableSource.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLTableSource.java
@@ -124,6 +124,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                         .setMetadataConverters(metadataConverters)
                         .setResultTypeInfo(typeInfo)
                         .setValueValidator(new PostgresValueValidator(schemaName, tableName))
+                        .setUserDefinedConverterFactory(
+                                PostgresDeserializationConverterFactory.instance())
                         .build();
         DebeziumSourceFunction<RowData> sourceFunction =
                 PostgreSQLSource.<RowData>builder()

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
@@ -29,7 +29,6 @@ import io.debezium.data.geometry.Point;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
-import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.Optional;
 

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.postgres.table;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import com.ververica.cdc.debezium.table.DeserializationRuntimeConverter;
+import com.ververica.cdc.debezium.table.DeserializationRuntimeConverterFactory;
+import io.debezium.data.geometry.Geography;
+import io.debezium.data.geometry.Geometry;
+import io.debezium.data.geometry.Point;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+
+import java.nio.charset.StandardCharsets;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.apache.flink.util.StringUtils.byteToHexString;
+
+/** Used to create {@link DeserializationRuntimeConverterFactory} specified to Postgres. */
+public class PostgresDeserializationConverterFactory {
+
+    public static boolean isGeometrySchema(String schema) {
+        switch (schema) {
+            case Point.LOGICAL_NAME:
+            case Geometry.LOGICAL_NAME:
+            case Geography.LOGICAL_NAME:
+                return true;
+        }
+
+        return false;
+    }
+
+    public static DeserializationRuntimeConverterFactory instance() {
+        return new DeserializationRuntimeConverterFactory() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Optional<DeserializationRuntimeConverter> createUserDefinedConverter(
+                    LogicalType logicalType, ZoneId serverTimeZone) {
+                switch (logicalType.getTypeRoot()) {
+                    case CHAR:
+                    case VARCHAR:
+                        return createStringConverter();
+                    case BINARY:
+                    case VARBINARY:
+                        return createBinaryConverter();
+                    default:
+                        // fallback to default converter
+                        return Optional.empty();
+                }
+            }
+        };
+    }
+
+    private static Optional<DeserializationRuntimeConverter> createBinaryConverter() {
+        return Optional.of(
+                new DeserializationRuntimeConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(Object dbzObj, Schema schema) throws Exception {
+                        if (isGeometrySchema(schema.name())) {
+                            // The stuct consists of 2 fields the wkb byte array and the srid
+                            // specifier
+                            Struct geometryStruct = (Struct) dbzObj;
+                            // The byte array is actually be ewkb thus srid could be encoded in
+                            // case of a geography object. See:
+                            // https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgisGeometry.java
+                            return geometryStruct.getBytes("wkb");
+                        } else {
+                            return StringData.fromString(dbzObj.toString());
+                        }
+                    }
+                });
+    }
+
+    private static Optional<DeserializationRuntimeConverter> createStringConverter() {
+        return Optional.of(
+                new DeserializationRuntimeConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(Object dbzObj, Schema schema) throws Exception {
+
+                        if (isGeometrySchema(schema.name())) {
+                            // The stuct consists of 2 fields the wkb byte array and the srid
+                            // specifier
+                            Struct geometryStruct = (Struct) dbzObj;
+                            // The byte array is actually be ewkb thus srid could be encoded in
+                            // case of a geography object. See
+                            // https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgisGeometry.java
+                            byte[] wkb = geometryStruct.getBytes("wkb");
+                            String s = byteToHexString(wkb);
+                            return StringData.fromString(s);
+                        } else {
+                            return StringData.fromString(dbzObj.toString());
+                        }
+                    }
+                });
+    }
+}

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
@@ -82,8 +82,8 @@ public class PostgresDeserializationConverterFactory {
                             // The stuct consists of 2 fields the wkb byte array and the srid
                             // specifier
                             Struct geometryStruct = (Struct) dbzObj;
-                            // The byte array is actually be ewkb thus srid could be encoded in
-                            // case of a geography object. See:
+                            // The byte array is actually ewkb thus srid should be encoded in
+                            // it in case of a geography object. See:
                             // https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgisGeometry.java
                             return geometryStruct.getBytes("wkb");
                         } else {
@@ -105,8 +105,8 @@ public class PostgresDeserializationConverterFactory {
                             // The stuct consists of 2 fields the wkb byte array and the srid
                             // specifier
                             Struct geometryStruct = (Struct) dbzObj;
-                            // The byte array is actually be ewkb thus srid could be encoded in
-                            // case of a geography object. See
+                            // The byte array is actually ewkb thus srid should be encoded in
+                            // it in case of a geography object. See
                             // https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgisGeometry.java
                             byte[] wkb = geometryStruct.getBytes("wkb");
                             String s = byteToHexString(wkb);

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgresDeserializationConverterFactory.java
@@ -38,11 +38,13 @@ import static org.apache.flink.util.StringUtils.byteToHexString;
 public class PostgresDeserializationConverterFactory {
 
     public static boolean isGeometrySchema(String schema) {
-        switch (schema) {
-            case Point.LOGICAL_NAME:
-            case Geometry.LOGICAL_NAME:
-            case Geography.LOGICAL_NAME:
-                return true;
+        if (schema != null) {
+            switch (schema) {
+                case Point.LOGICAL_NAME:
+                case Geometry.LOGICAL_NAME:
+                case Geography.LOGICAL_NAME:
+                    return true;
+            }
         }
 
         return false;
@@ -100,7 +102,6 @@ public class PostgresDeserializationConverterFactory {
 
                     @Override
                     public Object convert(Object dbzObj, Schema schema) throws Exception {
-
                         if (isGeometrySchema(schema.name())) {
                             // The stuct consists of 2 fields the wkb byte array and the srid
                             // specifier


### PR DESCRIPTION
This adds a simple DeserializationConverterFactory for PostgisGeometry objects, like it is done in with the com.ververica.cdc.connectors.mysql.table.MySqlDeserializationConverterFactory.
But in the case of PostGIS the data is encoded in ewkb, which should already include the srid (see here https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java and https://github.com/debezium/debezium/blob/main/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgisGeometry.java), thus converting it to GeoJSON would be an 
In the string case this converter returns an hex encoded string of the ewkb, which could be directly transformed to a corresponding geometry type column of apache sedona (https://sedona.apache.org/tutorial/flink/sql/) with the 'ST_GeomFromWKB' function. In the byte case the raw ewkb byte array is directly returned. This array again can easily be converted into the corresponding geometry object e.g. by using https://locationtech.github.io/jts/javadoc/org/locationtech/jts/io/WKBReader.html#read-byte:A-.