### PR TITLE
[oracle] Support partitioned table

### DIFF
--- a/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-connector-oracle-cdc/src/main/java/com/ververica/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -94,7 +94,7 @@ public class OracleConnectionUtils {
         Set<TableId> tableIdSet = new HashSet<>();
         String queryTablesSql =
                 "SELECT OWNER ,TABLE_NAME,TABLESPACE_NAME FROM ALL_TABLES \n"
-                        + "WHERE TABLESPACE_NAME IS NOT NULL AND TABLESPACE_NAME NOT IN ('SYSTEM','SYSAUX')";
+                        + "WHERE PARTITIONED = 'YES' OR TABLESPACE_NAME IS NOT NULL AND TABLESPACE_NAME NOT IN ('SYSTEM','SYSAUX')";
         try {
             jdbcConnection.query(
                     queryTablesSql,


### PR DESCRIPTION
reference: [Oracle doc](https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/ALL_TABLES.html#GUID-6823CD28-0681-468E-950B-966C6F71325D).  
This closes https://github.com/ververica/flink-cdc-connectors/issues/1737,https://github.com/ververica/flink-cdc-connectors/issues/2287.  

`WHERE TABLESPACE_NAME IS NOT NULL AND TABLESPACE_NAME NOT IN ('SYSTEM','SYSAUX')` will filter partitioned table.
As TABLESPACE_NAME means:
TABLESPACE_NAME | VARCHAR2(30) |  Name of the tablespace containing the table; NULL for partitioned, temporary, and index-organized tables
-- | -- | --

plan 1) we need to support partitioned table by using PARTITIONED:

PARTITIONED | VARCHAR2(3) |  Indicates whether the table is partitioned (YES) or not (NO)
-- | -- | --

An example：
<img width="640" alt="截屏2023-09-11 下午5 20 43" src="https://github.com/ververica/flink-cdc-connectors/assets/38547014/4d6c2ccc-4a5d-41d2-a3dd-971e0ba81b1c">  

plan 2) Or we use IOT_TYPE and TEMPORARY to filter unnecessary temporary/index-organized tables.


