### PR TITLE
fix bug 'mysql primary key of binary data type is compared incorrectly'

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
@@ -46,7 +46,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbcConnection;
@@ -311,7 +310,7 @@ public class MySqlChunkSplitter implements ChunkSplitter {
         // chunk end might be null when max values are removed
         Object chunkEnd =
                 queryNextChunkMax(jdbc, tableId, splitColumnName, chunkSize, previousChunkEnd);
-        if (Objects.equals(previousChunkEnd, chunkEnd)) {
+        if (ObjectUtils.equals(previousChunkEnd, chunkEnd)) {
             // we don't allow equal chunk start and end,
             // should query the next one larger than chunkEnd
             chunkEnd = queryMin(jdbc, tableId, splitColumnName, chunkEnd);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/ObjectUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/ObjectUtils.java
@@ -18,6 +18,7 @@ package com.ververica.cdc.connectors.mysql.source.utils;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 
 /** Utilities for operation on {@link Object}. */
 public class ObjectUtils {
@@ -84,8 +85,37 @@ public class ObjectUtils {
         if (obj1 instanceof Comparable && obj1.getClass().equals(obj2.getClass())) {
             return ((Comparable) obj1).compareTo(obj2);
         } else {
+            if (obj1 instanceof byte[] && obj1.getClass().equals(obj2.getClass())) {
+                return compareByteArray((byte[]) obj1, (byte[]) obj2);
+            }
             return obj1.toString().compareTo(obj2.toString());
         }
+    }
+
+    public static boolean equals(Object obj1, Object obj2) {
+        if (obj1 instanceof byte[] && obj1.getClass().equals(obj2.getClass())) {
+            return compareByteArray((byte[]) obj1, (byte[]) obj2) == 0;
+        } else {
+            return Objects.equals(obj1, obj2);
+        }
+    }
+
+    private static int compareByteArray(byte[] byteArray1, byte[] byteArray2) {
+        String s1 = bytesToHex(byteArray1);
+        String s2 = bytesToHex(byteArray2);
+        return s1.compareTo(s2);
+    }
+
+    public static String bytesToHex(byte[] bytes) {
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < bytes.length; i++) {
+            String hex = Integer.toHexString(bytes[i] & 0xFF);
+            if (hex.length() < 2) {
+                sb.append(0);
+            }
+            sb.append(hex);
+        }
+        return sb.toString();
     }
 
     /**

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/utils/ObjectUtilsTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/utils/ObjectUtilsTest.java
@@ -19,8 +19,16 @@ package com.ververica.cdc.connectors.mysql.source.utils;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /** Tests for {@link ObjectUtils}. */
 public class ObjectUtilsTest {
@@ -41,4 +49,48 @@ public class ObjectUtilsTest {
                 new BigDecimal("99.12344"),
                 ObjectUtils.minus(new BigDecimal("100.12345"), new BigDecimal("1.00001")));
     }
+
+    @Test
+    public void testCompareByteArray() {
+        List<byte[]> list = new ArrayList<>();
+        //below data is sorted in ascending order according to the binary column in MySQL
+        list.add(toBinary("90c83f1a-b5d0-4333-bb45-b793652a0039"));
+        list.add(toBinary("253025c1-47fd-4497-a780-2f067b6b0502"));
+        list.add(toBinary("dc92e409-4df0-457e-9e3d-0ac61a5f1517"));
+        list.add(toBinary("f09ec2d2-1612-4673-83a4-517292043061"));
+        list.add(toBinary("9524fb73-295b-480c-a828-1baf95b9c4e8"));
+        list.add(toBinary("13b982e3-4f86-487f-a490-5e9253246865"));
+        list.add(toBinary("bcd1c6dc-0845-4a8d-856e-1c2293e7b235"));
+        list.add(toBinary("f5a3408f-7974-4c5c-a235-da694806d6e2"));
+        list.add(toBinary("f36b0384-437a-4cb9-851e-76530d293513"));
+        list.add(toBinary("a71417e1-6990-4de8-b034-92a0f1737d4e"));
+
+        for (int i=0; i<list.size()-1; i++) {
+            assertTrue(ObjectUtils.compare(list.get(i), list.get(i + 1)) < 0);
+        }
+    }
+
+    /**
+     * Convert uuid string to binary.
+     *
+     * @param str uuid string
+     * @return uuid bin
+     */
+    public static byte[] toBinary(String str) {
+        UUID uuid = UUID.fromString(str);
+        long msb = uuid.getMostSignificantBits();
+        msb = msb << 48
+            | ((msb >> 16) & 0xFFFFL) << 32
+            | msb >>> 32;
+
+        byte[] bytes = new byte[16];
+        ByteBuffer.wrap(bytes)
+            .order(ByteOrder.BIG_ENDIAN)
+            .putLong(msb)
+            .putLong(uuid.getLeastSignificantBits());
+        return bytes;
+    }
+
+
+
 }


### PR DESCRIPTION
mysql table use the id column of binary type as the primary key, when mysql cdc do the snapshot split. It will get min and max value of id column by execute sql of 'SELECT MIN(id), MAX(id) FROM table'.   Then the values of splitStart and splitEnd are determined by dividing the range of maximum and minimum values by paging, and confirm if the splitEnd is bigger than the max value. But cdc use the "obj1.toString().compareTo(obj2.toString())" to compare the byte[], This comparison is different with mysql, and caused the middle splitEnd bigger than the max value. Then cdc use the sql of "select * from table where id > ? " to load the total line of the table, and make the taskmanger oom
 