### PR TITLE
[postgres] Add lsn as metadata

### DIFF
--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLReadableMetadata.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/table/PostgreSQLReadableMetadata.java
@@ -98,22 +98,23 @@ public enum PostgreSQLReadableMetadata {
             }),
 
     /**
-     * An LSN is a 64-bit integer, representing a byte position in the write-ahead log stream.
-     * If the record is read from snapshot of the table instead of the change stream, the value is always 0.
+     * An LSN is a 64-bit integer, representing a byte position in the write-ahead log stream. If
+     * the record is read from snapshot of the table instead of the change stream, the value is
+     * always 0.
      */
     LSN(
             "lsn",
             DataTypes.BIGINT().notNull(),
             new MetadataConverter() {
-        private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-        @Override
-        public Object read(SourceRecord record) {
-            Struct messageStruct = (Struct) record.value();
-            Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
-            return sourceStruct.get(SourceInfo.LSN_KEY);
-        }
-    });
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct messageStruct = (Struct) record.value();
+                    Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
+                    return sourceStruct.get(SourceInfo.LSN_KEY);
+                }
+            });
 
     private final String key;
 


### PR DESCRIPTION
lsn is useful when restarting a job, so we can add it to metadata.