### PR TITLE
The uniqueidentifier type in SQL Server cannot be compared using ObjectUtils.compare.

### DIFF
--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/dialect/SqlServerChunkSplitter.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/dialect/SqlServerChunkSplitter.java
@@ -218,7 +218,8 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
             }
         } else {
             if (splitColumnTypeName.equals("uniqueidentifier")) {
-                return splitUnevenlySizedChunksSqlCompare(jdbc, tableId, splitColumnName, min, max, chunkSize);
+                return splitUnevenlySizedChunksSqlCompare(
+                        jdbc, tableId, splitColumnName, min, max, chunkSize);
             }
             return splitUnevenlySizedChunks(jdbc, tableId, splitColumnName, min, max, chunkSize);
         }
@@ -266,9 +267,7 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
 
     // ------------------------------------------------------------------------------------------
 
-    /**
-     * Split table into unevenly sized chunks by continuously calculating next chunk max value.
-     */
+    /** Split table into unevenly sized chunks by continuously calculating next chunk max value. */
     private List<ChunkRange> splitUnevenlySizedChunks(
             JdbcConnection jdbc,
             TableId tableId,
@@ -296,9 +295,7 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
         return splits;
     }
 
-    /**
-     * Split table into unevenly sized chunks by continuously calculating next chunk max value.
-     */
+    /** Split table into unevenly sized chunks by continuously calculating next chunk max value. */
     private List<ChunkRange> splitUnevenlySizedChunksSqlCompare(
             JdbcConnection jdbc,
             TableId tableId,
@@ -308,10 +305,13 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
             int chunkSize)
             throws SQLException {
         LOG.info(
-                "Use unevenly-sized chunks for table {}, the chunk size is {}, compare by sql", tableId, chunkSize);
+                "Use unevenly-sized chunks for table {}, the chunk size is {}, compare by sql",
+                tableId,
+                chunkSize);
         final List<ChunkRange> splits = new ArrayList<>();
         Object chunkStart = null;
-        Object chunkEnd = nextChunkEndCompareBySql(jdbc, min, tableId, splitColumnName, max, chunkSize);
+        Object chunkEnd =
+                nextChunkEndCompareBySql(jdbc, min, tableId, splitColumnName, max, chunkSize);
         int count = 0;
         while (chunkEnd != null && queryCounts(jdbc, tableId, splitColumnName, chunkEnd, max) > 0) {
             // we start from [null, min + chunk_size) and avoid [null, min)
@@ -319,7 +319,9 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
             // may sleep awhile to avoid DDOS on SqlServer server
             maySleep(count++, tableId);
             chunkStart = chunkEnd;
-            chunkEnd = nextChunkEndCompareBySql(jdbc, chunkEnd, tableId, splitColumnName, max, chunkSize);
+            chunkEnd =
+                    nextChunkEndCompareBySql(
+                            jdbc, chunkEnd, tableId, splitColumnName, max, chunkSize);
         }
         // add the ending split
         splits.add(ChunkRange.of(chunkStart, null));
@@ -380,8 +382,8 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
             Object chunkStart,
             Object chunkEnd) {
         // currently, we only support single split column
-        Object[] splitStart = chunkStart == null ? null : new Object[]{chunkStart};
-        Object[] splitEnd = chunkEnd == null ? null : new Object[]{chunkEnd};
+        Object[] splitStart = chunkStart == null ? null : new Object[] {chunkStart};
+        Object[] splitEnd = chunkEnd == null ? null : new Object[] {chunkEnd};
         Map<TableId, TableChange> schema = new HashMap<>();
         schema.put(tableId, dialect.queryTableSchema(jdbc, tableId));
         return new SnapshotSplit(
@@ -394,9 +396,7 @@ public class SqlServerChunkSplitter implements JdbcSourceChunkSplitter {
                 schema);
     }
 
-    /**
-     * Returns the distribution factor of the given table.
-     */
+    /** Returns the distribution factor of the given table. */
     private double calculateDistributionFactor(
             TableId tableId, Object min, Object max, long approximateRowCnt) {
 

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
@@ -121,6 +121,31 @@ public class SqlServerUtils {
                 });
     }
 
+    public static Integer queryCounts(
+            JdbcConnection jdbc, TableId tableId, String columnName, Object min, Object max)
+            throws SQLException {
+        final String countQuery =
+                String.format(
+                        "SELECT COUNT(%s) FROM %s WHERE %s > ? AND %s <= ?",
+                        quote(columnName), quote(tableId), quote(columnName), quote(columnName));
+        Integer res = jdbc.prepareQueryAndMap(
+                countQuery,
+                ps -> {
+                    ps.setObject(1, min);
+                    ps.setObject(2, max);
+                },
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", countQuery));
+                    }
+                    return rs.getInt(1);
+                });
+        return res;
+    }
+
     /**
      * Returns the next LSN to be read from the database. This is the LSN of the last record that
      * was read from the database.

--- a/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
+++ b/flink-connector-sqlserver-cdc/src/main/java/com/ververica/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
@@ -128,21 +128,23 @@ public class SqlServerUtils {
                 String.format(
                         "SELECT COUNT(%s) FROM %s WHERE %s > ? AND %s <= ?",
                         quote(columnName), quote(tableId), quote(columnName), quote(columnName));
-        Integer res = jdbc.prepareQueryAndMap(
-                countQuery,
-                ps -> {
-                    ps.setObject(1, min);
-                    ps.setObject(2, max);
-                },
-                rs -> {
-                    if (!rs.next()) {
-                        // this should never happen
-                        throw new SQLException(
-                                String.format(
-                                        "No result returned after running query [%s]", countQuery));
-                    }
-                    return rs.getInt(1);
-                });
+        Integer res =
+                jdbc.prepareQueryAndMap(
+                        countQuery,
+                        ps -> {
+                            ps.setObject(1, min);
+                            ps.setObject(2, max);
+                        },
+                        rs -> {
+                            if (!rs.next()) {
+                                // this should never happen
+                                throw new SQLException(
+                                        String.format(
+                                                "No result returned after running query [%s]",
+                                                countQuery));
+                            }
+                            return rs.getInt(1);
+                        });
         return res;
     }
 


### PR DESCRIPTION
The uniqueidentifier type in SQL Server cannot be compared using ObjectUtils.compare. For example, in SQL Server, the value 'C6D6083A-4D2A-40D0-B20A-000005972E13' is considered less than 'B63D3AA7-8BC8-4C0F-BACD-FFFFFDAA57CD'.

```sql
DECLARE @uuid1 uniqueidentifier = 'C6D6083A-4D2A-40D0-B20A-000005972E13';
DECLARE @uuid2 uniqueidentifier = 'B63D3AA7-8BC8-4C0F-BACD-FFFFFDAA57CD';

SELECT CASE 
         WHEN BINARY_CHECKSUM(CAST(@uuid1 AS binary(16))) > BINARY_CHECKSUM(CAST(@uuid2 AS binary(16))) THEN 'uuid1 greater than uuid2'
         WHEN BINARY_CHECKSUM(CAST(@uuid1 AS binary(16))) < BINARY_CHECKSUM(CAST(@uuid2 AS binary(16))) THEN 'uuid1 小于 uuid2'
         ELSE 'uuid1 less than uuid2'
       END AS result; 
```
Due to the incorrect comparison, the split chunks are terminated prematurely. Therefore, I have chosen to address this issue by using a SQL query specifically for this type.
