### PR TITLE
[Mysql]  Mysql connector can't handle the case sensitive of rename/change column statement (#2144)

### DIFF
--- a/flink-connector-debezium/src/main/java/io/debezium/relational/TableEditorImpl.java
+++ b/flink-connector-debezium/src/main/java/io/debezium/relational/TableEditorImpl.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+class TableEditorImpl implements TableEditor {
+
+	private TableId id;
+	private LinkedHashMap<String, Column> sortedColumns = new LinkedHashMap<>();
+	private final List<String> pkColumnNames = new ArrayList<>();
+	private boolean uniqueValues = false;
+	private String defaultCharsetName;
+	private String comment;
+
+	protected TableEditorImpl() {
+	}
+
+	@Override
+	public TableId tableId() {
+		return id;
+	}
+
+	@Override
+	public TableEditor tableId(TableId id) {
+		this.id = id;
+		return this;
+	}
+
+	@Override
+	public List<Column> columns() {
+		return Collections.unmodifiableList(new ArrayList<>(sortedColumns.values()));
+	}
+
+	@Override
+	public Column columnWithName(String name) {
+		return sortedColumns.get(name.toLowerCase());
+	}
+
+	protected boolean hasColumnWithName(String name) {
+		return columnWithName(name) != null;
+	}
+
+	@Override
+	public List<String> primaryKeyColumnNames() {
+		return uniqueValues ? columnNames() : Collections.unmodifiableList(pkColumnNames);
+	}
+
+	@Override
+	public TableEditor addColumns(Column... columns) {
+		for (Column column : columns) {
+			add(column);
+		}
+		assert positionsAreValid();
+		return this;
+	}
+
+	@Override
+	public TableEditor addColumns(Iterable<Column> columns) {
+		columns.forEach(this::add);
+		assert positionsAreValid();
+		return this;
+	}
+
+	protected void add(Column defn) {
+		if (defn != null) {
+			Column existing = columnWithName(defn.name());
+			int position = existing != null ? existing.position() : sortedColumns.size() + 1;
+			sortedColumns.put(defn.name().toLowerCase(), defn.edit().position(position).create());
+		}
+		assert positionsAreValid();
+	}
+
+	@Override
+	public TableEditor setColumns(Column... columns) {
+		sortedColumns.clear();
+		addColumns(columns);
+		assert positionsAreValid();
+		return this;
+	}
+
+	@Override
+	public TableEditor setColumns(Iterable<Column> columns) {
+		sortedColumns.clear();
+		addColumns(columns);
+		assert positionsAreValid();
+		return this;
+	}
+
+	protected void updatePrimaryKeys() {
+		if (!uniqueValues) {
+			// table does have any primary key --> we need to remove it
+			this.pkColumnNames.removeIf(pkColumnName -> {
+				final boolean pkColumnDoesNotExists = !hasColumnWithName(pkColumnName);
+				if (pkColumnDoesNotExists) {
+					throw new IllegalArgumentException(
+							"The column \"" + pkColumnName + "\" is referenced as PRIMARY KEY, but a matching column is not defined in table \"" + tableId() + "\"!");
+				}
+				return pkColumnDoesNotExists;
+			});
+		}
+	}
+
+	@Override
+	public TableEditor setPrimaryKeyNames(String... pkColumnNames) {
+		return setPrimaryKeyNames(Arrays.asList(pkColumnNames));
+	}
+
+	@Override
+	public TableEditor setPrimaryKeyNames(List<String> pkColumnNames) {
+		this.pkColumnNames.clear();
+		this.pkColumnNames.addAll(pkColumnNames);
+		uniqueValues = false;
+		return this;
+	}
+
+	@Override
+	public TableEditor setUniqueValues() {
+		pkColumnNames.clear();
+		uniqueValues = true;
+		return this;
+	}
+
+	@Override
+	public boolean hasUniqueValues() {
+		return uniqueValues;
+	}
+
+	@Override
+	public TableEditor setDefaultCharsetName(String charsetName) {
+		this.defaultCharsetName = charsetName;
+		return this;
+	}
+
+	@Override
+	public TableEditor setComment(String comment) {
+		this.comment = comment;
+		return this;
+	}
+
+	@Override
+	public boolean hasDefaultCharsetName() {
+		return this.defaultCharsetName != null && !this.defaultCharsetName.trim().isEmpty();
+	}
+
+	@Override
+	public boolean hasComment() {
+		return this.comment != null && !this.comment.trim().isEmpty();
+	}
+
+	@Override
+	public TableEditor removeColumn(String columnName) {
+		Column existing = sortedColumns.remove(columnName.toLowerCase());
+		if (existing != null) {
+			updatePositions();
+			columnName = existing.name();
+		}
+		assert positionsAreValid();
+		pkColumnNames.remove(columnName);
+		return this;
+	}
+
+	@Override
+	public TableEditor updateColumn(Column newColumn) {
+		setColumns(columns().stream()
+				.map(c -> c.name().equals(newColumn.name()) ? newColumn : c)
+				.collect(Collectors.toList()));
+		return this;
+	}
+
+	@Override
+	public TableEditor reorderColumn(String columnName, String afterColumnName) {
+		Column columnToMove = columnWithName(columnName);
+		if (columnToMove == null) {
+			throw new IllegalArgumentException("No column with name '" + columnName + "'");
+		}
+		Column afterColumn = afterColumnName == null ? null : columnWithName(afterColumnName);
+		if (afterColumn != null && afterColumn.position() == sortedColumns.size()) {
+			// Just append ...
+			sortedColumns.remove(columnName);
+			sortedColumns.put(columnName, columnToMove);
+		}
+		else {
+			LinkedHashMap<String, Column> newColumns = new LinkedHashMap<>();
+			sortedColumns.remove(columnName.toLowerCase());
+			if (afterColumn == null) {
+				// Then the column to move comes first ...
+				newColumns.put(columnToMove.name().toLowerCase(), columnToMove);
+			}
+			sortedColumns.forEach((key, defn) -> {
+				newColumns.put(key, defn);
+				if (defn == afterColumn) {
+					// We just added the column that came before, so add our column here ...
+					newColumns.put(columnToMove.name().toLowerCase(), columnToMove);
+				}
+			});
+			sortedColumns = newColumns;
+		}
+		updatePositions();
+		return this;
+	}
+
+	@Override
+	public TableEditor renameColumn(String existingName, String newName) {
+		final Column existing = columnWithName(existingName);
+		if (existing == null) {
+			throw new IllegalArgumentException("No column with name '" + existingName + "'");
+		}
+		Column newColumn = existing.edit().name(newName).create();
+		// Determine the primary key names ...
+		List<String> newPkNames = null;
+		if (!hasUniqueValues() && primaryKeyColumnNames().contains(existing.name())) {
+			newPkNames = new ArrayList<>(primaryKeyColumnNames());
+			newPkNames.replaceAll(name -> existing.name().equals(name) ? newName : name);
+		}
+		if (!existingName.equalsIgnoreCase(newName)) {
+			addColumn(newColumn);
+			reorderColumn(newColumn.name(), existing.name());
+			removeColumn(existing.name());
+		}
+		else {
+			sortedColumns.replace(existingName.toLowerCase(), existing, newColumn);
+		}
+
+		if (newPkNames != null) {
+			setPrimaryKeyNames(newPkNames);
+		}
+		return this;
+	}
+
+	protected void updatePositions() {
+		AtomicInteger position = new AtomicInteger(1);
+		sortedColumns.replaceAll((name, defn) -> {
+			// Decrement the position ...
+			int nextPosition = position.getAndIncrement();
+			if (defn.position() != nextPosition) {
+				return defn.edit().position(nextPosition).create();
+			}
+			return defn;
+		});
+	}
+
+	protected boolean positionsAreValid() {
+		AtomicInteger position = new AtomicInteger(1);
+		return sortedColumns.values().stream().allMatch(defn -> defn.position() >= position.getAndSet(defn.position() + 1));
+	}
+
+	@Override
+	public String toString() {
+		return create().toString();
+	}
+
+	@Override
+	public Table create() {
+		if (id == null) {
+			throw new IllegalStateException("Unable to create a table from an editor that has no table ID");
+		}
+		List<Column> columns = new ArrayList<>();
+		sortedColumns.values().forEach(column -> {
+			column = column.edit().charsetNameOfTable(defaultCharsetName).create();
+			columns.add(column);
+		});
+		updatePrimaryKeys();
+		return new TableImpl(id, columns, primaryKeyColumnNames(), defaultCharsetName, comment);
+	}
+}

