### PR TITLE
[Fix a Bug] add supported for Oracle CDB mode at OracleIncrementalSource

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
@@ -16,7 +16,6 @@
 
 package com.ververica.cdc.connectors.oracle.source;
 
-import io.debezium.connector.oracle.OracleConnectorConfig;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -36,6 +35,7 @@ import com.ververica.cdc.connectors.oracle.source.reader.fetch.OracleStreamFetch
 import com.ververica.cdc.connectors.oracle.source.utils.OracleConnectionUtils;
 import com.ververica.cdc.connectors.oracle.source.utils.OracleSchema;
 import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.TableChanges.TableChange;
@@ -88,7 +88,8 @@ public class OracleDialect implements JdbcDataSourceDialect {
 
     @Override
     public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
-        return OracleConnectionUtils.createOracleConnection((OracleConnectorConfig) sourceConfig.getDbzConnectorConfig());
+        return OracleConnectionUtils.createOracleConnection(
+                (OracleConnectorConfig) sourceConfig.getDbzConnectorConfig());
     }
 
     @Override
@@ -116,7 +117,9 @@ public class OracleDialect implements JdbcDataSourceDialect {
     public Map<TableId, TableChange> discoverDataCollectionSchemas(JdbcSourceConfig sourceConfig) {
         final List<TableId> capturedTableIds = discoverDataCollections(sourceConfig);
 
-        try (OracleConnection jdbc = createOracleConnection((OracleConnectorConfig) sourceConfig.getDbzConnectorConfig())) {
+        try (OracleConnection jdbc =
+                createOracleConnection(
+                        (OracleConnectorConfig) sourceConfig.getDbzConnectorConfig())) {
             // fetch table schemas
             Map<TableId, TableChange> tableSchemas = new HashMap<>();
             for (TableId tableId : capturedTableIds) {
@@ -142,7 +145,8 @@ public class OracleDialect implements JdbcDataSourceDialect {
     public OracleSourceFetchTaskContext createFetchTaskContext(
             SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
         final OracleConnection jdbcConnection =
-                createOracleConnection((OracleConnectorConfig) taskSourceConfig.getDbzConnectorConfig());
+                createOracleConnection(
+                        (OracleConnectorConfig) taskSourceConfig.getDbzConnectorConfig());
         return new OracleSourceFetchTaskContext(taskSourceConfig, this, jdbcConnection);
     }
 

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/OracleDialect.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.oracle.source;
 
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -87,8 +88,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
 
     @Override
     public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
-        return OracleConnectionUtils.createOracleConnection(
-                sourceConfig.getDbzConnectorConfig().getJdbcConfig());
+        return OracleConnectionUtils.createOracleConnection((OracleConnectorConfig) sourceConfig.getDbzConnectorConfig());
     }
 
     @Override
@@ -116,7 +116,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
     public Map<TableId, TableChange> discoverDataCollectionSchemas(JdbcSourceConfig sourceConfig) {
         final List<TableId> capturedTableIds = discoverDataCollections(sourceConfig);
 
-        try (OracleConnection jdbc = createOracleConnection(sourceConfig.getDbzConfiguration())) {
+        try (OracleConnection jdbc = createOracleConnection((OracleConnectorConfig) sourceConfig.getDbzConnectorConfig())) {
             // fetch table schemas
             Map<TableId, TableChange> tableSchemas = new HashMap<>();
             for (TableId tableId : capturedTableIds) {
@@ -142,7 +142,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
     public OracleSourceFetchTaskContext createFetchTaskContext(
             SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
         final OracleConnection jdbcConnection =
-                createOracleConnection(taskSourceConfig.getDbzConfiguration());
+                createOracleConnection((OracleConnectorConfig) taskSourceConfig.getDbzConnectorConfig());
         return new OracleSourceFetchTaskContext(taskSourceConfig, this, jdbcConnection);
     }
 

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -172,7 +172,7 @@ public class OracleScanFetchTask implements FetchTask<SourceSplitBase> {
         // task to read binlog and backfill for current split
         return new RedoLogSplitReadTask(
                 new OracleConnectorConfig(dezConf),
-                createOracleConnection(context.getSourceConfig().getDbzConfiguration()),
+                createOracleConnection(context.getDbzConnectorConfig()),
                 context.getDispatcher(),
                 context.getErrorHandler(),
                 context.getDatabaseSchema(),

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -16,12 +16,11 @@
 
 package com.ververica.cdc.connectors.oracle.source.utils;
 
-import io.debezium.connector.oracle.OracleConnectorConfig;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import com.ververica.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
-import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.RelationalTableFilters;
@@ -34,8 +33,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static io.debezium.config.CommonConnectorConfig.DATABASE_CONFIG_PREFIX;
 
 /** Oracle connection Utilities. */
 public class OracleConnectionUtils {
@@ -50,8 +47,11 @@ public class OracleConnectionUtils {
 
     /** Creates a new {@link OracleConnection}, but not open the connection. */
     public static OracleConnection createOracleConnection(OracleConnectorConfig connectorConfig) {
-        OracleConnection conn = new OracleConnection(connectorConfig.getJdbcConfig(), OracleConnectionUtils.class::getClassLoader);
-        if(connectorConfig.getPdbName() != null){
+        OracleConnection conn =
+                new OracleConnection(
+                        connectorConfig.getJdbcConfig(),
+                        OracleConnectionUtils.class::getClassLoader);
+        if (connectorConfig.getPdbName() != null) {
             conn.setSessionToPdb(connectorConfig.getPdbName());
         }
         return conn;

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.oracle.source.utils;
 
+import io.debezium.connector.oracle.OracleConnectorConfig;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import com.ververica.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
@@ -48,11 +49,12 @@ public class OracleConnectionUtils {
     private static final String SHOW_CURRENT_SCN = "SELECT CURRENT_SCN FROM V$DATABASE";
 
     /** Creates a new {@link OracleConnection}, but not open the connection. */
-    public static OracleConnection createOracleConnection(Configuration dbzConfiguration) {
-        Configuration configuration = dbzConfiguration.subset(DATABASE_CONFIG_PREFIX, true);
-        return new OracleConnection(
-                configuration.isEmpty() ? dbzConfiguration : configuration,
-                OracleConnectionUtils.class::getClassLoader);
+    public static OracleConnection createOracleConnection(OracleConnectorConfig connectorConfig) {
+        OracleConnection conn = new OracleConnection(connectorConfig.getJdbcConfig(), OracleConnectionUtils.class::getClassLoader);
+        if(connectorConfig.getPdbName() != null){
+            conn.setSessionToPdb(connectorConfig.getPdbName());
+        }
+        return conn;
     }
 
     /** Fetch current redoLog offsets in Oracle Server. */

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleUtils.java
@@ -20,7 +20,6 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.logical.RowType;
 
 import com.ververica.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
-import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleUtils.java
@@ -265,7 +265,7 @@ public class OracleUtils {
         TopicSelector<TableId> topicSelector = OracleTopicSelector.defaultSelector(dbzOracleConfig);
         SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
         OracleConnection oracleConnection =
-                OracleConnectionUtils.createOracleConnection(dbzOracleConfig.getJdbcConfig());
+                OracleConnectionUtils.createOracleConnection(dbzOracleConfig);
         //        OracleConnectionUtils.createOracleConnection((Configuration) dbzOracleConfig);
         OracleValueConverters oracleValueConverters =
                 new OracleValueConverters(dbzOracleConfig, oracleConnection);
@@ -285,7 +285,7 @@ public class OracleUtils {
         TopicSelector<TableId> topicSelector = OracleTopicSelector.defaultSelector(dbzOracleConfig);
         SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
         OracleConnection oracleConnection =
-                OracleConnectionUtils.createOracleConnection((Configuration) dbzOracleConfig);
+                OracleConnectionUtils.createOracleConnection(dbzOracleConfig);
         OracleValueConverters oracleValueConverters =
                 new OracleValueConverters(dbzOracleConfig, oracleConnection);
         StreamingAdapter.TableNameCaseSensitivity tableNameCaseSensitivity =


### PR DESCRIPTION
it could not read the PDB tables when using OracleIncrementalSource at Oracle CDB mode,Therefore, check whether the pdb is empty when creating a connection. If it is not empty, switch to the pdb session