### PR TITLE
Switch to a MySQL image with arm64 support

### DIFF
--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/testutils/MySqlContainer.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/testutils/MySqlContainer.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class MySqlContainer extends JdbcDatabaseContainer<MySqlContainer> {
 
-    public static final String IMAGE = "mysql";
+    public static final String IMAGE = "biarms/mysql";
     public static final Integer MYSQL_PORT = 3306;
 
     private static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "MY_CNF";

--- a/flink-cdc-base/src/test/resources/docker/server-gtids/my.cnf
+++ b/flink-cdc-base/src/test/resources/docker/server-gtids/my.cnf
@@ -37,6 +37,8 @@ skip-name-resolve
 secure-file-priv=/var/lib/mysql
 user=mysql
 
+default_time_zone='+00:00'
+
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
 

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqlContainer.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqlContainer.java
@@ -31,7 +31,7 @@ import java.util.Set;
 @SuppressWarnings("rawtypes")
 public class MySqlContainer extends JdbcDatabaseContainer {
 
-    public static final String IMAGE = "mysql";
+    public static final String IMAGE = "biarms/mysql";
     public static final Integer MYSQL_PORT = 3306;
 
     private static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "MY_CNF";

--- a/flink-connector-mysql-cdc/src/test/resources/docker/server-gtids/my.cnf
+++ b/flink-connector-mysql-cdc/src/test/resources/docker/server-gtids/my.cnf
@@ -37,6 +37,8 @@ skip-name-resolve
 secure-file-priv=/var/lib/mysql
 user=mysql
 
+default_time_zone='+00:00'
+
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
 

--- a/flink-connector-mysql-cdc/src/test/resources/docker/server/my.cnf
+++ b/flink-connector-mysql-cdc/src/test/resources/docker/server/my.cnf
@@ -37,6 +37,8 @@ skip-name-resolve
 secure-file-priv=/var/lib/mysql
 user=mysql
 
+default_time_zone='+00:00'
+
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0
 


### PR DESCRIPTION
Closes #1367

[The official MySQL distribution](https://www.mysql.com/de/support/supportedplatforms/database.html) doesn't support arm64 architecture for 5.7, so it's not possible to run tests on an Apple Silicon machine natively. 

https://github.com/biarms/mysql is a distribution that's compatible with the official one, but it's also built for arm64.

Unfortunately, it doesn't use UTC timezone by default, so I had to update the configuration. 

All tests passed.