### PR TITLE
[postgres] Remove unnecessary schema fresh to improve performance.

### DIFF
--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/dialect/DataSourceDialect.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/dialect/DataSourceDialect.java
@@ -71,6 +71,12 @@ public interface DataSourceDialect<C extends SourceConfig>
     /** The task context used for fetch task to fetch data from external systems. */
     FetchTask.Context createFetchTaskContext(SourceSplitBase sourceSplitBase, C sourceConfig);
 
+    /** Try to reuse Context if reuse is true. */
+    default FetchTask.Context createFetchTaskContext(
+            SourceSplitBase sourceSplitBase, C sourceConfig, boolean reuse) {
+        return createFetchTaskContext(sourceSplitBase, sourceConfig);
+    }
+
     /**
      * We have an empty default implementation here because most dialects do not have to implement
      * the method.

--- a/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
+++ b/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
@@ -121,7 +121,7 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
             if (nextSplit.isSnapshotSplit()) {
                 if (currentFetcher == null) {
                     final FetchTask.Context taskContext =
-                            dataSourceDialect.createFetchTaskContext(nextSplit, sourceConfig);
+                            dataSourceDialect.createFetchTaskContext(nextSplit, sourceConfig, true);
                     currentFetcher = new IncrementalSourceScanFetcher(taskContext, subtaskId);
                 }
             } else {

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/PostgresDialect.java
@@ -70,6 +70,10 @@ public class PostgresDialect implements JdbcDataSourceDialect {
 
     @Nullable private PostgresStreamFetchTask streamFetchTask;
 
+    @Nullable private transient JdbcSourceConfig taskSourceConfig;
+
+    @Nullable private transient JdbcSourceFetchTaskContext fetchTaskContext;
+
     public PostgresDialect(PostgresSourceConfigFactory configFactory) {
         this.sourceConfig = configFactory.create(0);
     }
@@ -212,6 +216,21 @@ public class PostgresDialect implements JdbcDataSourceDialect {
     public JdbcSourceFetchTaskContext createFetchTaskContext(
             SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
         return new PostgresSourceFetchTaskContext(taskSourceConfig, this);
+    }
+
+    @Override
+    public FetchTask.Context createFetchTaskContext(
+            SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig, boolean reuse) {
+        if (!reuse) {
+            return createFetchTaskContext(sourceSplitBase, taskSourceConfig);
+        }
+        if (this.taskSourceConfig == null
+                || this.fetchTaskContext == null
+                || !this.taskSourceConfig.equals(taskSourceConfig)) {
+            this.taskSourceConfig = taskSourceConfig;
+            this.fetchTaskContext = createFetchTaskContext(sourceSplitBase, taskSourceConfig);
+        }
+        return this.fetchTaskContext;
     }
 
     @Override

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
@@ -60,7 +60,6 @@ import java.util.Objects;
 
 import static io.debezium.connector.postgresql.PostgresObjectUtils.waitForReplicationSlotReady;
 import static io.debezium.connector.postgresql.Utils.currentOffset;
-import static io.debezium.connector.postgresql.Utils.refreshSchema;
 
 /** A {@link FetchTask} implementation for Postgres to read snapshot split. */
 public class PostgresScanFetchTask implements FetchTask<SourceSplitBase> {
@@ -278,7 +277,11 @@ public class PostgresScanFetchTask implements FetchTask<SourceSplitBase> {
             final PostgresSnapshotContext ctx = (PostgresSnapshotContext) snapshotContext;
             ctx.offset = offsetContext;
             createSlotForBackFillReadTask();
-            refreshSchema(databaseSchema, jdbcConnection, true);
+            // It's not necessary to refresh schema again, which is very time-consuming.
+            // The databaseSchema is the reference of PostgresSourceFetchTaskContext#schema, and has
+            // been initialized when submit SnapshotSplit fetch task by
+            // IncrementalSourceScanFetcher#submitTask -> PostgresSourceFetchTaskContext#configure.
+            // refreshSchema(databaseSchema, jdbcConnection, true);
             final PostgresOffset lowWatermark = currentOffset(jdbcConnection);
             LOG.info(
                     "Snapshot step 1 - Determining low watermark {} for split {}",

--- a/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -173,13 +173,15 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                 sourceSplitBase.getTableSchemas().values());
 
         try {
-            this.schema =
-                    PostgresObjectUtils.newSchema(
-                            jdbcConnection,
-                            dbzConfig,
-                            jdbcConnection.getTypeRegistry(),
-                            topicSelector,
-                            valueConverterBuilder.build(jdbcConnection.getTypeRegistry()));
+            if (this.schema == null) {
+                this.schema =
+                        PostgresObjectUtils.newSchema(
+                                jdbcConnection,
+                                dbzConfig,
+                                jdbcConnection.getTypeRegistry(),
+                                topicSelector,
+                                valueConverterBuilder.build(jdbcConnection.getTypeRegistry()));
+            }
         } catch (SQLException e) {
             throw new RuntimeException("Failed to initialize PostgresSchema", e);
         }

--- a/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
+++ b/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java
@@ -5,7 +5,6 @@
  */
 package io.debezium.connector.postgresql;
 
-import io.debezium.DebeziumException;
 import io.debezium.connector.postgresql.connection.LogicalDecodingMessage;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
@@ -113,12 +112,17 @@ public class PostgresStreamingChangeEventSource
 
     @Override
     public void init() {
+        // It's not necessary to refresh schema again, which is very time-consuming.
+        // The schema of taskContext is the reference of PostgresSourceFetchTaskContext#schema, and
+        // has been initialized when submit StreamSplit fetch task by
+        // IncrementalSourceStreamFetcher#submitTask -> PostgresSourceFetchTaskContext#configure.
+
         // refresh the schema so we have a latest view of the DB tables
-        try {
-            taskContext.refreshSchema(connection, true);
-        } catch (SQLException e) {
-            throw new DebeziumException("Error while executing initial schema load", e);
-        }
+        // try {
+        //     taskContext.refreshSchema(connection, true);
+        // } catch (SQLException e) {
+        //     throw new DebeziumException("Error while executing initial schema load", e);
+        // }
     }
 
     @Override


### PR DESCRIPTION
PR of #2570 

### Motivation
It's very time-consuming for postgres to refresh schema if there are many tables to read. According to our testing, refreshing 400 tables takes 15 minutes. Because it takes a long time to refresh the current table's schema when reading a chunk in the scan stage, the data rate shows the following sawtooth pattern. Therefore, we need to minimize unnecessary shema refreshes as much as possible。

![image](https://github.com/ververica/flink-cdc-connectors/assets/5181963/8208864a-6857-4459-94ae-034acf9be52f)

### Solution
Firstly, the origin schema of postgres cdc is [the schema filed of PostgresSourceFetchTaskContext](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java#L91), which is created and refreshed when [PostgresSourceFetchTaskContext#configure](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java#L176) is called, and both [the schema refresh of scan stage](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java#L281) and [stream stage](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/PostgresStreamingChangeEventSource.java#L118) are refreshing the schema of PostgresSourceFetchTaskContext. A new PostgresSourceFetchTaskContext is created in IncrementalSourceSplitReader#checkSplitOrStartNext for each split (both [SnapshotSplit](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java#L124) and [StreamSplit](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java#L134)). For snapshot splits, even with the condition of [whether the currentFetcher is equal to null](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-cdc-base/src/main/java/com/ververica/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java#L129), in many cases it still leads to the re creation of the PostgresSourceFetchTaskContext because the IncrementalSourceSplitReader is often discarded by the Flink kernal when a snapshot chunk is finished and become idle. See
1. [SourceReaderBase#pollNext](https://github.com/apache/flink/blob/c7beda0da81ffc4bbb01befafd2eed08b7b35854/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java#L149) -> [SourceReaderBase#finishedOrAvailableLater](https://github.com/apache/flink/blob/c7beda0da81ffc4bbb01befafd2eed08b7b35854/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java#L332) -> [SplitFetcherManager#maybeShutdownFinishedFetchers](https://github.com/apache/flink/blob/c7beda0da81ffc4bbb01befafd2eed08b7b35854/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java#L233) -> SplitFetcher#shutdown and SplitFetcher is removed.
2. IncrementalSourceSplitReader(implements SplitReader) is [SplitFetcher#splitReader](https://github.com/apache/flink/blob/c7beda0da81ffc4bbb01befafd2eed08b7b35854/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java#L57) and removed also.

Based on the analysis of the above, we get two optimizations.
1. It's enough to refresh the schema when [PostgresSourceFetchTaskContext#configure](https://github.com/ververica/flink-cdc-connectors/blob/e0fd6f965b702cc2876372dc068379dafe066277/flink-connector-postgres-cdc/src/main/java/com/ververica/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java#L176) is called, and there is no need to refresh the schema afterwards.
2. Reuse PostgresSourceFetchTaskContext between SnapshotSplits based on sourceConfig, as PostgresSourceFetchTaskContext is created for almost every SnapshotSplit.