### PR TITLE
[Oracle]修复oracle数据库表主键是NUMBER类型且不指定p,s长度时报校验异常:org.apache.flink.table.api.Val…

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleTypeUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleTypeUtils.java
@@ -27,7 +27,7 @@ import java.sql.Types;
 /** Utilities for converting from oracle types to Flink types. */
 public class OracleTypeUtils {
 
-    //the length of the default oracle field type number attribute p  , number(p,s)
+    // the length of the default oracle field type number attribute p  , number(p,s)
     private static final int ORACLE_NUMBER_P_DEFAULT = 38;
 
     /** Returns a corresponding Flink data type from a debezium {@link Column}. */

--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleTypeUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleTypeUtils.java
@@ -27,6 +27,9 @@ import java.sql.Types;
 /** Utilities for converting from oracle types to Flink types. */
 public class OracleTypeUtils {
 
+    //the length of the default oracle field type number attribute p  , number(p,s)
+    private static final int ORACLE_NUMBER_P_DEFAULT = 38;
+
     /** Returns a corresponding Flink data type from a debezium {@link Column}. */
     public static DataType fromDbzColumn(Column column) {
         DataType dataType = convertFromColumn(column);
@@ -65,7 +68,9 @@ public class OracleTypeUtils {
                 return DataTypes.DOUBLE();
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return DataTypes.DECIMAL(column.length(), column.scale().orElse(0));
+                return DataTypes.DECIMAL(
+                        column.length() == 0 ? ORACLE_NUMBER_P_DEFAULT : column.length(),
+                        column.scale().orElse(0));
             case Types.DATE:
                 return DataTypes.DATE();
             case Types.TIMESTAMP:


### PR DESCRIPTION
修复oracle数据库表主键是NUMBER类型且不指定p,s长度时报校验异常:org.apache.flink.table.api.ValidationException: Decimal precision must be between 1 and 38 (both inclusive).