### PR TITLE
[mysql] Add a module to periodically check ip on DNS (for DB Switching)

### DIFF
--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -252,6 +252,12 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
+    /** Restart on DB Switch. */
+    public MySqlSourceBuilder<T> restartOnDbSwitch(boolean restartOnDbSwitch) {
+        this.configFactory.restartOnDbSwitch(restartOnDbSwitch);
+        return this;
+    }
+
     /**
      * Build the {@link MySqlSource}.
      *

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -58,6 +58,8 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean includeSchemaChanges;
     private final boolean scanNewlyAddedTableEnabled;
     private final boolean closeIdleReaders;
+    private final boolean restartOnDbSwitch;
+
     private final Properties jdbcProperties;
     private final Map<ObjectPath, String> chunkKeyColumns;
 
@@ -89,6 +91,7 @@ public class MySqlSourceConfig implements Serializable {
             boolean includeSchemaChanges,
             boolean scanNewlyAddedTableEnabled,
             boolean closeIdleReaders,
+            boolean restartOnDbSwitch,
             Properties dbzProperties,
             Properties jdbcProperties,
             Map<ObjectPath, String> chunkKeyColumns) {
@@ -112,6 +115,7 @@ public class MySqlSourceConfig implements Serializable {
         this.includeSchemaChanges = includeSchemaChanges;
         this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
         this.closeIdleReaders = closeIdleReaders;
+        this.restartOnDbSwitch = restartOnDbSwitch;
         this.dbzProperties = checkNotNull(dbzProperties);
         this.dbzConfiguration = Configuration.from(dbzProperties);
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
@@ -198,6 +202,10 @@ public class MySqlSourceConfig implements Serializable {
 
     public boolean isCloseIdleReaders() {
         return closeIdleReaders;
+    }
+
+    public boolean isRestartOnDbSwitch() {
+        return restartOnDbSwitch;
     }
 
     public Properties getDbzProperties() {

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -73,6 +73,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private boolean includeSchemaChanges = false;
     private boolean scanNewlyAddedTableEnabled = false;
     private boolean closeIdleReaders = false;
+    private boolean restartOnDbSwitch = false;
     private Properties jdbcProperties;
     private Duration heartbeatInterval = HEARTBEAT_INTERVAL.defaultValue();
     private Properties dbzProperties;
@@ -277,6 +278,12 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
+    /** Restart on DB Switch. */
+    public MySqlSourceConfigFactory restartOnDbSwitch(boolean restartOnDbSwitch) {
+        this.restartOnDbSwitch = restartOnDbSwitch;
+        return this;
+    }
+
     /** Creates a new {@link MySqlSourceConfig} for the given subtask {@code subtaskId}. */
     public MySqlSourceConfig createConfig(int subtaskId) {
         // hard code server name, because we don't need to distinguish it, docs:
@@ -366,6 +373,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 includeSchemaChanges,
                 scanNewlyAddedTableEnabled,
                 closeIdleReaders,
+                restartOnDbSwitch,
                 props,
                 jdbcProperties,
                 chunkKeyColumns);

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -34,6 +34,7 @@ import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitMetaEvent;
 import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitMetaRequestEvent;
 import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitUpdateAckEvent;
 import com.ververica.cdc.connectors.mysql.source.events.BinlogSplitUpdateRequestEvent;
+import com.ververica.cdc.connectors.mysql.source.events.DnsIpChangedEvent;
 import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsAckEvent;
 import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsReportEvent;
 import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsRequestEvent;
@@ -169,6 +170,9 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                     "The enumerator receives notice from subtask {} for the binlog split assignment. ",
                     subtaskId);
             binlogSplitTaskId = subtaskId;
+        } else if (sourceEvent instanceof DnsIpChangedEvent) {
+            LOG.warn("IP address in DNS has changed");
+            throw new FlinkRuntimeException("IP address in DNS has changed");
         }
     }
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/events/DnsIpChangedEvent.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/events/DnsIpChangedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.events;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+import com.ververica.cdc.connectors.mysql.source.enumerator.MySqlSourceEnumerator;
+import com.ververica.cdc.connectors.mysql.source.reader.MySqlSourceReader;
+
+/**
+ * The {@link SourceEvent} that {@link MySqlSourceReader} sends to {@link MySqlSourceEnumerator} to
+ * throw FlinkRuntimeException.
+ */
+public class DnsIpChangedEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    public DnsIpChangedEvent() {}
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
@@ -47,6 +47,7 @@ import com.ververica.cdc.connectors.mysql.source.split.MySqlSnapshotSplitState;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplit;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlSplitState;
 import com.ververica.cdc.connectors.mysql.source.split.SourceRecords;
