### PR TITLE
[hotfix] Modify the schema and table name snapshot data reading probl…

### DIFF
--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/utils/SqlServerConnectionUtils.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/utils/SqlServerConnectionUtils.java
@@ -68,7 +68,10 @@ public class SqlServerConnectionUtils {
                 "SELECT name, database_id, create_date  \n" + "FROM sys.databases;  ",
                 rs -> {
                     while (rs.next()) {
-                        databaseNames.add(rs.getString(1));
+                        String databaseName = rs.getString(1);
+                        if (jdbc.config().getDatabase().equals(databaseName)) {
+                            databaseNames.add(databaseName);
+                        }
                     }
                 });
         LOG.info("\t list of available databases is: {}", databaseNames);


### PR DESCRIPTION
Modify the schema and table name snapshot data reading problem with the same name.
For example:
I want to get data from databaseName: test1 schemaName: dbo tableName: fl_test, but my master database has the same schema and table, it will have exception.