### PR TITLE
升级Jackson版本

### DIFF
--- a/flink-connector-debezium/pom.xml
+++ b/flink-connector-debezium/pom.xml
@@ -47,7 +47,17 @@ under the License.
                     <groupId>org.glassfish.jersey.core</groupId>
                     <artifactId>*</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
         </dependency>
 
         <dependency>

--- a/flink-connector-mysql-cdc/pom.xml
+++ b/flink-connector-mysql-cdc/pom.xml
@@ -46,6 +46,16 @@ under the License.
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-mysql</artifactId>
             <version>${debezium.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- geometry dependencies -->
@@ -180,6 +190,12 @@ under the License.
             <artifactId>json-path</artifactId>
             <version>2.4.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.3</version>
         </dependency>
 
     </dependencies>

--- a/flink-connector-oracle-cdc/pom.xml
+++ b/flink-connector-oracle-cdc/pom.xml
@@ -46,6 +46,16 @@ under the License.
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-oracle</artifactId>
             <version>${debezium.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- test dependencies on Debezium -->
@@ -146,6 +156,18 @@ under the License.
             <artifactId>json-path</artifactId>
             <version>2.4.0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.3</version>
         </dependency>
 
     </dependencies>

--- a/flink-connector-postgres-cdc/pom.xml
+++ b/flink-connector-postgres-cdc/pom.xml
@@ -52,6 +52,14 @@ under the License.
                     <groupId>org.postgresql</groupId>
                     <artifactId>postgresql</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -158,6 +166,18 @@ under the License.
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.3</version>
         </dependency>
 
     </dependencies>

--- a/flink-connector-sqlserver-cdc/pom.xml
+++ b/flink-connector-sqlserver-cdc/pom.xml
@@ -47,6 +47,16 @@ under the License.
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-sqlserver</artifactId>
             <version>${debezium.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- test dependencies on Debezium -->
@@ -136,6 +146,18 @@ under the License.
             <artifactId>awaitility</artifactId>
             <version>${version.awaitility}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.13.3</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
cdc中使用的[debezium](https://github.com/debezium/debezium)版本为1.6.4.Final，其依赖的Jackson-core版本为2.10.5,[jackson-databind](https://github.com/FasterXML/jackson-databind)版本为2.10.5.1。

flink自从1.13之后使用的Jackson版本为2.13.2。

Jackson的[com.fasterxml.jackson.databind.cfg.MapperConfig.java](https://github.com/FasterXML/jackson-databind/blob/2.14/src/main/java/com/fasterxml/jackson/databind/cfg/MapperConfig.java)中属性_mapperFeatures类型在2.13版本之前为int，在2.13版本开始变更为long。

从而导致了使用sql-cdc会出现Caused by: java.io.InvalidClassException: com.ververica.cdc.connectors.shaded.com.fasterxml.jackson.databind.cfg.MapperConfig; incompatible types for field _mapperFeatures错误。