### PR TITLE
[cdc-base] Support `Scan Newly Added Tables` feature

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/BaseSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/BaseSourceConfig.java
@@ -35,6 +35,7 @@ public abstract class BaseSourceConfig implements SourceConfig {
     protected final boolean includeSchemaChanges;
     protected final boolean closeIdleReaders;
     protected final boolean skipSnapshotBackfill;
+    protected final boolean scanNewlyAddedTableEnabled;
 
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
@@ -52,7 +53,8 @@ public abstract class BaseSourceConfig implements SourceConfig {
             boolean closeIdleReaders,
             boolean skipSnapshotBackfill,
             Properties dbzProperties,
-            Configuration dbzConfiguration) {
+            Configuration dbzConfiguration,
+            boolean scanNewlyAddedTableEnabled) {
         this.startupOptions = startupOptions;
         this.splitSize = splitSize;
         this.splitMetaGroupSize = splitMetaGroupSize;
@@ -63,6 +65,7 @@ public abstract class BaseSourceConfig implements SourceConfig {
         this.skipSnapshotBackfill = skipSnapshotBackfill;
         this.dbzProperties = dbzProperties;
         this.dbzConfiguration = dbzConfiguration;
+        this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
     }
 
     @Override
@@ -96,6 +99,11 @@ public abstract class BaseSourceConfig implements SourceConfig {
     @Override
     public boolean isCloseIdleReaders() {
         return closeIdleReaders;
+    }
+
+    @Override
+    public boolean isScanNewlyAddedTableEnabled() {
+        return scanNewlyAddedTableEnabled;
     }
 
     public Properties getDbzProperties() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
@@ -69,7 +69,8 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
             int connectMaxRetries,
             int connectionPoolSize,
             String chunkKeyColumn,
-            boolean skipSnapshotBackfill) {
+            boolean skipSnapshotBackfill,
+            boolean scanNewlyAddedTableEnabled) {
         super(
                 startupOptions,
                 splitSize,
@@ -80,7 +81,8 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
                 closeIdleReaders,
                 skipSnapshotBackfill,
                 dbzProperties,
-                dbzConfiguration);
+                dbzConfiguration,
+                scanNewlyAddedTableEnabled);
         this.driverClassName = driverClassName;
         this.hostname = hostname;
         this.port = port;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
@@ -42,6 +42,7 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     protected StartupOptions startupOptions = StartupOptions.initial();
     protected boolean includeSchemaChanges = false;
     protected boolean closeIdleReaders = false;
+    protected boolean scanNewlyAddedTableEnabled = false;
     protected double distributionFactorUpper =
             SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.defaultValue();
     protected double distributionFactorLower =
@@ -179,6 +180,12 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     /** Whether the {@link SourceConfig} should output the schema changes or not. */
     public JdbcSourceConfigFactory includeSchemaChanges(boolean includeSchemaChanges) {
         this.includeSchemaChanges = includeSchemaChanges;
+        return this;
+    }
+
+    /** Whether the {@link SourceConfig} should scan the newly added tables or not. */
+    public JdbcSourceConfigFactory scanNewlyAddedTableEnabled(boolean scanNewlyAddedTableEnabled) {
+        this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
         return this;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/SourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/SourceConfig.java
@@ -37,6 +37,8 @@ public interface SourceConfig extends Serializable {
 
     boolean isSkipSnapshotBackfill();
 
+    boolean isScanNewlyAddedTableEnabled();
+
     /** Factory for the {@code SourceConfig}. */
     @FunctionalInterface
     interface Factory<C extends SourceConfig> extends Serializable {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/IncrementalSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/IncrementalSource.java
@@ -49,6 +49,7 @@ import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitSerializer
 import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
 import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReaderContext;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceRecordEmitter;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
 import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
@@ -116,19 +117,22 @@ public class IncrementalSource<T, C extends SourceConfig>
                 new SourceReaderMetrics(readerContext.metricGroup());
 
         sourceReaderMetrics.registerMetrics();
+        IncrementalSourceReaderContext sourceReaderContext =
+                new IncrementalSourceReaderContext(readerContext);
         Supplier<IncrementalSourceSplitReader<C>> splitReaderSupplier =
                 () ->
                         new IncrementalSourceSplitReader<>(
                                 readerContext.getIndexOfSubtask(),
                                 dataSourceDialect,
                                 sourceConfig,
-                                snapshotHooks);
+                                snapshotHooks,
+                                sourceReaderContext);
         return new IncrementalSourceReader<>(
                 elementsQueue,
                 splitReaderSupplier,
                 createRecordEmitter(sourceConfig, sourceReaderMetrics),
                 readerContext.getConfiguration(),
-                readerContext,
+                sourceReaderContext,
                 sourceConfig,
                 sourceSplitSerializer,
                 dataSourceDialect);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/AssignerStatus.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/AssignerStatus.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.assigner;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.String.format;
+
+/**
+ * The state of split assigner finite state machine, tips: we use word status instead of word state
+ * to avoid conflict with Flink state keyword. The assigner finite state machine goes this way.
+ *
+ * <pre>
+ *        INITIAL_ASSIGNING(start)
+ *              |
+ *              |
+ *          onFinish()
+ *              |
+ *              ↓
+ *    INITIAL_ASSIGNING_FINISHED(end)
+ *              |
+ *              |
+ *        suspend() // found newly added tables
+ *              |
+ *              ↓
+ *          SUSPENDED --- wakeup() --→ NEWLY_ADDED_ASSIGNING --- onFinish() --→ NEWLY_ADDED_ASSIGNING_FINISHED(end)
+ *              ↑                                                                  |
+ *              |                                                                  |
+ *              |----------------- suspend() //found newly added tables -----------|
+ * </pre>
+ */
+public enum AssignerStatus {
+    INITIAL_ASSIGNING(0) {
+        @Override
+        public AssignerStatus getNextStatus() {
+            return INITIAL_ASSIGNING_FINISHED;
+        }
+
+        @Override
+        public AssignerStatus onFinish() {
+            LOG.info(
+                    "Assigner status changes from INITIAL_ASSIGNING to INITIAL_ASSIGNING_FINISHED");
+            return this.getNextStatus();
+        }
+    },
+    INITIAL_ASSIGNING_FINISHED(1) {
+        @Override
+        public AssignerStatus getNextStatus() {
+            return SUSPENDED;
+        }
+
+        @Override
+        public AssignerStatus suspend() {
+            LOG.info("Assigner status changes from INITIAL_ASSIGNING_FINISHED to SUSPENDED");
+            return this.getNextStatus();
+        }
+    },
+    SUSPENDED(2) {
+        @Override
+        public AssignerStatus getNextStatus() {
+            return NEWLY_ADDED_ASSIGNING;
+        }
+
+        @Override
+        public AssignerStatus wakeup() {
+            LOG.info("Assigner status changes from SUSPENDED to NEWLY_ADDED_ASSIGNING");
+            return this.getNextStatus();
+        }
+    },
+    NEWLY_ADDED_ASSIGNING(3) {
+        @Override
+        public AssignerStatus getNextStatus() {
+            return NEWLY_ADDED_ASSIGNING_FINISHED;
+        }
+
+        @Override
+        public AssignerStatus onFinish() {
+            LOG.info(
+                    "Assigner status changes from NEWLY_ADDED_ASSIGNING to NEWLY_ADDED_ASSIGNING_FINISHED");
+            return this.getNextStatus();
+        }
+    },
+    NEWLY_ADDED_ASSIGNING_FINISHED(4) {
+        @Override
+        public AssignerStatus getNextStatus() {
+            return SUSPENDED;
+        }
+
+        @Override
+        public AssignerStatus suspend() {
+            LOG.info("Assigner status changes from NEWLY_ADDED_ASSIGNING_FINISHED to SUSPENDED");
+            return this.getNextStatus();
+        }
+    };
+
+    private static final Logger LOG = LoggerFactory.getLogger(AssignerStatus.class);
+    private final int statusCode;
+
+    AssignerStatus(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public abstract AssignerStatus getNextStatus();
+
+    public AssignerStatus onFinish() {
+        throw new IllegalStateException(
+                format(
+                        "Invalid call, assigner under %s state can not call onFinish()",
+                        fromStatusCode(this.getStatusCode())));
+    }
+
+    public AssignerStatus suspend() {
+        throw new IllegalStateException(
+                format(
+                        "Invalid call, assigner under %s state can not call suspend()",
+                        fromStatusCode(this.getStatusCode())));
+    }
+
+    public AssignerStatus wakeup() {
+        throw new IllegalStateException(
+                format(
+                        "Invalid call, assigner under %s state can not call wakeup()",
+                        fromStatusCode(this.getStatusCode())));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Utilities
+    // --------------------------------------------------------------------------------------------
+
+    /** Gets the {@link AssignerStatus} from status code. */
+    public static AssignerStatus fromStatusCode(int statusCode) {
+        switch (statusCode) {
+            case 0:
+                return INITIAL_ASSIGNING;
+            case 1:
+                return INITIAL_ASSIGNING_FINISHED;
+            case 2:
+                return SUSPENDED;
+            case 3:
+                return NEWLY_ADDED_ASSIGNING;
+            case 4:
+                return NEWLY_ADDED_ASSIGNING_FINISHED;
+            default:
+                throw new IllegalStateException(
+                        format(
+                                "Invalid status code %s,the valid code range is [0, 4]",
+                                statusCode));
+        }
+    }
+
+    /** Returns whether the split assigner state is suspended. */
+    public static boolean isSuspended(AssignerStatus assignerStatus) {
+        return assignerStatus == SUSPENDED;
+    }
+
+    /**
+     * Returns whether the split assigner has assigned all snapshot splits, which indicates there is
+     * no more splits and all records of splits have been completely processed in the pipeline.
+     */
+    public static boolean isAssigningFinished(AssignerStatus assignerStatus) {
+        return assignerStatus == INITIAL_ASSIGNING_FINISHED
+                || assignerStatus == NEWLY_ADDED_ASSIGNING_FINISHED;
+    }
+
+    /** Returns whether the split assigner is assigning snapshot splits. */
+    public static boolean isAssigning(AssignerStatus assignerStatus) {
+        return assignerStatus == INITIAL_ASSIGNING || assignerStatus == NEWLY_ADDED_ASSIGNING;
+    }
+
+    /** Returns whether the split assigner is assigning newly added snapshot splits. */
+    public static boolean isNewlyAddedAssigning(AssignerStatus assignerStatus) {
+        return assignerStatus == NEWLY_ADDED_ASSIGNING;
+    }
+
+    /** Returns whether the split assigner has finished its initial tables assignment. */
+    public static boolean isInitialAssigningFinished(AssignerStatus assignerStatus) {
+        return assignerStatus == INITIAL_ASSIGNING_FINISHED;
+    }
+
+    /** Returns whether the split assigner has finished its newly added tables assignment. */
+    public static boolean isNewlyAddedAssigningFinished(AssignerStatus assignerStatus) {
+        return assignerStatus == NEWLY_ADDED_ASSIGNING_FINISHED;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
@@ -39,6 +39,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isInitialAssigningFinished;
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isNewlyAddedAssigningFinished;
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isSuspended;
+
 /** Assigner for Hybrid split which contains snapshot splits and stream splits. */
 public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigner {
 
@@ -109,6 +113,10 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
 
     @Override
     public Optional<SourceSplitBase> getNext() {
+        if (isSuspended(getAssignerStatus())) {
+            // do not assign split until the assigner received SuspendBinlogReaderAckEvent
+            return Optional.empty();
+        }
         if (snapshotSplitAssigner.noMoreSplits()) {
             // stream split assigning
             if (isStreamSplitAssigned) {
@@ -116,7 +124,7 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
                 LOG.trace(
                         "No more splits for the SnapshotSplitAssigner. StreamSplit is already assigned.");
                 return Optional.empty();
-            } else if (snapshotSplitAssigner.isFinished()) {
+            } else if (isInitialAssigningFinished(snapshotSplitAssigner.getAssignerStatus())) {
                 // we need to wait snapshot-assigner to be finished before
                 // assigning the stream split. Otherwise, records emitted from stream split
                 // might be out-of-order in terms of same primary key with snapshot splits.
@@ -126,6 +134,10 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
                         "SnapshotSplitAssigner is finished: creating a new stream split {}",
                         streamSplit);
                 return Optional.of(streamSplit);
+            } else if (isNewlyAddedAssigningFinished(snapshotSplitAssigner.getAssignerStatus())) {
+                // do not need to create binlog, but send event to wake up the binlog reader
+                isStreamSplitAssigned = true;
+                return Optional.empty();
             } else {
                 // stream split is not ready by now
                 LOG.trace(
@@ -181,6 +193,21 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
     @Override
     public boolean isStreamSplitAssigned() {
         return isStreamSplitAssigned;
+    }
+
+    @Override
+    public AssignerStatus getAssignerStatus() {
+        return snapshotSplitAssigner.getAssignerStatus();
+    }
+
+    @Override
+    public void suspend() {
+        snapshotSplitAssigner.suspend();
+    }
+
+    @Override
+    public void wakeup() {
+        snapshotSplitAssigner.wakeup();
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.base.source.assigner;
 
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.Preconditions;
 
 import com.ververica.cdc.connectors.base.config.SourceConfig;
 import com.ververica.cdc.connectors.base.dialect.DataSourceDialect;
@@ -46,6 +47,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isAssigningFinished;
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isSuspended;
+
 /** Assigner for snapshot split. */
 public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssigner {
     private static final Logger LOG = LoggerFactory.getLogger(SnapshotSplitAssigner.class);
@@ -55,7 +59,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     private final Map<String, SchemalessSnapshotSplit> assignedSplits;
     private final Map<TableId, TableChanges.TableChange> tableSchemas;
     private final Map<String, Offset> splitFinishedOffsets;
-    private boolean assignerFinished;
+    private AssignerStatus assignerStatus;
 
     private final C sourceConfig;
     private final int currentParallelism;
@@ -84,7 +88,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                 new HashMap<>(),
                 new HashMap<>(),
                 new HashMap<>(),
-                false,
+                AssignerStatus.INITIAL_ASSIGNING,
                 remainingTables,
                 isTableIdCaseSensitive,
                 true,
@@ -106,7 +110,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                 checkpoint.getAssignedSplits(),
                 checkpoint.getTableSchemas(),
                 checkpoint.getSplitFinishedOffsets(),
-                checkpoint.isAssignerFinished(),
+                checkpoint.getSnapshotAssignerStatus(),
                 checkpoint.getRemainingTables(),
                 checkpoint.isTableIdCaseSensitive(),
                 checkpoint.isRemainingTablesCheckpointed(),
@@ -122,7 +126,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
             Map<String, SchemalessSnapshotSplit> assignedSplits,
             Map<TableId, TableChanges.TableChange> tableSchemas,
             Map<String, Offset> splitFinishedOffsets,
-            boolean assignerFinished,
+            AssignerStatus assignerStatus,
             List<TableId> remainingTables,
             boolean isTableIdCaseSensitive,
             boolean isRemainingTablesCheckpointed,
@@ -135,7 +139,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
         this.assignedSplits = assignedSplits;
         this.tableSchemas = tableSchemas;
         this.splitFinishedOffsets = splitFinishedOffsets;
-        this.assignerFinished = assignerFinished;
+        this.assignerStatus = assignerStatus;
         this.remainingTables = new LinkedList<>(remainingTables);
         this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
         this.isTableIdCaseSensitive = isTableIdCaseSensitive;
@@ -148,7 +152,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
         chunkSplitter = dialect.createChunkSplitter(sourceConfig);
 
         // the legacy state didn't snapshot remaining tables, discovery remaining table here
-        if (!isRemainingTablesCheckpointed && !assignerFinished) {
+        if (!isRemainingTablesCheckpointed && !isAssigningFinished(assignerStatus)) {
             try {
                 final List<TableId> discoverTables = dialect.discoverDataCollections(sourceConfig);
                 discoverTables.removeAll(alreadyProcessedTables);
@@ -159,6 +163,8 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                         "Failed to discover remaining tables to capture", e);
             }
         }
+
+        captureNewlyAddedTables();
     }
 
     @Override
@@ -229,14 +235,13 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     @Override
     public void onFinishedSplits(Map<String, Offset> splitFinishedOffsets) {
         this.splitFinishedOffsets.putAll(splitFinishedOffsets);
-        if (allSplitsFinished()) {
+        if (allSplitsFinished() && AssignerStatus.isAssigning(assignerStatus)) {
             // Skip the waiting checkpoint when current parallelism is 1 which means we do not need
             // to care about the global output data order of snapshot splits and stream split.
             if (currentParallelism == 1) {
-                assignerFinished = true;
+                assignerStatus = assignerStatus.onFinish();
                 LOG.info(
                         "Snapshot split assigner received all splits finished and the job parallelism is 1, snapshot split assigner is turn into finished status.");
-
             } else {
                 LOG.info(
                         "Snapshot split assigner received all splits finished, waiting for a complete checkpoint to mark the assigner finished.");
@@ -265,13 +270,15 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                         assignedSplits,
                         tableSchemas,
                         splitFinishedOffsets,
-                        assignerFinished,
+                        assignerStatus,
                         remainingTables,
                         isTableIdCaseSensitive,
                         true);
         // we need a complete checkpoint before mark this assigner to be finished, to wait for all
         // records of snapshot splits are completely processed
-        if (checkpointIdToFinish == null && !assignerFinished && allSplitsFinished()) {
+        if (checkpointIdToFinish == null
+                && !isAssigningFinished(assignerStatus)
+                && allSplitsFinished()) {
             checkpointIdToFinish = checkpointId;
         }
         return state;
@@ -281,10 +288,59 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     public void notifyCheckpointComplete(long checkpointId) {
         // we have waited for at-least one complete checkpoint after all snapshot-splits are
         // finished, then we can mark snapshot assigner as finished.
-        if (checkpointIdToFinish != null && !assignerFinished && allSplitsFinished()) {
-            assignerFinished = checkpointId >= checkpointIdToFinish;
+        if (checkpointIdToFinish != null
+                && !isAssigningFinished(assignerStatus)
+                && allSplitsFinished()) {
+            if (checkpointId >= checkpointIdToFinish) {
+                assignerStatus = assignerStatus.onFinish();
+            }
             LOG.info("Snapshot split assigner is turn into finished status.");
         }
+    }
+
+    private void captureNewlyAddedTables() {
+        if (sourceConfig.isScanNewlyAddedTableEnabled()) {
+            // check whether we got newly added tables
+            try {
+                final List<TableId> newlyAddedTables =
+                        dialect.discoverDataCollections(sourceConfig);
+                newlyAddedTables.removeAll(alreadyProcessedTables);
+                newlyAddedTables.removeAll(remainingTables);
+                if (!newlyAddedTables.isEmpty()) {
+                    // if job is still in snapshot reading phase, directly add all newly added
+                    // tables
+                    LOG.info("Found newly added tables, start capture newly added tables process");
+                    remainingTables.addAll(newlyAddedTables);
+                    if (isAssigningFinished(assignerStatus)) {
+                        // start the newly added tables process under stream reading phase
+                        LOG.info(
+                                "Found newly added tables, start capture newly added tables process under stream reading phase");
+                        this.suspend();
+                    }
+                }
+            } catch (Exception e) {
+                throw new FlinkRuntimeException("Failed to capture newly added tables", e);
+            }
+        }
+    }
+
+    @Override
+    public AssignerStatus getAssignerStatus() {
+        return assignerStatus;
+    }
+
+    @Override
+    public void suspend() {
+        Preconditions.checkState(
+                isAssigningFinished(assignerStatus), "Invalid assigner status {}", assignerStatus);
+        assignerStatus = assignerStatus.suspend();
+    }
+
+    @Override
+    public void wakeup() {
+        Preconditions.checkState(
+                isSuspended(assignerStatus), "Invalid assigner status {}", assignerStatus);
+        assignerStatus = assignerStatus.wakeup();
     }
 
     @Override
@@ -293,14 +349,6 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     /** Indicates there is no more splits available in this assigner. */
     public boolean noMoreSplits() {
         return remainingTables.isEmpty() && remainingSplits.isEmpty();
-    }
-
-    /**
-     * Returns whether the snapshot split assigner is finished, which indicates there is no more
-     * splits and all records of splits have been completely processed in the pipeline.
-     */
-    public boolean isFinished() {
-        return assignerFinished;
     }
 
     public Map<String, SchemalessSnapshotSplit> getAssignedSplits() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/SplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/SplitAssigner.java
@@ -106,6 +106,18 @@ public interface SplitAssigner {
      */
     void notifyCheckpointComplete(long checkpointId);
 
+    /** Gets the split assigner status, see {@code AssignerStatus}. */
+    AssignerStatus getAssignerStatus();
+
+    /**
+     * Suspends the assigner under {@link AssignerStatus#INITIAL_ASSIGNING_FINISHED} or {@link
+     * AssignerStatus#NEWLY_ADDED_ASSIGNING_FINISHED}.
+     */
+    void suspend();
+
+    /** Wakes up the assigner under {@link AssignerStatus#SUSPENDED}. */
+    void wakeup();
+
     /**
      * Called to close the assigner, in case it holds on to any resources, like threads or network
      * connections.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/StreamSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/StreamSplitAssigner.java
@@ -124,6 +124,17 @@ public class StreamSplitAssigner implements SplitAssigner {
     }
 
     @Override
+    public AssignerStatus getAssignerStatus() {
+        return AssignerStatus.INITIAL_ASSIGNING_FINISHED;
+    }
+
+    @Override
+    public void suspend() {}
+
+    @Override
+    public void wakeup() {}
+
+    @Override
     public void close() {}
 
     // ------------------------------------------------------------------------------------------

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/state/SnapshotPendingSplitsState.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/assigner/state/SnapshotPendingSplitsState.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.base.source.assigner.state;
 
+import com.ververica.cdc.connectors.base.source.assigner.AssignerStatus;
 import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
 import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
 import com.ververica.cdc.connectors.base.source.meta.split.SchemalessSnapshotSplit;
@@ -54,11 +55,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
      */
     private final Map<String, Offset> splitFinishedOffsets;
 
-    /**
-     * Whether the snapshot split assigner is finished, which indicates there is no more splits and
-     * all records of splits have been completely processed in the pipeline.
-     */
-    private final boolean isAssignerFinished;
+    /** The {@link AssignerStatus} that indicates the snapshot assigner status. */
+    private final AssignerStatus assignerStatus;
 
     /** Whether the table identifier is case sensitive. */
     private final boolean isTableIdCaseSensitive;
@@ -74,7 +72,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
             Map<String, SchemalessSnapshotSplit> assignedSplits,
             Map<TableId, TableChanges.TableChange> tableSchemas,
             Map<String, Offset> splitFinishedOffsets,
-            boolean isAssignerFinished,
+            AssignerStatus assignerStatus,
             List<TableId> remainingTables,
             boolean isTableIdCaseSensitive,
             boolean isRemainingTablesCheckpointed) {
@@ -82,7 +80,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         this.remainingSplits = remainingSplits;
         this.assignedSplits = assignedSplits;
         this.splitFinishedOffsets = splitFinishedOffsets;
-        this.isAssignerFinished = isAssignerFinished;
+        this.assignerStatus = assignerStatus;
         this.remainingTables = remainingTables;
         this.isTableIdCaseSensitive = isTableIdCaseSensitive;
         this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
@@ -109,8 +107,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         return splitFinishedOffsets;
     }
 
-    public boolean isAssignerFinished() {
-        return isAssignerFinished;
+    public AssignerStatus getSnapshotAssignerStatus() {
+        return assignerStatus;
     }
 
     public List<TableId> getRemainingTables() {
@@ -134,7 +132,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
             return false;
         }
         SnapshotPendingSplitsState that = (SnapshotPendingSplitsState) o;
-        return isAssignerFinished == that.isAssignerFinished
+        return assignerStatus == that.assignerStatus
                 && isTableIdCaseSensitive == that.isTableIdCaseSensitive
                 && isRemainingTablesCheckpointed == that.isRemainingTablesCheckpointed
                 && Objects.equals(remainingTables, that.remainingTables)
@@ -152,7 +150,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 remainingSplits,
                 assignedSplits,
                 splitFinishedOffsets,
-                isAssignerFinished,
+                assignerStatus,
                 isTableIdCaseSensitive,
                 isRemainingTablesCheckpointed);
     }
@@ -170,8 +168,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 + assignedSplits
                 + ", splitFinishedOffsets="
                 + splitFinishedOffsets
-                + ", isAssignerFinished="
-                + isAssignerFinished
+                + ", assignerStatus="
+                + assignerStatus
                 + ", isTableIdCaseSensitive="
                 + isTableIdCaseSensitive
                 + ", isRemainingTablesCheckpointed="

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/enumerator/IncrementalSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/enumerator/IncrementalSourceEnumerator.java
@@ -25,13 +25,19 @@ import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
 import com.ververica.cdc.common.annotation.Experimental;
 import com.ververica.cdc.connectors.base.config.SourceConfig;
+import com.ververica.cdc.connectors.base.source.assigner.HybridSplitAssigner;
 import com.ververica.cdc.connectors.base.source.assigner.SplitAssigner;
 import com.ververica.cdc.connectors.base.source.assigner.state.PendingSplitsState;
 import com.ververica.cdc.connectors.base.source.meta.events.FinishedSnapshotSplitsAckEvent;
 import com.ververica.cdc.connectors.base.source.meta.events.FinishedSnapshotSplitsReportEvent;
 import com.ververica.cdc.connectors.base.source.meta.events.FinishedSnapshotSplitsRequestEvent;
+import com.ververica.cdc.connectors.base.source.meta.events.LatestFinishedSplitsSizeEvent;
+import com.ververica.cdc.connectors.base.source.meta.events.LatestFinishedSplitsSizeRequestEvent;
 import com.ververica.cdc.connectors.base.source.meta.events.StreamSplitMetaEvent;
 import com.ververica.cdc.connectors.base.source.meta.events.StreamSplitMetaRequestEvent;
+import com.ververica.cdc.connectors.base.source.meta.events.SuspendStreamReaderAckEvent;
+import com.ververica.cdc.connectors.base.source.meta.events.SuspendStreamReaderEvent;
+import com.ververica.cdc.connectors.base.source.meta.events.WakeupReaderEvent;
 import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
 import com.ververica.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
@@ -47,6 +53,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isAssigning;
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isAssigningFinished;
+import static com.ververica.cdc.connectors.base.source.assigner.AssignerStatus.isSuspended;
 
 /**
  * Incremental source enumerator that enumerates receive the split request and assign the split to
@@ -65,6 +75,7 @@ public class IncrementalSourceEnumerator
     // using TreeSet to prefer assigning stream split to task-0 for easier debug
     private final TreeSet<Integer> readersAwaitingSplit;
     private List<List<FinishedSnapshotSplitInfo>> finishedSnapshotSplitMeta;
+    private boolean streamReaderIsSuspended = false;
 
     public IncrementalSourceEnumerator(
             SplitEnumeratorContext<SourceSplitBase> context,
@@ -74,11 +85,21 @@ public class IncrementalSourceEnumerator
         this.sourceConfig = sourceConfig;
         this.splitAssigner = splitAssigner;
         this.readersAwaitingSplit = new TreeSet<>();
+
+        // when restored from state, if the split assigner is assigning snapshot
+        // splits or has already assigned all splits, send wakeup event to
+        // SourceReader, SourceReader can omit the event based on its own status.
+        if (isAssigning(splitAssigner.getAssignerStatus())
+                || isAssigningFinished(splitAssigner.getAssignerStatus())) {
+            streamReaderIsSuspended = true;
+        }
     }
 
     @Override
     public void start() {
         splitAssigner.open();
+        suspendStreamReaderIfNeed();
+        wakeupStreamReaderIfNeed();
         this.context.callAsync(
                 this::getRegisteredReader,
                 this::syncWithReaders,
@@ -105,7 +126,11 @@ public class IncrementalSourceEnumerator
 
     @Override
     public void addReader(int subtaskId) {
-        // do nothing
+        // send SuspendStreamReaderEvent to source reader if the assigner's status is
+        // suspended
+        if (isSuspended(splitAssigner.getAssignerStatus())) {
+            context.sendEventToSourceReader(subtaskId, new SuspendStreamReaderEvent());
+        }
     }
 
     @Override
@@ -119,6 +144,9 @@ public class IncrementalSourceEnumerator
                     (FinishedSnapshotSplitsReportEvent) sourceEvent;
             Map<String, Offset> finishedOffsets = reportEvent.getFinishedOffsets();
             splitAssigner.onFinishedSplits(finishedOffsets);
+
+            wakeupStreamReaderIfNeed();
+
             // send acknowledge event
             FinishedSnapshotSplitsAckEvent ackEvent =
                     new FinishedSnapshotSplitsAckEvent(new ArrayList<>(finishedOffsets.keySet()));
@@ -128,6 +156,13 @@ public class IncrementalSourceEnumerator
                     "The enumerator receives request for stream split meta from subtask {}.",
                     subtaskId);
             sendStreamMetaRequestEvent(subtaskId, (StreamSplitMetaRequestEvent) sourceEvent);
+        } else if (sourceEvent instanceof SuspendStreamReaderAckEvent) {
+            LOG.info(
+                    "The enumerator receives event that the stream split reader has been suspended from subtask {}. ",
+                    subtaskId);
+            handleSuspendStreamReaderAckEvent(subtaskId);
+        } else if (sourceEvent instanceof LatestFinishedSplitsSizeRequestEvent) {
+            handleLatestFinishedSplitSizeRequest(subtaskId);
         }
     }
 
@@ -179,6 +214,7 @@ public class IncrementalSourceEnumerator
                 LOG.info("Assign split {} to subtask {}", sourceSplit, nextAwaiting);
             } else {
                 // there is no available splits by now, skip assigning
+                wakeupStreamReaderIfNeed();
                 break;
             }
         }
@@ -204,6 +240,29 @@ public class IncrementalSourceEnumerator
                 context.sendEventToSourceReader(
                         subtaskId, new FinishedSnapshotSplitsRequestEvent());
             }
+        }
+
+        suspendStreamReaderIfNeed();
+        wakeupStreamReaderIfNeed();
+    }
+
+    private void suspendStreamReaderIfNeed() {
+        if (isSuspended(splitAssigner.getAssignerStatus())) {
+            for (int subtaskId : getRegisteredReader()) {
+                context.sendEventToSourceReader(subtaskId, new SuspendStreamReaderEvent());
+            }
+            streamReaderIsSuspended = true;
+        }
+    }
+
+    private void wakeupStreamReaderIfNeed() {
+        if (isAssigningFinished(splitAssigner.getAssignerStatus()) && streamReaderIsSuspended) {
+            for (int subtaskId : getRegisteredReader()) {
+                context.sendEventToSourceReader(
+                        subtaskId,
+                        new WakeupReaderEvent(WakeupReaderEvent.WakeUpTarget.STREAM_READER));
+            }
+            streamReaderIsSuspended = false;
         }
     }
 
@@ -240,6 +299,29 @@ public class IncrementalSourceEnumerator
                     "Received invalid request meta group id {}, the invalid meta group id range is [0, {}]",
                     requestMetaGroupId,
                     finishedSnapshotSplitMeta.size() - 1);
+        }
+    }
+
+    private void handleSuspendStreamReaderAckEvent(int subTask) {
+        LOG.info(
+                "Received event that the stream split reader has been suspended from subtask {}. ",
+                subTask);
+        splitAssigner.wakeup();
+        if (splitAssigner instanceof HybridSplitAssigner) {
+            for (int subtaskId : this.getRegisteredReader()) {
+                context.sendEventToSourceReader(
+                        subtaskId,
+                        new WakeupReaderEvent(WakeupReaderEvent.WakeUpTarget.SNAPSHOT_READER));
+            }
+        }
+    }
+
+    private void handleLatestFinishedSplitSizeRequest(int subTask) {
+        if (splitAssigner instanceof HybridSplitAssigner) {
+            context.sendEventToSourceReader(
+                    subTask,
+                    new LatestFinishedSplitsSizeEvent(
+                            splitAssigner.getFinishedSplitInfos().size()));
         }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/LatestFinishedSplitsSizeEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/LatestFinishedSplitsSizeEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.meta.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+
+/**
+ * The {@link SourceEvent} that {@link IncrementalSourceEnumerator} sends to {@link
+ * IncrementalSourceReader} to pass the latest finished snapshot splits size.
+ */
+public class LatestFinishedSplitsSizeEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+    private final int latestFinishedSplitsSize;
+
+    public LatestFinishedSplitsSizeEvent(int latestFinishedSplitsSize) {
+        this.latestFinishedSplitsSize = latestFinishedSplitsSize;
+    }
+
+    public int getLatestFinishedSplitsSize() {
+        return latestFinishedSplitsSize;
+    }
+
+    @Override
+    public String toString() {
+        return "LatestFinishedSplitsSizeEvent{"
+                + "latestFinishedSplitsSize="
+                + latestFinishedSplitsSize
+                + '}';
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/LatestFinishedSplitsSizeRequestEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/LatestFinishedSplitsSizeRequestEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.meta.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+
+/**
+ * The {@link SourceEvent} that {@link IncrementalSourceReader} sends to {@link
+ * IncrementalSourceEnumerator} to ask the latest finished snapshot splits size.
+ */
+public class LatestFinishedSplitsSizeRequestEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    public LatestFinishedSplitsSizeRequestEvent() {}
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/SuspendStreamReaderAckEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/SuspendStreamReaderAckEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.meta.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+
+/**
+ * The {@link SourceEvent} that {@link IncrementalSourceReader} sends to {@link
+ * IncrementalSourceEnumerator} to notify the binlog split reader has been suspended.
+ */
+public class SuspendStreamReaderAckEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    public SuspendStreamReaderAckEvent() {}
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/SuspendStreamReaderEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/SuspendStreamReaderEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.meta.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+
+/**
+ * The {@link SourceEvent} that {@link IncrementalSourceEnumerator} broadcasts to {@link
+ * IncrementalSourceReader} to tell the source reader to suspend the binlog reader.
+ */
+public class SuspendStreamReaderEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    public SuspendStreamReaderEvent() {}
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/WakeupReaderEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/events/WakeupReaderEvent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.meta.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+
+/**
+ * The {@link SourceEvent} that {@link IncrementalSourceEnumerator} sends to {@link
+ * IncrementalSourceReader} to wake up source reader to consume split again.
+ */
+public class WakeupReaderEvent implements SourceEvent {
+    private static final long serialVersionUID = 1L;
+
+    /** Wake up target. */
+    public enum WakeUpTarget {
+        SNAPSHOT_READER,
+        STREAM_READER
+    }
+
+    private WakeUpTarget target;
+
+    public WakeupReaderEvent(WakeUpTarget target) {
+        this.target = target;
+    }
+
+    public WakeUpTarget getTarget() {
+        return target;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/split/StreamSplit.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/meta/split/StreamSplit.java
@@ -22,6 +22,8 @@ import io.debezium.relational.history.TableChanges.TableChange;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -35,6 +37,24 @@ public class StreamSplit extends SourceSplitBase {
     private final Map<TableId, TableChange> tableSchemas;
     private final int totalFinishedSplitSize;
     @Nullable transient byte[] serializedFormCache;
+    private final boolean isSuspended;
+
+    public StreamSplit(
+            String splitId,
+            Offset startingOffset,
+            Offset endingOffset,
+            List<FinishedSnapshotSplitInfo> finishedSnapshotSplitInfos,
+            Map<TableId, TableChange> tableSchemas,
+            int totalFinishedSplitSize,
+            boolean isSuspended) {
+        super(splitId);
+        this.startingOffset = startingOffset;
+        this.endingOffset = endingOffset;
+        this.finishedSnapshotSplitInfos = finishedSnapshotSplitInfos;
+        this.tableSchemas = tableSchemas;
+        this.totalFinishedSplitSize = totalFinishedSplitSize;
+        this.isSuspended = isSuspended;
+    }
 
     public StreamSplit(
             String splitId,
@@ -49,6 +69,7 @@ public class StreamSplit extends SourceSplitBase {
         this.finishedSnapshotSplitInfos = finishedSnapshotSplitInfos;
         this.tableSchemas = tableSchemas;
         this.totalFinishedSplitSize = totalFinishedSplitSize;
+        this.isSuspended = false;
     }
 
     public Offset getStartingOffset() {
@@ -72,6 +93,10 @@ public class StreamSplit extends SourceSplitBase {
         return totalFinishedSplitSize;
     }
 
+    public boolean isSuspended() {
+        return isSuspended;
+    }
+
     public boolean isCompletedSplit() {
         return totalFinishedSplitSize == finishedSnapshotSplitInfos.size();
     }
@@ -89,6 +114,7 @@ public class StreamSplit extends SourceSplitBase {
         }
         StreamSplit that = (StreamSplit) o;
         return totalFinishedSplitSize == that.totalFinishedSplitSize
+                && Objects.equals(isSuspended, that.isSuspended)
                 && Objects.equals(startingOffset, that.startingOffset)
                 && Objects.equals(endingOffset, that.endingOffset)
                 && Objects.equals(finishedSnapshotSplitInfos, that.finishedSnapshotSplitInfos)
@@ -103,7 +129,8 @@ public class StreamSplit extends SourceSplitBase {
                 endingOffset,
                 finishedSnapshotSplitInfos,
                 tableSchemas,
-                totalFinishedSplitSize);
+                totalFinishedSplitSize,
+                isSuspended);
     }
 
     @Override
@@ -116,6 +143,8 @@ public class StreamSplit extends SourceSplitBase {
                 + startingOffset
                 + ", endOffset="
                 + endingOffset
+                + ", isSuspended="
+                + isSuspended
                 + '}';
     }
 
@@ -131,7 +160,8 @@ public class StreamSplit extends SourceSplitBase {
                 streamSplit.getEndingOffset(),
                 splitInfos,
                 streamSplit.getTableSchemas(),
-                streamSplit.getTotalFinishedSplitSize());
+                streamSplit.getTotalFinishedSplitSize(),
+                streamSplit.isSuspended());
     }
 
     public static StreamSplit fillTableSchemas(
@@ -143,6 +173,30 @@ public class StreamSplit extends SourceSplitBase {
                 streamSplit.getEndingOffset(),
                 streamSplit.getFinishedSnapshotSplitInfos(),
                 tableSchemas,
-                streamSplit.getTotalFinishedSplitSize());
+                streamSplit.getTotalFinishedSplitSize(),
+                streamSplit.isSuspended());
+    }
+
+    public static StreamSplit toNormalStreamSplit(
+            StreamSplit suspendedStreamSplit, int totalFinishedSplitSize) {
+        return new StreamSplit(
+                suspendedStreamSplit.splitId,
+                suspendedStreamSplit.getStartingOffset(),
+                suspendedStreamSplit.getEndingOffset(),
+                suspendedStreamSplit.getFinishedSnapshotSplitInfos(),
+                suspendedStreamSplit.getTableSchemas(),
+                totalFinishedSplitSize,
+                false);
+    }
+
+    public static StreamSplit toSuspendedStreamSplit(StreamSplit normalStreamSplit) {
+        return new StreamSplit(
+                normalStreamSplit.splitId,
+                normalStreamSplit.getStartingOffset(),
+                normalStreamSplit.getEndingOffset(),
+                new ArrayList<>(),
+                new HashMap<>(),
+                normalStreamSplit.getTotalFinishedSplitSize(),
+                true);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceReaderContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceReaderContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.source.reader;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+
+/**
+ * A wrapper class that wraps {@link SourceReaderContext} for sharing message between {@link
+ * IncrementalSourceReader} and {@link IncrementalSourceSplitReader}.
+ */
+public class IncrementalSourceReaderContext {
+
+    private final SourceReaderContext sourceReaderContext;
+    private volatile boolean stopStreamSplitReader;
+
+    public IncrementalSourceReaderContext(final SourceReaderContext sourceReaderContext) {
+        this.sourceReaderContext = sourceReaderContext;
+        this.stopStreamSplitReader = false;
+    }
+
+    public SourceReaderContext getSourceReaderContext() {
+        return sourceReaderContext;
+    }
+
+    public boolean needStopStreamSplitReader() {
+        return stopStreamSplitReader;
+    }
+
+    public void setStopStreamSplitReader() {
+        this.stopStreamSplitReader = true;
+    }
+
+    public void resetStopStreamSplitReader() {
+        this.stopStreamSplitReader = false;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
@@ -53,7 +53,7 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
     private static final Logger LOG = LoggerFactory.getLogger(IncrementalSourceSplitReader.class);
     private final Queue<SourceSplitBase> splits;
     private final int subtaskId;
-
+    private final IncrementalSourceReaderContext context;
     @Nullable private Fetcher<SourceRecords, SourceSplitBase> currentFetcher;
     @Nullable private String currentSplitId;
     private final DataSourceDialect<C> dataSourceDialect;
@@ -65,18 +65,22 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
             int subtaskId,
             DataSourceDialect<C> dataSourceDialect,
             C sourceConfig,
-            SnapshotPhaseHooks snapshotHooks) {
+            SnapshotPhaseHooks snapshotHooks,
+            IncrementalSourceReaderContext context) {
         this.subtaskId = subtaskId;
         this.splits = new ArrayDeque<>();
         this.dataSourceDialect = dataSourceDialect;
         this.sourceConfig = sourceConfig;
         this.snapshotHooks = snapshotHooks;
+        this.context = context;
     }
 
     @Override
     public RecordsWithSplitIds<SourceRecords> fetch() throws IOException {
         checkSplitOrStartNext();
-        Iterator<SourceRecords> dataIt = null;
+        checkNeedStopSplitReader();
+
+        Iterator<SourceRecords> dataIt;
         try {
             dataIt = currentFetcher.pollSplitRecords();
         } catch (InterruptedException e) {
@@ -86,6 +90,18 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
         return dataIt == null
                 ? finishedSnapshotSplit()
                 : ChangeEventRecords.forRecords(currentSplitId, dataIt);
+    }
+
+    private void checkNeedStopSplitReader() {
+        if (currentFetcher instanceof IncrementalSourceStreamFetcher
+                && context.needStopStreamSplitReader()
+                && !currentFetcher.isFinished()) {
+            try {
+                ((IncrementalSourceStreamFetcher) currentFetcher).stopReadTask();
+            } catch (Exception e) {
+                LOG.error("Couldn't stop fetcher: ", e);
+            }
+        }
     }
 
     @Override
@@ -114,20 +130,21 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
     }
 
     protected void checkSplitOrStartNext() throws IOException {
-        // the stream fetcher should keep alive
-        if (currentFetcher instanceof IncrementalSourceStreamFetcher) {
-            return;
-        }
-
         if (canAssignNextSplit()) {
             final SourceSplitBase nextSplit = splits.poll();
 
             if (nextSplit == null) {
-                throw new IOException("Cannot fetch from another split - no split remaining.");
+                return;
             }
             currentSplitId = nextSplit.splitId();
             FetchTask fetchTask = dataSourceDialect.createFetchTask(nextSplit);
             if (nextSplit.isSnapshotSplit()) {
+                if (currentFetcher instanceof IncrementalSourceStreamFetcher) {
+                    LOG.info(
+                            "This is the point from stream split reading change to snapshot split reading");
+                    currentFetcher.close();
+                    currentFetcher = null;
+                }
                 if (currentFetcher == null) {
                     final FetchTask.Context taskContext =
                             dataSourceDialect.createFetchTaskContext(nextSplit, sourceConfig);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/JdbcConnectionPoolTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/JdbcConnectionPoolTest.java
@@ -121,7 +121,8 @@ public class JdbcConnectionPoolTest {
                 "UTC",
                 Duration.ofSeconds(10),
                 2,
-                3);
+                3,
+                false);
     }
 
     private static class MockConnectionPoolFactory extends JdbcConnectionPoolFactory {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/MySqlSourceBuilder.java
@@ -192,6 +192,12 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
+    /** Whether the {@link MySqlIncrementalSource} should scan the newly added tables or not. */
+    public MySqlSourceBuilder<T> scanNewlyAddedTableEnabled(boolean scanNewlyAddedTableEnabled) {
+        this.configFactory.scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled);
+        return this;
+    }
+
     /** Specifies the startup options. */
     public MySqlSourceBuilder<T> startupOptions(StartupOptions startupOptions) {
         this.configFactory.startupOptions(startupOptions);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
@@ -57,7 +57,8 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
             String serverTimeZone,
             Duration connectTimeout,
             int connectMaxRetries,
-            int connectionPoolSize) {
+            int connectionPoolSize,
+            boolean scanNewlyAddedTableEnabled) {
         super(
                 startupOptions,
                 databaseList,
@@ -82,7 +83,8 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 null,
-                true);
+                true,
+                scanNewlyAddedTableEnabled);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfigFactory.java
@@ -127,6 +127,7 @@ public class MySqlSourceConfigFactory extends JdbcSourceConfigFactory {
                 serverTimeZone,
                 connectTimeout,
                 connectMaxRetries,
-                connectionPoolSize);
+                connectionPoolSize,
+                scanNewlyAddedTableEnabled);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/com/ververica/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -193,6 +193,11 @@ public class MongoDBSourceConfig implements SourceConfig {
     }
 
     @Override
+    public boolean isScanNewlyAddedTableEnabled() {
+        return false;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBSnapshotSplitReaderTest.java
@@ -21,6 +21,7 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
 import com.ververica.cdc.connectors.base.source.meta.split.ChangeEventRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReaderContext;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
 import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.mongodb.source.MongoDBSourceTestBase;
@@ -114,9 +115,11 @@ public class MongoDBSnapshotSplitReaderTest extends MongoDBSourceTestBase {
         LinkedList<SnapshotSplit> snapshotSplits = new LinkedList<>(splitter.split(splitContext));
         assertTrue(snapshotSplits.size() > 0);
 
+        IncrementalSourceReaderContext sourceReaderContext =
+                new IncrementalSourceReaderContext(null);
         IncrementalSourceSplitReader<MongoDBSourceConfig> snapshotSplitReader =
                 new IncrementalSourceSplitReader<>(
-                        0, dialect, sourceConfig, SnapshotPhaseHooks.empty());
+                        0, dialect, sourceConfig, SnapshotPhaseHooks.empty(), sourceReaderContext);
 
         int retry = 0;
         long actualCount = 0;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBStreamSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/com/ververica/cdc/connectors/mongodb/source/reader/MongoDBStreamSplitReaderTest.java
@@ -23,6 +23,7 @@ import com.mongodb.client.model.changestream.OperationType;
 import com.ververica.cdc.connectors.base.source.meta.split.ChangeEventRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
 import com.ververica.cdc.connectors.base.source.meta.split.StreamSplit;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReaderContext;
 import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
 import com.ververica.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
 import com.ververica.cdc.connectors.mongodb.source.MongoDBSourceTestBase;
@@ -118,9 +119,11 @@ public class MongoDBStreamSplitReaderTest extends MongoDBSourceTestBase {
 
     @Test
     public void testStreamSplitReader() throws Exception {
+        IncrementalSourceReaderContext sourceReaderContext =
+                new IncrementalSourceReaderContext(null);
         IncrementalSourceSplitReader<MongoDBSourceConfig> streamSplitReader =
                 new IncrementalSourceSplitReader<>(
-                        0, dialect, sourceConfig, SnapshotPhaseHooks.empty());
+                        0, dialect, sourceConfig, SnapshotPhaseHooks.empty(), sourceReaderContext);
 
         try {
             ChangeStreamOffset startOffset = new ChangeStreamOffset(startupResumeToken);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
@@ -87,7 +87,8 @@ public class OracleSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 chunkKeyColumn,
-                skipSnapshotBackfill);
+                skipSnapshotBackfill,
+                false);
         this.url = url;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -87,7 +87,8 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 chunkKeyColumn,
-                skipSnapshotBackfill);
+                skipSnapshotBackfill,
+                false);
         this.subtaskId = subtaskId;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
@@ -79,7 +79,8 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
                 connectMaxRetries,
                 connectionPoolSize,
                 chunkKeyColumn,
-                skipSnapshotBackfill);
+                skipSnapshotBackfill,
+                false);
     }
 
     @Override


### PR DESCRIPTION
Resolves https://github.com/ververica/flink-cdc-connectors/issues/1152

Adding support for the `Scan Newly Added Tables` feature by bringing changes from the existing MySQL connector.

I'll have a follow-up PR to add support for Postgres once https://github.com/ververica/flink-cdc-connectors/pull/1823 and this PR are merged. I've tested this extensively for the Postgres connector. 

NOTE: this PR only adds common functionality. Adding support per connector will require separate PRs.

