### PR TITLE
[mysql] Add notification after snapshot phase ends, before binlog stream starts with GTIDs via Slack 

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -124,6 +124,8 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
                         statefulTaskContext.getTopicSelector(),
                         statefulTaskContext.getSnapshotReceiver(),
                         StatefulTaskContext.getClock(),
+                        statefulTaskContext.getSourceConfig().getWatchTowerId(),
+                        statefulTaskContext.getSourceConfig().getTableList().get(0),
                         currentSnapshotSplit);
         executorService.execute(
                 () -> {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -124,7 +124,6 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
                         statefulTaskContext.getTopicSelector(),
                         statefulTaskContext.getSnapshotReceiver(),
                         StatefulTaskContext.getClock(),
-                        statefulTaskContext.getSourceConfig().getWatchTowerId(),
                         statefulTaskContext.getSourceConfig().getTableList().get(0),
                         currentSnapshotSplit);
         executorService.execute(

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -125,6 +125,8 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
                         statefulTaskContext.getSnapshotReceiver(),
                         StatefulTaskContext.getClock(),
                         statefulTaskContext.getSourceConfig().getTableList().get(0),
+                        statefulTaskContext.getSourceConfig().getHookUrl(),
+                        statefulTaskContext.getSourceConfig().doNotifySnapshotToBinlogSwitch(),
                         currentSnapshotSplit);
         executorService.execute(
                 () -> {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -21,7 +21,6 @@ import com.ververica.cdc.connectors.mysql.debezium.dispatcher.SignalEventDispatc
 import com.ververica.cdc.connectors.mysql.debezium.reader.SnapshotSplitReader;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
-import com.ververica.cdc.connectors.mysql.source.utils.SlackWebhookUtils;
 import com.ververica.cdc.connectors.mysql.source.utils.StatementUtils;
 import io.debezium.DebeziumException;
 import io.debezium.connector.mysql.MySqlConnection;

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -21,8 +21,8 @@ import com.ververica.cdc.connectors.mysql.debezium.dispatcher.SignalEventDispatc
 import com.ververica.cdc.connectors.mysql.debezium.reader.SnapshotSplitReader;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
+import com.ververica.cdc.connectors.mysql.source.utils.SlackWebhookUtils;
 import com.ververica.cdc.connectors.mysql.source.utils.StatementUtils;
-import com.ververica.cdc.connectors.mysql.source.utils.WatchtowerUtils;
 import io.debezium.DebeziumException;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -78,7 +78,6 @@ public class MySqlSnapshotSplitReadTask
     private final TopicSelector<TableId> topicSelector;
     private final EventDispatcher.SnapshotReceiver<MySqlPartition> snapshotReceiver;
     private final SnapshotChangeEventSourceMetrics<MySqlPartition> snapshotChangeEventSourceMetrics;
-    private final int watchTowerId;
     private final String tableName;
 
     public MySqlSnapshotSplitReadTask(
@@ -90,7 +89,6 @@ public class MySqlSnapshotSplitReadTask
             TopicSelector<TableId> topicSelector,
             EventDispatcher.SnapshotReceiver<MySqlPartition> snapshotReceiver,
             Clock clock,
-            int watchTowerId,
             String tableName,
             MySqlSnapshotSplit snapshotSplit) {
         super(connectorConfig, snapshotChangeEventSourceMetrics);
@@ -103,7 +101,6 @@ public class MySqlSnapshotSplitReadTask
         this.topicSelector = topicSelector;
         this.snapshotReceiver = snapshotReceiver;
         this.snapshotChangeEventSourceMetrics = snapshotChangeEventSourceMetrics;
-        this.watchTowerId = watchTowerId;
         this.tableName = tableName;
     }
 
@@ -170,7 +167,7 @@ public class MySqlSnapshotSplitReadTask
                 .setHighWatermark(highWatermark);
 
         if (snapshotSplit.getSplitEnd() == null) {
-            WatchtowerUtils.notify(this.watchTowerId, this.tableName);
+            SlackWebhookUtils.notify(this.tableName);
         }
         return SnapshotResult.completed(ctx.offset);
     }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -171,11 +171,6 @@ public class MySqlSnapshotSplitReadTask
                 snapshotSplit, highWatermark, SignalEventDispatcher.WatermarkKind.HIGH);
         ((SnapshotSplitReader.SnapshotSplitChangeEventSourceContextImpl) (context))
                 .setHighWatermark(highWatermark);
-
-        if (this.doNotifySnapshotToBinlogSwitch && snapshotSplit.getSplitEnd() == null) {
-            SlackWebhookUtils.notify(
-                    this.hookUrl, "LAST SNAPSHOT SPLIT FINISHED", this.tableName, "");
-        }
         return SnapshotResult.completed(ctx.offset);
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -252,6 +252,12 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
+    /** Set watchtower id to notify phase switch from snapshot to binlog stream. */
+    public MySqlSourceBuilder<T> notifySnapshotToBinlogSwitch(int watchTowerId) {
+        this.configFactory.notifySnapshotToBinlogSwitch(watchTowerId);
+        return this;
+    }
+
     /**
      * Build the {@link MySqlSource}.
      *

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -252,9 +252,9 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
-    /** Set watchtower id to notify phase switch from snapshot to binlog stream. */
-    public MySqlSourceBuilder<T> notifySnapshotToBinlogSwitch(int watchTowerId) {
-        this.configFactory.notifySnapshotToBinlogSwitch(watchTowerId);
+    /** Enable to notify phase switch from snapshot to binlog stream. */
+    public MySqlSourceBuilder<T> notifySnapshotToBinlogSwitch() {
+        this.configFactory.notifySnapshotToBinlogSwitch();
         return this;
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -253,8 +253,8 @@ public class MySqlSourceBuilder<T> {
     }
 
     /** Enable to notify phase switch from snapshot to binlog stream. */
-    public MySqlSourceBuilder<T> notifySnapshotToBinlogSwitch() {
-        this.configFactory.notifySnapshotToBinlogSwitch();
+    public MySqlSourceBuilder<T> notifySnapshotToBinlogSwitch(String hookUrl) {
+        this.configFactory.notifySnapshotToBinlogSwitch(hookUrl);
         return this;
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -32,6 +32,7 @@ import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSchemalessSnapshotSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
+import com.ververica.cdc.connectors.mysql.source.utils.SlackWebhookUtils;
 import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
@@ -392,6 +393,13 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
             // to care about the global output data order of snapshot splits and binlog split.
             if (currentParallelism == 1) {
                 assignerStatus = assignerStatus.onFinish();
+                if (sourceConfig.doNotifySnapshotToBinlogSwitch()) {
+                    SlackWebhookUtils.notify(
+                            this.sourceConfig.getHookUrl(),
+                            "SNAPSHOT FINISHED",
+                            this.sourceConfig.getTableList().get(0),
+                            "");
+                }
                 LOG.info(
                         "Snapshot split assigner received all splits finished and the job parallelism is 1, snapshot split assigner is turn into finished status.");
             } else {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -59,6 +59,7 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean scanNewlyAddedTableEnabled;
     private final boolean closeIdleReaders;
     private final boolean notifySnapshotToBinlogSwitch;
+    private final String hookUrl;
     private final Properties jdbcProperties;
     private final Map<ObjectPath, String> chunkKeyColumns;
 
@@ -91,6 +92,7 @@ public class MySqlSourceConfig implements Serializable {
             boolean scanNewlyAddedTableEnabled,
             boolean closeIdleReaders,
             boolean notifySnapshotToBinlogSwitch,
+            String hookUrl,
             Properties dbzProperties,
             Properties jdbcProperties,
             Map<ObjectPath, String> chunkKeyColumns) {
@@ -115,6 +117,7 @@ public class MySqlSourceConfig implements Serializable {
         this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
         this.closeIdleReaders = closeIdleReaders;
         this.notifySnapshotToBinlogSwitch = notifySnapshotToBinlogSwitch;
+        this.hookUrl = hookUrl;
         this.dbzProperties = checkNotNull(dbzProperties);
         this.dbzConfiguration = Configuration.from(dbzProperties);
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
@@ -144,6 +147,14 @@ public class MySqlSourceConfig implements Serializable {
 
     public List<String> getTableList() {
         return tableList;
+    }
+
+    public boolean doNotifySnapshotToBinlogSwitch() {
+        return notifySnapshotToBinlogSwitch;
+    }
+
+    public String getHookUrl() {
+        return hookUrl;
     }
 
     @Nullable

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -58,6 +58,8 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean includeSchemaChanges;
     private final boolean scanNewlyAddedTableEnabled;
     private final boolean closeIdleReaders;
+    private final boolean notifySnapshotToBinlogSwitch;
+    private final int watchTowerId;
     private final Properties jdbcProperties;
     private final Map<ObjectPath, String> chunkKeyColumns;
 
@@ -89,6 +91,8 @@ public class MySqlSourceConfig implements Serializable {
             boolean includeSchemaChanges,
             boolean scanNewlyAddedTableEnabled,
             boolean closeIdleReaders,
+            boolean notifySnapshotToBinlogSwitch,
+            int watchTowerId,
             Properties dbzProperties,
             Properties jdbcProperties,
             Map<ObjectPath, String> chunkKeyColumns) {
@@ -112,6 +116,8 @@ public class MySqlSourceConfig implements Serializable {
         this.includeSchemaChanges = includeSchemaChanges;
         this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
         this.closeIdleReaders = closeIdleReaders;
+        this.notifySnapshotToBinlogSwitch = notifySnapshotToBinlogSwitch;
+        this.watchTowerId = watchTowerId;
         this.dbzProperties = checkNotNull(dbzProperties);
         this.dbzConfiguration = Configuration.from(dbzProperties);
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
@@ -198,6 +204,14 @@ public class MySqlSourceConfig implements Serializable {
 
     public boolean isCloseIdleReaders() {
         return closeIdleReaders;
+    }
+
+    public boolean isNotifySnapshotToBinlogSwitch() {
+        return notifySnapshotToBinlogSwitch;
+    }
+
+    public int getWatchTowerId() {
+        return watchTowerId;
     }
 
     public Properties getDbzProperties() {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -59,7 +59,6 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean scanNewlyAddedTableEnabled;
     private final boolean closeIdleReaders;
     private final boolean notifySnapshotToBinlogSwitch;
-    private final int watchTowerId;
     private final Properties jdbcProperties;
     private final Map<ObjectPath, String> chunkKeyColumns;
 
@@ -92,7 +91,6 @@ public class MySqlSourceConfig implements Serializable {
             boolean scanNewlyAddedTableEnabled,
             boolean closeIdleReaders,
             boolean notifySnapshotToBinlogSwitch,
-            int watchTowerId,
             Properties dbzProperties,
             Properties jdbcProperties,
             Map<ObjectPath, String> chunkKeyColumns) {
@@ -117,7 +115,6 @@ public class MySqlSourceConfig implements Serializable {
         this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
         this.closeIdleReaders = closeIdleReaders;
         this.notifySnapshotToBinlogSwitch = notifySnapshotToBinlogSwitch;
-        this.watchTowerId = watchTowerId;
         this.dbzProperties = checkNotNull(dbzProperties);
         this.dbzConfiguration = Configuration.from(dbzProperties);
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
@@ -208,10 +205,6 @@ public class MySqlSourceConfig implements Serializable {
 
     public boolean isNotifySnapshotToBinlogSwitch() {
         return notifySnapshotToBinlogSwitch;
-    }
-
-    public int getWatchTowerId() {
-        return watchTowerId;
     }
 
     public Properties getDbzProperties() {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -73,6 +73,8 @@ public class MySqlSourceConfigFactory implements Serializable {
     private boolean includeSchemaChanges = false;
     private boolean scanNewlyAddedTableEnabled = false;
     private boolean closeIdleReaders = false;
+    private boolean notifySnapshotToBinlogSwitch = false;
+    private int watchTowerId = 0;
     private Properties jdbcProperties;
     private Duration heartbeatInterval = HEARTBEAT_INTERVAL.defaultValue();
     private Properties dbzProperties;
@@ -277,6 +279,15 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
+    /**
+     * Enable notify and set watchtower id to notify phase switch from snapshot to binlog stream.
+     */
+    public MySqlSourceConfigFactory notifySnapshotToBinlogSwitch(int watchTowerId) {
+        this.notifySnapshotToBinlogSwitch = true;
+        this.watchTowerId = watchTowerId;
+        return this;
+    }
+
     /** Creates a new {@link MySqlSourceConfig} for the given subtask {@code subtaskId}. */
     public MySqlSourceConfig createConfig(int subtaskId) {
         // hard code server name, because we don't need to distinguish it, docs:
@@ -366,6 +377,8 @@ public class MySqlSourceConfigFactory implements Serializable {
                 includeSchemaChanges,
                 scanNewlyAddedTableEnabled,
                 closeIdleReaders,
+                notifySnapshotToBinlogSwitch,
+                watchTowerId,
                 props,
                 jdbcProperties,
                 chunkKeyColumns);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -73,6 +73,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private boolean includeSchemaChanges = false;
     private boolean scanNewlyAddedTableEnabled = false;
     private boolean closeIdleReaders = false;
+    private String hookUrl = null;
     private boolean notifySnapshotToBinlogSwitch = false;
     private Properties jdbcProperties;
     private Duration heartbeatInterval = HEARTBEAT_INTERVAL.defaultValue();
@@ -279,7 +280,8 @@ public class MySqlSourceConfigFactory implements Serializable {
     }
 
     /** Enable to notify phase switch from snapshot to binlog stream. */
-    public MySqlSourceConfigFactory notifySnapshotToBinlogSwitch() {
+    public MySqlSourceConfigFactory notifySnapshotToBinlogSwitch(String hookUrl) {
+        this.hookUrl = hookUrl;
         this.notifySnapshotToBinlogSwitch = true;
         return this;
     }
@@ -374,6 +376,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 scanNewlyAddedTableEnabled,
                 closeIdleReaders,
                 notifySnapshotToBinlogSwitch,
+                hookUrl,
                 props,
                 jdbcProperties,
                 chunkKeyColumns);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -74,7 +74,6 @@ public class MySqlSourceConfigFactory implements Serializable {
     private boolean scanNewlyAddedTableEnabled = false;
     private boolean closeIdleReaders = false;
     private boolean notifySnapshotToBinlogSwitch = false;
-    private int watchTowerId = 0;
     private Properties jdbcProperties;
     private Duration heartbeatInterval = HEARTBEAT_INTERVAL.defaultValue();
     private Properties dbzProperties;
@@ -279,12 +278,9 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
-    /**
-     * Enable notify and set watchtower id to notify phase switch from snapshot to binlog stream.
-     */
-    public MySqlSourceConfigFactory notifySnapshotToBinlogSwitch(int watchTowerId) {
+    /** Enable to notify phase switch from snapshot to binlog stream. */
+    public MySqlSourceConfigFactory notifySnapshotToBinlogSwitch() {
         this.notifySnapshotToBinlogSwitch = true;
-        this.watchTowerId = watchTowerId;
         return this;
     }
 
@@ -378,7 +374,6 @@ public class MySqlSourceConfigFactory implements Serializable {
                 scanNewlyAddedTableEnabled,
                 closeIdleReaders,
                 notifySnapshotToBinlogSwitch,
-                watchTowerId,
                 props,
                 jdbcProperties,
                 chunkKeyColumns);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -16,7 +16,6 @@
 
 package com.ververica.cdc.connectors.mysql.source.enumerator;
 
-import com.ververica.cdc.connectors.mysql.table.StartupMode;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SplitEnumerator;
@@ -45,6 +44,7 @@ import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import com.ververica.cdc.connectors.mysql.source.utils.SlackWebhookUtils;
+import com.ververica.cdc.connectors.mysql.table.StartupMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -245,7 +245,6 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                                 this.sourceConfig.getTableList().get(0),
                                 position);
                     }
-
                 }
                 awaitingReader.remove();
                 LOG.info("The enumerator assigns split {} to subtask {}", mySqlSplit, nextAwaiting);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/SlackWebhookUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/SlackWebhookUtils.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 public class SlackWebhookUtils {
     private static final Logger LOG = LoggerFactory.getLogger(SlackWebhookUtils.class);
 
-
     private static String removeNewlines(String text) {
         return text.replace("\n", "").replace("\r", "");
     }
@@ -73,6 +72,5 @@ public class SlackWebhookUtils {
             LOG.info("Fail to Send Notification to Slack");
             LOG.info(e.getMessage());
         }
-
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/SlackWebhookUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/SlackWebhookUtils.java
@@ -43,8 +43,8 @@ public class SlackWebhookUtils {
         conn.disconnect();
     }
 
-    private static HttpURLConnection createConnection() throws IOException {
-        URL url = new URL("slak-hook-url");
+    private static HttpURLConnection createConnection(String hookUrl) throws IOException {
+        URL url = new URL(hookUrl);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
         conn.setRequestMethod("POST");
         conn.setDoOutput(true);
@@ -58,7 +58,7 @@ public class SlackWebhookUtils {
     public static void notify(String hookUrl, String header, String tableName, String gtids) {
 
         try {
-            HttpURLConnection conn = createConnection();
+            HttpURLConnection conn = createConnection(hookUrl);
 
             String database = removeNewlines(tableName.split("\\.")[0]);
             String table = removeNewlines(tableName.split("\\.")[1]);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/SlackWebhookUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/SlackWebhookUtils.java
@@ -23,14 +23,14 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-/** Send notification to watchtower. */
-public class WatchtowerUtils {
-    private static final Logger LOG = LoggerFactory.getLogger(WatchtowerUtils.class);
+/** Send notification to slack. */
+public class SlackWebhookUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(SlackWebhookUtils.class);
 
-    public static void notify(int watchTowerId, String tableName) {
-        LOG.info("Send Notification to Watchtower {}", watchTowerId);
+    public static void notify(String tableName) {
+        LOG.info("Send Snapshot Finish Notification ");
         try {
-            URL url = new URL("");
+            URL url = new URL("https://hooks.slack.com/services/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");
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setDoOutput(true);
@@ -38,9 +38,7 @@ public class WatchtowerUtils {
             conn.setConnectTimeout(5000);
             conn.setRequestProperty("Content-Type", "application/json");
             String jsonInputString =
-                    "{\"to\":\""
-                            + watchTowerId
-                            + "\",\"msg\":\""
+                    "{\"text\":\""
                             + "[SNAPSHOT FINISHED]"
                             + "\\nDatabase: "
                             + tableName.split("\\.")[0]
@@ -54,7 +52,7 @@ public class WatchtowerUtils {
             conn.getResponseCode();
             conn.disconnect();
         } catch (Exception e) {
-            LOG.info("Fail to Send Notification to Watchtower {}", watchTowerId);
+            LOG.info("Fail to Send Notification");
             LOG.info(e.getMessage());
         }
     }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/WatchtowerUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/WatchtowerUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/** Send notification to watchtower. */
+public class WatchtowerUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(WatchtowerUtils.class);
+
+    public static void notify(int watchTowerId, String tableName) {
+        LOG.info("Send Notification to Watchtower {}", watchTowerId);
+        try {
+            URL url = new URL("");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setDoOutput(true);
+            conn.setDoInput(true);
+            conn.setConnectTimeout(5000);
+            conn.setRequestProperty("Content-Type", "application/json");
+            String jsonInputString =
+                    "{\"to\":\""
+                            + watchTowerId
+                            + "\",\"msg\":\""
+                            + "[SNAPSHOT FINISHED]"
+                            + "\\nDatabase: "
+                            + tableName.split("\\.")[0]
+                            + "\\nTable: "
+                            + tableName.split("\\.")[1]
+                            + "\"}";
+            try (OutputStream os = conn.getOutputStream()) {
+                byte[] input = jsonInputString.getBytes("utf-8");
+                os.write(input, 0, input.length);
+            }
+            conn.getResponseCode();
+            conn.disconnect();
+        } catch (Exception e) {
+            LOG.info("Fail to Send Notification to Watchtower {}", watchTowerId);
+            LOG.info(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
First, let me say thank you to everyone who contributes to Flink CDC.
Our team use Flink CDC to perform MySql CDC.

But since [there is no Snapshot Only mode for MySql yet](https://github.com/ververica/flink-cdc-connectors/issues/1687), we had a need to be notified when a snapshot is completed and when the binlog stream is started.

To accomplish this, we **implemented a notification when a snapshot ends and when a binlog stream starts with GTIDs.**

--- 

Here's the team's use case in more detail 
1. We set parallelism to 2 or more for large tables.
2. And we send change event log to kafka to use Debezium's JDBC Sink Connector, which supports [Schema Evolution](https://debezium.io/documentation/reference/stable/connectors/jdbc.html#jdbc-schema-evolution).
3. Sinking to Kafka is slower than MySqlSource operator, so we give more paralleisms to sink operator more parallelism than MySqlSource.
4. In this case, the transfer is done in rebalance mode from source operator to sink operator, so the order for the same PK is not guaranteed when transferring binlogs.
5. So we restart the job based on GTIDs with parallelism equal to 1 at the end of the snapshot phase .

To do this, we needed (1) to be notified that the snapshot ended and the binlog stream started, and (2) to know from which GTIDs the binlog stream started.

---

This is portion of our code. **We assumed that we only capture 1 table per flink cdc job**
```scala
  def getMySQLSourceOperator(): MySqlSource[String] = {
    MySqlSource.builder[String]()
      .hostname(mySqlConfig.host)
      .port(mySqlConfig.port)
      .serverTimeZone(mySqlConfig.timeZone)
      .databaseList(mySqlConfig.database)
      .tableList(mySqlConfig.table)
      .username(mySqlConfig.user)
      .serverId(mySqlConfig.serverIdRange)
      .password(mySqlConfig.password)
      .startupOptions(mySqlConfig.startupMode)
      .fetchSize(mySqlConfig.fetchSize)
      .splitSize(mySqlConfig.splitSize)
      .chunkKeyColumn(new ObjectPath(mySqlConfig.database, mySqlConfig.table), mySqlConfig.chunkKeyColumn)
      .connectionPoolSize(mySqlConfig.poolSize)
      .scanNewlyAddedTableEnabled(false)
      .includeSchemaChanges(false)
      .debeziumProperties(mySqlConfig.dbzProps)
      .closeIdleReaders(true)
      .notifySnapshotToBinlogSwitch("slack-hook-url") // here what we implemented
      .deserializer(new JsonDebeziumDeserializationSchema(true, mySqlConfig.jsonConverterProps))
      .build()
  }
```

---


We can't share a real picture of the notification, because our company recommends using in-house tools rather than Slack(🥲🥲🥲) and has some security policy..

But it looks something like the format below!
- Snapshot finished notifiaction.
```
[SNAPSHOT FINISHED]
 Database: test_database
 Table: test_table
```
- Binlog stream start notification.
```
[BINLOG STREAM START]
 Database: test_database
 Table: test_table
 GTIDs: 3bda59bb-2fc8-11eb-855f-fa163e2550e3:1-128377129,3c3a6a1b-c931-11ed-b0db-b4055dec129e:1-273703345,901d637c-8add-11eb-8e3f-b4055d3355a6:1-3641352422,b46b8251-5254-11ed-a648-d0946637df48:1-1069556331,db449f07-c53e-11e8-b8c2-d094663d3d1d:1-3543229125,e8d62f95-c77a-11e8-9270-d0946637df48:1-5715021533
```

---

If you are interested in this feature, please feel free to check it out.  Any comments or feedback would also be appreciated.
Have a great day all Flink users 😄