### PR TITLE
Add a table of cdc json type

### DIFF
--- a/flink-connector-table/pom.xml
+++ b/flink-connector-table/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-cdc-connectors</artifactId>
+        <groupId>com.ververica</groupId>
+        <version>2.4-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-table</artifactId>
+    <name>flink-connector-table</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-debezium</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>kafka-log4j-appender</artifactId>
+                    <groupId>org.apache.kafka</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-oracle-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-postgres-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-sqlserver-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/deserializa/CdcJsonRowDataDebeziumDeserializationSchema.java
+++ b/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/deserializa/CdcJsonRowDataDebeziumDeserializationSchema.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.table.deserializa;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+
+import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.json.JsonConverterConfig;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.apache.kafka.connect.storage.ConverterConfig;
+import org.apache.kafka.connect.storage.ConverterType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * cdc json Deserialization.
+ */
+public class CdcJsonRowDataDebeziumDeserializationSchema implements DebeziumDeserializationSchema<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient JsonConverter jsonConverter;
+
+    private final Boolean includeSchema;
+
+    /**
+     * The custom configurations for {@link JsonConverter}.
+     */
+    private Map<String, Object> customConverterConfigs;
+
+    public CdcJsonRowDataDebeziumDeserializationSchema() {
+        this(false);
+    }
+
+    public CdcJsonRowDataDebeziumDeserializationSchema(Boolean includeSchema) {
+        this.includeSchema = includeSchema;
+    }
+
+    public CdcJsonRowDataDebeziumDeserializationSchema(
+            Boolean includeSchema, Map<String, Object> customConverterConfigs) {
+        this.includeSchema = includeSchema;
+        this.customConverterConfigs = customConverterConfigs;
+    }
+
+    /**
+     * Initialize {@link JsonConverter} with given configs.
+     */
+    private void initializeJsonConverter() {
+        jsonConverter = new JsonConverter();
+        final HashMap<String, Object> configs = new HashMap<>(2);
+        configs.put(ConverterConfig.TYPE_CONFIG, ConverterType.VALUE.getName());
+        configs.put(JsonConverterConfig.SCHEMAS_ENABLE_CONFIG, includeSchema);
+        if (customConverterConfigs != null) {
+            configs.putAll(customConverterConfigs);
+        }
+        jsonConverter.configure(configs);
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        DataType dataType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("cdc_json", DataTypes.STRING())
+                );
+        RowType schema = (RowType) dataType.getLogicalType();
+        TypeInformation<RowData> resultTypeInfo = InternalTypeInfo.of(schema);
+        return resultTypeInfo;
+    }
+
+    @Override
+    public void deserialize(SourceRecord sourceRecord, Collector<RowData> collector) throws Exception {
+        if (jsonConverter == null) {
+            initializeJsonConverter();
+        }
+        byte[] bytes =
+                jsonConverter.fromConnectData(sourceRecord.topic(), sourceRecord.valueSchema(), sourceRecord.value());
+        String str = new String(bytes);
+        collector.collect(GenericRowData.ofKind(RowKind.INSERT, StringData.fromString(str)));
+    }
+}

