### PR TITLE
[oracle-cdc] Fix read one record in the incremental snapshot

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/external/IncrementalSourceStreamFetcher.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/external/IncrementalSourceStreamFetcher.java
@@ -164,7 +164,8 @@ public class IncrementalSourceStreamFetcher implements Fetcher<SourceRecords, So
         if (taskContext.isDataChangeRecord(sourceRecord)) {
             TableId tableId = taskContext.getTableId(sourceRecord);
             Offset position = taskContext.getStreamOffset(sourceRecord);
-            if (hasEnterPureStreamPhase(tableId, position)) {
+            // source record has no primary need no comparing for binlog position
+            if (hasEnterPureStreamPhase(tableId, position) || sourceRecord.key() == null) {
                 return true;
             }
             // only the table who captured snapshot splits need to filter


### PR DESCRIPTION
Fix bug: #1886 

In the snapshot, `record.key()` is null, so it will overwrite the previous record. So we can to add record without primary key into list.

```java
  if (!reachChangeLogStart) {
      if (record.key() == null) {
          snapshotRecordsWithoutKey.add(record);
      } else {
          outputBuffer.put((Struct) record.key(), record);
      }
  }
```