+import com.ververica.cdc.connectors.mysql.source.utils.DnsIpChecker;
 import com.ververica.cdc.connectors.mysql.source.utils.TableDiscoveryUtils;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.connector.mysql.MySqlPartition;
@@ -86,6 +87,7 @@ public class MySqlSourceReader<T>
     private final MySqlSourceReaderContext mySqlSourceReaderContext;
     private final MySqlPartition partition;
     private volatile MySqlBinlogSplit suspendedBinlogSplit;
+    private DnsIpChecker dnsIpChecker;
 
     public MySqlSourceReader(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementQueue,
@@ -108,6 +110,11 @@ public class MySqlSourceReader<T>
         this.suspendedBinlogSplit = null;
         this.partition =
                 new MySqlPartition(sourceConfig.getMySqlConnectorConfig().getLogicalName());
+
+        if (this.enableDnsIpChecker()) {
+            this.dnsIpChecker =
+                    new DnsIpChecker(this.subtaskId, this.context, sourceConfig.getHostname());
+        }
     }
 
     @Override
@@ -115,6 +122,18 @@ public class MySqlSourceReader<T>
         if (getNumberOfCurrentlyAssignedSplits() <= 1) {
             context.sendSplitRequest();
         }
+    }
+
+    public void close() throws Exception {
+        if (this.enableDnsIpChecker()) {
+            this.dnsIpChecker.close();
+            LOG.info("Closing MySqlSource Reader.");
+        }
+        super.close();
+    }
+
+    private boolean enableDnsIpChecker() {
+        return this.subtaskId == 0 && this.sourceConfig.isRestartOnDbSwitch();
     }
 
     @Override

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/DnsIpChecker.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/DnsIpChecker.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.utils;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import com.ververica.cdc.connectors.mysql.source.events.DnsIpChangedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A DNSIpChecker check whether ip address in DNS has changed or not. If changed, throw *
+ * FlinkRuntimeException
+ */
+public class DnsIpChecker {
+    private static final Logger LOG = LoggerFactory.getLogger(DnsIpChecker.class);
+    private int checkIntervalMs = 1000;
+    private int logInterval = 60 * checkIntervalMs / 1000;
+    private volatile boolean currentTaskRunning = false;
+    private ExecutorService executorService;
+    private final String fqdn;
+    private final SourceReaderContext context;
+    private final String initIp;
+    private static final long DNS_CHECKER_CLOSE_TIMEOUT = 30L;
+    private static final long DNS_CHECKER_CLOSE_MAX_TIMEOUT = 300L;
+
+    public DnsIpChecker(int subTaskId, SourceReaderContext context, String fqdn) {
+        ThreadFactory threadFactory =
+                new ThreadFactoryBuilder().setNameFormat("binlog-dns-checker-" + subTaskId).build();
+        this.executorService = Executors.newSingleThreadExecutor(threadFactory);
+        this.context = context;
+        this.fqdn = fqdn;
+        this.initIp = this.getIp();
+    }
+
+    public void run() {
+        this.currentTaskRunning = true;
+        this.executorService.execute(
+                () -> {
+                    try {
+                        this.execute();
+                    } catch (Exception e) {
+                        this.context.sendSourceEventToCoordinator(new DnsIpChangedEvent());
+                    }
+                });
+    }
+
+    private void execute() throws Exception {
+        LOG.info("Execute DNS IP Checker");
+        String currentIpInDNS = "";
+        Integer checkCnt = 0;
+        while (this.currentTaskRunning) {
+            checkCnt += 1;
+            currentIpInDNS = this.getIp();
+
+            if (currentIpInDNS.equals("")) {
+                LOG.info("No stdout from dig");
+            } else {
+                if (checkCnt % logInterval == 1) {
+                    LOG.info(
+                            "[{}] Current IP address for hostname {} is {}",
+                            checkCnt,
+                            this.fqdn,
+                            currentIpInDNS);
+                }
+                if (!currentIpInDNS.equals(this.initIp)) {
+                    LOG.warn(
+                            "IP address of {} has changed from {} to {} in DNS ",
+                            this.fqdn,
+                            this.initIp,
+                            currentIpInDNS);
+                    this.currentTaskRunning = false;
+                    throw new FlinkRuntimeException("IP address has changed");
+                }
+            }
+            Thread.sleep(checkIntervalMs);
+        }
+    }
+
+    private String getIp() {
+        String ipInDNS = "";
+        try {
+            ipInDNS = InetAddress.getByName(this.fqdn).getHostAddress();
+        } catch (Exception e) {
+            LOG.warn("Failed to get ip address from DNS");
+        }
+        return ipInDNS;
+    }
+
+    public void close() {
+        if (this.executorService != null) {
+            this.executorService.shutdownNow();
+            try {
+                if (!this.executorService.awaitTermination(
+                        DNS_CHECKER_CLOSE_TIMEOUT, TimeUnit.SECONDS)) {
+                    LOG.warn(
+                            "Failed to close the dns checker in {} seconds.",
+                            DNS_CHECKER_CLOSE_TIMEOUT);
+                    this.executorService.shutdownNow();
+                    if (!this.executorService.awaitTermination(
+                            DNS_CHECKER_CLOSE_MAX_TIMEOUT, TimeUnit.SECONDS)) {
+                        LOG.error("Still failed to close the dns checker.");
+                    }
+                }
+            } catch (InterruptedException e) {
+                LOG.error("Interrupted when closing the dns checker.");
+            } finally {
+                this.executorService = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
First, we'd like to thank everyone who contributes to Flink CDC.

Our team uses Flink CDC to perform MySql CDC.

In the real-world DB use case, DBs are organized in a master-slave structure and DB switching occurs periodically.
When DB Switching occurs, **the connected slave server is promoted to the master server.**

The problem is that flink CDC connector keeps the connection, but **in the real-world, there is a policy that it should not be attached to the master server of DB except for some permitted processes.**

--- 

For resolve this issue, our team implemented DnsIpChecker modules. (We saw [similar issue and answer](https://github.com/ververica/flink-cdc-connectors/issues/2419))

Here's how it works
1. Allocate one thread at the time of `MySqlSourceReader(subtaskId=0)` creation. (to share lifecycle of `MySqlSourceReader`)
2. That thread periodically checks the IP in DNS based on the FQDN. 
3. If the IP changes, it raises a `FlinkRuntimeException` by sending a `SourceEvent` to `MySqlSourceEnumerator` to restart the Flink Job to reset the DB connection.
4. Add a close function to `MySqlSourceReader`, so that the thread is also terminated when the Flink CDC Job is terminated, 

This is portion of our code. We assumed that we only capture 1 table per flink cdc job

```scala
  def getMySQLSourceOperator(): MySqlSource[String] = {
    MySqlSource.builder[String]()
      .hostname(mySqlConfig.host)
      .port(mySqlConfig.port)
      .serverTimeZone(mySqlConfig.timeZone)
      .databaseList(mySqlConfig.database)
      .tableList(mySqlConfig.table)
      .username(mySqlConfig.user)
      .serverId(mySqlConfig.serverIdRange)
      .password(mySqlConfig.password)
      .startupOptions(mySqlConfig.startupMode)
      .fetchSize(mySqlConfig.fetchSize)
      .splitSize(mySqlConfig.splitSize)
      .chunkKeyColumn(new ObjectPath(mySqlConfig.database, mySqlConfig.table), mySqlConfig.chunkKeyColumn)
      .connectionPoolSize(mySqlConfig.poolSize)
      .scanNewlyAddedTableEnabled(false)
      .includeSchemaChanges(false)
      .debeziumProperties(mySqlConfig.dbzProps)
      .closeIdleReaders(true)
      .restartOnDbSwitch(true) // here what we implemented
      .deserializer(new JsonDebeziumDeserializationSchema(true, mySqlConfig.jsonConverterProps))
      .build()
  }
```

We considered just resetting the DB connection only,
but it was difficult to get a recovery point, so we chose to restart the Flink Job for using Flink's checkpoints.

---

Like the log below, we also periodic logs to check if checking IP is performing normally. 
(Hostname and ip masked)
```d
2023-09-02 07:10:45.003 INFO  com.ververica.cdc.connectors.mysql.source.utils.DNSIpChecker [] - [264361] Current IP address for hostname test_host_name.db.server is XXX
...
2023-09-02 07:11:45.026 INFO  com.ververica.cdc.connectors.mysql.source.utils.DNSIpChecker [] - [264421] Current IP address for hostname test_host_name.db.server is XXX
```

--- 

If you are interested in this feature, please feel free to check it out.  Any comments or feedback would also be appreciated.
Have a great day all Flink users 😄