--- a/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/json/CdcJsonSourceTable.java
+++ b/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/json/CdcJsonSourceTable.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.table.json;
+
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import com.ververica.cdc.connectors.mysql.source.MySqlSource;
+import com.ververica.cdc.connectors.mysql.table.StartupOptions;
+import com.ververica.cdc.connectors.oracle.OracleSource;
+import com.ververica.cdc.connectors.postgres.PostgreSQLSource;
+import com.ververica.cdc.connectors.sqlserver.SqlServerSource;
+import com.ververica.cdc.connectors.table.deserializa.CdcJsonRowDataDebeziumDeserializationSchema;
+import com.ververica.cdc.debezium.DebeziumSourceFunction;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A {@link DynamicTableSource} that describes how to create a PostgreSQL source from a logical
+ * description.
+ */
+public class CdcJsonSourceTable implements ScanTableSource {
+
+    private final ResolvedSchema physicalSchema;
+    private final int port;
+    private final String hostname;
+    private final List<String> schemaList;
+    private final List<String> tableList;
+    private final String username;
+    private final String password;
+    private final Properties dbzProperties;
+    private final String sourceType;
+    private final Map<String, String> extraProperties;
+    private final List<String> databaseList;
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Data type that describes the final output of the source.
+     */
+    protected DataType producedDataType;
+
+    public CdcJsonSourceTable(ResolvedSchema physicalSchema, int port, String hostname, List<String> databaseList, List<String> schemaList, List<String> tableList, String username, String password,
+                              String sourceType, Map<String, String> extraProperties, Properties debeziumProperties) {
+
+        this.physicalSchema = physicalSchema;
+        this.port = port;
+        this.hostname = checkNotNull(hostname);
+        this.databaseList = checkNotNull(databaseList);
+        this.schemaList = checkNotNull(schemaList);
+        this.tableList = checkNotNull(tableList);
+        this.username = checkNotNull(username);
+        this.password = checkNotNull(password);
+        this.sourceType = checkNotNull(sourceType);
+        this.extraProperties = new HashMap<>(extraProperties);
+        extraProperties.keySet().forEach(key -> {
+            if (key.startsWith("debezium.")) {
+                this.extraProperties.remove(key);
+            }
+        });
+        this.dbzProperties = debeziumProperties;
+        this.producedDataType = physicalSchema.toPhysicalRowDataType();
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .build();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+        if (sourceType.equals("postgres")) {
+            return getPostgreCdc();
+        } else if (sourceType.equals("mysql")) {
+            return getMysqlCdc();
+        } else if (sourceType.equals("oracle")) {
+            return getOracleCdc();
+        } else if (sourceType.equals("sqlserver")) {
+            return getSqlserverCdc();
+        }
+        throw new RuntimeException("不支持此种类型的cdc:" + sourceType);
+    }
+
+    private ScanRuntimeProvider getPostgreCdc() {
+        SourceFunction<RowData> sourceFunction = PostgreSQLSource.<RowData>builder()
+                .hostname(hostname)
+                .port(port)
+                .database(databaseList.get(0)) // monitor postgres database
+                .schemaList(schemaList.toArray(new String[schemaList.size()]))  // monitor inventory schema
+                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
+                .username(username)
+                .password(password)
+                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
+                .debeziumProperties(dbzProperties)
+                .build();
+
+        return SourceFunctionProvider.of(sourceFunction, false);
+    }
+
+    private ScanRuntimeProvider getMysqlCdc() {
+        String scanStartMode = extraProperties.getOrDefault("scan.startup.mode", "initial");
+        StartupOptions scanStartOptions = StartupOptions.initial();
+        if (scanStartMode.equals("latest-offset")) {
+            scanStartOptions = StartupOptions.latest();
+        }
+
+        MySqlSource<RowData> sourceFunction = MySqlSource.<RowData>builder()
+                .hostname(hostname)
+                .port(port)
+                .databaseList(databaseList.toArray(new String[databaseList.size()])) // monitor postgres database
+                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
+                .username(username)
+                .password(password)
+                .serverTimeZone(this.extraProperties.getOrDefault("server-time-zone", "Asia/Shanghai"))
+                .includeSchemaChanges(Boolean.valueOf(extraProperties.getOrDefault("include-schema-changes", "false")))
+                .scanNewlyAddedTableEnabled(Boolean.valueOf(extraProperties.getOrDefault("scan-new-table", "false")))
+                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
+                .startupOptions(scanStartOptions)
+                .debeziumProperties(dbzProperties)
+                .build();
+
+        return SourceProvider.of(sourceFunction);
+    }
+
+    private ScanRuntimeProvider getOracleCdc() {
+        DebeziumSourceFunction<RowData> sourceFunction = OracleSource.<RowData>builder()
+                .hostname(hostname)
+                .port(port)
+                .database(databaseList.get(0)) // monitor postgres database
+                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
+                .username(username)
+                .password(password)
+                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
+                .debeziumProperties(dbzProperties)
+                .build();
+
+        return SourceFunctionProvider.of(sourceFunction, false);
+    }
+
+    private ScanRuntimeProvider getSqlserverCdc() {
+        DebeziumSourceFunction<RowData> sourceFunction = SqlServerSource.<RowData>builder()
+                .hostname(hostname)
+                .port(port)
+                .database(databaseList.get(0)) // monitor postgres database
+                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
+                .username(username)
+                .password(password)
+                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
+                .debeziumProperties(dbzProperties)
+                .build();
+
+        return SourceFunctionProvider.of(sourceFunction, false);
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        CdcJsonSourceTable source =
+                new CdcJsonSourceTable(
+                        physicalSchema,
+                        port,
+                        hostname,
+                        databaseList,
+                        schemaList,
+                        tableList,
+                        username,
+                        password,
+                        sourceType,
+                        extraProperties,
+                        dbzProperties);
+        return source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CdcJsonSourceTable that = (CdcJsonSourceTable) o;
+        return port == that.port
+                && Objects.equals(physicalSchema, that.physicalSchema)
+                && Objects.equals(hostname, that.hostname)
+                && Objects.equals(databaseList, that.databaseList)
+                && Objects.equals(schemaList, that.schemaList)
+                && Objects.equals(tableList, that.tableList)
+                && Objects.equals(username, that.username)
+                && Objects.equals(password, that.password)
+                && Objects.equals(dbzProperties, that.dbzProperties)
+                && Objects.equals(producedDataType, that.producedDataType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                physicalSchema,
+                port,
+                hostname,
+                databaseList,
+                schemaList,
+                tableList,
+                username,
+                password,
+                dbzProperties,
+                producedDataType);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "PostgreSQL-CDC";
+    }
+
+}

