### PR TITLE
support table splitting process control when read table snapshot

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -170,6 +170,17 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
+    public MySqlSourceBuilder<T> splitTableProcessControlEnabled(
+            boolean splitTableProcessControlEnabled) {
+        this.configFactory.splitTableProcessControlEnabled(splitTableProcessControlEnabled);
+        return this;
+    }
+
+    public MySqlSourceBuilder<T> splitTableAheadNums(int splitTableAheadNums) {
+        this.configFactory.splitTableAheadNums(splitTableAheadNums);
+        return this;
+    }
+
     /**
      * The maximum time that the connector should wait after trying to connect to the MySQL database
      * server before timing out.

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
@@ -153,6 +153,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
             SnapshotPendingSplitsState state, DataOutputSerializer out) throws IOException {
         writeTableIds(state.getAlreadyProcessedTables(), out);
         writeRemainingSplits(state.getRemainingSplits(), out);
+        writeTableIds(state.getAlreadySplitTables(), out);
         writeAssignedSnapshotSplits(state.getAssignedSplits(), out);
         writeFinishedOffsets(state.getSplitFinishedOffsets(), out);
         out.writeInt(state.getSnapshotAssignerStatus().getStatusCode());
@@ -179,6 +180,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
     private SnapshotPendingSplitsState deserializeLegacySnapshotPendingSplitsState(
             int splitVersion, DataInputDeserializer in) throws IOException {
         List<TableId> alreadyProcessedTables = readTableIds(in);
+        List<TableId> alreadySplitTables = readTableIds(in);
         List<MySqlSnapshotSplit> remainingSplits = readMySqlSnapshotSplits(splitVersion, in);
         Map<String, MySqlSnapshotSplit> assignedSnapshotSplits =
                 readAssignedSnapshotSplits(splitVersion, in);
@@ -211,6 +213,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
 
         return new SnapshotPendingSplitsState(
                 alreadyProcessedTables,
+                alreadySplitTables,
                 remainingSchemaLessSplits,
                 assignedSchemaLessSnapshotSplits,
                 tableSchemas,
@@ -232,6 +235,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
     private SnapshotPendingSplitsState deserializeSnapshotPendingSplitsState(
             int version, int splitVersion, DataInputDeserializer in) throws IOException {
         List<TableId> alreadyProcessedTables = readTableIds(in);
+        List<TableId> alreadySplitTables = readTableIds(in);
         List<MySqlSnapshotSplit> remainingSplits = readMySqlSnapshotSplits(splitVersion, in);
         Map<String, MySqlSnapshotSplit> assignedSnapshotSplits =
                 readAssignedSnapshotSplits(splitVersion, in);
@@ -271,6 +275,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         }
         return new SnapshotPendingSplitsState(
                 alreadyProcessedTables,
+                alreadySplitTables,
                 remainingSchemaLessSplits,
                 assignedSchemaLessSnapshotSplits,
                 tableSchemas,

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/state/SnapshotPendingSplitsState.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/state/SnapshotPendingSplitsState.java
@@ -40,6 +40,9 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
      */
     private final List<TableId> alreadyProcessedTables;
 
+    /** The tables that have been split by ChunkSplitter. */
+    private final List<TableId> alreadySplitTables;
+
     /** The splits in the checkpoint. */
     private final List<MySqlSchemaLessSnapshotSplit> remainingSplits;
 
