### PR TITLE
[FLINK-35313][mysql-cdc] Add upsert changelog mode to avoid UPDATE_BEFORE records …

### DIFF
--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
@@ -354,6 +354,15 @@ Flink SQL> SELECT * FROM orders;
           <td>Duration</td>
           <td>用于跟踪最新可用 binlog 偏移的发送心跳事件的间隔。</td>
     </tr>
+    </tr> 
+    <tr>
+          <td>changelog-mode</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">all</td>
+          <td>String</td>
+          <td>用于设置变更流的编码模式。支持的值有<code>all</code> (将变更流编码为带有所有RowKinds类型的retract流) 和 <code>upsert</code> (将变更流编码为可以根据主键进行幂等更新的upsert流)。
+          <br/>使用"upsert"模式必须声明主键。</td>
+    </tr> 
     <tr>
       <td>debezium.*</td>
       <td>optional</td>

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
@@ -353,6 +353,14 @@ During a snapshot operation, the connector will query each included table to pro
           <td>The interval of sending heartbeat event for tracing the latest available binlog offsets.</td>
     </tr>
     <tr>
+          <td>changelog-mode</td>
+          <td>optional</td>
+          <td style="word-wrap: break-word;">all</td>
+          <td>String</td>
+          <td>The changelog mode used for encoding streaming changes. Supported values are <code>all</code> (which encodes changes as retract stream using all RowKinds) and <code>upsert</code> (which encodes changes as upsert stream that describes idempotent updates on a key).
+          <br/> Primary keys must be set to use <code>upsert</code> mode.</td>
+    </tr>
+    <tr>
       <td>debezium.*</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.mysql.source.config;
 
 import org.apache.flink.cdc.common.annotation.Experimental;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
+import org.apache.flink.cdc.debezium.table.DebeziumChangelogMode;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
@@ -190,6 +191,15 @@ public class MySqlSourceOptions {
                     .defaultValue(Duration.ofSeconds(30))
                     .withDescription(
                             "Optional interval of sending heartbeat event for tracing the latest available binlog offsets");
+
+    public static final ConfigOption<DebeziumChangelogMode> CHANGELOG_MODE =
+            ConfigOptions.key("changelog-mode")
+                    .enumType(DebeziumChangelogMode.class)
+                    .defaultValue(DebeziumChangelogMode.ALL)
+                    .withDescription(
+                            "The changelog mode used for encoding streaming changes.\n"
+                                    + "\"all\": Encodes changes as retract stream using all RowKinds. This is the default mode.\n"
+                                    + "\"upsert\": Encodes changes as upsert stream that describes idempotent updates on a key.");
 
     // ----------------------------------------------------------------------------
     // experimental options, won't add them to documentation


### PR DESCRIPTION
This PR implements [#1898](https://github.com/ververica/flink-cdc-connectors/issues/1898) and exposing support in configuration just for mysql module.