### PR TITLE
Update mysql binlog connector & changes for transaction payload events

### DIFF
--- a/flink-connector-mysql-cdc/pom.xml
+++ b/flink-connector-mysql-cdc/pom.xml
@@ -47,6 +47,12 @@ under the License.
             <artifactId>debezium-connector-mysql</artifactId>
             <version>${debezium.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.zendesk</groupId>
+            <artifactId>mysql-binlog-connector-java</artifactId>
+            <version>${mysql.binlog.version}</version>
+        </dependency>
+
 
         <!-- geometry dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@ under the License.
     <properties>
         <flink.version>1.16.0</flink.version>
         <debezium.version>1.6.4.Final</debezium.version>
+        <mysql.binlog.version>0.26.1</mysql.binlog.version>
         <tikv.version>3.2.0</tikv.version>
         <geometry.version>2.2.0</geometry.version>
         <!-- OracleE2eITCase will report "container cannot be accessed" error when running in Azure Pipeline with 1.16.1 testconainters.


### PR DESCRIPTION
This change is w.r.t to the corresponding changes done to mysql binlog connector and Debezium to support transaction payload events (generated when mysql server has binlog compression ON).

Ticket in Debzium: [DBZ-2663](https://issues.redhat.com/browse/DBZ-2663)
Reference to Debezium changelog: https://debezium.io/releases/2.0/release-notes#new_features_4
Changes in debezium: https://github.com/debezium/debezium/pull/3769