--- a/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/antlr/listener/AlterTableParserListener.java
@@ -1,0 +1,461 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.mysql.antlr.listener;
+
+import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.ddl.parser.mysql.generated.MySqlParser;
+import io.debezium.ddl.parser.mysql.generated.MySqlParserBaseListener;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.ddl.AbstractDdlParser;
+import io.debezium.text.ParsingException;
+import org.antlr.v4.runtime.tree.ParseTreeListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.debezium.antlr.AntlrDdlParser.getText;
+
+/**
+ * Copied from Debezium project(v1.9.7.Final) to fix
+ * https://github.com/ververica/flink-cdc-connectors/issues/2144.
+ *
+ * <p>Line 227 and 433 use equals insdead of equalsIgnoreCase method
+ * to handle the case sensitive of rename/change column statement.
+ * https://issues.redhat.com/browse/DBZ-5589 has been fixed.
+ */
+public class AlterTableParserListener extends MySqlParserBaseListener {
+
+    private static final int STARTING_INDEX = 1;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AlterTableParserListener.class);
+
+    private final MySqlAntlrDdlParser parser;
+    private final List<ParseTreeListener> listeners;
+
+    private TableEditor tableEditor;
+    private ColumnEditor defaultValueColumnEditor;
+    private ColumnDefinitionParserListener columnDefinitionListener;
+    private DefaultValueParserListener defaultValueListener;
+
+    private List<ColumnEditor> columnEditors;
+    private int parsingColumnIndex = STARTING_INDEX;
+
+    public AlterTableParserListener(MySqlAntlrDdlParser parser, List<ParseTreeListener> listeners) {
+        this.parser = parser;
+        this.listeners = listeners;
+    }
+
+    @Override
+    public void enterAlterTable(MySqlParser.AlterTableContext ctx) {
+        final TableId tableId = parser.parseQualifiedTableId(ctx.tableName().fullId());
+        if (parser.databaseTables().forTable(tableId) == null) {
+            LOG.debug("Ignoring ALTER TABLE statement for non-captured table {}", tableId);
+            return;
+        }
+        tableEditor = parser.databaseTables().editTable(tableId);
+        if (tableEditor == null) {
+            throw new ParsingException(
+                    null,
+                    "Trying to alter table "
+                            + tableId.toString()
+                            + ", which does not exist. Query: "
+                            + getText(ctx));
+        }
+        super.enterAlterTable(ctx);
+    }
+
+    @Override
+    public void exitAlterTable(MySqlParser.AlterTableContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    listeners.remove(columnDefinitionListener);
+                    parser.databaseTables().overwriteTable(tableEditor.create());
+                    parser.signalAlterTable(tableEditor.tableId(), null, ctx.getParent());
+                },
+                tableEditor);
+        super.exitAlterTable(ctx);
+        tableEditor = null;
+    }
+
+    @Override
+    public void enterAlterByAddColumn(MySqlParser.AlterByAddColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    String columnName = parser.parseName(ctx.uid(0));
+                    ColumnEditor columnEditor = Column.editor().name(columnName);
+                    columnDefinitionListener =
+                            new ColumnDefinitionParserListener(
+                                    tableEditor, columnEditor, parser, listeners);
+                    listeners.add(columnDefinitionListener);
+                },
+                tableEditor);
+        super.exitAlterByAddColumn(ctx);
+    }
+
+    @Override
+    public void exitAlterByAddColumn(MySqlParser.AlterByAddColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    Column column = columnDefinitionListener.getColumn();
+                    tableEditor.addColumn(column);
+
+                    String columnName = column.name();
+                    if (ctx.FIRST() != null) {
+                        tableEditor.reorderColumn(columnName, null);
+                    } else if (ctx.AFTER() != null) {
+                        String afterColumn = parser.parseName(ctx.uid(1));
+                        tableEditor.reorderColumn(columnName, afterColumn);
+                    }
+                    listeners.remove(columnDefinitionListener);
+                },
+                tableEditor,
+                columnDefinitionListener);
+        super.exitAlterByAddColumn(ctx);
+    }
+
+    @Override
+    public void enterAlterByAddColumns(MySqlParser.AlterByAddColumnsContext ctx) {
+        // multiple columns are added. Initialize a list of column editors for them
+        parser.runIfNotNull(
+                () -> {
+                    columnEditors = new ArrayList<>(ctx.uid().size());
+                    for (MySqlParser.UidContext uidContext : ctx.uid()) {
+                        String columnName = parser.parseName(uidContext);
+                        columnEditors.add(Column.editor().name(columnName));
+                    }
+                    columnDefinitionListener =
+                            new ColumnDefinitionParserListener(
+                                    tableEditor, columnEditors.get(0), parser, listeners);
+                    listeners.add(columnDefinitionListener);
+                },
+                tableEditor);
+        super.enterAlterByAddColumns(ctx);
+    }
+
+    @Override
+    public void exitColumnDefinition(MySqlParser.ColumnDefinitionContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    if (columnEditors != null) {
+                        // column editor list is not null when a multiple columns are parsed in one
+                        // statement
+                        if (columnEditors.size() > parsingColumnIndex) {
+                            // assign next column editor to parse another column definition
+                            columnDefinitionListener.setColumnEditor(
+                                    columnEditors.get(parsingColumnIndex++));
+                        } else {
+                            // all columns parsed
+                            // reset global variables for next parsed statement
+                            columnEditors.forEach(
+                                    columnEditor -> tableEditor.addColumn(columnEditor.create()));
+                            columnEditors = null;
+                            parsingColumnIndex = STARTING_INDEX;
+                        }
+                    }
+                },
+                tableEditor,
+                columnEditors);
+        super.exitColumnDefinition(ctx);
+    }
+
+    @Override
+    public void exitAlterByAddColumns(MySqlParser.AlterByAddColumnsContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    columnEditors.forEach(
+                            columnEditor -> tableEditor.addColumn(columnEditor.create()));
+                    listeners.remove(columnDefinitionListener);
+                },
+                tableEditor,
+                columnEditors);
+        super.exitAlterByAddColumns(ctx);
+    }
+
+    @Override
+    public void enterAlterByChangeColumn(MySqlParser.AlterByChangeColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    String oldColumnName = parser.parseName(ctx.oldColumn);
+                    Column existingColumn = tableEditor.columnWithName(oldColumnName);
+                    if (existingColumn != null) {
+                        // DBZ-771 unset previously set default value, as it's not kept by MySQL;
+                        // for any column modifications a new
+                        // default value (which could be the same) has to be provided by the
+                        // column_definition which we'll parse later
+                        // on; only in 8.0 (not yet supported by this parser) columns can be renamed
+                        // without repeating the full column
+                        // definition; so in fact it's arguably not correct to use edit() on the
+                        // existing column to begin with, but
+                        // I'm going to leave this as is for now, to be prepared for the ability of
+                        // updating column definitions in 8.0
+                        ColumnEditor columnEditor = existingColumn.edit();
+                        columnEditor.unsetDefaultValueExpression();
+
+                        columnDefinitionListener =
+                                new ColumnDefinitionParserListener(
+                                        tableEditor, columnEditor, parser, listeners);
+                        listeners.add(columnDefinitionListener);
+                    } else {
+                        throw new ParsingException(
+                                null,
+                                "Trying to change column "
+                                        + oldColumnName
+                                        + " in "
+                                        + tableEditor.tableId().toString()
+                                        + " table, which does not exist. Query: "
+                                        + getText(ctx));
+                    }
+                },
+                tableEditor);
+        super.enterAlterByChangeColumn(ctx);
+    }
+
+    @Override
+    public void exitAlterByChangeColumn(MySqlParser.AlterByChangeColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    Column column = columnDefinitionListener.getColumn();
+                    tableEditor.addColumn(column);
+                    String newColumnName = parser.parseName(ctx.newColumn);
+                    if (newColumnName != null && !column.name().equals(newColumnName)) {
+                        tableEditor.renameColumn(column.name(), newColumnName);
+                    }
+
+                    if (ctx.FIRST() != null) {
+                        tableEditor.reorderColumn(newColumnName, null);
+                    } else if (ctx.afterColumn != null) {
+                        tableEditor.reorderColumn(newColumnName, parser.parseName(ctx.afterColumn));
+                    }
+                    listeners.remove(columnDefinitionListener);
+                },
+                tableEditor,
+                columnDefinitionListener);
+        super.exitAlterByChangeColumn(ctx);
+    }
+
+    @Override
+    public void enterAlterByModifyColumn(MySqlParser.AlterByModifyColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    String columnName = parser.parseName(ctx.uid(0));
+                    Column existingColumn = tableEditor.columnWithName(columnName);
+                    if (existingColumn != null) {
+                        ColumnEditor columnEditor = existingColumn.edit();
+                        columnEditor.unsetDefaultValueExpression();
+
+                        columnDefinitionListener =
+                                new ColumnDefinitionParserListener(
+                                        tableEditor, columnEditor, parser, listeners);
+                        listeners.add(columnDefinitionListener);
+                    } else {
+                        throw new ParsingException(
+                                null,
+                                "Trying to change column "
+                                        + columnName
+                                        + " in "
+                                        + tableEditor.tableId().toString()
+                                        + " table, which does not exist. Query: "
+                                        + getText(ctx));
+                    }
+                },
+                tableEditor);
+        super.enterAlterByModifyColumn(ctx);
+    }
+
+    @Override
+    public void exitAlterByModifyColumn(MySqlParser.AlterByModifyColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    Column column = columnDefinitionListener.getColumn();
+                    tableEditor.addColumn(column);
+
+                    if (ctx.FIRST() != null) {
+                        tableEditor.reorderColumn(column.name(), null);
+                    } else if (ctx.AFTER() != null) {
+                        String afterColumn = parser.parseName(ctx.uid(1));
+                        tableEditor.reorderColumn(column.name(), afterColumn);
+                    }
+                    listeners.remove(columnDefinitionListener);
+                },
+                tableEditor,
+                columnDefinitionListener);
+        super.exitAlterByModifyColumn(ctx);
+    }
+
+    @Override
+    public void enterAlterByDropColumn(MySqlParser.AlterByDropColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    tableEditor.removeColumn(parser.parseName(ctx.uid()));
+                },
+                tableEditor);
+        super.enterAlterByDropColumn(ctx);
+    }
+
+    @Override
+    public void enterAlterByRename(MySqlParser.AlterByRenameContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    final TableId newTableId =
+                            ctx.uid() != null
+                                    ? parser.resolveTableId(
+                                            parser.currentSchema(), parser.parseName(ctx.uid()))
+                                    : parser.parseQualifiedTableId(ctx.fullId());
+                    parser.databaseTables().overwriteTable(tableEditor.create());
+                    parser.databaseTables().renameTable(tableEditor.tableId(), newTableId);
+                    tableEditor = parser.databaseTables().editTable(newTableId);
+                },
+                tableEditor);
+        super.enterAlterByRename(ctx);
+    }
+
+    @Override
+    public void enterAlterByChangeDefault(MySqlParser.AlterByChangeDefaultContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    String columnName = parser.parseName(ctx.uid());
+                    Column column = tableEditor.columnWithName(columnName);
+                    if (column != null) {
+                        defaultValueColumnEditor = column.edit();
+                        if (ctx.SET() != null) {
+                            defaultValueListener =
+                                    new DefaultValueParserListener(
+                                            defaultValueColumnEditor,
+                                            new AtomicReference<Boolean>(column.isOptional()));
+                            listeners.add(defaultValueListener);
+                        } else if (ctx.DROP() != null) {
+                            defaultValueColumnEditor.unsetDefaultValueExpression();
+                        }
+                    }
+                },
+                tableEditor);
+        super.enterAlterByChangeDefault(ctx);
+    }
+
+    @Override
+    public void exitAlterByChangeDefault(MySqlParser.AlterByChangeDefaultContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    tableEditor.updateColumn(defaultValueColumnEditor.create());
+                    listeners.remove(defaultValueListener);
+                    defaultValueColumnEditor = null;
+                },
+                defaultValueColumnEditor);
+        super.exitAlterByChangeDefault(ctx);
+    }
+
+    @Override
+    public void enterAlterByAddPrimaryKey(MySqlParser.AlterByAddPrimaryKeyContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    parser.parsePrimaryIndexColumnNames(ctx.indexColumnNames(), tableEditor);
+                },
+                tableEditor);
+        super.enterAlterByAddPrimaryKey(ctx);
+    }
+
+    @Override
+    public void enterAlterByDropPrimaryKey(MySqlParser.AlterByDropPrimaryKeyContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    tableEditor.setPrimaryKeyNames(new ArrayList<>());
+                },
+                tableEditor);
+        super.enterAlterByDropPrimaryKey(ctx);
+    }
+
+    @Override
+    public void enterAlterByAddUniqueKey(MySqlParser.AlterByAddUniqueKeyContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    if (!tableEditor.hasPrimaryKey()) {
+                        // this may eventually get overwritten by a real PK
+                        parser.parsePrimaryIndexColumnNames(ctx.indexColumnNames(), tableEditor);
+                    }
+                },
+                tableEditor);
+        super.enterAlterByAddUniqueKey(ctx);
+    }
+
+    @Override
+    public void enterAlterByRenameColumn(MySqlParser.AlterByRenameColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    String oldColumnName = parser.parseName(ctx.oldColumn);
+                    Column existingColumn = tableEditor.columnWithName(oldColumnName);
+                    if (existingColumn != null) {
+                        // DBZ-771 unset previously set default value, as it's not kept by MySQL;
+                        // for any column modifications a new
+                        // default value (which could be the same) has to be provided by the
+                        // column_definition which we'll parse later
+                        // on; only in 8.0 (not yet supported by this parser) columns can be renamed
+                        // without repeating the full column
+                        // definition; so in fact it's arguably not correct to use edit() on the
+                        // existing column to begin with, but
+                        // I'm going to leave this as is for now, to be prepared for the ability of
+                        // updating column definitions in 8.0
+                        ColumnEditor columnEditor = existingColumn.edit();
+                        // columnEditor.unsetDefaultValue();
+
+                        columnDefinitionListener =
+                                new ColumnDefinitionParserListener(
+                                        tableEditor, columnEditor, parser, listeners);
+                        listeners.add(columnDefinitionListener);
+                    } else {
+                        throw new ParsingException(
+                                null,
+                                "Trying to change column "
+                                        + oldColumnName
+                                        + " in "
+                                        + tableEditor.tableId().toString()
+                                        + " table, which does not exist. Query: "
+                                        + getText(ctx));
+                    }
+                },
+                tableEditor);
+        super.enterAlterByRenameColumn(ctx);
+    }
+
+    @Override
+    public void exitAlterByRenameColumn(MySqlParser.AlterByRenameColumnContext ctx) {
+        parser.runIfNotNull(
+                () -> {
+                    Column column = columnDefinitionListener.getColumn();
+                    tableEditor.addColumn(column);
+                    String newColumnName = parser.parseName(ctx.newColumn);
+                    if (newColumnName != null && !column.name().equals(newColumnName)) {
+                        tableEditor.renameColumn(column.name(), newColumnName);
+                    }
+                    listeners.remove(columnDefinitionListener);
+                },
+                tableEditor,
+                columnDefinitionListener);
+        super.exitAlterByRenameColumn(ctx);
+    }
+
+    @Override
+    public void enterTableOptionComment(MySqlParser.TableOptionCommentContext ctx) {
+        if (!parser.skipComments()) {
+            parser.runIfNotNull(
+                    () -> {
+                        if (ctx.COMMENT() != null) {
+                            tableEditor.setComment(
+                                    AbstractDdlParser.withoutQuotes(
+                                            ctx.STRING_LITERAL().getText()));
+                        }
+                    },
+                    tableEditor);
+        }
+        super.enterTableOptionComment(ctx);
+    }
+}


### PR DESCRIPTION
DBZ-5589 Mysql connector can't handle the case sensitive of rename/change column statement 
The bug is only fixed in debezium2.0 version, and I have copied a copy of the solution.