### PR TITLE
[mysql-cdc] Fix MySqlSplitSerializer ConcurrentModificationException

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -184,7 +184,9 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
         DocumentWriter documentWriter = DocumentWriter.defaultWriter();
         final int size = tableSchemas.size();
         out.writeInt(size);
-        for (Map.Entry<TableId, TableChange> entry : tableSchemas.entrySet()) {
+        List<Map.Entry<TableId, TableChange>> entries = new ArrayList<>();
+        entries.addAll(tableSchemas.entrySet());
+        for (Map.Entry<TableId, TableChange> entry : entries) {
             out.writeUTF(entry.getKey().toString());
             final String tableChangeStr =
                     documentWriter.write(jsonSerializer.toDocument(entry.getValue()));

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -184,9 +184,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
         DocumentWriter documentWriter = DocumentWriter.defaultWriter();
         final int size = tableSchemas.size();
         out.writeInt(size);
-        List<Map.Entry<TableId, TableChange>> entries = new ArrayList<>();
-        entries.addAll(tableSchemas.entrySet());
-        for (Map.Entry<TableId, TableChange> entry : entries) {
+        for (Map.Entry<TableId, TableChange> entry : tableSchemas.entrySet()) {
             out.writeUTF(entry.getKey().toString());
             final String tableChangeStr =
                     documentWriter.write(jsonSerializer.toDocument(entry.getValue()));


### PR DESCRIPTION
MySqlSplitSerializer  iterate over  tableSchemas may cause  java.util.ConcurrentModificationException.