### PR TITLE
[WIP][mysql] Add ExternalSystemListener to notify user about the status of connector.

### DIFF
--- a/docs/content/connectors/mysql-cdc.md
+++ b/docs/content/connectors/mysql-cdc.md
@@ -329,6 +329,20 @@ During a snapshot operation, the connector will query each included table to pro
       <td>Boolean</td>
       <td>Whether to close idle readers at the end of the snapshot phase. The flink version is required to be greater than or equal to 1.14 when 'execution.checkpointing.checkpoints-after-tasks-finish.enabled' is set to true.</td>
     </tr>
+    <tr>
+      <td>external-system.listener.class</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>String</td>
+      <td>class name of custom listener, if there are multiple implementations, use `,` for segmentation.</td>
+    </tr>
+    <tr>
+      <td>external-system.*</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>String</td>
+      <td>Pass-through properties to custom listener, user can use those properties to build and initial custom listener.</td>
+    </tr>
     </tbody>
 </table>
 </div>

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -130,6 +130,15 @@ public class MySqlSourceBuilder<T> {
     }
 
     /**
+     * The chunk key of table snapshot, captured tables are split into multiple chunks by the chunk
+     * key column when read the snapshot of table.
+     */
+    public MySqlSourceBuilder<T> listenerProperties(Properties listenerProperties) {
+        this.configFactory.listenerProperties(listenerProperties);
+        return this;
+    }
+
+    /**
      * The split size (number of rows) of table snapshot, captured tables are split into multiple
      * splits when read the snapshot of table.
      */

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -60,6 +60,7 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean closeIdleReaders;
     private final Properties jdbcProperties;
     private final Map<ObjectPath, String> chunkKeyColumns;
+    private final Properties listenerProperties;
 
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
@@ -91,7 +92,8 @@ public class MySqlSourceConfig implements Serializable {
             boolean closeIdleReaders,
             Properties dbzProperties,
             Properties jdbcProperties,
-            Map<ObjectPath, String> chunkKeyColumns) {
+            Map<ObjectPath, String> chunkKeyColumns,
+            Properties listenerProperties) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
         this.username = checkNotNull(username);
