### PR TITLE
[pipeline-connector][doris] Extract type mapping logic

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisEventSerializer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisEventSerializer.java
@@ -35,9 +35,7 @@ import org.apache.doris.flink.sink.writer.serializer.DorisRecordSerializer;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.text.SimpleDateFormat;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,13 +46,6 @@ import static org.apache.doris.flink.sink.util.DeleteOperation.addDeleteSign;
 public class DorisEventSerializer implements DorisRecordSerializer<Event> {
     private ObjectMapper objectMapper = new ObjectMapper();
     private Map<TableId, Schema> schemaMaps = new HashMap<>();
-
-    /** Format DATE type data. */
-    public static final SimpleDateFormat DATE_FORMATTER = new SimpleDateFormat("yyyy-MM-dd");
-
-    /** Format timestamp-related type data. */
-    public static final DateTimeFormatter DATE_TIME_FORMATTER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     /** ZoneId from pipeline config to support timestamp with local time zone. */
     public final ZoneId pipelineZoneId;
@@ -125,7 +116,7 @@ public class DorisEventSerializer implements DorisRecordSerializer<Event> {
                     DorisRowConverter.createNullableExternalConverter(
                             columns.get(i).getType(), pipelineZoneId);
             Object field = converter.serialize(i, recordData);
-            record.put(columns.get(i).getName(), field);
+            record.put(columns.get(i).getName(), field == null ? null : field.toString());
         }
         return record;
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -29,12 +29,6 @@ import com.ververica.cdc.common.event.TableId;
 import com.ververica.cdc.common.schema.Column;
 import com.ververica.cdc.common.schema.Schema;
 import com.ververica.cdc.common.sink.MetadataApplier;
-import com.ververica.cdc.common.types.DataTypeChecks;
-import com.ververica.cdc.common.types.LocalZonedTimestampType;
-import com.ververica.cdc.common.types.TimestampType;
-import com.ververica.cdc.common.types.ZonedTimestampType;
-import com.ververica.cdc.common.types.utils.DataTypeUtils;
-import org.apache.doris.flink.catalog.DorisTypeMapper;
 import org.apache.doris.flink.catalog.doris.DataModel;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.catalog.doris.TableSchema;
@@ -116,18 +110,7 @@ public class DorisMetadataApplier implements MetadataApplier {
         List<String> columnNameList = schema.getColumnNames();
         for (String columnName : columnNameList) {
             Column column = schema.getColumn(columnName).get();
-            String typeString;
-            if (column.getType() instanceof LocalZonedTimestampType
-                    || column.getType() instanceof TimestampType
-                    || column.getType() instanceof ZonedTimestampType) {
-                int precision = DataTypeChecks.getPrecision(column.getType());
-                typeString =
-                        String.format("%s(%s)", "DATETIMEV2", Math.min(Math.max(precision, 0), 6));
-            } else {
-                typeString =
-                        DorisTypeMapper.toDorisType(
-                                DataTypeUtils.toFlinkDataType(column.getType()));
-            }
+            String typeString = DorisTypeMapper.toDorisType(column.getType());
             fieldSchemaMap.put(
                     column.getName(),
                     new FieldSchema(column.getName(), typeString, column.getComment()));
@@ -151,18 +134,7 @@ public class DorisMetadataApplier implements MetadataApplier {
         List<AddColumnEvent.ColumnWithPosition> addedColumns = event.getAddedColumns();
         for (AddColumnEvent.ColumnWithPosition col : addedColumns) {
             Column column = col.getAddColumn();
-            String typeString;
-            if (column.getType() instanceof LocalZonedTimestampType
-                    || column.getType() instanceof TimestampType
-                    || column.getType() instanceof ZonedTimestampType) {
-                int precision = DataTypeChecks.getPrecision(column.getType());
-                typeString =
-                        String.format("%s(%s)", "DATETIMEV2", Math.min(Math.max(precision, 0), 6));
-            } else {
-                typeString =
-                        DorisTypeMapper.toDorisType(
-                                DataTypeUtils.toFlinkDataType(column.getType()));
-            }
+            String typeString = DorisTypeMapper.toDorisType(column.getType());
             FieldSchema addFieldSchema =
                     new FieldSchema(column.getName(), typeString, column.getComment());
             schemaChangeManager.addColumn(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisTypeMapper.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/com/ververica/cdc/connectors/doris/sink/DorisTypeMapper.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.doris.sink;
+
+import com.ververica.cdc.common.types.ArrayType;
+import com.ververica.cdc.common.types.BigIntType;
+import com.ververica.cdc.common.types.BooleanType;
+import com.ververica.cdc.common.types.CharType;
+import com.ververica.cdc.common.types.DataType;
+import com.ververica.cdc.common.types.DataTypeChecks;
+import com.ververica.cdc.common.types.DataTypeDefaultVisitor;
+import com.ververica.cdc.common.types.DateType;
+import com.ververica.cdc.common.types.DecimalType;
+import com.ververica.cdc.common.types.DoubleType;
+import com.ververica.cdc.common.types.FloatType;
+import com.ververica.cdc.common.types.IntType;
+import com.ververica.cdc.common.types.LocalZonedTimestampType;
+import com.ververica.cdc.common.types.MapType;
+import com.ververica.cdc.common.types.RowType;
+import com.ververica.cdc.common.types.SmallIntType;
+import com.ververica.cdc.common.types.TimestampType;
+import com.ververica.cdc.common.types.TinyIntType;
+import com.ververica.cdc.common.types.VarBinaryType;
+import com.ververica.cdc.common.types.VarCharType;
+import com.ververica.cdc.common.types.ZonedTimestampType;
+import org.apache.doris.flink.catalog.doris.DorisType;
+
+import static org.apache.doris.flink.catalog.doris.DorisType.BIGINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.BOOLEAN;
+import static org.apache.doris.flink.catalog.doris.DorisType.DATE_V2;
+import static org.apache.doris.flink.catalog.doris.DorisType.DOUBLE;
+import static org.apache.doris.flink.catalog.doris.DorisType.FLOAT;
+import static org.apache.doris.flink.catalog.doris.DorisType.INT;
+import static org.apache.doris.flink.catalog.doris.DorisType.SMALLINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.STRING;
+import static org.apache.doris.flink.catalog.doris.DorisType.TINYINT;
+import static org.apache.doris.flink.catalog.doris.DorisType.VARCHAR;
+
+/** Mapping classes of cdc type and doris type. */
+public class DorisTypeMapper {
+
+    /** Max size of char type of Doris. */
+    public static final int MAX_CHAR_SIZE = 255;
+
+    /** Max size of varchar type of Doris. */
+    public static final int MAX_VARCHAR_SIZE = 65533;
+
+    public static String toDorisType(DataType type) {
+        return type.accept(new LogicalTypeVisitor());
+    }
+
+    private static class LogicalTypeVisitor extends DataTypeDefaultVisitor<String> {
+
+        @Override
+        public String visit(CharType charType) {
+            // In Doris, strings are stored in UTF-8 encoding, so English characters occupy 1 byte
+            // and Chinese characters occupy 3 bytes. The length here is multiplied by 3. The
+            // maximum length of CHAR is 255. Once exceeded, it will automatically be converted to
+            // VARCHAR type.
+            long length = charType.getLength() * 3L;
+            if (length <= MAX_CHAR_SIZE) {
+                return String.format("%s(%s)", DorisType.CHAR, length);
+            } else {
+                return visit(new VarCharType(charType.getLength()));
+            }
+        }
+
+        @Override
+        public String visit(VarCharType varCharType) {
+            long length = varCharType.getLength() * 3L;
+            return length >= MAX_VARCHAR_SIZE ? STRING : String.format("%s(%s)", VARCHAR, length);
+        }
+
+        @Override
+        public String visit(BooleanType booleanType) {
+            return BOOLEAN;
+        }
+
+        @Override
+        public String visit(VarBinaryType varBinaryType) {
+            return STRING;
+        }
+
+        @Override
+        public String visit(DecimalType decimalType) {
+            int precision = decimalType.getPrecision();
+            int scale = decimalType.getScale();
+            return precision <= 38
+                    ? String.format(
+                            "%s(%s,%s)", DorisType.DECIMAL_V3, precision, Math.max(scale, 0))
+                    : DorisType.STRING;
+        }
+
+        @Override
+        public String visit(TinyIntType tinyIntType) {
+            return TINYINT;
+        }
+
+        @Override
+        public String visit(SmallIntType smallIntType) {
+            return SMALLINT;
+        }
+
+        @Override
+        public String visit(IntType intType) {
+            return INT;
+        }
+
+        @Override
+        public String visit(BigIntType bigIntType) {
+            return BIGINT;
+        }
+
+        @Override
+        public String visit(FloatType floatType) {
+            return FLOAT;
+        }
+
+        @Override
+        public String visit(DoubleType doubleType) {
+            return DOUBLE;
+        }
+
+        @Override
+        public String visit(DateType dateType) {
+            return DATE_V2;
+        }
+
+        @Override
+        public String visit(TimestampType timestampType) {
+            int precision = DataTypeChecks.getPrecision(timestampType);
+            return String.format(
+                    "%s(%s)", DorisType.DATETIME_V2, Math.min(Math.max(precision, 0), 6));
+        }
+
+        @Override
+        public String visit(ZonedTimestampType timestampType) {
+            int precision = DataTypeChecks.getPrecision(timestampType);
+            return String.format(
+                    "%s(%s)", DorisType.DATETIME_V2, Math.min(Math.max(precision, 0), 6));
+        }
+
+        @Override
+        public String visit(LocalZonedTimestampType timestampType) {
+            int precision = DataTypeChecks.getPrecision(timestampType);
+            return String.format(
+                    "%s(%s)", DorisType.DATETIME_V2, Math.min(Math.max(precision, 0), 6));
+        }
+
+        @Override
+        public String visit(ArrayType arrayType) {
+            return STRING;
+        }
+
+        @Override
+        public String visit(MapType mapType) {
+            return STRING;
+        }
+
+        @Override
+        public String visit(RowType rowType) {
+            return STRING;
+        }
+
+        @Override
+        protected String defaultMethod(DataType dataType) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Flink doesn't support converting type %s to Doris type yet.",
+                            dataType.toString()));
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/com/ververica/cdc/connectors/doris/sink/DorisRowConverterTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/com/ververica/cdc/connectors/doris/sink/DorisRowConverterTest.java
@@ -84,7 +84,7 @@ public class DorisRowConverterTest {
             row.add(converter.serialize(i, recordData));
         }
         Assert.assertEquals(
-                "[true, 1.2, 1.2345, 1, 32, 64, 128, 2021-01-01 08:00:00, 2021-01-01, a, doris]",
+                "[true, 1.2, 1.2345, 1, 32, 64, 128, 2021-01-01 08:00:00.0, 2021-01-01, a, doris]",
                 row.toString());
     }
 }


### PR DESCRIPTION
Currently in DorisSink, the type mapping logic directly reuses the Flink Doris Connector. Although it is more convenient, it forms a strong binding relationship with the connector in terms of freedom, which greatly reduces the degree of freedom.
So the Doris type mapping is extracted here.