@@ -68,6 +71,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
 
     public SnapshotPendingSplitsState(
             List<TableId> alreadyProcessedTables,
+            List<TableId> alreadySplitTables,
             List<MySqlSchemaLessSnapshotSplit> remainingSplits,
             Map<String, MySqlSchemaLessSnapshotSplit> assignedSplits,
             Map<TableId, TableChange> tableSchemas,
@@ -77,6 +81,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
             boolean isTableIdCaseSensitive,
             boolean isRemainingTablesCheckpointed) {
         this.alreadyProcessedTables = alreadyProcessedTables;
+        this.alreadySplitTables = alreadySplitTables;
         this.remainingSplits = remainingSplits;
         this.assignedSplits = assignedSplits;
         this.splitFinishedOffsets = splitFinishedOffsets;
@@ -93,6 +98,10 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
 
     public List<MySqlSchemaLessSnapshotSplit> getRemainingSplits() {
         return remainingSplits;
+    }
+
+    public List<TableId> getAlreadySplitTables() {
+        return alreadySplitTables;
     }
 
     public Map<String, MySqlSchemaLessSnapshotSplit> getAssignedSplits() {
@@ -137,6 +146,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 && isRemainingTablesCheckpointed == that.isRemainingTablesCheckpointed
                 && Objects.equals(remainingTables, that.remainingTables)
                 && Objects.equals(alreadyProcessedTables, that.alreadyProcessedTables)
+                && Objects.equals(alreadySplitTables, that.alreadySplitTables)
                 && Objects.equals(remainingSplits, that.remainingSplits)
                 && Objects.equals(assignedSplits, that.assignedSplits)
                 && Objects.equals(splitFinishedOffsets, that.splitFinishedOffsets);
@@ -147,6 +157,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         return Objects.hash(
                 remainingTables,
                 alreadyProcessedTables,
+                alreadySplitTables,
                 remainingSplits,
                 assignedSplits,
                 splitFinishedOffsets,
@@ -162,6 +173,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 + remainingTables
                 + ", alreadyProcessedTables="
                 + alreadyProcessedTables
+                + ", alreadySplitTables="
+                + alreadySplitTables
                 + ", remainingSplits="
                 + remainingSplits
                 + ", assignedSplits="

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -46,6 +46,8 @@ public class MySqlSourceConfig implements Serializable {
     private final int splitSize;
     private final int splitMetaGroupSize;
     private final int fetchSize;
+    private final boolean splitTableProcessControlEnabled;
+    private final int splitTableAheadNums;
     private final String serverTimeZone;
     private final Duration connectTimeout;
     private final int connectMaxRetries;
@@ -76,6 +78,8 @@ public class MySqlSourceConfig implements Serializable {
             int splitSize,
             int splitMetaGroupSize,
             int fetchSize,
+            boolean splitTableProcessControlEnabled,
+            int splitTableAheadNums,
             String serverTimeZone,
             Duration connectTimeout,
             int connectMaxRetries,
@@ -96,6 +100,8 @@ public class MySqlSourceConfig implements Serializable {
         this.serverIdRange = serverIdRange;
         this.startupOptions = checkNotNull(startupOptions);
         this.splitSize = splitSize;
+        this.splitTableProcessControlEnabled = splitTableProcessControlEnabled;
+        this.splitTableAheadNums = splitTableAheadNums;
         this.splitMetaGroupSize = splitMetaGroupSize;
         this.fetchSize = fetchSize;
         this.serverTimeZone = checkNotNull(serverTimeZone);
@@ -148,6 +154,14 @@ public class MySqlSourceConfig implements Serializable {
 
     public int getSplitSize() {
         return splitSize;
+    }
+
+    public boolean getsplitTableProcessControlEnabled() {
+        return splitTableProcessControlEnabled;
+    }
+
+    public int getSplitTableAheadNums() {
+        return splitTableAheadNums;
     }
 
     public int getSplitMetaGroupSize() {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -39,6 +39,8 @@ import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOption
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.HEARTBEAT_INTERVAL;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_TABLE_AHEAD_NUMS;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_TABLE_PROCESS_CONTROL_ENABLED;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A factory to construct {@link MySqlSourceConfig}. */
@@ -59,6 +61,9 @@ public class MySqlSourceConfigFactory implements Serializable {
     private int splitSize = SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue();
     private int splitMetaGroupSize = CHUNK_META_GROUP_SIZE.defaultValue();
     private int fetchSize = SCAN_SNAPSHOT_FETCH_SIZE.defaultValue();
+    private boolean splitTableProcessControlEnabled =
+            SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue();
+    private int splitTableAheadNums = SPLIT_TABLE_AHEAD_NUMS.defaultValue();
     private Duration connectTimeout = CONNECT_TIMEOUT.defaultValue();
     private int connectMaxRetries = CONNECT_MAX_RETRIES.defaultValue();
     private int connectionPoolSize = CONNECTION_POOL_SIZE.defaultValue();
@@ -189,6 +194,22 @@ public class MySqlSourceConfigFactory implements Serializable {
     /** The maximum fetch size for per poll when read table snapshot. */
     public MySqlSourceConfigFactory fetchSize(int fetchSize) {
         this.fetchSize = fetchSize;
+        return this;
+    }
+
+    /** Whether to control the process of table splitting when read table snapshot. */
+    public MySqlSourceConfigFactory splitTableProcessControlEnabled(
+            boolean splitTableProcessControlEnabled) {
+        this.splitTableProcessControlEnabled = splitTableProcessControlEnabled;
+        return this;
+    }
+
+    /**
+     * The number of tables split ahead than the number of tables already processed when read table
+     * snapshot.
+     */
+    public MySqlSourceConfigFactory splitTableAheadNums(int splitTableAheadNums) {
+        this.splitTableAheadNums = splitTableAheadNums;
         return this;
     }
 
@@ -330,6 +351,8 @@ public class MySqlSourceConfigFactory implements Serializable {
                 splitSize,
                 splitMetaGroupSize,
                 fetchSize,
+                splitTableProcessControlEnabled,
+                splitTableAheadNums,
                 serverTimeZone,
                 connectTimeout,
                 connectMaxRetries,

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -114,6 +114,20 @@ public class MySqlSourceOptions {
                     .withDescription(
                             "The maximum fetch size for per poll when read table snapshot.");
 
+    public static final ConfigOption<Boolean> SPLIT_TABLE_PROCESS_CONTROL_ENABLED =
+            ConfigOptions.key("split.table.process.control.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to control the process of table splitting when read table snapshot.");
+
+    public static final ConfigOption<Integer> SPLIT_TABLE_AHEAD_NUMS =
+            ConfigOptions.key("split.table.ahead.nums")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "The number of tables already split ahead than the number of tables already processed when read table snapshot.");
+
     public static final ConfigOption<Duration> CONNECT_TIMEOUT =
             ConfigOptions.key("connect.timeout")
                     .durationType()

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
@@ -70,6 +70,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     private final int splitSize;
     private final int splitMetaGroupSize;
     private final int fetchSize;
+    private final boolean splitTableProcessControlEnabled;
+    private final int splitTableAheadNums;
     private final Duration connectTimeout;
     private final int connectionPoolSize;
     private final int connectMaxRetries;
@@ -106,6 +108,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             int splitSize,
             int splitMetaGroupSize,
             int fetchSize,
+            boolean splitTableProcessControlEnabled,
+            int splitTableAheadNums,
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
@@ -128,6 +132,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 splitSize,
                 splitMetaGroupSize,
                 fetchSize,
+                splitTableProcessControlEnabled,
+                splitTableAheadNums,
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
@@ -155,6 +161,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             int splitSize,
             int splitMetaGroupSize,
             int fetchSize,
+            boolean splitTableProcessControlEnabled,
+            int splitTableAheadNums,
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
@@ -179,6 +187,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.splitSize = splitSize;
         this.splitMetaGroupSize = splitMetaGroupSize;
         this.fetchSize = fetchSize;
+        this.splitTableProcessControlEnabled = splitTableProcessControlEnabled;
+        this.splitTableAheadNums = splitTableAheadNums;
         this.connectTimeout = connectTimeout;
         this.connectMaxRetries = connectMaxRetries;
         this.connectionPoolSize = connectionPoolSize;
@@ -237,6 +247,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .distributionFactorUpper(distributionFactorUpper)
                             .distributionFactorLower(distributionFactorLower)
                             .fetchSize(fetchSize)
+                            .splitTableProcessControlEnabled(splitTableProcessControlEnabled)
+                            .splitTableAheadNums(splitTableAheadNums)
                             .connectTimeout(connectTimeout)
                             .connectMaxRetries(connectMaxRetries)
                             .connectionPoolSize(connectionPoolSize)
@@ -317,6 +329,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         splitSize,
                         splitMetaGroupSize,
                         fetchSize,
+                        splitTableProcessControlEnabled,
+                        splitTableAheadNums,
                         connectTimeout,
                         connectMaxRetries,
                         connectionPoolSize,
@@ -386,6 +400,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 splitSize,
                 splitMetaGroupSize,
                 fetchSize,
+                splitTableProcessControlEnabled,
+                splitTableAheadNums,
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -60,6 +60,8 @@ import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOption
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SERVER_ID;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SERVER_TIME_ZONE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_TABLE_AHEAD_NUMS;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_TABLE_PROCESS_CONTROL_ENABLED;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.TABLE_NAME;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.USERNAME;
 import static com.ververica.cdc.connectors.mysql.source.utils.ObjectUtils.doubleCompare;
@@ -93,6 +95,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
         int fetchSize = config.get(SCAN_SNAPSHOT_FETCH_SIZE);
         ZoneId serverTimeZone = getServerTimeZone(config);
+        boolean splitTableProcessControlEnabled = config.get(SPLIT_TABLE_PROCESS_CONTROL_ENABLED);
+        int splitTableAheadNums = config.get(SPLIT_TABLE_AHEAD_NUMS);
 
         ResolvedSchema physicalSchema =
                 getPhysicalSchema(context.getCatalogTable().getResolvedSchema());
@@ -134,6 +138,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 splitSize,
                 splitMetaGroupSize,
                 fetchSize,
+                splitTableProcessControlEnabled,
+                splitTableAheadNums,
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
@@ -184,6 +190,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         options.add(HEARTBEAT_INTERVAL);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
+        options.add(SPLIT_TABLE_PROCESS_CONTROL_ENABLED);
+        options.add(SPLIT_TABLE_AHEAD_NUMS);
         return options;
     }
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
@@ -73,6 +73,7 @@ public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
 
         List<TableId> alreadyProcessedTables = Lists.newArrayList(tableId);
         List<MySqlSchemaLessSnapshotSplit> remainingSplits = new ArrayList<>();
+        List<TableId> alreadySplitTables = Lists.newArrayList(tableId);
 
         Map<String, MySqlSchemaLessSnapshotSplit> assignedSplits = new HashMap<>();
         Map<String, BinlogOffset> splitFinishedOffsets = new HashMap<>();
@@ -92,6 +93,7 @@ public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
         SnapshotPendingSplitsState snapshotPendingSplitsState =
                 new SnapshotPendingSplitsState(
                         alreadyProcessedTables,
+                        alreadySplitTables,
                         remainingSplits,
                         assignedSplits,
                         new HashMap<>(),

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializerTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializerTest.java
@@ -109,12 +109,16 @@ public class PendingSplitsStateSerializerTest {
         // the second table has 4 snapshot splits and has been assigned 2 splits
         // the third table has not assigned yet
         final List<TableId> alreadyProcessedTables = new ArrayList<>();
+        final List<TableId> alreadySplitTables = new ArrayList<>();
         final List<TableId> remainingTables = new ArrayList<>();
 
         final List<MySqlSchemaLessSnapshotSplit> remainingSplits = new ArrayList<>();
 
         alreadyProcessedTables.add(tableId0);
         alreadyProcessedTables.add(tableId1);
+
+        alreadySplitTables.add(tableId0);
+        alreadySplitTables.add(tableId1);
 
         remainingTables.add(tableId2);
 
@@ -142,6 +146,7 @@ public class PendingSplitsStateSerializerTest {
                 getTestTableSchema(tableId0, tableId1);
         return new SnapshotPendingSplitsState(
                 alreadyProcessedTables,
+                alreadySplitTables,
                 remainingSplits,
                 assignedSnapshotSplits,
                 tableSchemas,

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -53,6 +53,8 @@ import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOption
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
 import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_TABLE_AHEAD_NUMS;
+import static com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions.SPLIT_TABLE_PROCESS_CONTROL_ENABLED;
 import static org.apache.flink.core.testutils.FlinkMatchers.containsMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -114,6 +116,8 @@ public class MySqlTableSourceFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         CONNECT_TIMEOUT.defaultValue(),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -158,6 +162,8 @@ public class MySqlTableSourceFactoryTest {
                         8000,
                         3000,
                         100,
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         Duration.ofSeconds(45),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -198,6 +204,8 @@ public class MySqlTableSourceFactoryTest {
                         8000,
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         100,
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         Duration.ofSeconds(45),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -236,6 +244,8 @@ public class MySqlTableSourceFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         CONNECT_TIMEOUT.defaultValue(),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -282,6 +292,8 @@ public class MySqlTableSourceFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         CONNECT_TIMEOUT.defaultValue(),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -342,6 +354,8 @@ public class MySqlTableSourceFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         CONNECT_TIMEOUT.defaultValue(),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -411,6 +425,8 @@ public class MySqlTableSourceFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         CONNECT_TIMEOUT.defaultValue(),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),
@@ -452,6 +468,8 @@ public class MySqlTableSourceFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
                         CHUNK_META_GROUP_SIZE.defaultValue(),
                         SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        SPLIT_TABLE_PROCESS_CONTROL_ENABLED.defaultValue(),
+                        SPLIT_TABLE_AHEAD_NUMS.defaultValue(),
                         CONNECT_TIMEOUT.defaultValue(),
                         CONNECT_MAX_RETRIES.defaultValue(),
                         CONNECTION_POOL_SIZE.defaultValue(),


### PR DESCRIPTION
This resolves a problem encountered in our production environment when there are too many tables to be read on the snapshot phase and each takes quite a lot of time ,  as a result, the process of data reading falls behind the process of chunk splitting too much. 

To be more specific, say there are 100 tables to be read, the current process is:
1、 split all the tables into chunks one by one, which may last several hours, as it's a lightweight job.
2、read the chunks from procedure 1, which may last several days, as it's a heavyweight job.

When start reading the last split of the last table,  executing 'select from table where primary key > *** ',  too much data has accumulated for this chunk, because a long time has passed since it has been split, then the job will fail .

There are someone else who also encountered this problem (url) #1375 

As a  solution,  we can control the speed of chunk splitting thread, to prevent it from going too much ahead. when it reaches the threshold value, it will wait for the data reading thread. 