@@ -117,6 +119,7 @@ public class MySqlSourceConfig implements Serializable {
         this.dbzMySqlConfig = new MySqlConnectorConfig(dbzConfiguration);
         this.jdbcProperties = jdbcProperties;
         this.chunkKeyColumns = chunkKeyColumns;
+        this.listenerProperties = listenerProperties;
     }
 
     public String getHostname() {
@@ -222,5 +225,9 @@ public class MySqlSourceConfig implements Serializable {
 
     public Map<ObjectPath, String> getChunkKeyColumns() {
         return chunkKeyColumns;
+    }
+
+    public Properties getListenerProperties() {
+        return listenerProperties;
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -77,6 +77,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private Duration heartbeatInterval = HEARTBEAT_INTERVAL.defaultValue();
     private Properties dbzProperties;
     private Map<ObjectPath, String> chunkKeyColumns = new HashMap<>();
+    private Properties listenerProperties;
 
     public MySqlSourceConfigFactory hostname(String hostname) {
         this.hostname = hostname;
@@ -262,6 +263,12 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
+    /** The Listener properties. */
+    public MySqlSourceConfigFactory listenerProperties(Properties properties) {
+        this.listenerProperties = properties;
+        return this;
+    }
+
     /**
      * Whether to close idle readers at the end of the snapshot phase. This feature depends on
      * FLIP-147: Support Checkpoints After Tasks Finished. The flink version is required to be
@@ -345,6 +352,10 @@ public class MySqlSourceConfigFactory implements Serializable {
             jdbcProperties = new Properties();
         }
 
+        if (listenerProperties == null) {
+            listenerProperties = new Properties();
+        }
+
         return new MySqlSourceConfig(
                 hostname,
                 port,
@@ -368,6 +379,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 closeIdleReaders,
                 props,
                 jdbcProperties,
-                chunkKeyColumns);
+                chunkKeyColumns,
+                listenerProperties);
     }
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -39,8 +39,8 @@ import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsRe
 import com.ververica.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsRequestEvent;
 import com.ververica.cdc.connectors.mysql.source.events.LatestFinishedSplitsNumberEvent;
 import com.ververica.cdc.connectors.mysql.source.events.LatestFinishedSplitsNumberRequestEvent;
-import com.ververica.cdc.connectors.mysql.source.listener.ListenerMessageInformation;
 import com.ververica.cdc.connectors.mysql.source.listener.ListenerService;
+import com.ververica.cdc.connectors.mysql.source.listener.MysqlListenerMessage;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
 import com.ververica.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
@@ -240,8 +240,8 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                         gtids = mySqlBinlogSplit.getStartingOffset().getGtidSet();
                     }
                 }
-                ListenerMessageInformation listenerMessageInformation =
-                        new ListenerMessageInformation(startupMode.toString(), gtids);
+                MysqlListenerMessage listenerMessageInformation =
+                        new MysqlListenerMessage(startupMode.toString(), gtids);
                 awaitingReader.remove();
                 LOG.info("The enumerator assigns split {} to subtask {}", mySqlSplit, nextAwaiting);
 

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/AbstractListenerMessage.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/AbstractListenerMessage.java
@@ -16,13 +16,16 @@
 
 package com.ververica.cdc.connectors.mysql.source.listener;
 
-/** The information that will be sent with the notification. */
-public class ListenerMessageInformation {
-    private final String startupMode;
-    private final String gtids;
+import java.util.Properties;
 
-    public ListenerMessageInformation(String startupMode, String gtids) {
-        this.startupMode = startupMode;
-        this.gtids = gtids;
+/** The information that will be sent with the notification. */
+public abstract class AbstractListenerMessage {
+
+    public Properties getProperties() {
+        return properties;
     }
+
+    Properties properties = new Properties();
+
+    abstract String getName();
 }

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
@@ -34,7 +34,7 @@ public interface ExternalSystemListener extends Serializable {
     void init(Properties properties);
 
     /** Send the given event to the external system. */
-    void send(AssignerStatus assignerStatus, ListenerMessageInformation listenerMessageInformation);
+    void send(AssignerStatus assignerStatus, AbstractListenerMessage listenerMessage);
 
     /** Close the listener. */
     void close();

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.listener;
+
+import org.apache.flink.annotation.Experimental;
+
+import com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+/** The listener interface for receiving external system events. */
+@Experimental
+public interface ExternalSystemListener extends Serializable {
+
+    /** The identified name of the listener. */
+    String name();
+
+    /** Initialize the listener with the given properties. */
+    void init(Properties properties);
+
+    /** Send the given event to the external system. */
+    void send(AssignerStatus assignerStatus);
+
+    /** Close the listener. */
+    void close();
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ExternalSystemListener.java
@@ -34,7 +34,7 @@ public interface ExternalSystemListener extends Serializable {
     void init(Properties properties);
 
     /** Send the given event to the external system. */
-    void send(AssignerStatus assignerStatus);
+    void send(AssignerStatus assignerStatus, ListenerMessageInformation listenerMessageInformation);
 
     /** Close the listener. */
     void close();

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerMessageInformation.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerMessageInformation.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.listener;
+
+/** The information that will be sent with the notification. */
+public class ListenerMessageInformation {
+    private final String startupMode;
+    private final String gtids;
+
+    public ListenerMessageInformation(String startupMode, String gtids) {
+        this.startupMode = startupMode;
+        this.gtids = gtids;
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.listener;
+
+import org.apache.flink.annotation.Experimental;
+
+import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/** This service can be used to send notification to available and enabled channels. */
+@Experimental
+public class ListenerService implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(ListenerService.class);
+
+    private static final String CLASS_NAME = "listener.class";
+
+    private final ExecutorService executorService;
+
+    private final List<ExternalSystemListener> externalSystemListeners;
+
+    public ListenerService(Properties listenerProperties) {
+        externalSystemListeners = new ArrayList<>();
+
+        String classes = listenerProperties.getProperty(CLASS_NAME);
+        if (classes != null) {
+            String[] classNames = classes.split(",");
+            for (String className : classNames) {
+                try {
+                    className = className.trim();
+                    Class cls = Class.forName(className);
+                    ExternalSystemListener externalSystemListener =
+                            (ExternalSystemListener) cls.newInstance();
+                    externalSystemListener.init(listenerProperties);
+                    externalSystemListeners.add(externalSystemListener);
+                    LOG.info("succeeded to create instance of {}", className);
+                } catch (ClassNotFoundException
+                        | InstantiationException
+                        | IllegalAccessException e) {
+                    LOG.warn("failed to create instance of {}, skip it.", className);
+                }
+            }
+        }
+
+        /* Avoid wasting resources */
+        if (externalSystemListeners.isEmpty()) {
+            executorService = null;
+        } else {
+            ThreadFactory threadFactory =
+                    new ThreadFactoryBuilder().setNameFormat("listener_service").build();
+            executorService = Executors.newSingleThreadExecutor(threadFactory);
+        }
+    }
+
+    /** notify all external system listeners. */
+    public void notifyAllListeners(final AssignerStatus assignerStatus) {
+        if (externalSystemListeners.isEmpty() || executorService == null) {
+            return;
+        }
+
+        executorService.submit(
+                () -> {
+                    long startTime = System.currentTimeMillis();
+                    externalSystemListeners.forEach(
+                            externalSystemListener -> {
+                                try {
+                                    externalSystemListener.send(assignerStatus);
+                                } catch (Exception e) {
+                                    LOG.warn(
+                                            "failed to send notification to {}",
+                                            externalSystemListener.name());
+                                }
+                            });
+                    LOG.debug(
+                            "cost {}ms to notify all listeners",
+                            System.currentTimeMillis() - startTime);
+                });
+    }
+
+    public void close() {
+        if (executorService != null) {
+            executorService.shutdown();
+        }
+        externalSystemListeners.forEach(ExternalSystemListener::close);
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
@@ -80,7 +80,9 @@ public class ListenerService implements Serializable {
     }
 
     /** notify all external system listeners. */
-    public void notifyAllListeners(final AssignerStatus assignerStatus) {
+    public void notifyAllListeners(
+            final AssignerStatus assignerStatus,
+            ListenerMessageInformation listenerMessageInformation) {
         if (externalSystemListeners.isEmpty() || executorService == null) {
             return;
         }
@@ -91,7 +93,8 @@ public class ListenerService implements Serializable {
                     externalSystemListeners.forEach(
                             externalSystemListener -> {
                                 try {
-                                    externalSystemListener.send(assignerStatus);
+                                    externalSystemListener.send(
+                                            assignerStatus, listenerMessageInformation);
                                 } catch (Exception e) {
                                     LOG.warn(
                                             "failed to send notification to {}",

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerService.java
@@ -81,8 +81,7 @@ public class ListenerService implements Serializable {
 
     /** notify all external system listeners. */
     public void notifyAllListeners(
-            final AssignerStatus assignerStatus,
-            ListenerMessageInformation listenerMessageInformation) {
+            final AssignerStatus assignerStatus, AbstractListenerMessage listenerMessage) {
         if (externalSystemListeners.isEmpty() || executorService == null) {
             return;
         }
@@ -93,8 +92,7 @@ public class ListenerService implements Serializable {
                     externalSystemListeners.forEach(
                             externalSystemListener -> {
                                 try {
-                                    externalSystemListener.send(
-                                            assignerStatus, listenerMessageInformation);
+                                    externalSystemListener.send(assignerStatus, listenerMessage);
                                 } catch (Exception e) {
                                     LOG.warn(
                                             "failed to send notification to {}",

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/MysqlListenerMessage.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/listener/MysqlListenerMessage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.listener;
+
+import java.io.Serializable;
+
+/** implement of AbstractListenerMessage for mysql. */
+public class MysqlListenerMessage extends AbstractListenerMessage implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String startupMode;
+
+    private final String gtids;
+
+    public MysqlListenerMessage(String startupMode, String gtids) {
+        this.startupMode = startupMode;
+        this.gtids = gtids;
+    }
+
+    public String getStartupMode() {
+        return startupMode;
+    }
+
+    public String getGtids() {
+        return gtids;
+    }
+
+    @Override
+    String getName() {
+        return "MYSQL";
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/ListenerUtils.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/ListenerUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.utils;
+
+import java.util.Map;
+import java.util.Properties;
+
+/** Option utils for listener properties. */
+public class ListenerUtils {
+
+    // Prefix for listener properties.
+    public static final String PROPERTIES_PREFIX = "external-system.";
+
+    public static Properties getListenerProperties(Map<String, String> tableOptions) {
+        Properties listenerProperties = new Properties();
+        if (tableOptions != null) {
+            tableOptions.keySet().stream()
+                    .filter(key -> key.startsWith(PROPERTIES_PREFIX))
+                    .forEach(
+                            key -> {
+                                final String value = tableOptions.get(key);
+                                final String subKey = key.substring((PROPERTIES_PREFIX).length());
+                                listenerProperties.put(subKey, value);
+                            });
+        }
+        return listenerProperties;
+    }
+}

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSource.java
@@ -81,6 +81,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     private final Properties jdbcProperties;
     private final Duration heartbeatInterval;
     private final String chunkKeyColumn;
+    private final Properties listenerProperties;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -117,7 +118,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             boolean closeIdleReaders,
             Properties jdbcProperties,
             Duration heartbeatInterval,
-            @Nullable String chunkKeyColumn) {
+            @Nullable String chunkKeyColumn,
+            Properties listenerProperties) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -146,6 +148,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.metadataKeys = Collections.emptyList();
         this.heartbeatInterval = heartbeatInterval;
         this.chunkKeyColumn = chunkKeyColumn;
+        this.listenerProperties = listenerProperties;
     }
 
     @Override
@@ -200,6 +203,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .jdbcProperties(jdbcProperties)
                             .heartbeatInterval(heartbeatInterval)
                             .chunkKeyColumn(new ObjectPath(database, tableName), chunkKeyColumn)
+                            .listenerProperties(listenerProperties)
                             .build();
             return SourceProvider.of(parallelSource);
         } else {
@@ -280,7 +284,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         closeIdleReaders,
                         jdbcProperties,
                         heartbeatInterval,
-                        chunkKeyColumn);
+                        chunkKeyColumn,
+                        listenerProperties);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -353,7 +358,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 closeIdleReaders,
                 jdbcProperties,
                 heartbeatInterval,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                listenerProperties);
     }
 
     @Override

--- a/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -30,6 +30,7 @@ import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceOptions;
 import com.ververica.cdc.connectors.mysql.source.config.ServerIdRange;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffsetBuilder;
+import com.ververica.cdc.connectors.mysql.source.utils.ListenerUtils;
 import com.ververica.cdc.connectors.mysql.utils.OptionUtils;
 import com.ververica.cdc.debezium.table.DebeziumOptions;
 import com.ververica.cdc.debezium.utils.JdbcUrlUtils;
@@ -89,7 +90,9 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         final FactoryUtil.TableFactoryHelper helper =
                 FactoryUtil.createTableFactoryHelper(this, context);
         helper.validateExcept(
-                DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX, JdbcUrlUtils.PROPERTIES_PREFIX);
+                DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX,
+                JdbcUrlUtils.PROPERTIES_PREFIX,
+                ListenerUtils.PROPERTIES_PREFIX);
 
         final ReadableConfig config = helper.getOptions();
         String hostname = config.get(HOSTNAME);
@@ -160,7 +163,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 closeIdleReaders,
                 JdbcUrlUtils.getJdbcProperties(context.getCatalogTable().getOptions()),
                 heartbeatInterval,
-                chunkKeyColumn);
+                chunkKeyColumn,
+                ListenerUtils.getListenerProperties(context.getCatalogTable().getOptions()));
     }
 
     @Override

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
@@ -17,6 +17,7 @@
 package com.ververica.cdc.connectors.mysql.source.listener;
 
 import com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus;
+import com.ververica.cdc.connectors.mysql.table.StartupMode;
 import org.junit.Test;
 
 import java.util.Properties;
@@ -32,7 +33,11 @@ public class ListenerServiceTest {
         listenerProperties.setProperty(
                 "listener.class", ExternalSystemListenerImplTest.class.getName());
         ListenerService listenerService = new ListenerService(listenerProperties);
-        listenerService.notifyAllListeners(AssignerStatus.INITIAL_ASSIGNING_FINISHED);
+        ListenerMessageInformation listenerMessageInformation =
+                new ListenerMessageInformation(
+                        StartupMode.SPECIFIC_OFFSETS.toString(), "UUID:1-100");
+        listenerService.notifyAllListeners(
+                AssignerStatus.INITIAL_ASSIGNING_FINISHED, listenerMessageInformation);
         /* wait for async execution */
         Thread.sleep(200);
         listenerService.close();
@@ -44,6 +49,7 @@ public class ListenerServiceTest {
     static class ExternalSystemListenerImplTest implements ExternalSystemListener {
 
         public static AssignerStatus assignerStatus;
+        public static ListenerMessageInformation listenerMessageInformation;
 
         @Override
         public String name() {
@@ -56,8 +62,11 @@ public class ListenerServiceTest {
         }
 
         @Override
-        public void send(AssignerStatus assignerStatus) {
+        public void send(
+                AssignerStatus assignerStatus,
+                ListenerMessageInformation listenerMessageInformation) {
             ExternalSystemListenerImplTest.assignerStatus = assignerStatus;
+            ExternalSystemListenerImplTest.listenerMessageInformation = listenerMessageInformation;
         }
 
         @Override

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.mysql.source.listener;
+
+import com.ververica.cdc.connectors.mysql.source.assigners.AssignerStatus;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for {@link ListenerService}. */
+public class ListenerServiceTest {
+
+    @Test
+    public void testNotifyAllListeners() throws InterruptedException {
+        Properties listenerProperties = new Properties();
+        listenerProperties.setProperty(
+                "listener.class", ExternalSystemListenerImplTest.class.getName());
+        ListenerService listenerService = new ListenerService(listenerProperties);
+        listenerService.notifyAllListeners(AssignerStatus.INITIAL_ASSIGNING_FINISHED);
+        /* wait for async execution */
+        Thread.sleep(200);
+        listenerService.close();
+        assertEquals(
+                ExternalSystemListenerImplTest.assignerStatus,
+                AssignerStatus.INITIAL_ASSIGNING_FINISHED);
+    }
+
+    static class ExternalSystemListenerImplTest implements ExternalSystemListener {
+
+        public static AssignerStatus assignerStatus;
+
+        @Override
+        public String name() {
+            return "test_listener";
+        }
+
+        @Override
+        public void init(Properties properties) {
+            assignerStatus = AssignerStatus.INITIAL_ASSIGNING;
+        }
+
+        @Override
+        public void send(AssignerStatus assignerStatus) {
+            ExternalSystemListenerImplTest.assignerStatus = assignerStatus;
+        }
+
+        @Override
+        public void close() {}
+    }
+}

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/listener/ListenerServiceTest.java
@@ -33,9 +33,8 @@ public class ListenerServiceTest {
         listenerProperties.setProperty(
                 "listener.class", ExternalSystemListenerImplTest.class.getName());
         ListenerService listenerService = new ListenerService(listenerProperties);
-        ListenerMessageInformation listenerMessageInformation =
-                new ListenerMessageInformation(
-                        StartupMode.SPECIFIC_OFFSETS.toString(), "UUID:1-100");
+        MysqlListenerMessage listenerMessageInformation =
+                new MysqlListenerMessage(StartupMode.SPECIFIC_OFFSETS.toString(), "UUID:1-100");
         listenerService.notifyAllListeners(
                 AssignerStatus.INITIAL_ASSIGNING_FINISHED, listenerMessageInformation);
         /* wait for async execution */
@@ -49,7 +48,7 @@ public class ListenerServiceTest {
     static class ExternalSystemListenerImplTest implements ExternalSystemListener {
 
         public static AssignerStatus assignerStatus;
-        public static ListenerMessageInformation listenerMessageInformation;
+        public static AbstractListenerMessage listenerMessage;
 
         @Override
         public String name() {
@@ -62,11 +61,9 @@ public class ListenerServiceTest {
         }
 
         @Override
-        public void send(
-                AssignerStatus assignerStatus,
-                ListenerMessageInformation listenerMessageInformation) {
+        public void send(AssignerStatus assignerStatus, AbstractListenerMessage listenerMessage) {
             ExternalSystemListenerImplTest.assignerStatus = assignerStatus;
-            ExternalSystemListenerImplTest.listenerMessageInformation = listenerMessageInformation;
+            ExternalSystemListenerImplTest.listenerMessage = listenerMessage;
         }
 
         @Override

--- a/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -124,7 +124,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -169,7 +170,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        "testCol");
+                        "testCol",
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -210,7 +212,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -249,7 +252,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -265,12 +269,19 @@ public class MySqlTableSourceFactoryTest {
         options.put("heartbeat.interval", "15213ms");
         options.put("scan.incremental.snapshot.chunk.key-column", "testCol");
         options.put("scan.incremental.close-idle-reader.enabled", "true");
+        options.put(
+                "external-system.listener.class",
+                "com.ververica.cdc.connectors.mysql.source.listener.ExternalSystemListenerImpl");
 
         DynamicTableSource actualSource = createTableSource(options);
         Properties dbzProperties = new Properties();
         dbzProperties.put("snapshot.mode", "never");
         Properties jdbcProperties = new Properties();
         jdbcProperties.setProperty("useSSL", "false");
+        Properties listenerProperties = new Properties();
+        listenerProperties.setProperty(
+                "listener.class",
+                "com.ververica.cdc.connectors.mysql.source.listener.ExternalSystemListenerImpl");
         MySqlTableSource expectedSource =
                 new MySqlTableSource(
                         SCHEMA,
@@ -297,7 +308,8 @@ public class MySqlTableSourceFactoryTest {
                         true,
                         jdbcProperties,
                         Duration.ofMillis(15213),
-                        "testCol");
+                        "testCol",
+                        listenerProperties);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -342,7 +354,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -379,7 +392,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -417,7 +431,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -456,7 +471,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -493,7 +509,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -535,7 +552,8 @@ public class MySqlTableSourceFactoryTest {
                         false,
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
-                        null);
+                        null,
+                        new Properties());
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");
 


### PR DESCRIPTION
this closes https://github.com/ververica/flink-cdc-connectors/issues/2520

Try to support notification about the status of connector, since it may be a common demand from community.
However, I met some problem when add a preliminary implementation, want to get some advice from yours.
1. When I try to define an enum of ExternalSystemEvent, I found that it's similar to [AssignerStatus](https://github.com/ververica/flink-cdc-connectors/blob/6ca87c4d57a790c0e51247b275f82c03d8a8f9f8/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/assigners/AssignerStatus.java#L117), can we reuse it?
2. Should we send information about finished splits to listener? then it would be very similar to checkpoint.
3. Should we add a default implement like KafkaListener?

 