### PR TITLE
[metric] fix flink cdc metric conflict with flink built in metric

### DIFF
--- a/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-connector-debezium/src/main/java/com/ververica/cdc/debezium/DebeziumSourceFunction.java
@@ -433,7 +433,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 getRuntimeContext().getClass().getMethod("getMetricGroup");
         getMetricGroupMethod.setAccessible(true);
         final MetricGroup metricGroup =
-                (MetricGroup) getMetricGroupMethod.invoke(getRuntimeContext());
+                ((MetricGroup) getMetricGroupMethod.invoke(getRuntimeContext())).addGroup("cdc");
 
         metricGroup.gauge(
                 "currentFetchEventTimeLag",

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSource.java
@@ -138,7 +138,7 @@ public class MySqlSource<T>
 
         final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");
         metricGroupMethod.setAccessible(true);
-        final MetricGroup metricGroup = (MetricGroup) metricGroupMethod.invoke(readerContext);
+        final MetricGroup metricGroup = ((MetricGroup) metricGroupMethod.invoke(readerContext)).addGroup("cdc");
 
         final MySqlSourceReaderMetrics sourceReaderMetrics =
                 new MySqlSourceReaderMetrics(metricGroup);

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -338,7 +338,7 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
         // make  SourceReaderContext#metricGroup compatible between Flink 1.13 and Flink 1.14
         final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");
         metricGroupMethod.setAccessible(true);
-        final MetricGroup metricGroup = (MetricGroup) metricGroupMethod.invoke(readerContext);
+        final MetricGroup metricGroup = ((MetricGroup) metricGroupMethod.invoke(readerContext)).addGroup("cdc");
         final RecordEmitter<SourceRecords, SourceRecord, MySqlSplitState> recordEmitter =
                 limit > 0
                         ? new MysqlLimitedRecordEmitter(


### PR DESCRIPTION
 CurrentEmitEventTimeLag and currentFetchEventTimeLag metrics are both registered in flink cdc and flink framework.Flink MetricRegistryImpl is responsible for metric registering, when the metric with same name is registered twice, only the first will be successfully. 

Flink cdc metric register after flink framework, so  flink cdc metric will be ignored. The following log proves it: 
2022-07-29 11:41:58.031 WARN org.apache.flink.metrics.MetricGroup     [] - Name collision: Group already contains a Metric with the name 'currentEmitEventTimeLag'.Metric will not be reported.

To deal with the conflict, i suggest  add cdc prefix to metric name.