### PR TITLE
[mysql] Fix the binlogSplit state incompatibility when upgrading from 2.2.0

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -161,7 +161,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
             boolean isSuspended = false;
             if (version >= 3) {
                 totalFinishedSplitSize = in.readInt();
-                if (version > 3) {
+                if (version > 3 && in.available() > 0) {
                     isSuspended = in.readBoolean();
                 }
             }


### PR DESCRIPTION
EOFException will happen when upgrading from mysql-cdc 2.2.0 and restoring from a savepoint. The exception stack is ac follows:
`java.io.EOFException
	at org.apache.flink.core.memory.DataInputDeserializer.readBoolean(DataInputDeserializer.java:125)
	at com.ververica.cdc.connectors.mysql.source.split.MySqlSplitSerializer.deserializeSplit(MySqlSplitSerializer.java:165)
	at com.ververica.cdc.connectors.mysql.source.split.MySqlSplitSerializer.deserialize(MySqlSplitSerializer.java:124)` 

The reason is that isSuspended flag is serialized for MySqlBinlogSplit  in #996 which results in state incompatibility and we should increase serializer version normally, but we did not.

We can fix the problem simply by checking whether there is data left in buffer as  isSuspended flag is the last field.
  
