### PR TITLE
[tidb-cdc]When the task runs for a period of time, there are only Resolved Events

### DIFF
--- a/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TiKVRichParallelSourceFunction.java
+++ b/flink-connector-tidb-cdc/src/main/java/com/ververica/cdc/connectors/tidb/TiKVRichParallelSourceFunction.java
@@ -176,10 +176,10 @@ public class TiKVRichParallelSourceFunction<T> extends RichParallelSourceFunctio
         switch (row.getType()) {
             case COMMITTED:
                 prewrites.put(RowKeyWithTs.ofStart(row), row);
-                commits.put(RowKeyWithTs.ofCommit(row), row);
+                commits.put(RowKeyWithTs.ofStart(row), row);
                 break;
             case COMMIT:
-                commits.put(RowKeyWithTs.ofCommit(row), row);
+                commits.put(RowKeyWithTs.ofStart(row), row);
                 break;
             case PREWRITE:
                 prewrites.put(RowKeyWithTs.ofStart(row), row);


### PR DESCRIPTION
Environment :

Flink version : 1.14.4
Flink CDC version: 2.2 ,2.3 ,master
Database and version: tidb5.0 and tidb5.1
To Reproduce
flink-tidb-cdc table： A

flink-jdbc table: B

query:
insert into A select * from B;

desc:
The task data is normal at the beginning of the program startup, but after running for a period of time, the data is not updated.
but there is no error message.

The log:
2022-10-31 17:56:03,786 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 437049141169750048, regionId: 1721083
2022-10-31 17:56:04,787 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 437049141431894020, regionId: 1721083
2022-10-31 17:56:05,787 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 437049141694038029, regionId: 1721083
2022-10-31 17:56:06,789 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 437049141956182110, regionId: 1721083
2022-10-31 17:56:07,790 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 437049142218326018, regionId: 1721083
2022-10-31 17:56:08,793 INFO org.tikv.cdc.CDCClient [] - handle resolvedTs: 437049142480470176, regionId: 1721083



The solutions：
1.COMMITTED ' data：
 type: COMMITTED, data: start_ts: 437500764314664991
commit_ts: 437500764314664996
type: COMMITTED

2.PREWRITE' data:
** start_ts: 437503701009039388 ** 
type: PREWRITE
op_type: PUT
key: "xxxxx"

3.COMMIT' data:
** start_ts: 437503701009039388 **
commit_ts: 437503701009039391
type: COMMIT
op_type: PUT
key: "xxxx"