--- a/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/json/CdcJsonSourceTable.java
+++ b/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/json/CdcJsonSourceTable.java
@@ -65,13 +65,21 @@ public class CdcJsonSourceTable implements ScanTableSource {
     // Mutable attributes
     // --------------------------------------------------------------------------------------------
 
-    /**
-     * Data type that describes the final output of the source.
-     */
+    /** Data type that describes the final output of the source. */
     protected DataType producedDataType;
 
-    public CdcJsonSourceTable(ResolvedSchema physicalSchema, int port, String hostname, List<String> databaseList, List<String> schemaList, List<String> tableList, String username, String password,
-                              String sourceType, Map<String, String> extraProperties, Properties debeziumProperties) {
+    public CdcJsonSourceTable(
+            ResolvedSchema physicalSchema,
+            int port,
+            String hostname,
+            List<String> databaseList,
+            List<String> schemaList,
+            List<String> tableList,
+            String username,
+            String password,
+            String sourceType,
+            Map<String, String> extraProperties,
+            Properties debeziumProperties) {
 
         this.physicalSchema = physicalSchema;
         this.port = port;
@@ -83,20 +91,21 @@ public class CdcJsonSourceTable implements ScanTableSource {
         this.password = checkNotNull(password);
         this.sourceType = checkNotNull(sourceType);
         this.extraProperties = new HashMap<>(extraProperties);
-        extraProperties.keySet().forEach(key -> {
-            if (key.startsWith("debezium.")) {
-                this.extraProperties.remove(key);
-            }
-        });
+        extraProperties
+                .keySet()
+                .forEach(
+                        key -> {
+                            if (key.startsWith("debezium.")) {
+                                this.extraProperties.remove(key);
+                            }
+                        });
         this.dbzProperties = debeziumProperties;
         this.producedDataType = physicalSchema.toPhysicalRowDataType();
     }
 
     @Override
     public ChangelogMode getChangelogMode() {
-        return ChangelogMode.newBuilder()
-                .addContainedKind(RowKind.INSERT)
-                .build();
+        return ChangelogMode.newBuilder().addContainedKind(RowKind.INSERT).build();
     }
 
     @Override
@@ -114,17 +123,24 @@ public class CdcJsonSourceTable implements ScanTableSource {
     }
 
     private ScanRuntimeProvider getPostgreCdc() {
-        SourceFunction<RowData> sourceFunction = PostgreSQLSource.<RowData>builder()
-                .hostname(hostname)
-                .port(port)
-                .database(databaseList.get(0)) // monitor postgres database
-                .schemaList(schemaList.toArray(new String[schemaList.size()]))  // monitor inventory schema
-                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
-                .username(username)
-                .password(password)
-                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
-                .debeziumProperties(dbzProperties)
-                .build();
+        SourceFunction<RowData> sourceFunction =
+                PostgreSQLSource.<RowData>builder()
+                        .hostname(hostname)
+                        .port(port)
+                        .database(databaseList.get(0)) // monitor postgres database
+                        .schemaList(
+                                schemaList.toArray(
+                                        new String[schemaList.size()])) // monitor inventory schema
+                        .tableList(
+                                tableList.toArray(
+                                        new String[tableList.size()])) // monitor products table
+                        .username(username)
+                        .password(password)
+                        .deserializer(
+                                new CdcJsonRowDataDebeziumDeserializationSchema(
+                                        false)) // converts SourceRecord to JSON String
+                        .debeziumProperties(dbzProperties)
+                        .build();
 
         return SourceFunctionProvider.of(sourceFunction, false);
     }
@@ -136,50 +152,75 @@ public class CdcJsonSourceTable implements ScanTableSource {
             scanStartOptions = StartupOptions.latest();
         }
 
-        MySqlSource<RowData> sourceFunction = MySqlSource.<RowData>builder()
-                .hostname(hostname)
-                .port(port)
-                .databaseList(databaseList.toArray(new String[databaseList.size()])) // monitor postgres database
-                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
-                .username(username)
-                .password(password)
-                .serverTimeZone(this.extraProperties.getOrDefault("server-time-zone", "Asia/Shanghai"))
-                .includeSchemaChanges(Boolean.valueOf(extraProperties.getOrDefault("include-schema-changes", "false")))
-                .scanNewlyAddedTableEnabled(Boolean.valueOf(extraProperties.getOrDefault("scan-new-table", "false")))
-                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
-                .startupOptions(scanStartOptions)
-                .debeziumProperties(dbzProperties)
-                .build();
+        MySqlSource<RowData> sourceFunction =
+                MySqlSource.<RowData>builder()
+                        .hostname(hostname)
+                        .port(port)
+                        .databaseList(
+                                databaseList.toArray(
+                                        new String
+                                                [databaseList.size()])) // monitor postgres database
+                        .tableList(
+                                tableList.toArray(
+                                        new String[tableList.size()])) // monitor products table
+                        .username(username)
+                        .password(password)
+                        .serverTimeZone(
+                                this.extraProperties.getOrDefault(
+                                        "server-time-zone", "Asia/Shanghai"))
+                        .includeSchemaChanges(
+                                Boolean.valueOf(
+                                        extraProperties.getOrDefault(
+                                                "include-schema-changes", "false")))
+                        .scanNewlyAddedTableEnabled(
+                                Boolean.valueOf(
+                                        extraProperties.getOrDefault("scan-new-table", "false")))
+                        .deserializer(
+                                new CdcJsonRowDataDebeziumDeserializationSchema(
+                                        false)) // converts SourceRecord to JSON String
+                        .startupOptions(scanStartOptions)
+                        .debeziumProperties(dbzProperties)
+                        .build();
 
         return SourceProvider.of(sourceFunction);
     }
 
     private ScanRuntimeProvider getOracleCdc() {
-        DebeziumSourceFunction<RowData> sourceFunction = OracleSource.<RowData>builder()
-                .hostname(hostname)
-                .port(port)
-                .database(databaseList.get(0)) // monitor postgres database
-                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
-                .username(username)
-                .password(password)
-                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
-                .debeziumProperties(dbzProperties)
-                .build();
+        DebeziumSourceFunction<RowData> sourceFunction =
+                OracleSource.<RowData>builder()
+                        .hostname(hostname)
+                        .port(port)
+                        .database(databaseList.get(0)) // monitor postgres database
+                        .tableList(
+                                tableList.toArray(
+                                        new String[tableList.size()])) // monitor products table
+                        .username(username)
+                        .password(password)
+                        .deserializer(
+                                new CdcJsonRowDataDebeziumDeserializationSchema(
+                                        false)) // converts SourceRecord to JSON String
+                        .debeziumProperties(dbzProperties)
+                        .build();
 
         return SourceFunctionProvider.of(sourceFunction, false);
     }
 
     private ScanRuntimeProvider getSqlserverCdc() {
-        DebeziumSourceFunction<RowData> sourceFunction = SqlServerSource.<RowData>builder()
-                .hostname(hostname)
-                .port(port)
-                .database(databaseList.get(0)) // monitor postgres database
-                .tableList(tableList.toArray(new String[tableList.size()])) // monitor products table
-                .username(username)
-                .password(password)
-                .deserializer(new CdcJsonRowDataDebeziumDeserializationSchema(false)) // converts SourceRecord to JSON String
-                .debeziumProperties(dbzProperties)
-                .build();
+        DebeziumSourceFunction<RowData> sourceFunction =
+                SqlServerSource.<RowData>builder()
+                        .hostname(hostname)
+                        .port(port)
+                        .database(databaseList.get(0)) // monitor postgres database
+                        .tableList(
+                                tableList.toArray(
+                                        new String[tableList.size()])) // monitor products table
+                        .username(username)
+                        .password(password)
+                        .deserializer(
+                                new CdcJsonRowDataDebeziumDeserializationSchema(
+                                        false)) // converts SourceRecord to JSON String
+                        .debeziumProperties(dbzProperties)
+                        .build();
 
         return SourceFunctionProvider.of(sourceFunction, false);
     }
@@ -242,5 +283,4 @@ public class CdcJsonSourceTable implements ScanTableSource {
     public String asSummaryString() {
         return "PostgreSQL-CDC";
     }
-
 }

--- a/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/json/CdcJsonSourceTableFactory.java
+++ b/flink-connector-table/src/main/java/com/ververica/cdc/connectors/table/json/CdcJsonSourceTableFactory.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.table.json;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.ververica.cdc.debezium.table.DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX;
+import static com.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
+import static com.ververica.cdc.debezium.utils.ResolvedSchemaUtils.getPhysicalSchema;
+
+/**
+ * The table type reads cdc and returns cdc json.
+ */
+public class CdcJsonSourceTableFactory implements DynamicTableSourceFactory {
+
+
+    private static final String IDENTIFIER = "cdc-json";
+
+    public static final ConfigOption<String> HOSTNAME =
+            ConfigOptions.key("hostname")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("IP address or hostname of the PostgreSQL database server.");
+
+    public static final ConfigOption<Integer> PORT =
+            ConfigOptions.key("port")
+                    .intType()
+                    .defaultValue(5432)
+                    .withDescription("Integer port number of the PostgreSQL database server.");
+
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of the PostgreSQL database to use when connecting to the PostgreSQL database server.");
+
+    public static final ConfigOption<String> PASSWORD =
+            ConfigOptions.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Password to use when connecting to the PostgreSQL database server.");
+
+    public static final ConfigOption<String> DATABASE_LIST =
+            ConfigOptions.key("database-list")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Database name of the PostgreSQL server to monitor.");
+
+    public static final ConfigOption<String> SCHEMA_LIST =
+            ConfigOptions.key("schema-list")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Schema name of the PostgreSQL database to monitor.");
+
+    public static final ConfigOption<String> TABLE_LIST =
+            ConfigOptions.key("table-list")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Table name of the PostgreSQL database to monitor.");
+
+    public static final ConfigOption<String> SOURCE_TYPE =
+            ConfigOptions.key("source-type")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Table name of the PostgreSQL database to monitor.");
+
+    public static final ConfigOption<String> EXTRA_PROP =
+            ConfigOptions.key("extra-prop.")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Table name of the PostgreSQL database to monitor.");
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validateExcept(DEBEZIUM_OPTIONS_PREFIX, EXTRA_PROP.key());
+
+        final ReadableConfig config = helper.getOptions();
+        String hostname = config.get(HOSTNAME);
+        String username = config.get(USERNAME);
+        String password = config.get(PASSWORD);
+        List<String> databaseList = Arrays.asList(config.get(DATABASE_LIST).split(","));
+        String sourceType = config.get(SOURCE_TYPE);
+        List<String> schemaList = Arrays.asList(config.get(SCHEMA_LIST).split(","));
+        List<String> tableList = Arrays.asList(config.get(TABLE_LIST).split(","));
+        int port = config.get(PORT);
+        ResolvedSchema physicalSchema =
+                getPhysicalSchema(context.getCatalogTable().getResolvedSchema());
+
+        return new CdcJsonSourceTable(
+                physicalSchema,
+                port,
+                hostname,
+                databaseList,
+                schemaList,
+                tableList,
+                username,
+                password,
+                sourceType,
+                getExtraProperties(context.getCatalogTable().getOptions()),
+                getDebeziumProperties(getExtraProperties(context.getCatalogTable().getOptions())));
+    }
+
+    public static Map<String, String> getExtraProperties(Map<String, String> properties) {
+        final Map<String, String> extraProperties = new HashMap<String, String>();
+
+        properties.keySet().stream()
+                .filter(key -> key.startsWith(EXTRA_PROP.key()))
+                .forEach(
+                        key -> {
+                            final String value = properties.get(key);
+                            final String subKey =
+                                    key.substring((EXTRA_PROP.key()).length());
+                            extraProperties.put(subKey, value);
+                        });
+        return extraProperties;
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(HOSTNAME);
+        options.add(USERNAME);
+        options.add(PASSWORD);
+        options.add(DATABASE_LIST);
+        options.add(TABLE_LIST);
+        options.add(SOURCE_TYPE);
+        options.add(PORT);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(SCHEMA_LIST);
+        return options;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@ under the License.
         <module>flink-sql-connector-tidb-cdc</module>
         <module>flink-sql-connector-db2-cdc</module>
         <module>flink-cdc-e2e-tests</module>
+        <module>flink-connector-table</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
Add a table of cdc json type. Read mysql/oracle/postgres/sqlserver cdc data and output it as a json string. The effect is the same as that of the datastream api, here it is implemented in the form of a table.

mysql cdc:
create table test_json
(
    cdc_json string
)WITH (
     'hostname' = 'xxx',
     'connector' = 'cdc-json',
     'port'='53309',
     'username'='root',
     'password'='xxx',
     'database-list'='test',
     'table-list'='test.cc_test1',
     'source-type'='mysql',
    'extra-prop.scan.startup.mode' = 'latest-offset'
     )
;

select cdc_json from test_json;

the result:

3> +I[{"before":null,"after":{"id":12,"name":"c","test_decimal":"11"},"source":{"version":"1.5.4.Final","connector":"mysql","name":"mysql_binlog_source","ts_ms":0,"snapshot":"false","db":"test","sequence":null,"table":"cc_test1","server_id":0,"gtid":null,"file":"","pos":0,"row":0,"thread":null,"query":null},"op":"r","ts_ms":1680763113699,"transaction":null}]
3> +I[{"before":null,"after":{"id":1666,"name":"c","test_decimal":"11"},"source":{"version":"1.5.4.Final","connector":"mysql","name":"mysql_binlog_source","ts_ms":0,"snapshot":"false","db":"test","sequence":null,"table":"cc_test1","server_id":0,"gtid":null,"file":"","pos":0,"row":0,"thread":null,"query":null},"op":"r","ts_ms":1680763113699,"transaction":null}]
3> +I[{"before":null,"after":{"id":1,"name":"c","test_decimal":"11"},"source":{"version":"1.5.4.Final","connector":"mysql","name":"mysql_binlog_source","ts_ms":0,"snapshot":"false","db":"test","sequence":null,"table":"cc_test1","server_id":0,"gtid":null,"file":"","pos":0,"row":0,"thread":null,"query":null},"op":"r","ts_ms":1680763113699,"transaction":null}]
