### PR TITLE
Add tables.exclude.list option

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfig.java
@@ -37,7 +37,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
     protected final String password;
     protected final List<String> databaseList;
     protected final List<String> schemaList;
-    protected final List<String> tableList;
+    protected final Tables tables;
     protected final int fetchSize;
     protected final String serverTimeZone;
     protected final Duration connectTimeout;
@@ -49,7 +49,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
             StartupOptions startupOptions,
             List<String> databaseList,
             List<String> schemaList,
-            List<String> tableList,
+            Tables tables,
             int splitSize,
             int splitMetaGroupSize,
             double distributionFactorUpper,
@@ -86,7 +86,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
         this.password = password;
         this.databaseList = databaseList;
         this.schemaList = schemaList;
-        this.tableList = tableList;
+        this.tables = tables;
         this.fetchSize = fetchSize;
         this.serverTimeZone = serverTimeZone;
         this.connectTimeout = connectTimeout;
@@ -121,8 +121,8 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
         return databaseList;
     }
 
-    public List<String> getTableList() {
-        return tableList;
+    public Tables getTables() {
+        return tables;
     }
 
     public int getFetchSize() {

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/JdbcSourceConfigFactory.java
@@ -39,7 +39,7 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     protected String username;
     protected String password;
     protected List<String> databaseList;
-    protected List<String> tableList;
+    protected Tables tables;
     protected StartupOptions startupOptions = StartupOptions.initial();
     protected boolean includeSchemaChanges = false;
     protected boolean closeIdleReaders = false;
@@ -82,11 +82,21 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     /**
      * An optional list of regular expressions that match fully-qualified table identifiers for
      * tables to be monitored; any table not included in the list will be excluded from monitoring.
-     * Each identifier is of t、he form databaseName.tableName. By default the connector will monitor
+     * Each identifier is of the form databaseName.tableName. By default the connector will monitor
      * every non-system table in each monitored database.
      */
+    @Deprecated
     public JdbcSourceConfigFactory tableList(String... tableList) {
-        this.tableList = Arrays.asList(tableList);
+        return tables(Tables.include(tableList));
+    }
+
+    /**
+     * An optional list of regular expressions that match fully-qualified table identifiers for
+     * tables to be monitored or excluded. Each identifier is of the form databaseName.tableName. By
+     * default, the connector will monitor every non-system table in each monitored database.
+     */
+    public JdbcSourceConfigFactory tables(Tables tables) {
+        this.tables = tables;
         return this;
     }
 

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/Tables.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/config/Tables.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.base.config;
+
+import org.apache.flink.annotation.Experimental;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+/** A list of tables to include or exclude from extraction. */
+@Experimental
+public class Tables implements Serializable {
+
+    private final TableOption tableType;
+    private final List<String> tableList;
+
+    private Tables(TableOption tableType, List<String> tableList) {
+        this.tableType = tableType;
+        this.tableList = tableList;
+    }
+
+    public boolean isToInclude() {
+        return TableOption.INCLUDE.equals(this.tableType);
+    }
+
+    public boolean isToExclude() {
+        return TableOption.EXCLUDE.equals(this.tableType);
+    }
+
+    public List<String> getTableList() {
+        return this.tableList;
+    }
+
+    public static Tables include(String... tableList) {
+        return include(Arrays.asList(tableList));
+    }
+
+    public static Tables include(List<String> tableList) {
+        return new Tables(TableOption.INCLUDE, tableList);
+    }
+
+    public static Tables exclude(String... tableList) {
+        return exclude(Arrays.asList(tableList));
+    }
+
+    public static Tables exclude(List<String> tableList) {
+        return new Tables(TableOption.EXCLUDE, tableList);
+    }
+
+    /** Type for tables. */
+    public enum TableOption implements Serializable {
+        EXCLUDE,
+        INCLUDE
+    }
+}

--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfig.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.base.experimental.config;
 
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.Tables;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -39,7 +40,7 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
     public MySqlSourceConfig(
             StartupOptions startupOptions,
             List<String> databaseList,
-            List<String> tableList,
+            Tables tables,
             int splitSize,
             int splitMetaGroupSize,
             double distributionFactorUpper,
@@ -62,7 +63,7 @@ public class MySqlSourceConfig extends JdbcSourceConfig {
                 startupOptions,
                 databaseList,
                 null,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/experimental/config/MySqlSourceConfigFactory.java
@@ -92,8 +92,9 @@ public class MySqlSourceConfigFactory extends JdbcSourceConfigFactory {
         if (databaseList != null) {
             props.setProperty("database.include.list", String.join(",", databaseList));
         }
-        if (tableList != null) {
-            props.setProperty("table.include.list", String.join(",", tableList));
+        if (tables != null) {
+            String type = tables.isToInclude() ? "table.include.list" : "table.exclude.list";
+            props.setProperty(type, String.join(",", tables.getTableList()));
         }
         if (serverTimeZone != null) {
             props.setProperty("database.serverTimezone", serverTimeZone);
@@ -109,7 +110,7 @@ public class MySqlSourceConfigFactory extends JdbcSourceConfigFactory {
         return new MySqlSourceConfig(
                 startupOptions,
                 databaseList,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfig.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.oracle.source.config;
 
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.Tables;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnectorConfig;
@@ -41,7 +42,7 @@ public class OracleSourceConfig extends JdbcSourceConfig {
     public OracleSourceConfig(
             StartupOptions startupOptions,
             List<String> databaseList,
-            List<String> tableList,
+            Tables tables,
             int splitSize,
             int splitMetaGroupSize,
             double distributionFactorUpper,
@@ -66,7 +67,7 @@ public class OracleSourceConfig extends JdbcSourceConfig {
                 startupOptions,
                 databaseList,
                 null,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -97,8 +97,9 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
             props.setProperty("schema.include.list", String.join(",", schemaList));
         }
 
-        if (tableList != null) {
-            props.setProperty("table.include.list", String.join(",", tableList));
+        if (tables != null) {
+            String type = tables.isToInclude() ? "table.include.list" : "table.exclude.list";
+            props.setProperty(type, String.join(",", tables.getTableList()));
         }
 
         // override the user-defined debezium properties
@@ -110,7 +111,7 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
         return new OracleSourceConfig(
                 startupOptions,
                 databaseList,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresSourceBuilder.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.util.FlinkRuntimeException;
 
+import com.ververica.cdc.connectors.base.config.Tables;
 import com.ververica.cdc.connectors.base.options.StartupMode;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import com.ververica.cdc.connectors.base.source.assigner.HybridSplitAssigner;
@@ -95,6 +96,16 @@ public class PostgresSourceBuilder<T> {
      */
     public PostgresSourceBuilder<T> tableList(String... tableList) {
         this.configFactory.tableList(tableList);
+        return this;
+    }
+
+    /**
+     * An optional list of regular expressions that match fully-qualified table identifiers for
+     * tables to be monitored or excluded. Each identifier is of the form databaseName.tableName. By
+     * default, the connector will monitor every non-system table in each monitored database.
+     */
+    public PostgresSourceBuilder<T> tables(Tables tables) {
+        this.configFactory.tables(tables);
         return this;
     }
 

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.postgres.source.config;
 
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.Tables;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -42,7 +43,7 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
             StartupOptions startupOptions,
             List<String> databaseList,
             List<String> schemaList,
-            List<String> tableList,
+            Tables tables,
             int splitSize,
             int splitMetaGroupSize,
             double distributionFactorUpper,
@@ -66,7 +67,7 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
                 startupOptions,
                 databaseList,
                 schemaList,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
@@ -86,8 +86,9 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
             props.setProperty("schema.include.list", String.join(",", schemaList));
         }
 
-        if (tableList != null) {
-            props.setProperty("table.include.list", String.join(",", tableList));
+        if (tables != null) {
+            String type = tables.isToInclude() ? "table.include.list" : "table.exclude.list";
+            props.setProperty(type, String.join(",", tables.getTableList()));
         }
 
         // override the user-defined debezium properties
@@ -105,7 +106,7 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
                 startupOptions,
                 Collections.singletonList(database),
                 schemaList,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfig.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.sqlserver.source.config;
 
 import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.Tables;
 import com.ververica.cdc.connectors.base.options.StartupOptions;
 import io.debezium.config.Configuration;
 import io.debezium.connector.sqlserver.SqlServerConnectorConfig;
@@ -35,7 +36,7 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
     public SqlServerSourceConfig(
             StartupOptions startupOptions,
             List<String> databaseList,
-            List<String> tableList,
+            Tables tables,
             int splitSize,
             int splitMetaGroupSize,
             double distributionFactorUpper,
@@ -59,7 +60,7 @@ public class SqlServerSourceConfig extends JdbcSourceConfig {
                 startupOptions,
                 databaseList,
                 null,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfigFactory.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/config/SqlServerSourceConfigFactory.java
@@ -71,8 +71,9 @@ public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
         props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
         props.setProperty("database.dbname", checkNotNull(databaseList.get(0)));
 
-        if (tableList != null) {
-            props.setProperty("table.include.list", String.join(",", tableList));
+        if (tables != null) {
+            String type = tables.isToInclude() ? "table.include.list" : "table.exclude.list";
+            props.setProperty(type, String.join(",", tables.getTableList()));
         }
 
         switch (startupOptions.startupMode) {
@@ -94,7 +95,7 @@ public class SqlServerSourceConfigFactory extends JdbcSourceConfigFactory {
         return new SqlServerSourceConfig(
                 startupOptions,
                 databaseList,
-                tableList,
+                tables,
                 splitSize,
                 splitMetaGroupSize,
                 distributionFactorUpper,

--- a/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/read/fetch/SqlServerScanFetchTaskTest.java
+++ b/flink-connector-sqlserver-cdc/src/test/java/com/ververica/cdc/connectors/sqlserver/source/read/fetch/SqlServerScanFetchTaskTest.java
@@ -267,7 +267,7 @@ public class SqlServerScanFetchTaskTest extends SqlServerSourceTestBase {
             SqlServerSourceConfig sourceConfig, JdbcDataSourceDialect sourceDialect) {
         String databaseName = sourceConfig.getDatabaseList().get(0);
         List<TableId> tableIdList =
-                sourceConfig.getTableList().stream()
+                sourceConfig.getTables().getTableList().stream()
                         .map(tableId -> TableId.parse(databaseName + "." + tableId))
                         .collect(Collectors.toList());
         final ChunkSplitter chunkSplitter = sourceDialect.createChunkSplitter(sourceConfig);


### PR DESCRIPTION
This allow to use the tables.exclude.list on DataStream API

Is backwards compatible as old method to add tableList is still available

Could be changed for all dialect (added option for Postgres)