### PR TITLE
[tdsql] The first draft of TDSQL-CDC

### DIFF
--- a/docs/content/connectors/tdsql-cdc.md
+++ b/docs/content/connectors/tdsql-cdc.md
@@ -1,0 +1,436 @@
+# TDSQL CDC Connector
+
+The TDSQL CDC connector allows for reading snapshot data and incremental data from TDSQL database. This document describes how to setup the TDSQL CDC connector to run SQL queries against TDSQL databases.
+
+Dependencies
+------------
+
+In order to setup the TDSQL CDC connector, the following table provides dependency information for both projects using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR bundles.
+
+### Maven dependency
+
+```
+<dependency>
+  <groupId>com.ververica</groupId>
+  <artifactId>flink-connector-tdsql-cdc</artifactId>
+  <!-- The dependency is available only for stable releases, SNAPSHOT dependency need build by yourself. -->
+  <version>2.3-SNAPSHOT</version>
+</dependency>
+```
+
+### SQL Client JAR
+
+```Download link is available only for stable releases.```
+
+Download [flink-sql-connector-tdsql-cdc-2.3-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-sql-connector-tdsql-cdc/2.3-SNAPSHOT/flink-sql-connector-mysql-cdc-2.3-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
+
+**Note:** flink-sql-connector-tdsql-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-tdsql-cdc-XXX.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-mysql-cdc), the released version will be available in the Maven central warehouse.
+
+Setup TDSQL server
+----------------
+
+You have to define a TDSQL user with appropriate permissions on all databases that the Debezium MySQL connector monitors.
+
+1. Create the TDSQL user:
+
+```sql
+mysql> CREATE USER 'user'@'localhost' IDENTIFIED BY 'password';
+```
+
+2. Grant the required permissions to the user:
+
+```sql
+mysql> GRANT SELECT, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'user' IDENTIFIED BY 'password';
+```
+**Note:** The RELOAD permissions is not required any more when `scan.incremental.snapshot.enabled` is enabled (enabled by default).
+
+3. Finalize the user’s permissions:
+
+```sql
+mysql> FLUSH PRIVILEGES;
+```
+
+See more about the [permission explanation](https://debezium.io/documentation/reference/1.5/connectors/mysql.html#mysql-creating-user).
+
+
+Notes
+----------------
+
+### Set a different SERVER ID for each reader
+
+Every MySQL database client for reading binlog should have an unique id, called server id. MySQL server will use this id to maintain network connection and the binlog position. Therefore, if different jobs share a same server id, it may result to read from wrong binlog position.
+Thus, it is recommended to set different server id for each reader via the [SQL Hints](https://ci.apache.org/projects/flink/flink-docs-release-1.11/dev/table/sql/hints.html),
+e.g.  assuming the source parallelism is 4, then we can use `SELECT * FROM source_table /*+ OPTIONS('server-id'='5401-5404') */ ;` to assign unique server id for each of the 4 source readers.
+
+
+### Setting up MySQL session timeouts
+
+When an initial consistent snapshot is made for large databases, your established connection could timeout while the tables are being read. You can prevent this behavior by configuring interactive_timeout and wait_timeout in your MySQL configuration file.
+- `interactive_timeout`: The number of seconds the server waits for activity on an interactive connection before closing it. See [MySQL documentations](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_interactive_timeout).
+- `wait_timeout`: The number of seconds the server waits for activity on a noninteractive connection before closing it. See [MySQL documentations](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_wait_timeout).
+
+
+How to create a TDSQL CDC table
+----------------
+
+The TDSQL CDC table can be defined as following:
+
+```sql
+-- checkpoint every 3000 milliseconds                       
+Flink SQL> SET 'execution.checkpointing.interval' = '3s';   
+
+-- register a TDSQL table 'orders' in Flink SQL
+Flink SQL> CREATE TABLE orders (
+     order_id INT,
+     order_date TIMESTAMP(0),
+     customer_name STRING,
+     price DECIMAL(10, 5),
+     product_id INT,
+     order_status BOOLEAN,
+     PRIMARY KEY(order_id) NOT ENFORCED
+     ) WITH (
+     'connector' = 'tdsql-cdc',
+     'hostname' = 'localhost',
+     'port' = '3306',
+     'username' = 'root',
+     'password' = '123456',
+     'database-name' = 'mydb',
+     'table-name' = 'orders');
+  
+-- read snapshot and binlogs from orders table
+Flink SQL> SELECT * FROM orders;
+```
+
+Connector Options
+----------------
+
+<div class="highlight">
+<table class="colwidths-auto docutils">
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 10%">Option</th>
+        <th class="text-left" style="width: 8%">Required</th>
+        <th class="text-left" style="width: 7%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 65%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>connector</td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Specify what connector to use, here should be <code>'tdsql-cdc'</code>.</td>
+    </tr>
+    <tr>
+      <td>hostname</td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>IP address or hostname of the TDSQL database server.</td>
+    </tr>
+    <tr>
+      <td>username</td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Name of the TDSQL database to use when connecting to the TDSQL database server.</td>
+    </tr>
+    <tr>
+      <td>password</td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Password to use when connecting to the TDSQL database server.</td>
+    </tr>
+    <tr>
+      <td>database-name</td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Database name of the TDSQL server to monitor. The database-name also supports regular expressions to monitor multiple tables matches the regular expression.</td>
+    </tr> 
+    <tr>
+      <td>table-name</td>
+      <td>required</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Table name of the TDSQL database to monitor. The table-name also supports regular expressions to monitor multiple tables matches the regular expression.</td>
+    </tr>
+    <tr>
+      <td>port</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">3306</td>
+      <td>Integer</td>
+      <td>Integer port number of the TDSQL database server.</td>
+    </tr>
+    <tr>
+      <td>server-id</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Integer</td>
+      <td>A numeric ID or a numeric ID range of this database client, The numeric ID syntax is like '5400', 
+          the numeric ID range syntax is like '5400-5408', The numeric ID range syntax is recommended when 'scan.incremental.snapshot.enabled' enabled.
+          Every ID must be unique across all currently-running database processes in the TDSQL MySQL cluster. This connector joins the TDSQL MySQL cluster
+          as another server (with this unique ID) so it can read the binlog. By default, a random number is generated between 5400 and 6400,
+          though we recommend setting an explicit value.
+      </td>
+    </tr>
+    <tr>
+          <td>scan.incremental.snapshot.enabled</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">true</td>
+          <td>Boolean</td>
+          <td>Incremental snapshot is a new mechanism to read snapshot of a table. Compared to the old snapshot mechanism,
+              the incremental snapshot has many advantages, including:
+                (1) source can be parallel during snapshot reading, 
+                (2) source can perform checkpoints in the chunk granularity during snapshot reading, 
+                (3) source doesn't need to acquire global read lock (FLUSH TABLES WITH READ LOCK) before snapshot reading.
+              If you would like the source run in parallel, each parallel reader should have an unique server id, so 
+              the 'server-id' must be a range like '5400-6400', and the range must be larger than the parallelism.
+              Please see <a href="#incremental-snapshot-reading ">Incremental Snapshot Reading</a>section for more detailed information.
+          </td>
+    </tr>
+    <tr>
+          <td>scan.incremental.snapshot.chunk.size</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">8096</td>
+          <td>Integer</td>
+          <td>The chunk size (number of rows) of table snapshot, captured tables are split into multiple chunks when read the snapshot of table.</td>
+    </tr>
+    <tr>
+          <td>scan.snapshot.fetch.size</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">1024</td>
+          <td>Integer</td>
+          <td>The maximum fetch size for per poll when read table snapshot.</td>
+    </tr>
+    <tr>
+      <td>scan.startup.mode</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">initial</td>
+      <td>String</td>
+      <td>Optional startup mode for MySQL CDC consumer, valid enumerations are "initial"
+           and "latest-offset". 
+           Please see <a href="#startup-reading-position">Startup Reading Position</a>section for more detailed information.</td>
+    </tr> 
+    <tr>
+      <td>server-time-zone</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">UTC</td>
+      <td>String</td>
+      <td>The session time zone in database server, e.g. "Asia/Shanghai". 
+          It controls how the TIMESTAMP type in MYSQL converted to STRING.
+          See more <a href="https://debezium.io/documentation/reference/1.5/connectors/mysql.html#mysql-temporal-types">here</a>.</td>
+    </tr>
+    <tr>
+      <td>debezium.min.row.
+      count.to.stream.result</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">1000</td>
+      <td>Integer</td>
+      <td>	
+During a snapshot operation, the connector will query each included table to produce a read event for all rows in that table. This parameter determines whether the MySQL connection will pull all results for a table into memory (which is fast but requires large amounts of memory), or whether the results will instead be streamed (can be slower, but will work for very large tables). The value specifies the minimum number of rows a table must contain before the connector will stream results, and defaults to 1,000. Set this parameter to '0' to skip all table size checks and always stream all results during a snapshot.</td>
+    </tr>
+    <tr>
+          <td>connect.timeout</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">30s</td>
+          <td>Duration</td>
+          <td>The maximum time that the connector should wait after trying to connect to the MySQL database server before timing out.</td>
+    </tr>    
+    <tr>
+          <td>connect.max-retries</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">3</td>
+          <td>Integer</td>
+          <td>The max retry times that the connector should retry to build MySQL database server connection.</td>
+    </tr>
+    <tr>
+          <td>connection.pool.size</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">20</td>
+          <td>Integer</td>
+          <td>The connection pool size.</td>
+    </tr>
+    <tr>
+          <td>jdbc.properties.*</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">20</td>
+          <td>String</td>
+          <td>Option to pass custom JDBC URL properties. User can pass custom properties like 'jdbc.properties.useSSL' = 'false'.</td>
+    </tr>
+    <tr>
+          <td>heartbeat.interval</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">30s</td>
+          <td>Duration</td>
+          <td>The interval of sending heartbeat event for tracing the latest available binlog offsets.</td>
+    </tr>
+    <tr>
+      <td>debezium.*</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Pass-through Debezium's properties to Debezium Embedded Engine which is used to capture data changes from MySQL server.
+          For example: <code>'debezium.snapshot.mode' = 'never'</code>.
+          See more about the <a href="https://debezium.io/documentation/reference/1.5/connectors/mysql.html#mysql-connector-properties">Debezium's MySQL Connector properties</a></td> 
+    </tr>
+    </tbody>
+</table>
+</div>
+
+Available Metadata
+----------------
+
+The following format metadata can be exposed as read-only (VIRTUAL) columns in a table definition.
+
+<table class="colwidths-auto docutils">
+  <thead>
+     <tr>
+       <th class="text-left" style="width: 15%">Key</th>
+       <th class="text-left" style="width: 30%">DataType</th>
+       <th class="text-left" style="width: 55%">Description</th>
+     </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>table_name</td>
+      <td>STRING NOT NULL</td>
+      <td>Name of the table that contain the row.</td>
+    </tr>
+    <tr>
+      <td>database_name</td>
+      <td>STRING NOT NULL</td>
+      <td>Name of the database that contain the row.</td>
+    </tr>
+    <tr>
+      <td>op_ts</td>
+      <td>TIMESTAMP_LTZ(3) NOT NULL</td>
+      <td>It indicates the time that the change was made in the database. <br>If the record is read from snapshot of the table instead of the binlog, the value is always 0.</td>
+    </tr>
+  </tbody>
+</table>
+
+The extended CREATE TABLE example demonstrates the syntax for exposing these metadata fields:
+```sql
+CREATE TABLE products (
+    db_name STRING METADATA FROM 'database_name' VIRTUAL,
+    table_name STRING METADATA  FROM 'table_name' VIRTUAL,
+    operation_ts TIMESTAMP_LTZ(3) METADATA FROM 'op_ts' VIRTUAL,
+    order_id INT,
+    order_date TIMESTAMP(0),
+    customer_name STRING,
+    price DECIMAL(10, 5),
+    product_id INT,
+    order_status BOOLEAN,
+    PRIMARY KEY(order_id) NOT ENFORCED
+) WITH (
+    'connector' = 'tdsql-cdc',
+    'hostname' = 'localhost',
+    'port' = '3306',
+    'username' = 'root',
+    'password' = '123456',
+    'database-name' = 'mydb',
+    'table-name' = 'orders'
+);
+```
+
+Features
+--------
+
+### Incremental Snapshot Reading
+
+Incremental snapshot reading is a new mechanism to read snapshot of a table. Compared to the old snapshot mechanism, the incremental snapshot has many advantages, including:
+* (1) TDSQL CDC Source can be parallel during snapshot reading
+* (2) TDSQL CDC Source can perform checkpoints in the chunk granularity during snapshot reading
+* (3) TDSQL CDC Source doesn't need to acquire global read lock (FLUSH TABLES WITH READ LOCK) before snapshot reading
+
+If you would like the source run in parallel, each parallel reader should have an unique server id, so the 'server-id' must be a range like '5400-6400',
+and the range must be larger than the parallelism.
+
+During the incremental snapshot reading, the TDSQL CDC Source firstly splits snapshot chunks (splits) by primary key of table,
+and then TDSQL CDC Source assigns the chunks to multiple readers to read the data of snapshot chunk.
+
+**important:** TDSQL CDC don't guarantee each *TDSQL cluster set* global record in order, but guarantee each single *cluster set* record in order.
+
+#### Controlling Parallelism
+
+Incremental snapshot reading provides the ability to read snapshot data parallelly.
+You can control the source parallelism by setting the job parallelism `parallelism.default`. For example, in SQL CLI:
+
+```sql
+Flink SQL> SET 'parallelism.default' = 8;
+```
+
+#### Checkpoint
+
+Incremental snapshot reading provides the ability to perform checkpoint in chunk level. It resolves the checkpoint timeout problem in previous version with old snapshot reading mechanism.
+
+#### Lock-free
+
+The TDSQL CDC source use **incremental snapshot algorithm**, which avoid acquiring global read lock (FLUSH TABLES WITH READ LOCK) and thus doesn't need `RELOAD` permission.
+
+#### TDSQL Heartbeat Event Support
+
+If the table updates infrequently, the binlog file or GTID set may have been cleaned in its last committed binlog position.
+The CDC job may restart fails in this case. So the heartbeat event will help update binlog position. By default heartbeat event is enabled in TDSQL CDC source and the interval is set to 30 seconds. You can specify the interval by using table option ```heartbeat.interval```, or set the option to `0s` to disable heartbeat events.
+
+### Exactly-Once Processing
+
+The TDSQL CDC connector is a Flink Source connector which will read table snapshot chunks first and then continues to read binlog,
+both snapshot phase and binlog phase, TDSQL CDC connector read with **exactly-once processing** even failures happen.
+
+### Startup Reading Position
+
+The config option `scan.startup.mode` specifies the startup mode for TDSQL CDC consumer. The valid enumerations are:
+
+- `initial` (default): Performs an initial snapshot on the monitored database tables upon first startup, and continue to read the latest binlog.
+- `latest-offset`: Never to perform snapshot on the monitored database tables upon first startup, just read from
+  the end of the binlog which means only have the changes since the connector was started.
+
+_Note: the mechanism of `scan.startup.mode` option relying on Debezium's `snapshot.mode` configuration. So please do not using them together. If you speicifying both `scan.startup.mode` and `debezium.snapshot.mode` options in the table DDL, it may make `scan.startup.mode` doesn't work._
+
+### DataStream Source
+
+```java
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
+import com.ververica.cdc.connectors.tdsql.source.TdSqlSource;
+
+public class MySqlSourceExample {
+  public static void main(String[] args) throws Exception {
+    TdSqlSource<String> tdSqlSource = TdSqlSource.<String>builder()
+        .hostname("yourHostname")
+        .port(yourPort)
+        .databaseList("yourDatabaseName") // set captured database, If you need to synchronize the whole database, Please set tableList to ".*".
+        .tableList("yourDatabaseName.yourTableName") // set captured table
+        .username("yourUsername")
+        .password("yourPassword")
+        .deserializer(new JsonDebeziumDeserializationSchema()) // converts SourceRecord to JSON String
+        .build();
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+    // enable checkpoint
+    env.enableCheckpointing(3000);
+
+    env
+      .fromSource(tdSqlSource, WatermarkStrategy.noWatermarks(), "tdSql Source")
+      // set 4 parallel source tasks
+      .setParallelism(4)
+      .print().setParallelism(1); // use parallelism 1 for sink to keep message ordering
+
+    env.execute("Print TDSQL Snapshot + Binlog");
+  }
+}
+```
+
+**Note:** Please refer [Deserialization](../about.html#deserialization) for more details about the JSON deserialization.
+
+Data Type Mapping
+----------------
+
+TDSQL CDC data type mapping same as [MySQL CDC](./mysql-cdc.md)

--- a/flink-connector-tdsql-cdc/pom.xml
+++ b/flink-connector-tdsql-cdc/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-cdc-connectors</artifactId>
+        <groupId>com.ververica</groupId>
+        <version>2.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-tdsql-cdc</artifactId>
+
+    <properties>
+        <flink-cdc-base.version>2.3-SNAPSHOT</flink-cdc-base.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${flink-cdc-base.version}</version>
+        </dependency>
+
+        <!-- test dependencies on Flink -->
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-tests</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- test dependencies on TestContainers -->
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/bases/TdSqlUtils.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/bases/TdSqlUtils.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.bases;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import io.debezium.jdbc.JdbcConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Utilities related to TdSql. */
+public class TdSqlUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(TdSqlUtils.class);
+
+    private static final String SET_KEY = "set";
+    private static final String IP_KEY_SUFFIX = ":ip";
+
+    public static List<TdSqlSet> discoverSets(JdbcConnection jdbc) {
+        final String showStatusStmts = "/*proxy*/show status";
+
+        try {
+            return jdbc.queryAndMap(
+                    showStatusStmts,
+                    rs -> {
+                        Map<String, String> tdsqlStatus = new HashMap<>(rs.getFetchSize());
+                        while (rs.next()) {
+                            tdsqlStatus.put(rs.getString(1), rs.getString(2));
+                        }
+                        Optional<String[]> sets =
+                                Optional.ofNullable(tdsqlStatus.get(SET_KEY))
+                                        .map(v -> v.split(","));
+                        if (!sets.isPresent()) {
+                            throw new FlinkRuntimeException(
+                                    "Cannot found set infos via '"
+                                            + showStatusStmts
+                                            + "', Make sure your server is correctly configured");
+                        }
+
+                        LOG.trace("configs {}", asString(tdsqlStatus));
+
+                        String[] setKeys = sets.get();
+                        List<TdSqlSet> res = new ArrayList<>(setKeys.length);
+
+                        for (String setKey : setKeys) {
+                            String setIpKey = setKey.trim() + IP_KEY_SUFFIX;
+                            String value = tdsqlStatus.get(setIpKey);
+                            LOG.trace("get set ip {} by key {}", value, setIpKey);
+
+                            int setMasterIPSplitIndex = value.indexOf(";");
+                            int setHostIndex = value.indexOf(":");
+
+                            if (setMasterIPSplitIndex == -1 || setHostIndex == -1) {
+                                throw new FlinkRuntimeException(
+                                        "Cannot found set '"
+                                                + setKey
+                                                + "' info. all status is: "
+                                                + asString(tdsqlStatus)
+                                                + ", please check.");
+                            }
+
+                            String host = value.substring(0, setHostIndex);
+                            int port =
+                                    Integer.parseInt(
+                                            value.substring(
+                                                    setHostIndex + 1, setMasterIPSplitIndex));
+
+                            TdSqlSet set = new TdSqlSet(setKey.trim(), host, port);
+                            LOG.info("add set: {}", set);
+                            res.add(set);
+                        }
+                        return res;
+                    });
+        } catch (SQLException e) {
+            throw new RuntimeException(
+                    "Cannot found set infos via '"
+                            + showStatusStmts
+                            + "', Make sure your server is correctly configured",
+                    e);
+        }
+    }
+
+    private static <K, V> String asString(Map<K, V> map) {
+        return map.entrySet().stream()
+                .map(kv -> kv.getKey() + "=" + kv.getValue())
+                .collect(Collectors.joining(","));
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/bases/set/TdSqlSet.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/bases/set/TdSqlSet.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.bases.set;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** tdsql set info. */
+public class TdSqlSet implements Serializable {
+    private static final long serialVersionUID = -3395810101971522360L;
+    private String setKey;
+
+    private String host;
+
+    private int port;
+
+    public TdSqlSet() {}
+
+    public TdSqlSet(String setId, String host, int port) {
+        this.setKey = setId;
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getSetKey() {
+        return setKey;
+    }
+
+    public void setSetKey(String setKey) {
+        this.setKey = setKey;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TdSqlSet)) {
+            return false;
+        }
+        TdSqlSet tdSqlSet = (TdSqlSet) o;
+        return port == tdSqlSet.port
+                && setKey.equals(tdSqlSet.setKey)
+                && host.equals(tdSqlSet.host);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(setKey, host, port);
+    }
+
+    @Override
+    public String toString() {
+        return "TdSqlSet{"
+                + "setKey='"
+                + setKey
+                + '\''
+                + ", host='"
+                + host
+                + '\''
+                + ", port="
+                + port
+                + '}';
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSource.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSource.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.ververica.cdc.connectors.mysql.MySqlValidator;
+import com.ververica.cdc.connectors.mysql.source.assigners.MySqlBinlogSplitAssigner;
+import com.ververica.cdc.connectors.mysql.source.assigners.MySqlHybridSplitAssigner;
+import com.ververica.cdc.connectors.mysql.source.assigners.MySqlSplitAssigner;
+import com.ververica.cdc.connectors.mysql.source.assigners.state.BinlogPendingSplitsState;
+import com.ververica.cdc.connectors.mysql.source.assigners.state.HybridPendingSplitsState;
+import com.ververica.cdc.connectors.mysql.source.assigners.state.PendingSplitsState;
+import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
+import com.ververica.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
+import com.ververica.cdc.connectors.mysql.source.reader.MySqlSourceReaderContext;
+import com.ververica.cdc.connectors.mysql.source.reader.MySqlSplitReader;
+import com.ververica.cdc.connectors.mysql.table.StartupMode;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplit;
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplitSerializer;
+import com.ververica.cdc.connectors.tdsql.source.assigner.state.TdSqlPendingSplitsState;
+import com.ververica.cdc.connectors.tdsql.source.assigner.state.TdSqlPendingSplitsStateSerializer;
+import com.ververica.cdc.connectors.tdsql.source.enumerator.TdSqlSourceEnumerator;
+import com.ververica.cdc.connectors.tdsql.source.reader.TdSqlRecordEmitter;
+import com.ververica.cdc.connectors.tdsql.source.reader.TdSqlSourceReader;
+import com.ververica.cdc.connectors.tdsql.source.reader.TdSqlSplitReader;
+import com.ververica.cdc.connectors.tdsql.source.reader.fetcher.TdSqlFetcherManager;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.eclipse.jetty.util.ajax.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.discoverCapturedTables;
+import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.isTableIdCaseSensitive;
+import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbcConnection;
+import static com.ververica.cdc.connectors.tdsql.bases.TdSqlUtils.discoverSets;
+
+/**
+ * The TdSql CDC Source based on {@link com.ververica.cdc.connectors.mysql.source.MySqlSource}.
+ * TdSql CDC Source usage as same as MySql CDC Source.
+ *
+ * @param <T> the output type of the source.
+ */
+@Internal
+public class TdSqlSource<T>
+        implements Source<T, TdSqlSplit, TdSqlPendingSplitsState>, ResultTypeQueryable<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TdSqlSource.class);
+    private static final long serialVersionUID = 943718471756513230L;
+
+    private final MySqlSourceConfigFactory configFactory;
+    private final DebeziumDeserializationSchema<T> deserializationSchema;
+
+    private List<TdSqlSet> testSets;
+
+    TdSqlSource(
+            MySqlSourceConfigFactory configFactory,
+            DebeziumDeserializationSchema<T> deserializationSchema) {
+        this.configFactory = configFactory;
+        this.deserializationSchema = deserializationSchema;
+    }
+
+    @PublicEvolving
+    public static <T> TdSqlSourceBuilder<T> builder() {
+        return new TdSqlSourceBuilder<>();
+    }
+
+    @VisibleForTesting
+    public void setTestSets(List<TdSqlSet> sets) {
+        LOGGER.info("set tdsql sets: {}", JSON.toString(sets));
+        this.testSets = sets;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public SourceReader<T, TdSqlSplit> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        // create source config for the given subtask (e.g. unique server id)
+        MySqlSourceConfig sourceConfig =
+                configFactory.createConfig(readerContext.getIndexOfSubtask());
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecord>> elementsQueue =
+                new FutureCompletingBlockingQueue<>();
+
+        final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");
+        metricGroupMethod.setAccessible(true);
+        final MetricGroup metricGroup = (MetricGroup) metricGroupMethod.invoke(readerContext);
+
+        final MySqlSourceReaderMetrics sourceReaderMetrics =
+                new MySqlSourceReaderMetrics(metricGroup);
+        sourceReaderMetrics.registerMetrics();
+        MySqlSourceReaderContext mySqlSourceReaderContext =
+                new MySqlSourceReaderContext(readerContext);
+        Supplier<TdSqlSplitReader> splitReaderSupplier =
+                () ->
+                        new TdSqlSplitReader(
+                                set ->
+                                        addMySqlSplitReaderBySet(
+                                                set,
+                                                readerContext.getIndexOfSubtask(),
+                                                mySqlSourceReaderContext));
+
+        return new TdSqlSourceReader<>(
+                elementsQueue,
+                new TdSqlFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                new TdSqlRecordEmitter<>(
+                        deserializationSchema,
+                        sourceReaderMetrics,
+                        sourceConfig.isIncludeSchemaChanges()),
+                readerContext.getConfiguration(),
+                mySqlSourceReaderContext.getSourceReaderContext(),
+                set -> createConfig(set.getHost(), set.getPort()));
+    }
+
+    private MySqlSplitReader addMySqlSplitReaderBySet(
+            TdSqlSet set, int subtaskId, MySqlSourceReaderContext context) {
+        configFactory.port(set.getPort());
+        configFactory.hostname(set.getHost());
+        MySqlSourceConfig sourceConfig = configFactory.createConfig(0);
+        return new MySqlSplitReader(sourceConfig, subtaskId, context);
+    }
+
+    @Override
+    public SplitEnumerator<TdSqlSplit, TdSqlPendingSplitsState> createEnumerator(
+            SplitEnumeratorContext<TdSqlSplit> enumContext) throws Exception {
+        MySqlSourceConfig sourceConfig = configFactory.createConfig(0);
+        new MySqlValidator(sourceConfig).validate();
+
+        List<TdSqlSet> sets;
+        Map<TdSqlSet, MySqlSplitAssigner> assignerMap = new HashMap<>();
+
+        if (testSets != null && testSets.size() > 0) {
+            sets = this.testSets;
+        } else {
+            try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
+                sets = discoverSets(jdbc);
+            }
+        }
+        boolean initialStartMode =
+                sourceConfig.getStartupOptions().startupMode == StartupMode.INITIAL;
+
+        for (TdSqlSet set : sets) {
+            LOGGER.trace("init tdsql set {} assigner.", set.getSetKey());
+            MySqlSplitAssigner splitAssigner;
+
+            MySqlSourceConfig setSourceConfig = createConfig(set.getHost(), set.getPort());
+
+            if (initialStartMode) {
+                try (JdbcConnection setJdbc = openJdbcConnection(setSourceConfig)) {
+                    final List<TableId> remainingTables =
+                            discoverCapturedTables(setJdbc, setSourceConfig);
+                    boolean isTableIdCaseSensitive = isTableIdCaseSensitive(setJdbc);
+                    splitAssigner =
+                            new MySqlHybridSplitAssigner(
+                                    setSourceConfig,
+                                    enumContext.currentParallelism(),
+                                    remainingTables,
+                                    isTableIdCaseSensitive);
+                } catch (Exception e) {
+                    throw new FlinkRuntimeException(
+                            "Failed to discover captured tables for enumerator", e);
+                }
+            } else {
+                splitAssigner = new MySqlBinlogSplitAssigner(setSourceConfig);
+            }
+
+            assignerMap.put(set, splitAssigner);
+        }
+
+        return new TdSqlSourceEnumerator(
+                enumContext, set -> createConfig(set.getHost(), set.getPort()), assignerMap);
+    }
+
+    @Override
+    public SplitEnumerator<TdSqlSplit, TdSqlPendingSplitsState> restoreEnumerator(
+            SplitEnumeratorContext<TdSqlSplit> enumContext, TdSqlPendingSplitsState checkpoint)
+            throws Exception {
+        Map<TdSqlSet, PendingSplitsState> pendingSplitsStateMap = checkpoint.getStateMap();
+
+        Map<TdSqlSet, MySqlSplitAssigner> assignerMap = new HashMap<>();
+        for (TdSqlSet set : pendingSplitsStateMap.keySet()) {
+            PendingSplitsState pendingSplitsState = pendingSplitsStateMap.get(set);
+
+            MySqlSourceConfig sourceConfig = createConfig(set.getHost(), set.getPort());
+
+            MySqlSplitAssigner splitAssigner;
+            if (pendingSplitsState instanceof HybridPendingSplitsState) {
+                splitAssigner =
+                        new MySqlHybridSplitAssigner(
+                                sourceConfig,
+                                enumContext.currentParallelism(),
+                                (HybridPendingSplitsState) pendingSplitsState);
+            } else if (pendingSplitsState instanceof BinlogPendingSplitsState) {
+                splitAssigner =
+                        new MySqlBinlogSplitAssigner(
+                                sourceConfig, (BinlogPendingSplitsState) pendingSplitsState);
+            } else {
+                throw new UnsupportedOperationException(
+                        "Unsupported restored PendingSplitsState: " + checkpoint);
+            }
+
+            assignerMap.put(set, splitAssigner);
+        }
+
+        return new TdSqlSourceEnumerator(
+                enumContext, set -> createConfig(set.getHost(), set.getPort()), assignerMap);
+    }
+
+    private MySqlSourceConfig createConfig(String host, int port) {
+        configFactory.hostname(host);
+        configFactory.port(port);
+        return configFactory.createConfig(0);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<TdSqlSplit> getSplitSerializer() {
+        return TdSqlSplitSerializer.INSTANCE;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<TdSqlPendingSplitsState> getEnumeratorCheckpointSerializer() {
+        return new TdSqlPendingSplitsStateSerializer(TdSqlSplitSerializer.INSTANCE);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceBuilder.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceBuilder.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import com.ververica.cdc.connectors.mysql.source.MySqlSource;
+import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * tdsql source builder like {@link com.ververica.cdc.connectors.mysql.source.MySqlSourceBuilder}.
+ */
+@PublicEvolving
+public class TdSqlSourceBuilder<T> {
+    private final MySqlSourceConfigFactory configFactory = new MySqlSourceConfigFactory();
+    private DebeziumDeserializationSchema<T> deserializer;
+
+    public TdSqlSourceBuilder<T> hostname(String hostname) {
+        configFactory.hostname(hostname);
+        return this;
+    }
+
+    /** Integer port number of the MySQL database server. */
+    public TdSqlSourceBuilder<T> port(int port) {
+        configFactory.port(port);
+        return this;
+    }
+
+    /**
+     * An required list of regular expressions that match database names to be monitored; any
+     * database name not included in the whitelist will be excluded from monitoring.
+     */
+    public TdSqlSourceBuilder<T> databaseList(String... databaseList) {
+        this.configFactory.databaseList(databaseList);
+        return this;
+    }
+
+    /**
+     * An required list of regular expressions that match fully-qualified table identifiers for
+     * tables to be monitored; any table not included in the list will be excluded from monitoring.
+     * Each identifier is of the form {@code <databaseName>.<tableName>}.
+     */
+    public TdSqlSourceBuilder<T> tableList(String... tableList) {
+        this.configFactory.tableList(tableList);
+        return this;
+    }
+
+    /** Name of the MySQL database to use when connecting to the MySQL database server. */
+    public TdSqlSourceBuilder<T> username(String username) {
+        this.configFactory.username(username);
+        return this;
+    }
+
+    /** Password to use when connecting to the MySQL database server. */
+    public TdSqlSourceBuilder<T> password(String password) {
+        this.configFactory.password(password);
+        return this;
+    }
+
+    /**
+     * A numeric ID or a numeric ID range of this database client, The numeric ID syntax is like
+     * '5400', the numeric ID range syntax is like '5400-5408', The numeric ID range syntax is
+     * required when 'scan.incremental.snapshot.enabled' enabled. Every ID must be unique across all
+     * currently-running database processes in the MySQL cluster. This connector joins the MySQL
+     * cluster as another server (with this unique ID) so it can read the binlog. By default, a
+     * random number is generated between 5400 and 6400, though we recommend setting an explicit
+     * value."
+     */
+    public TdSqlSourceBuilder<T> serverId(String serverId) {
+        this.configFactory.serverId(serverId);
+        return this;
+    }
+
+    /**
+     * The session time zone in database server, e.g. "America/Los_Angeles". It controls how the
+     * TIMESTAMP type in MYSQL converted to STRING. See more
+     * https://debezium.io/documentation/reference/1.5/connectors/mysql.html#mysql-temporal-types
+     */
+    public TdSqlSourceBuilder<T> serverTimeZone(String timeZone) {
+        this.configFactory.serverTimeZone(timeZone);
+        return this;
+    }
+
+    /**
+     * The split size (number of rows) of table snapshot, captured tables are split into multiple
+     * splits when read the snapshot of table.
+     */
+    public TdSqlSourceBuilder<T> splitSize(int splitSize) {
+        this.configFactory.splitSize(splitSize);
+        return this;
+    }
+
+    /**
+     * The group size of split meta, if the meta size exceeds the group size, the meta will be will
+     * be divided into multiple groups.
+     */
+    public TdSqlSourceBuilder<T> splitMetaGroupSize(int splitMetaGroupSize) {
+        this.configFactory.splitMetaGroupSize(splitMetaGroupSize);
+        return this;
+    }
+
+    /**
+     * The upper bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public TdSqlSourceBuilder<T> distributionFactorUpper(double distributionFactorUpper) {
+        this.configFactory.distributionFactorUpper(distributionFactorUpper);
+        return this;
+    }
+
+    /**
+     * The lower bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public TdSqlSourceBuilder<T> distributionFactorLower(double distributionFactorLower) {
+        this.configFactory.distributionFactorLower(distributionFactorLower);
+        return this;
+    }
+
+    /** The maximum fetch size for per poll when read table snapshot. */
+    public TdSqlSourceBuilder<T> fetchSize(int fetchSize) {
+        this.configFactory.fetchSize(fetchSize);
+        return this;
+    }
+
+    /**
+     * The maximum time that the connector should wait after trying to connect to the MySQL database
+     * server before timing out.
+     */
+    public TdSqlSourceBuilder<T> connectTimeout(Duration connectTimeout) {
+        this.configFactory.connectTimeout(connectTimeout);
+        return this;
+    }
+
+    /** The max retry times to get connection. */
+    public TdSqlSourceBuilder<T> connectMaxRetries(int connectMaxRetries) {
+        this.configFactory.connectMaxRetries(connectMaxRetries);
+        return this;
+    }
+
+    /** The connection pool size. */
+    public TdSqlSourceBuilder<T> connectionPoolSize(int connectionPoolSize) {
+        this.configFactory.connectionPoolSize(connectionPoolSize);
+        return this;
+    }
+
+    /** Whether the {@link MySqlSource} should output the schema changes or not. */
+    public TdSqlSourceBuilder<T> includeSchemaChanges(boolean includeSchemaChanges) {
+        this.configFactory.includeSchemaChanges(includeSchemaChanges);
+        return this;
+    }
+
+    /** Whether the {@link MySqlSource} should scan the newly added tables or not. */
+    public TdSqlSourceBuilder<T> scanNewlyAddedTableEnabled(boolean scanNewlyAddedTableEnabled) {
+        this.configFactory.scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled);
+        return this;
+    }
+
+    /** Specifies the startup options. */
+    public TdSqlSourceBuilder<T> startupOptions(StartupOptions startupOptions) {
+        this.configFactory.startupOptions(startupOptions);
+        return this;
+    }
+
+    /** Custom properties that will overwrite the default JDBC connection URL. */
+    public TdSqlSourceBuilder<T> jdbcProperties(Properties jdbcProperties) {
+        this.configFactory.jdbcProperties(jdbcProperties);
+        return this;
+    }
+
+    /** The Debezium MySQL connector properties. For example, "snapshot.mode". */
+    public TdSqlSourceBuilder<T> debeziumProperties(Properties properties) {
+        this.configFactory.debeziumProperties(properties);
+        return this;
+    }
+
+    /**
+     * The deserializer used to convert from consumed {@link
+     * org.apache.kafka.connect.source.SourceRecord}.
+     */
+    public TdSqlSourceBuilder<T> deserializer(DebeziumDeserializationSchema<T> deserializer) {
+        this.deserializer = deserializer;
+        return this;
+    }
+
+    /** The interval of heartbeat event. */
+    public TdSqlSourceBuilder<T> heartbeatInterval(Duration heartbeatInterval) {
+        this.configFactory.heartbeatInterval(heartbeatInterval);
+        return this;
+    }
+
+    /**
+     * Build the {@link MySqlSource}.
+     *
+     * @return a MySqlParallelSource with the settings made for this builder.
+     */
+    public TdSqlSource<T> build() {
+        return new TdSqlSource<>(configFactory, checkNotNull(deserializer));
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/splitter/TdSqlSplit.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/splitter/TdSqlSplit.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.assigner.splitter;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** tdsql split. it contain mysql split info. */
+public class TdSqlSplit implements SourceSplit {
+    private final TdSqlSet setInfo;
+    private final MySqlSplit mySqlSplit;
+    @Nullable transient byte[] serializedFormCache;
+
+    public TdSqlSplit(TdSqlSet setInfo, MySqlSplit mySqlSplit) {
+        this.setInfo = setInfo;
+        this.mySqlSplit = mySqlSplit;
+    }
+
+    public MySqlSplit mySqlSplit() {
+        return mySqlSplit;
+    }
+
+    public TdSqlSet setInfo() {
+        return setInfo;
+    }
+
+    public String setKey() {
+        return setInfo.getSetKey();
+    }
+
+    public boolean isBinlogSplit() {
+        return mySqlSplit.isBinlogSplit();
+    }
+
+    public boolean isSnapshotSplit() {
+        return mySqlSplit().isSnapshotSplit();
+    }
+
+    @Override
+    public String splitId() {
+        return setInfo.getSetKey() + ":" + mySqlSplit.splitId();
+    }
+
+    @Override
+    public String toString() {
+        return "TdSqlSplit{" + "setInfo=" + setInfo + ", mySqlSplit=" + mySqlSplit + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TdSqlSplit)) {
+            return false;
+        }
+        TdSqlSplit split = (TdSqlSplit) o;
+        return Objects.equals(setInfo, split.setInfo)
+                && Objects.equals(mySqlSplit, split.mySqlSplit)
+                && Arrays.equals(serializedFormCache, split.serializedFormCache);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(setInfo, mySqlSplit);
+        result = 31 * result + Arrays.hashCode(serializedFormCache);
+        return result;
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/splitter/TdSqlSplitSerializer.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/splitter/TdSqlSplitSerializer.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.assigner.splitter;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitSerializer;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+
+import java.io.IOException;
+
+/** A serializer for the {@link TdSqlSplit}. */
+public class TdSqlSplitSerializer implements SimpleVersionedSerializer<TdSqlSplit> {
+    public static final TdSqlSplitSerializer INSTANCE = new TdSqlSplitSerializer();
+
+    private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
+            ThreadLocal.withInitial(() -> new DataOutputSerializer(64));
+
+    private final MySqlSplitSerializer mySqlSplitSerializer;
+
+    public TdSqlSplitSerializer() {
+        this.mySqlSplitSerializer = MySqlSplitSerializer.INSTANCE;
+    }
+
+    public MySqlSplitSerializer mySqlSplitSerializer() {
+        return this.mySqlSplitSerializer;
+    }
+
+    @Override
+    public int getVersion() {
+        return mySqlSplitSerializer.getVersion();
+    }
+
+    @Override
+    public byte[] serialize(TdSqlSplit split) throws IOException {
+        if (split.serializedFormCache != null) {
+            return split.serializedFormCache;
+        }
+        final DataOutputSerializer out = SERIALIZER_CACHE.get();
+        serializeTdSqlSet(split.setInfo(), out);
+
+        final byte[] mySqlSeri = mySqlSplitSerializer.serialize(split.mySqlSplit());
+        out.writeInt(mySqlSeri.length);
+        out.write(mySqlSeri);
+
+        final byte[] result = out.getCopyOfBuffer();
+        out.clear();
+
+        split.serializedFormCache = result;
+
+        return result;
+    }
+
+    public void serializeTdSqlSet(TdSqlSet set, DataOutputSerializer out) throws IOException {
+        out.writeUTF(set.getSetKey());
+        out.writeUTF(set.getHost());
+        out.writeInt(set.getPort());
+    }
+
+    public TdSqlSet deserializeTdSqlSet(final DataInputDeserializer in) throws IOException {
+        String setKey = in.readUTF();
+        String setHost = in.readUTF();
+        int port = in.readInt();
+
+        return new TdSqlSet(setKey, setHost, port);
+    }
+
+    @Override
+    public TdSqlSplit deserialize(int version, byte[] serialized) throws IOException {
+        final DataInputDeserializer in = new DataInputDeserializer(serialized);
+
+        TdSqlSet set = deserializeTdSqlSet(in);
+
+        int mySqlSerLen = in.readInt();
+
+        byte[] mySqlSeri = new byte[mySqlSerLen];
+        in.read(mySqlSeri);
+        MySqlSplit mySqlSplit = mySqlSplitSerializer.deserialize(version, mySqlSeri);
+
+        in.releaseArrays();
+
+        return new TdSqlSplit(set, mySqlSplit);
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/state/TdSqlPendingSplitsState.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/state/TdSqlPendingSplitsState.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.assigner.state;
+
+import com.ververica.cdc.connectors.mysql.source.assigners.state.PendingSplitsState;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+import java.util.Objects;
+
+/** A {@link PendingSplitsState} for pending mysql pending state(snapshot & binlog) splits. */
+public class TdSqlPendingSplitsState extends PendingSplitsState {
+    private final Map<TdSqlSet, PendingSplitsState> stateMap;
+
+    @Nullable private transient byte[] serializedCache;
+
+    public TdSqlPendingSplitsState(Map<TdSqlSet, PendingSplitsState> stateMap) {
+        this.stateMap = stateMap;
+    }
+
+    public Map<TdSqlSet, PendingSplitsState> getStateMap() {
+        return stateMap;
+    }
+
+    @Nullable
+    public byte[] getSerializedCache() {
+        return serializedCache;
+    }
+
+    public void setSerializedCache(@Nullable byte[] serializedCache) {
+        this.serializedCache = serializedCache;
+    }
+
+    public boolean isSerialized() {
+        return this.serializedCache != null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TdSqlPendingSplitsState)) {
+            return false;
+        }
+        TdSqlPendingSplitsState that = (TdSqlPendingSplitsState) o;
+        return Objects.equals(getStateMap(), that.getStateMap());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getStateMap());
+    }
+
+    @Override
+    public String toString() {
+        return "TdSqlPendingSplitsState{" + "stateMap=" + stateMap + '}';
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/state/TdSqlPendingSplitsStateSerializer.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/assigner/state/TdSqlPendingSplitsStateSerializer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.assigner.state;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import com.ververica.cdc.connectors.mysql.source.assigners.state.PendingSplitsState;
+import com.ververica.cdc.connectors.mysql.source.assigners.state.PendingSplitsStateSerializer;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplitSerializer;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The {@link SimpleVersionedSerializer Serializer} for the {@link
+ * com.ververica.cdc.connectors.tdsql.source.split.TdSqlSplitState} of TdSQL CDC source.
+ */
+public class TdSqlPendingSplitsStateSerializer
+        implements SimpleVersionedSerializer<TdSqlPendingSplitsState> {
+
+    private final PendingSplitsStateSerializer mySqlStateSerializer;
+    private final TdSqlSplitSerializer splitSerializer;
+
+    private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
+            ThreadLocal.withInitial(() -> new DataOutputSerializer(64));
+
+    public TdSqlPendingSplitsStateSerializer(TdSqlSplitSerializer splitSerializer) {
+        this.mySqlStateSerializer =
+                new PendingSplitsStateSerializer(splitSerializer.mySqlSplitSerializer());
+        this.splitSerializer = splitSerializer;
+    }
+
+    @Override
+    public int getVersion() {
+        return this.mySqlStateSerializer.getVersion();
+    }
+
+    @Override
+    public byte[] serialize(TdSqlPendingSplitsState state) throws IOException {
+        if (state.isSerialized()) {
+            return state.getSerializedCache();
+        }
+        Map<TdSqlSet, PendingSplitsState> sets = state.getStateMap();
+
+        final DataOutputSerializer out = SERIALIZER_CACHE.get();
+
+        for (TdSqlSet set : sets.keySet()) {
+            splitSerializer.serializeTdSqlSet(set, out);
+
+            PendingSplitsState pendingSplitsState = sets.get(set);
+            final byte[] mySqlPendingSplitStateBytes =
+                    mySqlStateSerializer.serialize(pendingSplitsState);
+
+            out.writeInt(mySqlPendingSplitStateBytes.length);
+            out.write(mySqlPendingSplitStateBytes);
+        }
+
+        final byte[] result = out.getCopyOfBuffer();
+        state.setSerializedCache(result);
+
+        return result;
+    }
+
+    @Override
+    public TdSqlPendingSplitsState deserialize(int version, byte[] serialized) throws IOException {
+        final DataInputDeserializer in = new DataInputDeserializer(serialized);
+
+        Map<TdSqlSet, PendingSplitsState> stateMap = new HashMap<>();
+        while (in.available() > 0) {
+            TdSqlSet set = splitSerializer.deserializeTdSqlSet(in);
+
+            int len = in.readInt();
+
+            byte[] mySqlPendingSplitStateBytes = new byte[len];
+            in.read(mySqlPendingSplitStateBytes);
+
+            PendingSplitsState pendingSplitsState =
+                    mySqlStateSerializer.deserialize(version, mySqlPendingSplitStateBytes);
+            stateMap.put(set, pendingSplitsState);
+        }
+
+        return new TdSqlPendingSplitsState(stateMap);
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/config/TdSqlSourceOptions.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/config/TdSqlSourceOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.config;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import com.ververica.cdc.connectors.tdsql.source.TdSqlSource;
+
+/** configurations for {@link TdSqlSource}. */
+public class TdSqlSourceOptions {
+
+    public static final ConfigOption<Boolean> IS_TEST =
+            ConfigOptions.key("is_test")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("configuration just for unit test.");
+
+    public static final ConfigOption<String> TEST_TDSQL_SETS =
+            ConfigOptions.key("test_tdsql_sets")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription(
+                            "set host and port,partition by semicolon. it like host_1:port_1;host_2:port_2");
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/enumerator/TdSqlSourceEnumerator.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/enumerator/TdSqlSourceEnumerator.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.guava18.com.google.common.collect.Lists;
+
+import com.ververica.cdc.connectors.mysql.source.assigners.MySqlSplitAssigner;
+import com.ververica.cdc.connectors.mysql.source.assigners.state.PendingSplitsState;
+import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitMetaEvent;
+import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitMetaRequestEvent;
+import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsAckEvent;
+import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsReportEvent;
+import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsRequestEvent;
+import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
+import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplit;
+import com.ververica.cdc.connectors.tdsql.source.assigner.state.TdSqlPendingSplitsState;
+import com.ververica.cdc.connectors.tdsql.source.events.TdSqlSourceEvent;
+import org.eclipse.jetty.util.ajax.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** tdsql source enumerator. */
+@Internal
+public class TdSqlSourceEnumerator implements SplitEnumerator<TdSqlSplit, TdSqlPendingSplitsState> {
+    private static final Logger LOG = LoggerFactory.getLogger(TdSqlSourceEnumerator.class);
+
+    private final SplitEnumeratorContext<TdSqlSplit> context;
+    private final Function<TdSqlSet, MySqlSourceConfig> sourceConfigFunction;
+    private final Map<TdSqlSet, MySqlSplitAssigner> tdSqlAssigners;
+    private final int currentParallelism;
+    private final Map<Integer, List<TdSqlSet>> readerRef;
+    private final Map<TdSqlSet, List<List<FinishedSnapshotSplitInfo>>> binlogSplitMeta;
+
+    private final Set<Integer> readersAwaitingSplit;
+
+    public TdSqlSourceEnumerator(
+            SplitEnumeratorContext<TdSqlSplit> context,
+            Function<TdSqlSet, MySqlSourceConfig> sourceConfigFunction,
+            Map<TdSqlSet, MySqlSplitAssigner> tdSqlAssigners) {
+        this.context = context;
+        this.sourceConfigFunction = sourceConfigFunction;
+        this.tdSqlAssigners = tdSqlAssigners;
+        this.currentParallelism = context.currentParallelism();
+        this.readerRef = new HashMap<>(context.currentParallelism());
+        this.binlogSplitMeta = new HashMap<>();
+        this.readersAwaitingSplit = new HashSet<>();
+    }
+
+    @Override
+    public void start() {
+        int size = tdSqlAssigners.size();
+        List<TdSqlSet> sets = new ArrayList<>(tdSqlAssigners.keySet());
+
+        if (currentParallelism >= size) {
+            for (int i = 0; i < currentParallelism; i++) {
+                int subtaskId = i % currentParallelism;
+                int setIndex = i % size;
+                List<TdSqlSet> partitionSet =
+                        readerRef.getOrDefault(subtaskId, new ArrayList<>(size));
+                partitionSet.add(sets.get(setIndex));
+                readerRef.put(subtaskId, partitionSet);
+            }
+        } else {
+            int index = 0;
+            for (TdSqlSet set : tdSqlAssigners.keySet()) {
+                int subtaskId = index % currentParallelism;
+                List<TdSqlSet> partitionSet =
+                        readerRef.getOrDefault(subtaskId, new ArrayList<>(size));
+                partitionSet.add(set);
+                readerRef.put(subtaskId, partitionSet);
+                index++;
+            }
+        }
+
+        LOG.trace("dispatch rule: {}", JSON.toString(readerRef));
+        tdSqlAssigners.values().forEach(MySqlSplitAssigner::open);
+
+        context.callAsync(this::getRegisteredReader, this::syncWithReaders);
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        if (!context.registeredReaders().containsKey(subtaskId)) {
+            // reader failed between sending the request and now. skip this request.
+            return;
+        }
+        readersAwaitingSplit.add(subtaskId);
+        prepareAssign();
+    }
+
+    @Override
+    public void addSplitsBack(List<TdSqlSplit> splits, int subtaskId) {
+        LOG.info("TdSql Source Enumerator adds splits back: {}, subtaskId {}", splits, subtaskId);
+
+        splits.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                TdSqlSplit::setInfo,
+                                Collectors.mapping(TdSqlSplit::mySqlSplit, Collectors.toList())))
+                .forEach((k, v) -> tdSqlAssigners.get(k).addSplits(v));
+        readersAwaitingSplit.add(subtaskId);
+        prepareAssign();
+    }
+
+    private void prepareAssign() {
+        Iterator<Integer> readers = readersAwaitingSplit.iterator();
+        while (readers.hasNext()) {
+            Integer subtaskId = readers.next();
+
+            if (!context.registeredReaders().containsKey(subtaskId)) {
+                readers.remove();
+                continue;
+            }
+            if (assignSplits(subtaskId)) {
+                readers.remove();
+            }
+        }
+    }
+
+    @Override
+    public void addReader(int subtaskId) {}
+
+    @Override
+    public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+        LOG.info("receive subtask {} source event.", subtaskId);
+        TdSqlSourceEvent tdSqlSourceEvent = (TdSqlSourceEvent) sourceEvent;
+        SourceEvent mySqlSourceEvent = tdSqlSourceEvent.getMySqlEvent();
+        TdSqlSet tdSqlSet = tdSqlSourceEvent.getSet();
+
+        if (mySqlSourceEvent instanceof FinishedSnapshotSplitsReportEvent) {
+            FinishedSnapshotSplitsReportEvent reportEvent =
+                    (FinishedSnapshotSplitsReportEvent) mySqlSourceEvent;
+            Map<String, BinlogOffset> finishedOffsets = reportEvent.getFinishedOffsets();
+            LOG.info(
+                    "finished split reader in set {} offset: {}",
+                    tdSqlSet.getSetKey(),
+                    JSON.toString(finishedOffsets));
+            tdSqlAssigners.get(tdSqlSet).onFinishedSplits(finishedOffsets);
+
+            FinishedSnapshotSplitsAckEvent ackEvent =
+                    new FinishedSnapshotSplitsAckEvent(new ArrayList<>(finishedOffsets.keySet()));
+            context.sendEventToSourceReader(subtaskId, new TdSqlSourceEvent(ackEvent, tdSqlSet));
+        } else if (mySqlSourceEvent instanceof BinlogSplitMetaRequestEvent) {
+            LOG.trace(
+                    "handle BinlogSplitMetaRequestEvent... subtaskId {}, split id {}",
+                    subtaskId,
+                    ((BinlogSplitMetaRequestEvent) mySqlSourceEvent).getSplitId());
+            sendBinlogMeta(subtaskId, (BinlogSplitMetaRequestEvent) mySqlSourceEvent, tdSqlSet);
+        }
+    }
+
+    private Map<String, BinlogOffset> asMySqlBinlogOffset(
+            TdSqlSet set, Map<String, BinlogOffset> finishedOffsets) {
+        Map<String, BinlogOffset> removeSetInfoFinishedOffset =
+                new HashMap<>(finishedOffsets.size());
+
+        int setInfoOffset = set.getSetKey().length();
+        for (String tdSqlSplitId : finishedOffsets.keySet()) {
+            removeSetInfoFinishedOffset.put(
+                    tdSqlSplitId.substring(setInfoOffset), finishedOffsets.get(tdSqlSplitId));
+        }
+
+        return removeSetInfoFinishedOffset;
+    }
+
+    private boolean assignSplits(int subtaskId) {
+        List<TdSqlSet> sets = readerRef.get(subtaskId);
+
+        if (sets == null || sets.isEmpty()) {
+            LOG.info("subtaskid {} can not find tdsql set.", subtaskId);
+            return true;
+        }
+
+        for (TdSqlSet set : sets) {
+            Optional<MySqlSplit> split = tdSqlAssigners.get(set).getNext();
+
+            if (split.isPresent()) {
+                TdSqlSplit tdSqlSplit = new TdSqlSplit(set, split.get());
+                LOG.info("Assign split {} to subtask {}", tdSqlSplit, subtaskId);
+                context.assignSplit(tdSqlSplit, subtaskId);
+                return true;
+            } else {
+                LOG.info(
+                        "Finished Assign split to subtask {} in set {}",
+                        subtaskId,
+                        set.getSetKey());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        tdSqlAssigners.values().forEach(s -> s.notifyCheckpointComplete(checkpointId));
+        // binlog split may be available after checkpoint complete.
+        // checkpoint mark snapshotAssigner change assign status.
+        prepareAssign();
+    }
+
+    @Override
+    public TdSqlPendingSplitsState snapshotState(long checkpointId) throws Exception {
+        Map<TdSqlSet, PendingSplitsState> stateMap = new HashMap<>(tdSqlAssigners.size());
+
+        for (Map.Entry<TdSqlSet, MySqlSplitAssigner> assignerEntry : tdSqlAssigners.entrySet()) {
+            stateMap.put(
+                    assignerEntry.getKey(), assignerEntry.getValue().snapshotState(checkpointId));
+        }
+        return new TdSqlPendingSplitsState(stateMap);
+    }
+
+    @Override
+    public void close() throws IOException {
+        tdSqlAssigners.values().forEach(MySqlSplitAssigner::close);
+    }
+
+    private int[] getRegisteredReader() {
+        return this.context.registeredReaders().keySet().stream()
+                .mapToInt(Integer::intValue)
+                .toArray();
+    }
+
+    private void syncWithReaders(int[] subtaskIds, Throwable t) {
+        if (t != null) {
+            throw new FlinkRuntimeException("Failed to list obtain registered readers due to:", t);
+        }
+        // when the SourceEnumerator restores or the communication failed between
+        // SourceEnumerator and SourceReader, it may missed some notification event.
+        // tell all SourceReader(s) to report there finished but unacked splits.
+        for (int subtaskId : subtaskIds) {
+            List<TdSqlSet> partitions = readerRef.get(subtaskId);
+
+            for (TdSqlSet set : partitions) {
+                MySqlSplitAssigner assigner = tdSqlAssigners.get(set);
+                if (assigner.waitingForFinishedSplits()) {
+                    LOG.trace(
+                            "set {} had waiting for finished split. trigger FinishedSnapshotSplitsRequestEvent",
+                            set.getSetKey());
+                    context.sendEventToSourceReader(
+                            subtaskId, new FinishedSnapshotSplitsRequestEvent());
+                }
+            }
+        }
+    }
+
+    private void sendBinlogMeta(
+            int subTask, BinlogSplitMetaRequestEvent requestEvent, TdSqlSet tdSqlSet) {
+        List<List<FinishedSnapshotSplitInfo>> metas = binlogSplitMeta.get(tdSqlSet);
+
+        if (metas == null) {
+            final List<FinishedSnapshotSplitInfo> finishedSnapshotSplitInfos =
+                    tdSqlAssigners.get(tdSqlSet).getFinishedSplitInfos();
+            if (finishedSnapshotSplitInfos.isEmpty()) {
+                LOG.error(
+                        "The assigner offer empty finished split information, this should not happen");
+                throw new FlinkRuntimeException(
+                        "The assigner offer empty finished split information, this should not happen");
+            }
+            metas =
+                    Lists.partition(
+                            finishedSnapshotSplitInfos,
+                            sourceConfigFunction.apply(tdSqlSet).getSplitMetaGroupSize());
+            binlogSplitMeta.put(tdSqlSet, metas);
+        }
+        final int requestMetaGroupId = requestEvent.getRequestMetaGroupId();
+        if (metas.size() > requestMetaGroupId) {
+            List<FinishedSnapshotSplitInfo> metaToSend = metas.get(requestMetaGroupId);
+            BinlogSplitMetaEvent metadataEvent =
+                    new BinlogSplitMetaEvent(
+                            requestEvent.getSplitId(),
+                            requestMetaGroupId,
+                            metaToSend.stream()
+                                    .map(FinishedSnapshotSplitInfo::serialize)
+                                    .collect(Collectors.toList()));
+            context.sendEventToSourceReader(subTask, new TdSqlSourceEvent(metadataEvent, tdSqlSet));
+        } else {
+            LOG.error(
+                    "Received invalid request meta group id {}, the invalid meta group id range is [0, {}]",
+                    requestMetaGroupId,
+                    binlogSplitMeta.size() - 1);
+        }
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/events/TdSqlSourceEvent.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/events/TdSqlSourceEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+
+/** send mysql event with tdsql set info. */
+public class TdSqlSourceEvent implements SourceEvent {
+    private static final long serialVersionUID = -5194600926649657532L;
+
+    private final SourceEvent mySqlEvent;
+    private final TdSqlSet set;
+
+    public TdSqlSourceEvent(SourceEvent mySqlEvent, TdSqlSet set) {
+        this.mySqlEvent = mySqlEvent;
+        this.set = set;
+    }
+
+    public SourceEvent getMySqlEvent() {
+        return mySqlEvent;
+    }
+
+    public TdSqlSet getSet() {
+        return set;
+    }
+
+    @Override
+    public String toString() {
+        return "TdSqlSourceEvent{" + "mySqlEvent=" + mySqlEvent + ", set=" + set + '}';
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/TdSqlRecordEmitter.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/TdSqlRecordEmitter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.reader;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+
+import com.ververica.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
+import com.ververica.cdc.connectors.mysql.source.reader.MySqlRecordEmitter;
+import com.ververica.cdc.connectors.tdsql.source.split.TdSqlSplitState;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link TdSqlSourceReader}.
+ *
+ * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the binlog reader to
+ * emit records rather than emit the records directly.
+ */
+public class TdSqlRecordEmitter<T> implements RecordEmitter<SourceRecord, T, TdSqlSplitState> {
+    private final MySqlRecordEmitter<T> mySqlRecordEmitter;
+
+    public TdSqlRecordEmitter(
+            DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
+            MySqlSourceReaderMetrics sourceReaderMetrics,
+            boolean includeSchemaChanges) {
+        this.mySqlRecordEmitter =
+                new MySqlRecordEmitter<>(
+                        debeziumDeserializationSchema, sourceReaderMetrics, includeSchemaChanges);
+    }
+
+    @Override
+    public void emitRecord(SourceRecord element, SourceOutput<T> output, TdSqlSplitState splitState)
+            throws Exception {
+        this.mySqlRecordEmitter.emitRecord(element, output, splitState.mySqlSplitState());
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/TdSqlSourceReader.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/TdSqlSourceReader.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.reader;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherManager;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils;
+import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitMetaEvent;
+import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitMetaRequestEvent;
+import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsAckEvent;
+import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsReportEvent;
+import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsRequestEvent;
+import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
+import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplitState;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplitState;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitState;
+import com.ververica.cdc.connectors.mysql.source.utils.ChunkUtils;
+import com.ververica.cdc.connectors.mysql.source.utils.TableDiscoveryUtils;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplit;
+import com.ververica.cdc.connectors.tdsql.source.events.TdSqlSourceEvent;
+import com.ververica.cdc.connectors.tdsql.source.split.TdSqlSplitState;
+import io.debezium.connector.mysql.MySqlConnection;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.eclipse.jetty.util.ajax.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.ververica.cdc.connectors.mysql.source.utils.ChunkUtils.getNextMetaGroupId;
+
+/**
+ * The source reader for TdSql source splits.
+ *
+ * @param <T> The output type for flink.
+ */
+public class TdSqlSourceReader<T>
+        extends SourceReaderBase<SourceRecord, T, TdSqlSplit, TdSqlSplitState> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TdSqlSourceReader.class);
+    private final Map<String, MySqlSnapshotSplit> finishedUnackedSplits;
+    private final Map<String, TdSqlSet> splitIdBelongSet;
+    private final Map<String, MySqlBinlogSplit> uncompletedBinlogSplits;
+    private final Function<TdSqlSet, MySqlSourceConfig> sourceConfigFunction;
+
+    public TdSqlSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecord>> elementsQueue,
+            SplitFetcherManager<SourceRecord, TdSqlSplit> splitFetcherManager,
+            RecordEmitter<SourceRecord, T, TdSqlSplitState> recordEmitter,
+            Configuration config,
+            SourceReaderContext context,
+            Function<TdSqlSet, MySqlSourceConfig> sourceConfigFunction) {
+        super(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+        this.finishedUnackedSplits = new HashMap<>();
+        this.splitIdBelongSet = new HashMap<>();
+        this.uncompletedBinlogSplits = new HashMap<>();
+        this.sourceConfigFunction = sourceConfigFunction;
+    }
+
+    @Override
+    public void start() {
+        if (getNumberOfCurrentlyAssignedSplits() == 0) {
+            context.sendSplitRequest();
+        }
+    }
+
+    @Override
+    protected TdSqlSplitState initializedState(TdSqlSplit split) {
+        MySqlSplitState mySqlSplitState;
+        if (split.mySqlSplit().isBinlogSplit()) {
+            mySqlSplitState = new MySqlBinlogSplitState(split.mySqlSplit().asBinlogSplit());
+        } else {
+            mySqlSplitState = new MySqlSnapshotSplitState(split.mySqlSplit().asSnapshotSplit());
+        }
+        return new TdSqlSplitState(split.setInfo(), mySqlSplitState);
+    }
+
+    @Override
+    public void addSplits(List<TdSqlSplit> splits) {
+        List<TdSqlSplit> unfinishedSplits = new ArrayList<>();
+        for (TdSqlSplit split : splits) {
+            if (split.isBinlogSplit()) {
+                MySqlBinlogSplit binlogSplit = split.mySqlSplit().asBinlogSplit();
+                LOGGER.trace(
+                        "binlog split {}, isCompletedSplit {}, start offset is {}, getTotalFinishedSplitSize {}",
+                        binlogSplit,
+                        binlogSplit.isCompletedSplit(),
+                        binlogSplit.getStartingOffset(),
+                        binlogSplit.getTotalFinishedSplitSize());
+                if (!binlogSplit.isCompletedSplit()) {
+                    uncompletedBinlogSplits.put(split.splitId(), binlogSplit);
+                    requestBinlogSplitMetaIfNeeded(split);
+                } else {
+                    uncompletedBinlogSplits.remove(split.splitId());
+                    split = discoverTableSchemasForBinlogSplit(split);
+                    unfinishedSplits.add(split);
+                    // request next tdsql set splits.
+                    context.sendSplitRequest();
+                }
+            } else {
+                MySqlSplit mySqlSplit = split.mySqlSplit();
+                if (mySqlSplit.isSnapshotSplit()) {
+                    MySqlSnapshotSplit mySqlSnapshotSplit = mySqlSplit.asSnapshotSplit();
+                    if (mySqlSnapshotSplit.isSnapshotReadFinished()) {
+                        finishedUnackedSplits.put(split.splitId(), mySqlSnapshotSplit);
+                    } else {
+                        unfinishedSplits.add(split);
+                    }
+                }
+            }
+        }
+        LOGGER.trace("add splits: {}", JSON.toString(unfinishedSplits));
+        if (!unfinishedSplits.isEmpty()) {
+            super.addSplits(unfinishedSplits);
+        }
+    }
+
+    @Override
+    protected TdSqlSplit toSplitType(String splitId, TdSqlSplitState splitState) {
+        return new TdSqlSplit(splitState.setInfo(), splitState.mySqlSplit());
+    }
+
+    @Override
+    public void handleSourceEvents(SourceEvent sourceEvent) {
+        if (sourceEvent instanceof TdSqlSourceEvent) {
+            TdSqlSourceEvent tdSqlSourceEvent = (TdSqlSourceEvent) sourceEvent;
+            SourceEvent mySqlSourceEvent = tdSqlSourceEvent.getMySqlEvent();
+            TdSqlSet tdSqlSet = tdSqlSourceEvent.getSet();
+
+            if (mySqlSourceEvent instanceof FinishedSnapshotSplitsAckEvent) {
+                FinishedSnapshotSplitsAckEvent ackEvent =
+                        (FinishedSnapshotSplitsAckEvent) mySqlSourceEvent;
+                for (String mySqlSplitId : ackEvent.getFinishedSplits()) {
+                    String tdSqlSplitId = tdSqlSet.getSetKey() + ":" + mySqlSplitId;
+                    LOGGER.info("remove unack split {}.", tdSqlSplitId);
+                    this.finishedUnackedSplits.remove(tdSqlSplitId);
+                    this.splitIdBelongSet.remove(tdSqlSplitId);
+                }
+            } else if (mySqlSourceEvent instanceof FinishedSnapshotSplitsRequestEvent) {
+                reportFinishedSnapshotSplitsIfNeed();
+            } else if (mySqlSourceEvent instanceof BinlogSplitMetaEvent) {
+                fillMetaDataForBinlogSplit(
+                        tdSqlSourceEvent.getSet(), (BinlogSplitMetaEvent) mySqlSourceEvent);
+            }
+        } else {
+            super.handleSourceEvents(sourceEvent);
+        }
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, TdSqlSplitState> finishedSplitIds) {
+        for (String tdSqlSplitId : finishedSplitIds.keySet()) {
+            LOGGER.info("split reader finish split[{}] read.", tdSqlSplitId);
+            TdSqlSplitState state = finishedSplitIds.get(tdSqlSplitId);
+            finishedUnackedSplits.put(tdSqlSplitId, state.mySqlSplit().asSnapshotSplit());
+            LOGGER.info(
+                    "split {} set info is {}, offset {}",
+                    tdSqlSplitId,
+                    state.setInfo(),
+                    finishedUnackedSplits.get(tdSqlSplitId));
+            splitIdBelongSet.put(tdSqlSplitId, state.setInfo());
+        }
+        reportFinishedSnapshotSplitsIfNeed();
+        context.sendSplitRequest();
+    }
+
+    @Override
+    public List<TdSqlSplit> snapshotState(long checkpointId) {
+        List<TdSqlSplit> stateSplits = super.snapshotState(checkpointId);
+        // unfinished splits
+        List<TdSqlSplit> unfinishedSplits =
+                stateSplits.stream()
+                        .filter(split -> !finishedUnackedSplits.containsKey(split.splitId()))
+                        .collect(Collectors.toList());
+
+        addUnackedSplit(unfinishedSplits);
+
+        return unfinishedSplits;
+    }
+
+    private void addUnackedSplit(List<TdSqlSplit> unfinishedSplits) {
+        for (String splitId : finishedUnackedSplits.keySet()) {
+            TdSqlSet set = splitIdBelongSet.get(splitId);
+            unfinishedSplits.add(new TdSqlSplit(set, finishedUnackedSplits.get(splitId)));
+        }
+    }
+
+    private void reportFinishedSnapshotSplitsIfNeed() {
+        if (!finishedUnackedSplits.isEmpty()) {
+            final Map<TdSqlSet, Map<String, BinlogOffset>> reportGroup = new HashMap<>();
+
+            for (String tdSqlSplitId : finishedUnackedSplits.keySet()) {
+                MySqlSnapshotSplit mySqlSnapshotSplit = finishedUnackedSplits.get(tdSqlSplitId);
+                TdSqlSet set = splitIdBelongSet.get(tdSqlSplitId);
+
+                Map<String, BinlogOffset> finishedOffsets =
+                        reportGroup.getOrDefault(set, new HashMap<>());
+                finishedOffsets.put(
+                        mySqlSnapshotSplit.splitId(), mySqlSnapshotSplit.getHighWatermark());
+                LOGGER.trace(
+                        "tdSqlSplitId {} finished offset: {}",
+                        tdSqlSplitId,
+                        JSON.toString(finishedOffsets));
+                reportGroup.put(set, finishedOffsets);
+            }
+
+            for (TdSqlSet set : reportGroup.keySet()) {
+                final Map<String, BinlogOffset> finishedOffsets = reportGroup.get(set);
+                FinishedSnapshotSplitsReportEvent mySqlReportEvent =
+                        new FinishedSnapshotSplitsReportEvent(finishedOffsets);
+                TdSqlSourceEvent tdSqlSourceEvent = new TdSqlSourceEvent(mySqlReportEvent, set);
+                context.sendSourceEventToCoordinator(tdSqlSourceEvent);
+            }
+        } else {
+            LOGGER.info("finished but unacknowledged collection is empty.");
+        }
+    }
+
+    private void requestBinlogSplitMetaIfNeeded(TdSqlSplit tdSqlSplit) {
+        if (tdSqlSplit.isSnapshotSplit()) {
+            return;
+        }
+        final String tdSqlSplitId = tdSqlSplit.splitId();
+        MySqlBinlogSplit binlogSplit = tdSqlSplit.mySqlSplit().asBinlogSplit();
+        if (!binlogSplit.isCompletedSplit()) {
+            final int nextMetaGroupId =
+                    ChunkUtils.getNextMetaGroupId(
+                            binlogSplit.getFinishedSnapshotSplitInfos().size(),
+                            this.sourceConfigFunction
+                                    .apply(tdSqlSplit.setInfo())
+                                    .getSplitMetaGroupSize());
+            BinlogSplitMetaRequestEvent splitMetaRequestEvent =
+                    new BinlogSplitMetaRequestEvent(tdSqlSplitId, nextMetaGroupId);
+            context.sendSourceEventToCoordinator(
+                    new TdSqlSourceEvent(splitMetaRequestEvent, tdSqlSplit.setInfo()));
+        } else {
+            LOGGER.info("The meta of binlog split {} has been collected success", tdSqlSplitId);
+            this.addSplits(Collections.singletonList(tdSqlSplit));
+        }
+    }
+
+    private TdSqlSplit discoverTableSchemasForBinlogSplit(TdSqlSplit tdSqlSplit) {
+        if (tdSqlSplit.isSnapshotSplit()) {
+            return tdSqlSplit;
+        }
+        final String splitId = tdSqlSplit.splitId();
+        MySqlBinlogSplit binlogSplit = tdSqlSplit.mySqlSplit().asBinlogSplit();
+        if (binlogSplit.getTableSchemas().isEmpty()) {
+            MySqlSourceConfig sourceConfig = sourceConfigFunction.apply(tdSqlSplit.setInfo());
+            try (MySqlConnection jdbc =
+                    DebeziumUtils.createMySqlConnection(sourceConfig.getDbzConfiguration())) {
+                Map<TableId, TableChanges.TableChange> tableSchemas =
+                        TableDiscoveryUtils.discoverCapturedTableSchemas(sourceConfig, jdbc);
+                LOGGER.info("The table schema discovery for binlog split {} success", splitId);
+                binlogSplit = MySqlBinlogSplit.fillTableSchemas(binlogSplit, tableSchemas);
+                return new TdSqlSplit(tdSqlSplit.setInfo(), binlogSplit);
+            } catch (SQLException e) {
+                LOGGER.error("Failed to obtains table schemas due to {}", e.getMessage());
+                throw new FlinkRuntimeException(e);
+            }
+        } else {
+            LOGGER.warn(
+                    "The binlog split {} has table schemas yet, skip the table schema discovery",
+                    tdSqlSplit);
+            return tdSqlSplit;
+        }
+    }
+
+    private void fillMetaDataForBinlogSplit(TdSqlSet set, BinlogSplitMetaEvent metadataEvent) {
+        final String tdSqlSplitId = metadataEvent.getSplitId();
+
+        MySqlBinlogSplit binlogSplit = uncompletedBinlogSplits.get(tdSqlSplitId);
+        if (binlogSplit != null) {
+            final int receivedMetaGroupId = metadataEvent.getMetaGroupId();
+            final int expectedMetaGroupId =
+                    getNextMetaGroupId(
+                            binlogSplit.getFinishedSnapshotSplitInfos().size(),
+                            sourceConfigFunction.apply(set).getSplitMetaGroupSize());
+            if (receivedMetaGroupId == expectedMetaGroupId) {
+                List<FinishedSnapshotSplitInfo> metaDataGroup =
+                        metadataEvent.getMetaGroup().stream()
+                                .map(FinishedSnapshotSplitInfo::deserialize)
+                                .collect(Collectors.toList());
+
+                binlogSplit = MySqlBinlogSplit.appendFinishedSplitInfos(binlogSplit, metaDataGroup);
+
+                uncompletedBinlogSplits.put(tdSqlSplitId, binlogSplit);
+
+                LOGGER.info("Fill meta data of group {} to binlog split", metaDataGroup.size());
+            } else {
+                LOGGER.warn(
+                        "Received out of oder binlog meta event for split {}, the received meta group id is {}, but expected is {}, ignore it",
+                        metadataEvent.getSplitId(),
+                        receivedMetaGroupId,
+                        expectedMetaGroupId);
+            }
+            requestBinlogSplitMetaIfNeeded(new TdSqlSplit(set, binlogSplit));
+        }
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/TdSqlSplitReader.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/TdSqlSplitReader.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.reader;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+
+import com.ververica.cdc.connectors.mysql.source.reader.MySqlSplitReader;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplit;
+import com.ververica.cdc.connectors.tdsql.source.split.TdSqlRecords;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * The {@link SplitReader} implementation for the {@link
+ * com.ververica.cdc.connectors.tdsql.source.TdSqlSource}.
+ */
+public class TdSqlSplitReader implements SplitReader<SourceRecord, TdSqlSplit> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TdSqlSourceReader.class);
+    private MySqlSplitReader mySqlSplitReader;
+    private final Function<TdSqlSet, MySqlSplitReader> getRealReader;
+
+    private TdSqlSet tdSqlSet;
+
+    public TdSqlSplitReader(Function<TdSqlSet, MySqlSplitReader> getRealReader) {
+        this.getRealReader = getRealReader;
+    }
+
+    @Override
+    public RecordsWithSplitIds<SourceRecord> fetch() throws IOException {
+        RecordsWithSplitIds<SourceRecord> data = mySqlSplitReader.fetch();
+        return new TdSqlRecords(data, tdSqlSet);
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<TdSqlSplit> splitsChanges) {
+        if (!(splitsChanges instanceof SplitsAddition)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The SplitChange type of %s is not supported.",
+                            splitsChanges.getClass()));
+        }
+
+        if (mySqlSplitReader == null) {
+            TdSqlSplit tdSqlSplit = splitsChanges.splits().get(0);
+            LOGGER.trace("init mySqlSplitReader.");
+            mySqlSplitReader = getRealReader.apply(tdSqlSplit.setInfo());
+            this.tdSqlSet = tdSqlSplit.setInfo();
+        }
+
+        mySqlSplitReader.handleSplitsChanges(asMySqlSplit(splitsChanges));
+    }
+
+    private SplitsChange<MySqlSplit> asMySqlSplit(SplitsChange<TdSqlSplit> splitsChanges) {
+        List<MySqlSplit> mySqlSplits =
+                splitsChanges.splits().stream()
+                        .map(TdSqlSplit::mySqlSplit)
+                        .collect(Collectors.toList());
+
+        return new SplitsAddition<>(mySqlSplits);
+    }
+
+    @Override
+    public void wakeUp() {}
+
+    @Override
+    public void close() throws Exception {
+        mySqlSplitReader.close();
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/fetcher/TdSqlFetcherManager.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/reader/fetcher/TdSqlFetcherManager.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.reader.fetcher;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
+import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherManager;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+
+import com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Fetcher manager for TDSQL.
+ *
+ * @param <T> The output type for flink.
+ */
+public class TdSqlFetcherManager<T> extends SplitFetcherManager<T, TdSqlSplit> {
+    /**
+     * Creates a new SplitFetcherManager with multiple I/O threads.
+     *
+     * @param elementsQueue The queue that is used to hand over data from the I/O thread (the
+     *     fetchers) to the reader (which emits the records). This must be the same queue instance
+     *     that is also passed to the {@link SourceReaderBase}.
+     * @param splitReaderFactory The factory for the split reader that connects to the source
+     */
+    public TdSqlFetcherManager(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<T>> elementsQueue,
+            Supplier<SplitReader<T, TdSqlSplit>> splitReaderFactory) {
+        super(elementsQueue, splitReaderFactory);
+    }
+
+    @Override
+    public void addSplits(List<TdSqlSplit> splitsToAdd) {
+        for (TdSqlSplit split : splitsToAdd) {
+            SplitFetcher<T, TdSqlSplit> fetcher = createSplitFetcher();
+            fetcher.addSplits(Collections.singletonList(split));
+            startFetcher(fetcher);
+        }
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/split/TdSqlRecords.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/split/TdSqlRecords.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.split;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import javax.annotation.Nullable;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An implementation of {@link RecordsWithSplitIds} which contains the records of one table split.
+ */
+public class TdSqlRecords implements RecordsWithSplitIds<SourceRecord> {
+    private final RecordsWithSplitIds<SourceRecord> mySqlRecords;
+    private final TdSqlSet set;
+
+    public TdSqlRecords(RecordsWithSplitIds<SourceRecord> mySqlRecords, TdSqlSet set) {
+        this.mySqlRecords = mySqlRecords;
+        this.set = set;
+    }
+
+    @Nullable
+    @Override
+    public String nextSplit() {
+        String mysqlSplitId = mySqlRecords.nextSplit();
+        if (mysqlSplitId == null) {
+            return null;
+        }
+        return tdSqlSplitId(mysqlSplitId);
+    }
+
+    @Nullable
+    @Override
+    public SourceRecord nextRecordFromSplit() {
+        return mySqlRecords.nextRecordFromSplit();
+    }
+
+    @Override
+    public Set<String> finishedSplits() {
+        Set<String> finishedSplits = mySqlRecords.finishedSplits();
+        return finishedSplits.stream().map(this::tdSqlSplitId).collect(Collectors.toSet());
+    }
+
+    private String tdSqlSplitId(String mysqlSplitId) {
+        return set.getSetKey() + ":" + mysqlSplitId;
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/split/TdSqlSplitState.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/source/split/TdSqlSplitState.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source.split;
+
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitState;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+
+/**
+ * State of the reader, essentially a mutable version of the {@link
+ * com.ververica.cdc.connectors.tdsql.source.assigner.splitter.TdSqlSplit}.
+ */
+public class TdSqlSplitState {
+    private final TdSqlSet setInfo;
+
+    private final MySqlSplitState mySqlSplitState;
+
+    public TdSqlSplitState(TdSqlSet setInfo, MySqlSplitState mySqlSplitState) {
+        this.setInfo = setInfo;
+        this.mySqlSplitState = mySqlSplitState;
+    }
+
+    public TdSqlSet setInfo() {
+        return setInfo;
+    }
+
+    public MySqlSplitState mySqlSplitState() {
+        return mySqlSplitState;
+    }
+
+    public MySqlSplit mySqlSplit() {
+        return mySqlSplitState.toMySqlSplit();
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/table/TdSqlTableSource.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/table/TdSqlTableSource.java
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.StringUtils;
+
+import com.ververica.cdc.connectors.mysql.table.MySqlDeserializationConverterFactory;
+import com.ververica.cdc.connectors.mysql.table.MySqlReadableMetadata;
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.source.TdSqlSource;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.MetadataConverter;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link DynamicTableSource} that describes how to create a MySQL binlog source from a logical
+ * description.
+ */
+public class TdSqlTableSource implements ScanTableSource, SupportsReadingMetadata {
+    private final ResolvedSchema physicalSchema;
+    private final int port;
+    private final String hostname;
+    private final String database;
+    private final String username;
+    private final String password;
+    private final String serverId;
+    private final String tableName;
+    private final ZoneId serverTimeZone;
+    private final Properties dbzProperties;
+    private final boolean enableParallelRead;
+    private final int splitSize;
+    private final int splitMetaGroupSize;
+    private final int fetchSize;
+    private final Duration connectTimeout;
+    private final int connectionPoolSize;
+    private final int connectMaxRetries;
+    private final double distributionFactorUpper;
+    private final double distributionFactorLower;
+    private final StartupOptions startupOptions;
+    private final boolean scanNewlyAddedTableEnabled;
+    private final Properties jdbcProperties;
+    private final Duration heartbeatInterval;
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    /** Data type that describes the final output of the source. */
+    protected DataType producedDataType;
+
+    /** Metadata that is appended at the end of a physical source row. */
+    protected List<String> metadataKeys;
+
+    private final boolean isTest;
+    private final String testSets;
+
+    public TdSqlTableSource(
+            ResolvedSchema physicalSchema,
+            int port,
+            String hostname,
+            String database,
+            String tableName,
+            String username,
+            String password,
+            ZoneId serverTimeZone,
+            Properties dbzProperties,
+            @Nullable String serverId,
+            boolean enableParallelRead,
+            int splitSize,
+            int splitMetaGroupSize,
+            int fetchSize,
+            Duration connectTimeout,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            double distributionFactorUpper,
+            double distributionFactorLower,
+            StartupOptions startupOptions,
+            Duration heartbeatInterval) {
+        this(
+                physicalSchema,
+                port,
+                hostname,
+                database,
+                tableName,
+                username,
+                password,
+                serverTimeZone,
+                dbzProperties,
+                serverId,
+                enableParallelRead,
+                splitSize,
+                splitMetaGroupSize,
+                fetchSize,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                startupOptions,
+                false,
+                new Properties(),
+                heartbeatInterval,
+                false,
+                "");
+    }
+
+    public TdSqlTableSource(
+            ResolvedSchema physicalSchema,
+            int port,
+            String hostname,
+            String database,
+            String tableName,
+            String username,
+            String password,
+            ZoneId serverTimeZone,
+            Properties dbzProperties,
+            @Nullable String serverId,
+            boolean enableParallelRead,
+            int splitSize,
+            int splitMetaGroupSize,
+            int fetchSize,
+            Duration connectTimeout,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            double distributionFactorUpper,
+            double distributionFactorLower,
+            StartupOptions startupOptions,
+            boolean scanNewlyAddedTableEnabled,
+            Properties jdbcProperties,
+            Duration heartbeatInterval,
+            boolean isTest,
+            String testSets) {
+        this.physicalSchema = physicalSchema;
+        this.port = port;
+        this.hostname = checkNotNull(hostname);
+        this.database = checkNotNull(database);
+        this.tableName = checkNotNull(tableName);
+        this.username = checkNotNull(username);
+        this.password = checkNotNull(password);
+        this.serverId = serverId;
+        this.serverTimeZone = serverTimeZone;
+        this.dbzProperties = dbzProperties;
+        this.enableParallelRead = enableParallelRead;
+        this.splitSize = splitSize;
+        this.splitMetaGroupSize = splitMetaGroupSize;
+        this.fetchSize = fetchSize;
+        this.connectTimeout = connectTimeout;
+        this.connectMaxRetries = connectMaxRetries;
+        this.connectionPoolSize = connectionPoolSize;
+        this.distributionFactorUpper = distributionFactorUpper;
+        this.distributionFactorLower = distributionFactorLower;
+        this.startupOptions = startupOptions;
+        this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
+        this.jdbcProperties = jdbcProperties;
+        // Mutable attributes
+        this.producedDataType = physicalSchema.toPhysicalRowDataType();
+        this.metadataKeys = Collections.emptyList();
+        this.heartbeatInterval = heartbeatInterval;
+        this.isTest = isTest;
+        this.testSets = testSets;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.UPDATE_BEFORE)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .addContainedKind(RowKind.DELETE)
+                .build();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+        RowType physicalDataType =
+                (RowType) physicalSchema.toPhysicalRowDataType().getLogicalType();
+        MetadataConverter[] metadataConverters = getMetadataConverters();
+        final TypeInformation<RowData> typeInfo =
+                scanContext.createTypeInformation(producedDataType);
+
+        DebeziumDeserializationSchema<RowData> deserializer =
+                RowDataDebeziumDeserializeSchema.newBuilder()
+                        .setPhysicalRowType(physicalDataType)
+                        .setMetadataConverters(metadataConverters)
+                        .setResultTypeInfo(typeInfo)
+                        .setServerTimeZone(serverTimeZone)
+                        .setUserDefinedConverterFactory(
+                                MySqlDeserializationConverterFactory.instance())
+                        .build();
+        TdSqlSource<RowData> parallelSource =
+                TdSqlSource.<RowData>builder()
+                        .hostname(hostname)
+                        .port(port)
+                        .databaseList(database)
+                        .tableList(database + "." + tableName)
+                        .username(username)
+                        .password(password)
+                        .serverTimeZone(serverTimeZone.toString())
+                        .serverId(serverId)
+                        .splitSize(splitSize)
+                        .splitMetaGroupSize(splitMetaGroupSize)
+                        .distributionFactorUpper(distributionFactorUpper)
+                        .distributionFactorLower(distributionFactorLower)
+                        .fetchSize(fetchSize)
+                        .connectTimeout(connectTimeout)
+                        .connectMaxRetries(connectMaxRetries)
+                        .connectionPoolSize(connectionPoolSize)
+                        .debeziumProperties(dbzProperties)
+                        .startupOptions(startupOptions)
+                        .deserializer(deserializer)
+                        .scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled)
+                        .jdbcProperties(jdbcProperties)
+                        .heartbeatInterval(heartbeatInterval)
+                        .build();
+
+        if (isTest && !StringUtils.isNullOrWhitespaceOnly(testSets)) {
+            String[] sets = testSets.split(";");
+            parallelSource.setTestSets(
+                    Stream.of(sets)
+                            .map(
+                                    s -> {
+                                        String[] addr = s.split(":");
+                                        return new TdSqlSet(s, addr[0], Integer.parseInt(addr[1]));
+                                    })
+                            .collect(Collectors.toList()));
+        }
+        return SourceProvider.of(parallelSource);
+    }
+
+    protected MetadataConverter[] getMetadataConverters() {
+        if (metadataKeys.isEmpty()) {
+            return new MetadataConverter[0];
+        }
+
+        return metadataKeys.stream()
+                .map(
+                        key ->
+                                Stream.of(MySqlReadableMetadata.values())
+                                        .filter(m -> m.getKey().equals(key))
+                                        .findFirst()
+                                        .orElseThrow(IllegalStateException::new))
+                .map(MySqlReadableMetadata::getConverter)
+                .toArray(MetadataConverter[]::new);
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        return Stream.of(MySqlReadableMetadata.values())
+                .collect(
+                        Collectors.toMap(
+                                MySqlReadableMetadata::getKey, MySqlReadableMetadata::getDataType));
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        this.metadataKeys = metadataKeys;
+        this.producedDataType = producedDataType;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        TdSqlTableSource source =
+                new TdSqlTableSource(
+                        physicalSchema,
+                        port,
+                        hostname,
+                        database,
+                        tableName,
+                        username,
+                        password,
+                        serverTimeZone,
+                        dbzProperties,
+                        serverId,
+                        enableParallelRead,
+                        splitSize,
+                        splitMetaGroupSize,
+                        fetchSize,
+                        connectTimeout,
+                        connectMaxRetries,
+                        connectionPoolSize,
+                        distributionFactorUpper,
+                        distributionFactorLower,
+                        startupOptions,
+                        scanNewlyAddedTableEnabled,
+                        jdbcProperties,
+                        heartbeatInterval,
+                        isTest,
+                        testSets);
+        source.metadataKeys = metadataKeys;
+        source.producedDataType = producedDataType;
+        return source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TdSqlTableSource)) {
+            return false;
+        }
+        TdSqlTableSource that = (TdSqlTableSource) o;
+        return port == that.port
+                && enableParallelRead == that.enableParallelRead
+                && splitSize == that.splitSize
+                && splitMetaGroupSize == that.splitMetaGroupSize
+                && fetchSize == that.fetchSize
+                && distributionFactorUpper == that.distributionFactorUpper
+                && distributionFactorLower == that.distributionFactorLower
+                && scanNewlyAddedTableEnabled == that.scanNewlyAddedTableEnabled
+                && Objects.equals(physicalSchema, that.physicalSchema)
+                && Objects.equals(hostname, that.hostname)
+                && Objects.equals(database, that.database)
+                && Objects.equals(username, that.username)
+                && Objects.equals(password, that.password)
+                && Objects.equals(serverId, that.serverId)
+                && Objects.equals(tableName, that.tableName)
+                && Objects.equals(serverTimeZone, that.serverTimeZone)
+                && Objects.equals(dbzProperties, that.dbzProperties)
+                && Objects.equals(connectTimeout, that.connectTimeout)
+                && Objects.equals(connectMaxRetries, that.connectMaxRetries)
+                && Objects.equals(connectionPoolSize, that.connectionPoolSize)
+                && Objects.equals(startupOptions, that.startupOptions)
+                && Objects.equals(producedDataType, that.producedDataType)
+                && Objects.equals(metadataKeys, that.metadataKeys)
+                && Objects.equals(jdbcProperties, that.jdbcProperties)
+                && Objects.equals(heartbeatInterval, that.heartbeatInterval);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                physicalSchema,
+                port,
+                hostname,
+                database,
+                username,
+                password,
+                serverId,
+                tableName,
+                serverTimeZone,
+                dbzProperties,
+                enableParallelRead,
+                splitSize,
+                splitMetaGroupSize,
+                fetchSize,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                startupOptions,
+                producedDataType,
+                metadataKeys,
+                scanNewlyAddedTableEnabled,
+                jdbcProperties,
+                heartbeatInterval);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "TDSQL-CDC";
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/table/TdSqlTableSourceFactory.java
+++ b/flink-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsql/table/TdSqlTableSourceFactory.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions;
+import com.ververica.cdc.connectors.mysql.source.config.ServerIdRange;
+import com.ververica.cdc.connectors.mysql.table.JdbcUrlUtils;
+import com.ververica.cdc.connectors.mysql.table.StartupMode;
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
+import com.ververica.cdc.connectors.tdsql.source.config.TdSqlSourceOptions;
+import com.ververica.cdc.debezium.table.DebeziumOptions;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.CHUNK_META_GROUP_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.CONNECTION_POOL_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.CONNECT_MAX_RETRIES;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.CONNECT_TIMEOUT;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.DATABASE_NAME;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.HEARTBEAT_INTERVAL;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.HOSTNAME;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.PASSWORD;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.PORT;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_STARTUP_MODE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_STARTUP_SPECIFIC_OFFSET_FILE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_STARTUP_SPECIFIC_OFFSET_POS;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SERVER_ID;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SERVER_TIME_ZONE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.TABLE_NAME;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.USERNAME;
+import static com.ververica.cdc.connectors.mysql.source.utils.ObjectUtils.doubleCompare;
+import static com.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
+import static com.ververica.cdc.debezium.utils.ResolvedSchemaUtils.getPhysicalSchema;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Factory for creating configured instance of {@link TdSqlTableSource}. */
+public class TdSqlTableSourceFactory implements DynamicTableSourceFactory {
+    private static final String IDENTIFIER = "tdsql-cdc";
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validateExcept(
+                DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX, JdbcUrlUtils.PROPERTIES_PREFIX);
+
+        final ReadableConfig config = helper.getOptions();
+        String hostname = config.get(HOSTNAME);
+        String username = config.get(USERNAME);
+        String password = config.get(PASSWORD);
+        String databaseName = config.get(DATABASE_NAME);
+        validateRegex(DATABASE_NAME.key(), databaseName);
+        String tableName = config.get(TABLE_NAME);
+        validateRegex(TABLE_NAME.key(), tableName);
+        int port = config.get(PORT);
+        int splitSize = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE);
+        int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
+        int fetchSize = config.get(SCAN_SNAPSHOT_FETCH_SIZE);
+        ZoneId serverTimeZone = ZoneId.of(config.get(SERVER_TIME_ZONE));
+
+        ResolvedSchema physicalSchema =
+                getPhysicalSchema(context.getCatalogTable().getResolvedSchema());
+        String serverId = validateAndGetServerId(config);
+        StartupOptions startupOptions = getStartupOptions(config);
+        Duration connectTimeout = config.get(CONNECT_TIMEOUT);
+        int connectMaxRetries = config.get(CONNECT_MAX_RETRIES);
+        int connectionPoolSize = config.get(CONNECTION_POOL_SIZE);
+        double distributionFactorUpper = config.get(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND);
+        double distributionFactorLower = config.get(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
+        boolean scanNewlyAddedTableEnabled = config.get(SCAN_NEWLY_ADDED_TABLE_ENABLED);
+        Duration heartbeatInterval = config.get(HEARTBEAT_INTERVAL);
+
+        boolean enableParallelRead = config.get(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
+        if (enableParallelRead) {
+            validatePrimaryKeyIfEnableParallel(physicalSchema);
+            validateStartupOptionIfEnableParallel(startupOptions);
+            validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
+            validateIntegerOption(CHUNK_META_GROUP_SIZE, splitMetaGroupSize, 1);
+            validateIntegerOption(SCAN_SNAPSHOT_FETCH_SIZE, fetchSize, 1);
+            validateIntegerOption(CONNECTION_POOL_SIZE, connectionPoolSize, 1);
+            validateIntegerOption(CONNECT_MAX_RETRIES, connectMaxRetries, 0);
+            validateDistributionFactorUpper(distributionFactorUpper);
+            validateDistributionFactorLower(distributionFactorLower);
+        }
+        return new TdSqlTableSource(
+                physicalSchema,
+                port,
+                hostname,
+                databaseName,
+                tableName,
+                username,
+                password,
+                serverTimeZone,
+                getDebeziumProperties(context.getCatalogTable().getOptions()),
+                serverId,
+                enableParallelRead,
+                splitSize,
+                splitMetaGroupSize,
+                fetchSize,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                startupOptions,
+                scanNewlyAddedTableEnabled,
+                JdbcUrlUtils.getJdbcProperties(context.getCatalogTable().getOptions()),
+                heartbeatInterval,
+                config.get(TdSqlSourceOptions.IS_TEST),
+                config.get(TdSqlSourceOptions.TEST_TDSQL_SETS));
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(HOSTNAME);
+        options.add(USERNAME);
+        options.add(PASSWORD);
+        options.add(DATABASE_NAME);
+        options.add(TABLE_NAME);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PORT);
+        options.add(SERVER_TIME_ZONE);
+        options.add(SERVER_ID);
+        options.add(SCAN_STARTUP_MODE);
+        options.add(SCAN_STARTUP_SPECIFIC_OFFSET_FILE);
+        options.add(SCAN_STARTUP_SPECIFIC_OFFSET_POS);
+        options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE);
+        options.add(CHUNK_META_GROUP_SIZE);
+        options.add(SCAN_SNAPSHOT_FETCH_SIZE);
+        options.add(CONNECT_TIMEOUT);
+        options.add(CONNECTION_POOL_SIZE);
+        options.add(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND);
+        options.add(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
+        options.add(CONNECT_MAX_RETRIES);
+        options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
+        options.add(HEARTBEAT_INTERVAL);
+        options.add(TdSqlSourceOptions.IS_TEST);
+        options.add(TdSqlSourceOptions.TEST_TDSQL_SETS);
+        return options;
+    }
+
+    private static final String SCAN_STARTUP_MODE_VALUE_INITIAL = "initial";
+    private static final String SCAN_STARTUP_MODE_VALUE_EARLIEST = "earliest-offset";
+    private static final String SCAN_STARTUP_MODE_VALUE_LATEST = "latest-offset";
+    private static final String SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSET = "specific-offset";
+    private static final String SCAN_STARTUP_MODE_VALUE_TIMESTAMP = "timestamp";
+
+    private static StartupOptions getStartupOptions(ReadableConfig config) {
+        String modeString = config.get(SCAN_STARTUP_MODE);
+
+        switch (modeString.toLowerCase()) {
+            case SCAN_STARTUP_MODE_VALUE_INITIAL:
+                return StartupOptions.initial();
+
+            case SCAN_STARTUP_MODE_VALUE_LATEST:
+                return StartupOptions.latest();
+
+            case SCAN_STARTUP_MODE_VALUE_EARLIEST:
+            case SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSET:
+            case SCAN_STARTUP_MODE_VALUE_TIMESTAMP:
+                throw new ValidationException(
+                        String.format(
+                                "Unsupported option value '%s', the options [%s, %s, %s] are not supported correctly, please do not use them until they're correctly supported",
+                                modeString,
+                                SCAN_STARTUP_MODE_VALUE_EARLIEST,
+                                SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSET,
+                                SCAN_STARTUP_MODE_VALUE_TIMESTAMP));
+
+            default:
+                throw new ValidationException(
+                        String.format(
+                                "Invalid value for option '%s'. Supported values are [%s, %s], but was: %s",
+                                SCAN_STARTUP_MODE.key(),
+                                SCAN_STARTUP_MODE_VALUE_INITIAL,
+                                SCAN_STARTUP_MODE_VALUE_LATEST,
+                                modeString));
+        }
+    }
+
+    private void validatePrimaryKeyIfEnableParallel(ResolvedSchema physicalSchema) {
+        if (!physicalSchema.getPrimaryKey().isPresent()) {
+            throw new ValidationException(
+                    String.format(
+                            "The primary key is necessary when enable '%s' to 'true'",
+                            SCAN_INCREMENTAL_SNAPSHOT_ENABLED));
+        }
+    }
+
+    private void validateStartupOptionIfEnableParallel(StartupOptions startupOptions) {
+        // validate mode
+        checkState(
+                startupOptions.startupMode == StartupMode.INITIAL
+                        || startupOptions.startupMode == StartupMode.LATEST_OFFSET,
+                String.format(
+                        "MySql Parallel Source only supports startup mode 'initial' and 'latest-offset',"
+                                + " but actual is %s",
+                        startupOptions.startupMode));
+    }
+
+    private String validateAndGetServerId(ReadableConfig configuration) {
+        final String serverIdValue = configuration.get(MySqlSourceOptions.SERVER_ID);
+        if (serverIdValue != null) {
+            // validation
+            try {
+                ServerIdRange.from(serverIdValue);
+            } catch (Exception e) {
+                throw new ValidationException(
+                        String.format(
+                                "The value of option 'server-id' is invalid: '%s'", serverIdValue),
+                        e);
+            }
+        }
+        return serverIdValue;
+    }
+
+    /** Checks the value of given integer option is valid. */
+    private void validateIntegerOption(
+            ConfigOption<Integer> option, int optionValue, int exclusiveMin) {
+        checkState(
+                optionValue > exclusiveMin,
+                String.format(
+                        "The value of option '%s' must larger than %d, but is %d",
+                        option.key(), exclusiveMin, optionValue));
+    }
+
+    /**
+     * Checks the given regular expression's syntax is valid.
+     *
+     * @param optionName the option name of the regex
+     * @param regex The regular expression to be checked
+     * @throws ValidationException If the expression's syntax is invalid
+     */
+    private void validateRegex(String optionName, String regex) {
+        try {
+            Pattern.compile(regex);
+        } catch (Exception e) {
+            throw new ValidationException(
+                    String.format(
+                            "The %s '%s' is not a valid regular expression", optionName, regex),
+                    e);
+        }
+    }
+
+    /** Checks the value of given evenly distribution factor upper bound is valid. */
+    private void validateDistributionFactorUpper(double distributionFactorUpper) {
+        checkState(
+                doubleCompare(distributionFactorUpper, 1.0d) >= 0,
+                String.format(
+                        "The value of option '%s' must larger than or equals %s, but is %s",
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.key(),
+                        1.0d,
+                        distributionFactorUpper));
+    }
+
+    /** Checks the value of given evenly distribution factor lower bound is valid. */
+    private void validateDistributionFactorLower(double distributionFactorLower) {
+        checkState(
+                doubleCompare(distributionFactorLower, 0.0d) >= 0
+                        && doubleCompare(distributionFactorLower, 1.0d) <= 0,
+                String.format(
+                        "The value of option '%s' must between %s and %s inclusively, but is %s",
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.key(),
+                        0.0d,
+                        1.0d,
+                        distributionFactorLower));
+    }
+}

--- a/flink-connector-tdsql-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-tdsql-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+com.ververica.cdc.connectors.tdsql.table.TdSqlTableSourceFactory

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceExampleTest.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceExampleTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import com.ververica.cdc.connectors.tdsql.bases.set.TdSqlSet;
+import com.ververica.cdc.connectors.tdsql.testutils.TdSqlDatabase;
+import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Example test for {@link TdSqlSource}. */
+public class TdSqlSourceExampleTest extends TdSqlSourceTestBase {
+    private static final Logger LOG = LoggerFactory.getLogger(TdSqlSourceExampleTest.class);
+    private final TdSqlDatabase inventoryDatabase =
+            new TdSqlDatabase(tdSqlSets(), "inventory", "tdsqluser", "tdsqlpw");
+
+    @Test
+    @Ignore("Test ignored because it won't stop and is used for manual test")
+    public void testConsumingAllEvents() throws Exception {
+        inventoryDatabase.createAndInitialize();
+
+        LOG.info(
+                "first container address: {}:{}",
+                inventoryDatabase.getHost(0),
+                inventoryDatabase.getDatabasePort(0));
+        LOG.info(
+                "second container address: {}:{}",
+                inventoryDatabase.getHost(1),
+                inventoryDatabase.getDatabasePort(1));
+
+        TdSqlSource<String> tdSqlSource =
+                TdSqlSource.<String>builder()
+                        .hostname(inventoryDatabase.getHost(0))
+                        .port(inventoryDatabase.getDatabasePort(0))
+                        .databaseList(inventoryDatabase.getDatabaseName())
+                        .tableList(inventoryDatabase.getDatabaseName() + ".products")
+                        .username(inventoryDatabase.getUsername())
+                        .password(inventoryDatabase.getPassword())
+                        .serverId("5401-5404")
+                        .deserializer(new JsonDebeziumDeserializationSchema())
+                        .includeSchemaChanges(true) // output the schema changes as well
+                        .build();
+
+        tdSqlSource.setTestSets(
+                Stream.of(
+                                new TdSqlSet(
+                                        "set_1",
+                                        inventoryDatabase.getHost(0),
+                                        inventoryDatabase.getDatabasePort(0)),
+                                new TdSqlSet(
+                                        "set_2",
+                                        inventoryDatabase.getHost(1),
+                                        inventoryDatabase.getDatabasePort(1)))
+                        .collect(Collectors.toList()));
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        // enable checkpoint
+        env.enableCheckpointing(3000);
+        // set the source parallelism to 4
+        env.fromSource(tdSqlSource, WatermarkStrategy.noWatermarks(), "TdSqlParallelSource")
+                .setParallelism(4)
+                .print()
+                .setParallelism(1);
+
+        env.execute("Print TdSql Snapshot + Binlog");
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceITCase.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceITCase.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils;
+import com.ververica.cdc.connectors.tdsql.testutils.TdSqlDatabase;
+import io.debezium.connector.mysql.MySqlConnection;
+import io.debezium.jdbc.JdbcConnection;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static java.lang.String.format;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** IT test for {@link TdSqlSource}. */
+public class TdSqlSourceITCase extends TdSqlSourceTestBase {
+    private static final Logger LOG = LoggerFactory.getLogger(TdSqlSourceITCase.class);
+
+    @Rule public final Timeout timeoutPerTest = Timeout.seconds(300);
+
+    private final TdSqlDatabase customDatabase =
+            new TdSqlDatabase(tdSqlSets(), "customer", "tdsqluser", "tdsqlpw");
+
+    @Test
+    public void testReadSingleTableWithSingleParallelism() throws Exception {
+        testTdSqlParallelSource(
+                1, FailoverType.NONE, FailoverPhase.NEVER, new String[] {"customers"});
+    }
+
+    @Test
+    public void testReadSingleTableWithMultipleParallelism() throws Exception {
+        testTdSqlParallelSource(
+                4, FailoverType.NONE, FailoverPhase.NEVER, new String[] {"customers"});
+    }
+
+    @Test
+    public void testTaskManagerFailoverInSnapshotPhase() throws Exception {
+        testTdSqlParallelSource(
+                FailoverType.TM, FailoverPhase.SNAPSHOT, new String[] {"customers", "customers_1"});
+    }
+
+    @Test
+    public void testTaskManagerFailoverInBinlogPhase() throws Exception {
+        testTdSqlParallelSource(
+                FailoverType.TM, FailoverPhase.BINLOG, new String[] {"customers", "customers_1"});
+    }
+
+    @Test
+    public void testJobManagerFailoverInSnapshotPhase() throws Exception {
+        testTdSqlParallelSource(
+                FailoverType.JM, FailoverPhase.SNAPSHOT, new String[] {"customers", "customers_1"});
+    }
+
+    @Test
+    public void testJobManagerFailoverInBinlogPhase() throws Exception {
+        testTdSqlParallelSource(
+                FailoverType.JM, FailoverPhase.BINLOG, new String[] {"customers", "customers_1"});
+    }
+
+    @Test
+    public void testTaskManagerFailoverSingleParallelism() throws Exception {
+        testTdSqlParallelSource(
+                1, FailoverType.TM, FailoverPhase.SNAPSHOT, new String[] {"customers"});
+    }
+
+    @Test
+    public void testJobManagerFailoverSingleParallelism() throws Exception {
+        testTdSqlParallelSource(
+                1, FailoverType.JM, FailoverPhase.SNAPSHOT, new String[] {"customers"});
+    }
+
+    private void testTdSqlParallelSource(
+            FailoverType failoverType, FailoverPhase failoverPhase, String[] captureCustomerTables)
+            throws Exception {
+        testTdSqlParallelSource(
+                DEFAULT_PARALLELISM, failoverType, failoverPhase, captureCustomerTables);
+    }
+
+    public void testTdSqlParallelSource(
+            int parallelism,
+            FailoverType failoverType,
+            FailoverPhase failoverPhase,
+            String[] captureCustomerTables)
+            throws Exception {
+        customDatabase.createAndInitialize();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        env.setParallelism(parallelism);
+        env.enableCheckpointing(60000L);
+        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+
+        String sourceDDL =
+                format(
+                        "CREATE TABLE customers ("
+                                + " id BIGINT NOT NULL,"
+                                + " name STRING,"
+                                + " address STRING,"
+                                + " phone_number STRING,"
+                                + " primary key (id) not enforced"
+                                + ") WITH ("
+                                + " 'connector' = 'tdsql-cdc',"
+                                + " 'scan.incremental.snapshot.enabled' = 'true',"
+                                + " 'hostname' = '%s',"
+                                + " 'port' = '%s',"
+                                + " 'username' = '%s',"
+                                + " 'password' = '%s',"
+                                + " 'database-name' = '%s',"
+                                + " 'table-name' = '%s',"
+                                + " 'scan.incremental.snapshot.chunk.size' = '100',"
+                                + " 'server-id' = '%s',"
+                                + " 'is_test' = 'true',"
+                                + " 'test_tdsql_sets' = '%s'"
+                                + ")",
+                        customDatabase.getHost(0),
+                        customDatabase.getDatabasePort(0),
+                        customDatabase.getUsername(),
+                        customDatabase.getPassword(),
+                        customDatabase.getDatabaseName(),
+                        getTableNameRegex(captureCustomerTables),
+                        getServerId(),
+                        String.format(
+                                "%s:%d;%s:%d",
+                                customDatabase.getHost(0),
+                                customDatabase.getDatabasePort(0),
+                                customDatabase.getHost(1),
+                                customDatabase.getDatabasePort(1)));
+
+        // first step: check the snapshot data
+        String[] snapshotForSingleTable =
+                new String[] {
+                    "+I[101, user_1, Shanghai, 123567891234]",
+                    "+I[102, user_2, Shanghai, 123567891234]",
+                    "+I[103, user_3, Shanghai, 123567891234]",
+                    "+I[109, user_4, Shanghai, 123567891234]",
+                    "+I[110, user_5, Shanghai, 123567891234]",
+                    "+I[111, user_6, Shanghai, 123567891234]",
+                    "+I[118, user_7, Shanghai, 123567891234]",
+                    "+I[121, user_8, Shanghai, 123567891234]",
+                    "+I[123, user_9, Shanghai, 123567891234]",
+                    "+I[1009, user_10, Shanghai, 123567891234]",
+                    "+I[1010, user_11, Shanghai, 123567891234]",
+                    "+I[1011, user_12, Shanghai, 123567891234]",
+                    "+I[1012, user_13, Shanghai, 123567891234]",
+                    "+I[1013, user_14, Shanghai, 123567891234]",
+                    "+I[1014, user_15, Shanghai, 123567891234]",
+                    "+I[1015, user_16, Shanghai, 123567891234]",
+                    "+I[1016, user_17, Shanghai, 123567891234]",
+                    "+I[1017, user_18, Shanghai, 123567891234]",
+                    "+I[1018, user_19, Shanghai, 123567891234]",
+                    "+I[1019, user_20, Shanghai, 123567891234]",
+                    "+I[2000, user_21, Shanghai, 123567891234]"
+                };
+        tEnv.executeSql(sourceDDL);
+
+        TableResult tableResult = tEnv.executeSql("select * from customers");
+        CloseableIterator<Row> iterator = tableResult.collect();
+        JobID jobId = tableResult.getJobClient().get().getJobID();
+        List<String> expectedSnapshotData = new ArrayList<>();
+        for (int i = 0; i < captureCustomerTables.length; i++) {
+            expectedSnapshotData.addAll(Arrays.asList(snapshotForSingleTable));
+        }
+
+        // trigger failover after some snapshot splits read finished
+        if (failoverPhase == FailoverPhase.SNAPSHOT && iterator.hasNext()) {
+            LOG.info("trigger failover after some snapshot splits read finished");
+            triggerFailover(
+                    failoverType, jobId, miniClusterResource.getMiniCluster(), () -> sleepMs(100));
+        }
+
+        assertEqualsInAnyOrder(
+                expectedSnapshotData, fetchRows(iterator, expectedSnapshotData.size()));
+
+        // second step: check the binlog data
+        for (String tableId : captureCustomerTables) {
+            makeFirstPartBinlogEvents(
+                    getConnection(TDSQL_SET_1.getHost(), TDSQL_SET_1.getDatabasePort()),
+                    customDatabase.getDatabaseName() + '.' + tableId);
+        }
+        if (failoverPhase == FailoverPhase.BINLOG) {
+            triggerFailover(
+                    failoverType, jobId, miniClusterResource.getMiniCluster(), () -> sleepMs(200));
+        }
+        for (String tableId : captureCustomerTables) {
+            makeSecondPartBinlogEvents(
+                    getConnection(TDSQL_SET_2.getHost(), TDSQL_SET_2.getDatabasePort()),
+                    customDatabase.getDatabaseName() + '.' + tableId);
+        }
+
+        String[] binlogForSingleTable =
+                new String[] {
+                    "-U[103, user_3, Shanghai, 123567891234]",
+                    "+U[103, user_3, Hangzhou, 123567891234]",
+                    "-D[102, user_2, Shanghai, 123567891234]",
+                    "+I[102, user_2, Shanghai, 123567891234]",
+                    "-U[103, user_3, Hangzhou, 123567891234]",
+                    "+U[103, user_3, Shanghai, 123567891234]",
+                    "-U[1010, user_11, Shanghai, 123567891234]",
+                    "+U[1010, user_11, Hangzhou, 123567891234]",
+                    "+I[2001, user_22, Shanghai, 123567891234]",
+                    "+I[2002, user_23, Shanghai, 123567891234]",
+                    "+I[2003, user_24, Shanghai, 123567891234]"
+                };
+        List<String> expectedBinlogData = new ArrayList<>();
+        for (int i = 0; i < captureCustomerTables.length; i++) {
+            expectedBinlogData.addAll(Arrays.asList(binlogForSingleTable));
+        }
+        assertEqualsInAnyOrder(expectedBinlogData, fetchRows(iterator, expectedBinlogData.size()));
+        tableResult.getJobClient().get().cancel().get();
+    }
+
+    private void makeSecondPartBinlogEvents(JdbcConnection connection, String tableId)
+            throws SQLException {
+        try {
+            connection.setAutoCommit(false);
+
+            // make binlog events for split-1
+            connection.execute("UPDATE " + tableId + " SET address = 'Hangzhou' where id = 1010");
+            connection.commit();
+
+            // make binlog events for the last split
+            connection.execute(
+                    "INSERT INTO "
+                            + tableId
+                            + " VALUES(2001, 'user_22','Shanghai','123567891234'),"
+                            + " (2002, 'user_23','Shanghai','123567891234'),"
+                            + "(2003, 'user_24','Shanghai','123567891234')");
+            connection.commit();
+        } finally {
+            connection.close();
+        }
+    }
+
+    private MySqlConnection getConnection(String host, int port) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("database.hostname", host);
+        properties.put("database.port", String.valueOf(port));
+        properties.put("database.user", customDatabase.getUsername());
+        properties.put("database.password", customDatabase.getPassword());
+        properties.put("database.serverTimezone", ZoneId.of("UTC").toString());
+        io.debezium.config.Configuration configuration =
+                io.debezium.config.Configuration.from(properties);
+        return DebeziumUtils.createMySqlConnection(configuration);
+    }
+
+    private void sleepMs(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ignored) {
+        }
+    }
+
+    private void makeFirstPartBinlogEvents(JdbcConnection connection, String tableId)
+            throws SQLException {
+        try {
+            connection.setAutoCommit(false);
+
+            // make binlog events for the first split
+            connection.execute(
+                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 103",
+                    "DELETE FROM " + tableId + " where id = 102",
+                    "INSERT INTO " + tableId + " VALUES(102, 'user_2','Shanghai','123567891234')",
+                    "UPDATE " + tableId + " SET address = 'Shanghai' where id = 103");
+            connection.commit();
+        } finally {
+            connection.close();
+        }
+    }
+
+    private static void triggerFailover(
+            FailoverType type, JobID jobId, MiniCluster miniCluster, Runnable afterFailAction)
+            throws Exception {
+        switch (type) {
+            case TM:
+                restartTaskManager(miniCluster, afterFailAction);
+                break;
+            case JM:
+                triggerJobManagerFailover(jobId, miniCluster, afterFailAction);
+                break;
+            case NONE:
+                break;
+            default:
+                throw new IllegalStateException("Unexpected value: " + type);
+        }
+    }
+
+    private static void triggerJobManagerFailover(
+            JobID jobId, MiniCluster miniCluster, Runnable afterFailAction) throws Exception {
+        final HaLeadershipControl haLeadershipControl = miniCluster.getHaLeadershipControl().get();
+        haLeadershipControl.revokeJobMasterLeadership(jobId).get();
+        afterFailAction.run();
+        haLeadershipControl.grantJobMasterLeadership(jobId).get();
+    }
+
+    private static void restartTaskManager(MiniCluster miniCluster, Runnable afterFailAction)
+            throws Exception {
+        miniCluster.terminateTaskManager(0).get();
+        afterFailAction.run();
+        miniCluster.startTaskManager();
+    }
+
+    private static List<String> fetchRows(Iterator<Row> iter, int size) {
+        List<String> rows = new ArrayList<>(size);
+        while (size > 0 && iter.hasNext()) {
+            Row row = iter.next();
+            rows.add(row.toString());
+            size--;
+        }
+        return rows;
+    }
+
+    private String getTableNameRegex(String[] captureCustomerTables) {
+        checkState(captureCustomerTables.length > 0);
+        if (captureCustomerTables.length == 1) {
+            return captureCustomerTables[0];
+        } else {
+            // pattern that matches multiple tables
+            return format("(%s)", StringUtils.join(captureCustomerTables, "|"));
+        }
+    }
+
+    private String getServerId() {
+        final Random random = new Random();
+        int serverId = random.nextInt(100) + 5400;
+        return serverId + "-" + (serverId + DEFAULT_PARALLELISM);
+    }
+
+    private enum FailoverType {
+        TM,
+        JM,
+        NONE
+    }
+
+    /** The phase of failover. */
+    private enum FailoverPhase {
+        SNAPSHOT,
+        BINLOG,
+        NEVER
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceTestBase.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/source/TdSqlSourceTestBase.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.source;
+
+import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.TestLogger;
+
+import com.ververica.cdc.connectors.tdsql.testutils.MySqlContainer;
+import com.ververica.cdc.connectors.tdsql.testutils.MySqlVersion;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** base test for {@link TdSqlSource}. */
+public abstract class TdSqlSourceTestBase extends TestLogger {
+    private static final Logger LOG = LoggerFactory.getLogger(TdSqlSourceTestBase.class);
+
+    protected static final int DEFAULT_PARALLELISM = 4;
+
+    public static final String AARCH64_OS = "aarch64";
+
+    protected static final MySqlContainer TDSQL_SET_1 = createMySqlContainer(3306);
+    protected static final MySqlContainer TDSQL_SET_2 = createMySqlContainer(3306);
+
+    @Rule
+    public final MiniClusterWithClientResource miniClusterResource =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
+                            .withHaLeadershipControl()
+                            .build());
+
+    @BeforeClass
+    public static void startContainers() {
+        LOG.info("Starting containers...");
+        Startables.deepStart(tdSqlSets()).join();
+        LOG.info("Containers are started.");
+    }
+
+    public static List<MySqlContainer> tdSqlSets() {
+        return Stream.of(TDSQL_SET_1, TDSQL_SET_2).collect(Collectors.toList());
+    }
+
+    protected static MySqlContainer createMySqlContainer(int port) {
+        String osArch = System.getProperty("os.arch");
+        MySqlVersion version;
+        if (AARCH64_OS.equals(osArch)) {
+            version = MySqlVersion.AARACH64_V8_0;
+        } else {
+            version = MySqlVersion.V8_0;
+        }
+        return (MySqlContainer)
+                new MySqlContainer(version, port)
+                        .withConfigurationOverride("docker/server-gtids/my.cnf")
+                        .withSetupSQL("docker/setup.sql")
+                        .withDatabaseName("flink-test")
+                        .withUsername("flinkuser")
+                        .withPassword("flinkpw")
+                        .withLogConsumer(new Slf4jLogConsumer(LOG));
+    }
+
+    public static void assertEqualsInAnyOrder(List<String> expected, List<String> actual) {
+        assertTrue(expected != null && actual != null);
+        assertEqualsInOrder(
+                expected.stream().sorted().collect(Collectors.toList()),
+                actual.stream().sorted().collect(Collectors.toList()));
+    }
+
+    public static void assertEqualsInOrder(List<String> expected, List<String> actual) {
+        assertTrue(expected != null && actual != null);
+        assertEquals(expected.size(), actual.size());
+        assertArrayEquals(expected.toArray(new String[0]), actual.toArray(new String[0]));
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/MySqlContainer.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/MySqlContainer.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.testutils;
+
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Docker container for MySQL. The difference between this class and {@link
+ * org.testcontainers.containers.MySQLContainer} is that TC MySQLContainer has problems when
+ * overriding mysql conf file, i.e. my.cnf.
+ */
+@SuppressWarnings("rawtypes")
+public class MySqlContainer extends JdbcDatabaseContainer {
+
+    private static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "MY_CNF";
+    private static final String SETUP_SQL_PARAM_NAME = "SETUP_SQL";
+    private static final String MYSQL_ROOT_USER = "root";
+
+    private String databaseName = "test";
+    private String username = "test";
+    private String password = "test";
+
+    private final int port;
+
+    public MySqlContainer(MySqlVersion version, int port) {
+        super(DockerImageName.parse(version.getImage() + ":" + version.getVersion()));
+        this.port = port;
+        addExposedPort(port);
+    }
+
+    @Override
+    protected Set<Integer> getLivenessCheckPorts() {
+        return new HashSet<>(getMappedPort(this.port));
+    }
+
+    @Override
+    protected void configure() {
+        optionallyMapResourceParameterAsVolume(
+                MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/", "mysql-default-conf");
+
+        if (parameters.containsKey(SETUP_SQL_PARAM_NAME)) {
+            optionallyMapResourceParameterAsVolume(
+                    SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A");
+        }
+
+        addEnv("MYSQL_DATABASE", databaseName);
+        addEnv("MYSQL_USER", username);
+        if (password != null && !password.isEmpty()) {
+            addEnv("MYSQL_PASSWORD", password);
+            addEnv("MYSQL_ROOT_PASSWORD", password);
+        } else if (MYSQL_ROOT_USER.equalsIgnoreCase(username)) {
+            addEnv("MYSQL_ALLOW_EMPTY_PASSWORD", "yes");
+        } else {
+            throw new ContainerLaunchException(
+                    "Empty password can be used only with the root user");
+        }
+        setStartupAttempts(3);
+    }
+
+    @Override
+    public String getDriverClassName() {
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+            return "com.mysql.cj.jdbc.Driver";
+        } catch (ClassNotFoundException e) {
+            return "com.mysql.jdbc.Driver";
+        }
+    }
+
+    public String getJdbcUrl(String databaseName) {
+        String additionalUrlParams = constructUrlParameters("?", "&");
+        String url =
+                "jdbc:mysql://"
+                        + getHost()
+                        + ":"
+                        + getDatabasePort()
+                        + "/"
+                        + databaseName
+                        + additionalUrlParams;
+        logger().info("connect {} in  port {}", url, this.port);
+        return url;
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return getJdbcUrl(databaseName);
+    }
+
+    public int getDatabasePort() {
+        return getMappedPort(this.port);
+    }
+
+    @Override
+    protected String constructUrlForConnection(String queryString) {
+        String url = super.constructUrlForConnection(queryString);
+
+        if (!url.contains("useSSL=")) {
+            String separator = url.contains("?") ? "&" : "?";
+            url = url + separator + "useSSL=false";
+        }
+
+        if (!url.contains("allowPublicKeyRetrieval=")) {
+            url = url + "&allowPublicKeyRetrieval=true";
+        }
+
+        return url;
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1";
+    }
+
+    @SuppressWarnings("unchecked")
+    public MySqlContainer withConfigurationOverride(String s) {
+        parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public MySqlContainer withSetupSQL(String sqlPath) {
+        parameters.put(SETUP_SQL_PARAM_NAME, sqlPath);
+        return this;
+    }
+
+    @Override
+    public MySqlContainer withDatabaseName(final String databaseName) {
+        this.databaseName = databaseName;
+        return this;
+    }
+
+    @Override
+    public MySqlContainer withUsername(final String username) {
+        this.username = username;
+        return this;
+    }
+
+    @Override
+    public MySqlContainer withPassword(final String password) {
+        this.password = password;
+        return this;
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/MySqlVersion.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/MySqlVersion.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.testutils;
+
+/** MySql version enum. */
+public enum MySqlVersion {
+    V8_0("mysql", "8.0"),
+    AARACH64_V8_0("arm64v8/mysql", "8.0-oracle");
+
+    private String version;
+    private String image;
+
+    MySqlVersion(String image, String version) {
+        this.version = version;
+        this.image = image;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    @Override
+    public String toString() {
+        return "MySqlVersion{" + "version='" + version + '\'' + '}';
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/RecordsFormatter.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/RecordsFormatter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.testutils;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.RowRowConverter;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.Collector;
+
+import com.ververica.cdc.connectors.mysql.source.utils.RecordUtils;
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Formatter that formats the {@link SourceRecord} to String. */
+public class RecordsFormatter {
+
+    private final DataType dataType;
+    private final ZoneId zoneId;
+
+    private TypeInformation<RowData> typeInfo;
+    private DebeziumDeserializationSchema<RowData> deserializationSchema;
+    private SimpleCollector collector;
+    private RowRowConverter rowRowConverter;
+
+    public RecordsFormatter(DataType dataType) {
+        this(dataType, ZoneId.of("UTC"));
+    }
+
+    public RecordsFormatter(DataType dataType, ZoneId zoneId) {
+        this.dataType = dataType;
+        this.zoneId = zoneId;
+        this.typeInfo =
+                (TypeInformation<RowData>) TypeConversions.fromDataTypeToLegacyInfo(dataType);
+        this.deserializationSchema =
+                RowDataDebeziumDeserializeSchema.newBuilder()
+                        .setPhysicalRowType((RowType) dataType.getLogicalType())
+                        .setResultTypeInfo(typeInfo)
+                        .build();
+        this.collector = new SimpleCollector();
+        this.rowRowConverter = RowRowConverter.create(dataType);
+        rowRowConverter.open(Thread.currentThread().getContextClassLoader());
+    }
+
+    public List<String> format(List<SourceRecord> records) {
+        records.stream()
+                // Keep DataChangeEvent only
+                .filter(RecordUtils::isDataChangeRecord)
+                .forEach(
+                        r -> {
+                            try {
+                                deserializationSchema.deserialize(r, collector);
+                            } catch (Exception e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+        return collector.list.stream()
+                .map(rowRowConverter::toExternal)
+                .map(Row::toString)
+                .collect(Collectors.toList());
+    }
+
+    private static class SimpleCollector implements Collector<RowData> {
+
+        private List<RowData> list = new ArrayList<>();
+
+        @Override
+        public void collect(RowData record) {
+            list.add(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/TdSqlDatabase.java
+++ b/flink-connector-tdsql-cdc/src/test/java/com/ververica/cdc/connectors/tdsql/testutils/TdSqlDatabase.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsql.testutils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Create and populate a unique instance of a MySQL database for each run of JUnit test. A user of
+ * class needs to provide a logical name for Debezium and database name. It is expected that there
+ * is a init file in <code>src/test/resources/ddl/&lt;database_name&gt;.sql</code>. The database
+ * name is enriched with a unique suffix that guarantees complete isolation between runs <code>
+ * &lt;database_name&gt_&lt;suffix&gt</code>
+ *
+ * <p>This class is inspired from Debezium project.
+ */
+public class TdSqlDatabase {
+    private static final Logger LOG = LoggerFactory.getLogger(TdSqlDatabase.class);
+    private static final String[] CREATE_DATABASE_DDL =
+            new String[] {"CREATE DATABASE $DBNAME$;", "USE $DBNAME$;"};
+    private static final String DROP_DATABASE_DDL = "DROP DATABASE IF EXISTS $DBNAME$;";
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)--.*$");
+
+    private final List<MySqlContainer> containers;
+    private final String databaseName;
+    private final String templateName;
+    private final String username;
+    private final String password;
+
+    public TdSqlDatabase(
+            List<MySqlContainer> containers,
+            String databaseName,
+            String username,
+            String password) {
+        this(
+                containers,
+                databaseName,
+                Integer.toUnsignedString(new Random().nextInt(), 36),
+                username,
+                password);
+    }
+
+    private TdSqlDatabase(
+            List<MySqlContainer> containers,
+            String databaseName,
+            final String identifier,
+            String username,
+            String password) {
+        this.containers = containers;
+        this.databaseName = databaseName + "_" + identifier;
+        this.templateName = databaseName;
+        this.username = username;
+        this.password = password;
+    }
+
+    public String getHost(int index) {
+        return containers.get(index).getHost();
+    }
+
+    public int getDatabasePort(int index) {
+        return containers.get(index).getDatabasePort();
+    }
+
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    /** @return Fully qualified table name <code>&lt;databaseName&gt;.&lt;tableName&gt;</code> */
+    public String qualifiedTableName(final String tableName) {
+        return String.format("%s.%s", databaseName, tableName);
+    }
+
+    /** Creates the database and populates it with initialization SQL script. */
+    public void createAndInitialize() {
+        int index = 1;
+        for (MySqlContainer container : containers) {
+            final String ddlFile = String.format("ddl/%s_%d.sql", templateName, index++);
+            LOG.info("exec ddl file: {}", ddlFile);
+            final URL ddlTestFile = TdSqlDatabase.class.getClassLoader().getResource(ddlFile);
+            assertNotNull("Cannot locate " + ddlFile, ddlTestFile);
+            try {
+                try (Connection connection =
+                                DriverManager.getConnection(
+                                        container.getJdbcUrl(), username, password);
+                        Statement statement = connection.createStatement()) {
+                    final List<String> statements =
+                            Arrays.stream(
+                                            Stream.concat(
+                                                            Arrays.stream(CREATE_DATABASE_DDL),
+                                                            Files.readAllLines(
+                                                                    Paths.get(ddlTestFile.toURI()))
+                                                                    .stream())
+                                                    .map(String::trim)
+                                                    .filter(
+                                                            x ->
+                                                                    !x.startsWith("--")
+                                                                            && !x.isEmpty())
+                                                    .map(
+                                                            x -> {
+                                                                final Matcher m =
+                                                                        COMMENT_PATTERN.matcher(x);
+                                                                return m.matches() ? m.group(1) : x;
+                                                            })
+                                                    .map(this::convertSQL)
+                                                    .collect(Collectors.joining("\n"))
+                                                    .split(";"))
+                                    .map(x -> x.replace("$$", ";"))
+                                    .collect(Collectors.toList());
+                    for (String stmt : statements) {
+                        statement.execute(stmt);
+                    }
+                }
+            } catch (final Exception e) {
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    /** Drop the database if is exists. */
+    public void dropDatabase() {
+        try {
+            for (MySqlContainer container : containers) {
+                try (Connection connection =
+                                DriverManager.getConnection(
+                                        container.getJdbcUrl(), username, password);
+                        Statement statement = connection.createStatement()) {
+                    final String dropDatabaseStatement = convertSQL(DROP_DATABASE_DDL);
+                    statement.execute(dropDatabaseStatement);
+                }
+            }
+        } catch (final Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private String convertSQL(final String sql) {
+        return sql.replace("$DBNAME$", databaseName);
+    }
+}

--- a/flink-connector-tdsql-cdc/src/test/resources/ddl/customer_1.sql
+++ b/flink-connector-tdsql-cdc/src/test/resources/ddl/customer_1.sql
@@ -1,0 +1,212 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--   http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  customer
+-- ----------------------------------------------------------------------------------------------------------------
+
+-- Create and populate our users using a single insert with many rows
+CREATE TABLE customers (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+
+INSERT INTO customers
+VALUES (101,"user_1","Shanghai","123567891234"),
+       (102,"user_2","Shanghai","123567891234"),
+       (103,"user_3","Shanghai","123567891234"),
+       (109,"user_4","Shanghai","123567891234"),
+       (110,"user_5","Shanghai","123567891234"),
+       (111,"user_6","Shanghai","123567891234"),
+       (118,"user_7","Shanghai","123567891234"),
+       (121,"user_8","Shanghai","123567891234"),
+       (123,"user_9","Shanghai","123567891234");
+
+-- table has same name prefix with 'customers.*'
+CREATE TABLE customers_1 (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+
+INSERT INTO customers_1
+VALUES (101,"user_1","Shanghai","123567891234"),
+       (102,"user_2","Shanghai","123567891234"),
+       (103,"user_3","Shanghai","123567891234"),
+       (109,"user_4","Shanghai","123567891234"),
+       (110,"user_5","Shanghai","123567891234"),
+       (111,"user_6","Shanghai","123567891234"),
+       (118,"user_7","Shanghai","123567891234"),
+       (121,"user_8","Shanghai","123567891234"),
+       (123,"user_9","Shanghai","123567891234"),
+       (1009,"user_10","Shanghai","123567891234");
+
+-- create table whose split key is evenly distributed
+CREATE TABLE customers_even_dist (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL ,
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+INSERT INTO customers_even_dist
+VALUES (101,'user_1','Shanghai','123567891234'),
+       (102,'user_2','Shanghai','123567891234'),
+       (103,'user_3','Shanghai','123567891234'),
+       (104,'user_4','Shanghai','123567891234'),
+       (105,'user_5','Shanghai','123567891234'),
+       (106,'user_6','Shanghai','123567891234');
+
+-- create table whose split key is evenly distributed and sparse
+CREATE TABLE customers_sparse_dist (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL ,
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+INSERT INTO customers_sparse_dist
+VALUES (2,'user_1','Shanghai','123567891234'),
+       (4,'user_2','Shanghai','123567891234'),
+       (6,'user_3','Shanghai','123567891234'),
+       (8,'user_4','Shanghai','123567891234'),
+       (10,'user_5','Shanghai','123567891234'),
+       (16,'user_6','Shanghai','123567891234');
+
+-- create table whose split key is evenly distributed and dense
+CREATE TABLE customers_dense_dist (
+ id1 INTEGER NOT NULL,
+ id2 VARCHAR(255) NOT NULL ,
+ address VARCHAR(1024),
+ phone_number VARCHAR(512),
+ PRIMARY KEY(id1, id2)
+);
+INSERT INTO customers_dense_dist
+VALUES (1,'user_1','Shanghai','123567891234'),
+       (1,'user_2','Shanghai','123567891234'),
+       (1,'user_3','Shanghai','123567891234'),
+       (1,'user_4','Shanghai','123567891234'),
+       (2,'user_5','Shanghai','123567891234'),
+       (2,'user_6','Shanghai','123567891234');
+
+CREATE TABLE customers_no_pk (
+   id INTEGER NOT NULL,
+   name VARCHAR(255) NOT NULL DEFAULT 'flink',
+   address VARCHAR(1024),
+   phone_number VARCHAR(512)
+);
+
+INSERT INTO customers_no_pk
+VALUES (101,"user_1","Shanghai","123567891234"),
+       (102,"user_2","Shanghai","123567891234"),
+       (103,"user_3","Shanghai","123567891234"),
+       (109,"user_4","Shanghai","123567891234"),
+       (110,"user_5","Shanghai","123567891234"),
+       (111,"user_6","Shanghai","123567891234"),
+       (118,"user_7","Shanghai","123567891234"),
+       (121,"user_8","Shanghai","123567891234"),
+       (123,"user_9","Shanghai","123567891234");
+
+-- table has combined primary key
+CREATE TABLE customer_card (
+  card_no BIGINT NOT NULL,
+  level VARCHAR(10) NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  note VARCHAR(1024),
+  PRIMARY KEY(card_no, level)
+);
+
+insert into customer_card
+VALUES (20001, 'LEVEL_4', 'user_1', 'user with level 4'),
+       (20002, 'LEVEL_4', 'user_2', 'user with level 4'),
+       (20003, 'LEVEL_4', 'user_3', 'user with level 4'),
+       (20004, 'LEVEL_4', 'user_4', 'user with level 4'),
+       (20004, 'LEVEL_1', 'user_4', 'user with level 4'),
+       (20004, 'LEVEL_2', 'user_4', 'user with level 4'),
+       (20004, 'LEVEL_3', 'user_4', 'user with level 4'),
+       (30006, 'LEVEL_3', 'user_5', 'user with level 3'),
+       (30007, 'LEVEL_3', 'user_6', 'user with level 3'),
+       (30008, 'LEVEL_3', 'user_7', 'user with level 3');
+
+-- table has single line
+CREATE TABLE customer_card_single_line (
+  card_no BIGINT NOT NULL,
+  level VARCHAR(10) NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  note VARCHAR(1024),
+  PRIMARY KEY(card_no, level)
+);
+
+insert into customer_card_single_line
+VALUES (20001, 'LEVEL_1', 'user_1', 'user with level 1');
+
+
+-- table has combined primary key
+CREATE TABLE shopping_cart (
+  product_no INT NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  PRIMARY KEY(user_id, product_no, product_kind)
+);
+
+insert into shopping_cart
+VALUES (801, 'KIND_010', 'user_4', 'my shopping list'),
+       (600, 'KIND_009', 'user_4', 'my shopping list'),
+       (401, 'KIND_002', 'user_5', 'leo list'),
+       (401, 'KIND_007', 'user_5', 'leo list'),
+       (404, 'KIND_008', 'user_5', 'leo list'),
+       (600, 'KIND_009', 'user_6', 'my shopping cart');
+
+-- table has bigint unsigned auto increment primary key
+CREATE TABLE shopping_cart_big (
+  product_no BIGINT UNSIGNED AUTO_INCREMENT NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  PRIMARY KEY(product_no)
+);
+
+insert into shopping_cart_big
+VALUES (default, 'KIND_003', 'user_1', 'my shopping cart');
+
+-- table has decimal primary key
+CREATE TABLE shopping_cart_dec (
+  product_no DECIMAL(10, 4) NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) DEFAULT 'flink',
+  PRIMARY KEY(product_no)
+);
+
+insert into shopping_cart_dec
+VALUES (123458.6789, 'KIND_003', 'user_3', 'my shopping cart'),
+       (123459.1234, 'KIND_004', 'user_4', null);
+
+-- create table whose primary key are produced by snowflake algorithm
+CREATE TABLE address (
+  id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+  country VARCHAR(255) NOT NULL,
+  city VARCHAR(255) NOT NULL,
+  detail_address VARCHAR(1024)
+);
+
+INSERT INTO address
+VALUES (416874195632735147, 'China', 'Beijing', 'West Town address 1'),
+       (416927583791428523, 'China', 'Beijing', 'West Town address 2'),
+       (417022095255614379, 'China', 'Beijing', 'West Town address 3'),
+       (417111867899200427, 'America', 'New York', 'East Town address 1'),
+       (417271541558096811, 'America', 'New York', 'East Town address 2');

--- a/flink-connector-tdsql-cdc/src/test/resources/ddl/customer_2.sql
+++ b/flink-connector-tdsql-cdc/src/test/resources/ddl/customer_2.sql
@@ -1,0 +1,210 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--   http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  customer
+-- ----------------------------------------------------------------------------------------------------------------
+
+-- Create and populate our users using a single insert with many rows
+CREATE TABLE customers (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+
+INSERT INTO customers
+VALUES (1009,"user_10","Shanghai","123567891234"),
+       (1010,"user_11","Shanghai","123567891234"),
+       (1011,"user_12","Shanghai","123567891234"),
+       (1012,"user_13","Shanghai","123567891234"),
+       (1013,"user_14","Shanghai","123567891234"),
+       (1014,"user_15","Shanghai","123567891234"),
+       (1015,"user_16","Shanghai","123567891234"),
+       (1016,"user_17","Shanghai","123567891234"),
+       (1017,"user_18","Shanghai","123567891234"),
+       (1018,"user_19","Shanghai","123567891234"),
+       (1019,"user_20","Shanghai","123567891234"),
+       (2000,"user_21","Shanghai","123567891234");
+
+-- table has same name prefix with 'customers.*'
+CREATE TABLE customers_1 (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+
+INSERT INTO customers_1
+VALUES (1010,"user_11","Shanghai","123567891234"),
+       (1011,"user_12","Shanghai","123567891234"),
+       (1012,"user_13","Shanghai","123567891234"),
+       (1013,"user_14","Shanghai","123567891234"),
+       (1014,"user_15","Shanghai","123567891234"),
+       (1015,"user_16","Shanghai","123567891234"),
+       (1016,"user_17","Shanghai","123567891234"),
+       (1017,"user_18","Shanghai","123567891234"),
+       (1018,"user_19","Shanghai","123567891234"),
+       (1019,"user_20","Shanghai","123567891234"),
+       (2000,"user_21","Shanghai","123567891234");
+
+-- create table whose split key is evenly distributed
+CREATE TABLE customers_even_dist (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL ,
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+INSERT INTO customers_even_dist
+VALUES (107,'user_7','Shanghai','123567891234'),
+       (108,'user_8','Shanghai','123567891234'),
+       (109,'user_9','Shanghai','123567891234'),
+       (110,'user_10','Shanghai','123567891234');
+
+-- create table whose split key is evenly distributed and sparse
+CREATE TABLE customers_sparse_dist (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL ,
+  address VARCHAR(1024),
+  phone_number VARCHAR(512)
+);
+INSERT INTO customers_sparse_dist
+VALUES (17,'user_7','Shanghai','123567891234'),
+       (18,'user_8','Shanghai','123567891234'),
+       (20,'user_9','Shanghai','123567891234'),
+       (22,'user_10','Shanghai','123567891234');
+
+-- create table whose split key is evenly distributed and dense
+CREATE TABLE customers_dense_dist (
+ id1 INTEGER NOT NULL,
+ id2 VARCHAR(255) NOT NULL ,
+ address VARCHAR(1024),
+ phone_number VARCHAR(512),
+ PRIMARY KEY(id1, id2)
+);
+INSERT INTO customers_dense_dist
+VALUES (2,'user_7','Shanghai','123567891234'),
+       (3,'user_8','Shanghai','123567891234'),
+       (3,'user_9','Shanghai','123567891234'),
+       (3,'user_10','Shanghai','123567891234');
+
+CREATE TABLE customers_no_pk (
+   id INTEGER NOT NULL,
+   name VARCHAR(255) NOT NULL DEFAULT 'flink',
+   address VARCHAR(1024),
+   phone_number VARCHAR(512)
+);
+
+INSERT INTO customers_no_pk
+VALUES (1009,"user_10","Shanghai","123567891234"),
+       (1010,"user_11","Shanghai","123567891234"),
+       (1011,"user_12","Shanghai","123567891234"),
+       (1012,"user_13","Shanghai","123567891234"),
+       (1013,"user_14","Shanghai","123567891234"),
+       (1014,"user_15","Shanghai","123567891234"),
+       (1015,"user_16","Shanghai","123567891234"),
+       (1016,"user_17","Shanghai","123567891234"),
+       (1017,"user_18","Shanghai","123567891234"),
+       (1018,"user_19","Shanghai","123567891234"),
+       (1019,"user_20","Shanghai","123567891234"),
+       (2000,"user_21","Shanghai","123567891234");
+
+-- table has combined primary key
+CREATE TABLE customer_card (
+  card_no BIGINT NOT NULL,
+  level VARCHAR(10) NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  note VARCHAR(1024),
+  PRIMARY KEY(card_no, level)
+);
+
+insert into customer_card
+VALUES (30009, 'LEVEL_3', 'user_8', 'user with level 3'),
+       (30009, 'LEVEL_2', 'user_8', 'user with level 3'),
+       (30009, 'LEVEL_1', 'user_8', 'user with level 3'),
+       (40001, 'LEVEL_2', 'user_9', 'user with level 2'),
+       (40002, 'LEVEL_2', 'user_10', 'user with level 2'),
+       (40003, 'LEVEL_2', 'user_11', 'user with level 2'),
+       (50001, 'LEVEL_1', 'user_12', 'user with level 1'),
+       (50002, 'LEVEL_1', 'user_13', 'user with level 1'),
+       (50003, 'LEVEL_1', 'user_14', 'user with level 1');
+
+-- table has single line
+CREATE TABLE customer_card_single_line (
+  card_no BIGINT NOT NULL,
+  level VARCHAR(10) NOT NULL,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  note VARCHAR(1024),
+  PRIMARY KEY(card_no, level)
+);
+
+insert into customer_card_single_line
+VALUES (20002, 'LEVEL_1', 'user_1', 'user with level 1');
+
+
+-- table has combined primary key
+CREATE TABLE shopping_cart (
+  product_no INT NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  PRIMARY KEY(user_id, product_no, product_kind)
+);
+
+insert into shopping_cart
+VALUES (101, 'KIND_001', 'user_1', 'my shopping cart'),
+       (101, 'KIND_002', 'user_1', 'my shopping cart'),
+       (102, 'KIND_007', 'user_1', 'my shopping cart'),
+       (102, 'KIND_008', 'user_1', 'my shopping cart'),
+       (501, 'KIND_100', 'user_2', 'my shopping list'),
+       (701, 'KIND_999', 'user_3', 'my shopping list');
+
+-- table has bigint unsigned auto increment primary key
+CREATE TABLE shopping_cart_big (
+  product_no BIGINT UNSIGNED AUTO_INCREMENT NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) NOT NULL,
+  PRIMARY KEY(product_no)
+);
+
+insert into shopping_cart_big
+VALUES (default, 'KIND_001', 'user_1', 'my shopping cart'),
+       (default, 'KIND_002', 'user_1', 'my shopping cart');
+
+-- table has decimal primary key
+CREATE TABLE shopping_cart_dec (
+  product_no DECIMAL(10, 4) NOT NULL,
+  product_kind VARCHAR(255),
+  user_id VARCHAR(255) NOT NULL,
+  description VARCHAR(255) DEFAULT 'flink',
+  PRIMARY KEY(product_no)
+);
+
+insert into shopping_cart_dec
+VALUES (123456.123, 'KIND_001', 'user_1', 'my shopping cart'),
+       (123457.456, 'KIND_002', 'user_2', 'my shopping cart');
+-- create table whose primary key are produced by snowflake algorithm
+CREATE TABLE address (
+  id BIGINT UNSIGNED NOT NULL PRIMARY KEY,
+  country VARCHAR(255) NOT NULL,
+  city VARCHAR(255) NOT NULL,
+  detail_address VARCHAR(1024)
+);
+
+INSERT INTO address
+VALUES (417272886855938987, 'America', 'New York', 'East Town address 3'),
+       (417420106184475563, 'Germany', 'Berlin', 'West Town address 1'),
+       (418161258277847979, 'Germany', 'Berlin', 'West Town address 2');

--- a/flink-connector-tdsql-cdc/src/test/resources/ddl/inventory_1.sql
+++ b/flink-connector-tdsql-cdc/src/test/resources/ddl/inventory_1.sql
@@ -1,0 +1,95 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--   http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  inventory
+-- ----------------------------------------------------------------------------------------------------------------
+
+-- Create and populate our products using a single insert with many rows
+CREATE TABLE products (
+  id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  description VARCHAR(512),
+  weight FLOAT
+);
+ALTER TABLE products AUTO_INCREMENT = 101;
+
+INSERT INTO products
+VALUES (default,"scooter","Small 2-wheel scooter",3.14),
+       (default,"car battery","12V car battery",8.1),
+       (default,"12-pack drill bits","12-pack of drill bits with sizes ranging from #40 to #3",0.8),
+       (default,"hammer","12oz carpenter's hammer",0.75),
+       (default,"hammer","14oz carpenter's hammer",0.875);
+
+-- Create and populate the products on hand using multiple inserts
+CREATE TABLE products_on_hand (
+  product_id INTEGER NOT NULL PRIMARY KEY,
+  quantity INTEGER NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+INSERT INTO products_on_hand VALUES (101,3);
+INSERT INTO products_on_hand VALUES (102,8);
+INSERT INTO products_on_hand VALUES (103,18);
+INSERT INTO products_on_hand VALUES (104,4);
+INSERT INTO products_on_hand VALUES (105,5);
+
+-- Create some customers ...
+CREATE TABLE customers (
+  id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE KEY
+) AUTO_INCREMENT=1001;
+
+
+INSERT INTO customers
+VALUES (default,"Sally","Thomas","sally.thomas@acme.com"),
+       (default,"George","Bailey","gbailey@foobar.com");
+
+-- Create some very simple orders
+CREATE TABLE orders (
+  order_number INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  order_date DATE NOT NULL,
+  purchaser INTEGER NOT NULL,
+  quantity INTEGER NOT NULL,
+  product_id INTEGER NOT NULL,
+  FOREIGN KEY order_customer (purchaser) REFERENCES customers(id),
+  FOREIGN KEY ordered_product (product_id) REFERENCES products(id)
+) AUTO_INCREMENT = 10001;
+
+INSERT INTO orders
+VALUES (default, '2016-01-16', 1001, 1, 102),
+       (default, '2016-01-17', 1002, 2, 105);
+
+CREATE TABLE category
+(
+    id            INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    category_name VARCHAR(255)
+);
+
+CREATE TABLE `varbinary_pk_table`
+(
+    `order_id`   varbinary(8) NOT NULL,
+    `order_date` date         NOT NULL,
+    `quantity`   int(11) NOT NULL,
+    `product_id` int(11) NOT NULL,
+    `purchaser`  varchar(512) NOT NULL,
+    PRIMARY KEY (`order_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO varbinary_pk_table
+VALUES (b'0000010000000100000001000000010000000100000001000000010000000000', '2021-03-08', 0, 0, 'flink'),
+       (b'0000010000000100000001000000010000000100000001000000010000000001', '2021-03-08', 10, 100, 'flink'),
+       (b'0000010000000100000001000000010000000100000001000000010000000010', '2021-03-08', 20, 200, 'flink');

--- a/flink-connector-tdsql-cdc/src/test/resources/ddl/inventory_2.sql
+++ b/flink-connector-tdsql-cdc/src/test/resources/ddl/inventory_2.sql
@@ -1,0 +1,92 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--   http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  inventory
+-- ----------------------------------------------------------------------------------------------------------------
+
+-- Create and populate our products using a single insert with many rows
+CREATE TABLE products (
+  id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  description VARCHAR(512),
+  weight FLOAT
+);
+ALTER TABLE products AUTO_INCREMENT = 106;
+
+INSERT INTO products
+VALUES (default,"hammer","16oz carpenter's hammer",1.0),
+       (default,"rocks","box of assorted rocks",5.3),
+       (default,"jacket","water resistent black wind breaker",0.1),
+       (default,"spare tire","24 inch spare tire",22.2);
+
+-- Create and populate the products on hand using multiple inserts
+CREATE TABLE products_on_hand (
+  product_id INTEGER NOT NULL PRIMARY KEY,
+  quantity INTEGER NOT NULL,
+  FOREIGN KEY (product_id) REFERENCES products(id)
+);
+
+INSERT INTO products_on_hand VALUES (106,0);
+INSERT INTO products_on_hand VALUES (107,44);
+INSERT INTO products_on_hand VALUES (108,2);
+INSERT INTO products_on_hand VALUES (109,5);
+
+-- Create some customers ...
+CREATE TABLE customers (
+  id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  first_name VARCHAR(255) NOT NULL,
+  last_name VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NOT NULL UNIQUE KEY
+) AUTO_INCREMENT=1003;
+
+
+INSERT INTO customers
+VALUES (default,"Edward","Walker","ed@walker.com"),
+       (default,"Anne","Kretchmar","annek@noanswer.org");
+
+-- Create some very simple orders
+CREATE TABLE orders (
+  order_number INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  order_date DATE NOT NULL,
+  purchaser INTEGER NOT NULL,
+  quantity INTEGER NOT NULL,
+  product_id INTEGER NOT NULL,
+  FOREIGN KEY order_customer (purchaser) REFERENCES customers(id),
+  FOREIGN KEY ordered_product (product_id) REFERENCES products(id)
+) AUTO_INCREMENT = 10004;
+
+INSERT INTO orders
+VALUES (default, '2016-02-18', 1004, 3, 109),
+       (default, '16-02-21', 1003, 1, 107);
+
+CREATE TABLE category
+(
+    id            INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    category_name VARCHAR(255)
+);
+
+CREATE TABLE `varbinary_pk_table`
+(
+    `order_id`   varbinary(8) NOT NULL,
+    `order_date` date         NOT NULL,
+    `quantity`   int(11) NOT NULL,
+    `product_id` int(11) NOT NULL,
+    `purchaser`  varchar(512) NOT NULL,
+    PRIMARY KEY (`order_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+INSERT INTO varbinary_pk_table
+VALUES (b'0000010000000100000001000000010000000100000001000000010000000011', '2021-03-08', 30, 300, 'flink'),
+       (b'0000010000000100000001000000010000000100000001000000010000000100', '2021-03-08', 40, 400, 'flink');

--- a/flink-connector-tdsql-cdc/src/test/resources/docker/server-gtids/my.cnf
+++ b/flink-connector-tdsql-cdc/src/test/resources/docker/server-gtids/my.cnf
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+#datadir=/var/lib/mysql
+#socket=/var/lib/mysql/mysql.sock
+secure-file-priv=/var/lib/mysql
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+#log-error=/var/log/mysqld.log
+#pid-file=/var/run/mysqld/mysqld.pid
+
+# ----------------------------------------------
+# Enable the binlog for replication & CDC
+# ----------------------------------------------
+
+# Enable binary replication log and set the prefix, expiration, and log format.
+# The prefix is arbitrary, expiration can be short for integration tests but would
+# be longer on a production system. Row-level info is required for ingest to work.
+# Server ID is required, but this will vary on production systems
+server-id         = 223344
+log_bin           = mysql-bin
+expire_logs_days  = 1
+binlog_format     = row
+
+# enable gtid mode
+gtid_mode = on
+enforce_gtid_consistency = on

--- a/flink-connector-tdsql-cdc/src/test/resources/docker/server/my.cnf
+++ b/flink-connector-tdsql-cdc/src/test/resources/docker/server/my.cnf
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# For advice on how to change settings please see
+# http://dev.mysql.com/doc/refman/5.7/en/server-configuration-defaults.html
+
+[mysqld]
+#
+# Remove leading # and set to the amount of RAM for the most important data
+# cache in MySQL. Start at 70% of total RAM for dedicated server, else 10%.
+# innodb_buffer_pool_size = 128M
+#
+# Remove leading # to turn on a very important data integrity option: logging
+# changes to the binary log between backups.
+# log_bin
+#
+# Remove leading # to set options mainly useful for reporting servers.
+# The server defaults are faster for transactions and fast SELECTs.
+# Adjust sizes as needed, experiment to find the optimal values.
+# join_buffer_size = 128M
+# sort_buffer_size = 2M
+# read_rnd_buffer_size = 2M
+skip-host-cache
+skip-name-resolve
+#datadir=/var/lib/mysql
+#socket=/var/lib/mysql/mysql.sock
+secure-file-priv=/var/lib/mysql
+user=mysql
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+#log-error=/var/log/mysqld.log
+#pid-file=/var/run/mysqld/mysqld.pid
+
+# ----------------------------------------------
+# Enable the binlog for replication & CDC
+# ----------------------------------------------
+
+# Enable binary replication log and set the prefix, expiration, and log format.
+# The prefix is arbitrary, expiration can be short for integration tests but would
+# be longer on a production system. Row-level info is required for ingest to work.
+# Server ID is required, but this will vary on production systems
+server-id         = 223344
+log_bin           = mysql-bin
+expire_logs_days  = 1
+binlog_format     = row

--- a/flink-connector-tdsql-cdc/src/test/resources/docker/setup.sql
+++ b/flink-connector-tdsql-cdc/src/test/resources/docker/setup.sql
@@ -1,0 +1,30 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--   http://www.apache.org/licenses/LICENSE-2.0
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- In production you would almost certainly limit the replication user must be on the follower (slave) machine,
+-- to prevent other clients accessing the log from other machines. For example, 'replicator'@'follower.acme.com'.
+-- However, in this database we'll grant 2 users different privileges:
+--
+-- 1) 'flinkuser' - all privileges required by the snapshot reader AND binlog reader (used for testing)
+-- 2) 'mysqluser' - all privileges
+--
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT, LOCK TABLES  ON *.* TO 'flinkuser'@'%';
+CREATE USER 'tdsqluser' IDENTIFIED BY 'tdsqlpw';
+GRANT ALL PRIVILEGES ON *.* TO 'tdsqluser'@'%';
+
+-- ----------------------------------------------------------------------------------------------------------------
+-- DATABASE:  emptydb
+-- ----------------------------------------------------------------------------------------------------------------
+CREATE DATABASE emptydb;

--- a/flink-connector-tdsql-cdc/src/test/resources/log4j2-test.properties
+++ b/flink-connector-tdsql-cdc/src/test/resources/log4j2-test.properties
@@ -1,0 +1,31 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=INFO
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n
+
+logger.tdsqlenumerator.name= com.ververica.cdc.connectors.tdsql.source.enumerator.TdSqlSourceEnumerator
+logger.tdsqlenumerator.level = trace

--- a/flink-sql-connector-tdsql-cdc/pom.xml
+++ b/flink-sql-connector-tdsql-cdc/pom.xml
@@ -52,16 +52,45 @@ under the License.
                             <shadeTestJar>false</shadeTestJar>
                             <artifactSet>
                                 <includes>
+                                    <include>io.debezium:debezium-api</include>
+                                    <include>io.debezium:debezium-embedded</include>
+                                    <include>io.debezium:debezium-core</include>
+                                    <include>io.debezium:debezium-ddl-parser</include>
+                                    <include>io.debezium:debezium-connector-mysql</include>
                                     <include>com.ververica:flink-connector-debezium</include>
+                                    <include>com.ververica:flink-connector-mysql-cdc</include>
                                     <include>com.ververica:flink-connector-tdsql-cdc</include>
-                                    <include>org.tikv:tikv-client-java</include>
-                                    <include>com.google.protobuf:*</include>
-                                    <include>io.grpc:*</include>
+                                    <include>org.antlr:antlr4-runtime</include>
+                                    <include>org.apache.kafka:*</include>
+                                    <include>mysql:mysql-connector-java</include>
+                                    <include>com.zendesk:mysql-binlog-connector-java</include>
+                                    <include>com.fasterxml.*:*</include>
+                                    <include>com.google.guava:*</include>
+                                    <include>com.esri.geometry:esri-geometry-api</include>
+                                    <include>com.zaxxer:HikariCP</include>
                                     <!--  Include fixed version 18.0-13.0 of flink shaded guava  -->
                                     <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
+                                <relocation>
+                                    <pattern>org.apache.kafka</pattern>
+                                    <shadedPattern>
+                                        com.ververica.cdc.connectors.shaded.org.apache.kafka
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.antlr</pattern>
+                                    <shadedPattern>
+                                        com.ververica.cdc.connectors.shaded.org.antlr
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>
+                                        com.ververica.cdc.connectors.shaded.com.fasterxml
+                                    </shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>
@@ -69,9 +98,13 @@ under the License.
                                     </shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>io.grpc</pattern>
+                                    <pattern>com.esri.geometry</pattern>
+                                    <shadedPattern>com.ververica.cdc.connectors.shaded.com.esri.geometry</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.zaxxer</pattern>
                                     <shadedPattern>
-                                        com.ververica.cdc.connectors.shaded.io.grpc
+                                        com.ververica.cdc.connectors.shaded.com.zaxxer
                                     </shadedPattern>
                                 </relocation>
                             </relocations>

--- a/flink-sql-connector-tdsql-cdc/pom.xml
+++ b/flink-sql-connector-tdsql-cdc/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-cdc-connectors</artifactId>
+        <groupId>com.ververica</groupId>
+        <version>2.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-sql-connector-tdsql-cdc</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-tdsql-cdc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadeTestJar>false</shadeTestJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.ververica:flink-connector-debezium</include>
+                                    <include>com.ververica:flink-connector-tdsql-cdc</include>
+                                    <include>org.tikv:tikv-client-java</include>
+                                    <include>com.google.protobuf:*</include>
+                                    <include>io.grpc:*</include>
+                                    <!--  Include fixed version 18.0-13.0 of flink shaded guava  -->
+                                    <include>org.apache.flink:flink-shaded-guava</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>
+                                        com.ververica.cdc.connectors.shaded.com.google
+                                    </shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.grpc</pattern>
+                                    <shadedPattern>
+                                        com.ververica.cdc.connectors.shaded.io.grpc
+                                    </shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-sql-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsqlserver/DummyDocs.java
+++ b/flink-sql-connector-tdsql-cdc/src/main/java/com/ververica/cdc/connectors/tdsqlserver/DummyDocs.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.tdsqlserver;
+
+/** This is used to generate a dummy docs jar for this module to pass OSS repository rule. */
+public class DummyDocs {}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@ under the License.
         <module>flink-sql-connector-sqlserver-cdc</module>
         <module>flink-sql-connector-tidb-cdc</module>
         <module>flink-cdc-e2e-tests</module>
+        <module>flink-connector-tdsql-cdc</module>
     </modules>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@ under the License.
         <module>flink-connector-oceanbase-cdc</module>
         <module>flink-connector-sqlserver-cdc</module>
         <module>flink-connector-tidb-cdc</module>
+        <module>flink-connector-tdsql-cdc</module>
         <module>flink-sql-connector-mysql-cdc</module>
         <module>flink-sql-connector-postgres-cdc</module>
         <module>flink-sql-connector-mongodb-cdc</module>
@@ -51,7 +52,7 @@ under the License.
         <module>flink-sql-connector-sqlserver-cdc</module>
         <module>flink-sql-connector-tidb-cdc</module>
         <module>flink-cdc-e2e-tests</module>
-        <module>flink-connector-tdsql-cdc</module>
+        <module>flink-sql-connector-tdsql-cdc</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
TDSQL is an abbreviation for TecentDistributed SQL. **It is derived from MySQL** and designed like mysql cluster.

TDSQL CDC base on mysql cdc. It discovers tdsql's set and assigns them's splits to explicit readers for consumption. Fetcher Manager support multiple split reader thread when TM slot size lower then tdsql cluster set size.

TDSQL Document Link: https://cloud.tencent.com/document/product/557