### PR TITLE
[cdc-composer][tests] Refactor newline handling for cross-platform compatibility

### DIFF
--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -55,6 +55,8 @@ class FlinkPipelineComposerITCase {
     private static final org.apache.flink.configuration.Configuration MINI_CLUSTER_CONFIG =
             new org.apache.flink.configuration.Configuration();
 
+    private static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
     static {
         MINI_CLUSTER_CONFIG.set(
                 ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL,
@@ -130,7 +132,7 @@ class FlinkPipelineComposerITCase {
                         "default_namespace.default_schema.table1:col1=3;newCol3=");
 
         // Check the order and content of all received events
-        String[] outputEvents = outCaptor.toString().trim().split(System.getProperty("line.separator"));
+        String[] outputEvents = outCaptor.toString().trim().split(LINE_SEPARATOR);
         assertThat(outputEvents)
                 .containsExactly(
                         "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING}, primaryKeys=col1, options=()}",
@@ -190,7 +192,7 @@ class FlinkPipelineComposerITCase {
                         "default_namespace.default_schema.table2:col1=3;col2=3");
 
         // Check the order and content of all received events
-        String[] outputEvents = outCaptor.toString().trim().split(System.getProperty("line.separator"));
+        String[] outputEvents = outCaptor.toString().trim().split(LINE_SEPARATOR);
         assertThat(outputEvents)
                 .containsExactly(
                         "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING}, primaryKeys=col1, options=()}",

--- a/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/com/ververica/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -130,7 +130,7 @@ class FlinkPipelineComposerITCase {
                         "default_namespace.default_schema.table1:col1=3;newCol3=");
 
         // Check the order and content of all received events
-        String[] outputEvents = outCaptor.toString().trim().split("\n");
+        String[] outputEvents = outCaptor.toString().trim().split(System.getProperty("line.separator"));
         assertThat(outputEvents)
                 .containsExactly(
                         "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING}, primaryKeys=col1, options=()}",
@@ -190,7 +190,7 @@ class FlinkPipelineComposerITCase {
                         "default_namespace.default_schema.table2:col1=3;col2=3");
 
         // Check the order and content of all received events
-        String[] outputEvents = outCaptor.toString().trim().split("\n");
+        String[] outputEvents = outCaptor.toString().trim().split(System.getProperty("line.separator"));
         assertThat(outputEvents)
                 .containsExactly(
                         "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING}, primaryKeys=col1, options=()}",


### PR DESCRIPTION
The hardcoded '\n' character was causing failures in unit tests on Windows platforms.
Replace hardcoded newline character '\n' with 'System.lineSeparator()' to improve code portability across different operating systems.