### PR TITLE
[test][mysql] add env variables to support executing the test cases locally

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
@@ -31,8 +31,6 @@ import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.P
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.PORT;
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES;
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.USERNAME;
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -40,16 +38,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MySqlDataSourceFactoryTest extends MySqlSourceTestBase {
 
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     @Test
     public void testCreateSource() {
         inventoryDatabase.createAndInitialize();
         Map<String, String> options = new HashMap<>();
-        options.put(HOSTNAME.key(), MYSQL_CONTAINER.getHost());
-        options.put(PORT.key(), String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
-        options.put(USERNAME.key(), TEST_USER);
-        options.put(PASSWORD.key(), TEST_PASSWORD);
+        options.put(HOSTNAME.key(), inventoryDatabase.getHost());
+        options.put(PORT.key(), String.valueOf(inventoryDatabase.getDatabasePort()));
+        options.put(USERNAME.key(), inventoryDatabase.getUsername());
+        options.put(PASSWORD.key(), inventoryDatabase.getPassword());
         options.put(TABLES.key(), inventoryDatabase.getDatabaseName() + ".prod\\.*");
         Factory.Context context = new MockContext(Configuration.fromMap(options));
 
@@ -63,10 +61,10 @@ public class MySqlDataSourceFactoryTest extends MySqlSourceTestBase {
     public void testNoMatchedTable() {
         inventoryDatabase.createAndInitialize();
         Map<String, String> options = new HashMap<>();
-        options.put(HOSTNAME.key(), MYSQL_CONTAINER.getHost());
-        options.put(PORT.key(), String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
-        options.put(USERNAME.key(), TEST_USER);
-        options.put(PASSWORD.key(), TEST_PASSWORD);
+        options.put(HOSTNAME.key(), inventoryDatabase.getHost());
+        options.put(PORT.key(), String.valueOf(inventoryDatabase.getDatabasePort()));
+        options.put(USERNAME.key(), inventoryDatabase.getUsername());
+        options.put(PASSWORD.key(), inventoryDatabase.getPassword());
         String tables = inventoryDatabase.getDatabaseName() + ".test";
         options.put(TABLES.key(), tables);
         Factory.Context context = new MockContext(Configuration.fromMap(options));

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlFullTypesITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlFullTypesITCase.java
@@ -31,6 +31,7 @@ import com.ververica.cdc.common.event.Event;
 import com.ververica.cdc.common.source.FlinkSourceProvider;
 import com.ververica.cdc.common.types.DataTypes;
 import com.ververica.cdc.common.types.RowType;
+import com.ververica.cdc.connectors.mysql.MySqlTestUtils;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
@@ -52,8 +53,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.fetchResults;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.getServerId;
 import static com.ververica.cdc.connectors.mysql.testutils.RecordDataTestUtils.recordFields;
@@ -64,13 +63,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MySqlFullTypesITCase extends MySqlSourceTestBase {
 
     private static final MySqlContainer MYSQL8_CONTAINER =
-            createMySqlContainer(MySqlVersion.V8_0, "docker/server-gtids/expire-seconds/my.cnf");
+            MySqlTestUtils.createMySqlContainer(
+                    MySqlVersion.V8_0, "docker/server-gtids/expire-seconds/my.cnf");
 
     private final UniqueDatabase fullTypesMySql57Database =
-            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test");
     private final UniqueDatabase fullTypesMySql8Database =
-            new UniqueDatabase(
-                    MYSQL8_CONTAINER, "column_type_test_mysql8", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL8_CONTAINER, "column_type_test_mysql8");
 
     private final StreamExecutionEnvironment env =
             StreamExecutionEnvironment.getExecutionEnvironment();

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlMetadataAccessorITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlMetadataAccessorITCase.java
@@ -24,6 +24,7 @@ import com.ververica.cdc.common.schema.Schema;
 import com.ververica.cdc.common.types.DataType;
 import com.ververica.cdc.common.types.DataTypes;
 import com.ververica.cdc.common.types.RowType;
+import com.ververica.cdc.connectors.mysql.MySqlTestUtils;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
@@ -42,8 +43,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -51,14 +50,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MySqlMetadataAccessorITCase extends MySqlSourceTestBase {
 
     private static final MySqlContainer MYSQL8_CONTAINER =
-            createMySqlContainer(MySqlVersion.V8_0, "docker/server-gtids/expire-seconds/my.cnf");
+            MySqlTestUtils.createMySqlContainer(
+                    MySqlVersion.V8_0, "docker/server-gtids/expire-seconds/my.cnf");
 
     private final UniqueDatabase fullTypesMySql57Database =
-            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test");
 
     private final UniqueDatabase fullTypesMySql8Database =
-            new UniqueDatabase(
-                    MYSQL8_CONTAINER, "column_type_test_mysql8", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL8_CONTAINER, "column_type_test_mysql8");
 
     private final StreamExecutionEnvironment env =
             StreamExecutionEnvironment.getExecutionEnvironment();

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlPipelineITCase.java
@@ -61,8 +61,6 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.SCHEMA_CHANGE_ENABLED;
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
-import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.fetchResults;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.getServerId;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,7 +72,7 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
             createMySqlContainer(MySqlVersion.V8_0);
 
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL8_CONTAINER, "inventory", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL8_CONTAINER, "inventory");
 
     private final StreamExecutionEnvironment env =
             StreamExecutionEnvironment.getExecutionEnvironment();
@@ -106,10 +104,10 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
         inventoryDatabase.createAndInitialize();
         MySqlSourceConfigFactory configFactory =
                 new MySqlSourceConfigFactory()
-                        .hostname(MYSQL8_CONTAINER.getHost())
-                        .port(MYSQL8_CONTAINER.getDatabasePort())
-                        .username(TEST_USER)
-                        .password(TEST_PASSWORD)
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
+                        .username(inventoryDatabase.getUsername())
+                        .password(inventoryDatabase.getPassword())
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(inventoryDatabase.getDatabaseName() + "\\.products")
                         .startupOptions(StartupOptions.initial())
@@ -234,10 +232,10 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
         inventoryDatabase.createAndInitialize();
         MySqlSourceConfigFactory configFactory =
                 new MySqlSourceConfigFactory()
-                        .hostname(MYSQL8_CONTAINER.getHost())
-                        .port(MYSQL8_CONTAINER.getDatabasePort())
-                        .username(TEST_USER)
-                        .password(TEST_PASSWORD)
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
+                        .username(inventoryDatabase.getUsername())
+                        .password(inventoryDatabase.getPassword())
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(inventoryDatabase.getDatabaseName() + "\\.products")
                         .startupOptions(StartupOptions.latest())

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqSourceTestUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqSourceTestUtils.java
@@ -24,9 +24,6 @@ import java.util.Random;
 /** Test utilities for MySQL event source. */
 public class MySqSourceTestUtils {
 
-    public static final String TEST_USER = "mysqluser";
-    public static final String TEST_PASSWORD = "mysqlpw";
-
     public static <T> List<T> fetchResults(Iterator<T> iter, int size) {
         List<T> result = new ArrayList<>(size);
         while (size > 0 && iter.hasNext()) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
@@ -52,22 +52,14 @@ under the License.
         </dependency>
 
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
-            <version>${flink.version}</version>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-test-util</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-runtime</artifactId>
-            <version>${flink.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-test-utils</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/MySqlChangeEventSourceExampleTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/MySqlChangeEventSourceExampleTest.java
@@ -41,6 +41,7 @@ import com.ververica.cdc.debezium.JsonDebeziumDeserializationSchema;
 import com.ververica.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.jdbc.JdbcConnection;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -90,8 +91,15 @@ public class MySqlChangeEventSourceExampleTest {
         LOG.info("Containers are started.");
     }
 
+    @AfterClass
+    public static void stopContainers() {
+        LOG.info("Stopping containers...");
+        MYSQL_CONTAINER.stop();
+        LOG.info("Containers are stopped.");
+    }
+
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     @Test
     @Ignore("Test ignored because it won't stop and is used for manual test")
@@ -99,8 +107,8 @@ public class MySqlChangeEventSourceExampleTest {
         inventoryDatabase.createAndInitialize();
         MySqlSourceBuilder.MySqlIncrementalSource<String> mySqlChangeEventSource =
                 new MySqlSourceBuilder<String>()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(inventoryDatabase.getDatabaseName() + ".products")
                         .username(inventoryDatabase.getUsername())
@@ -139,8 +147,8 @@ public class MySqlChangeEventSourceExampleTest {
         final String tableId = inventoryDatabase.getDatabaseName() + ".products";
         MySqlSourceBuilder.MySqlIncrementalSource<RowData> mySqlChangeEventSource =
                 new MySqlSourceBuilder<RowData>()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(tableId)
                         .username(inventoryDatabase.getUsername())
@@ -232,8 +240,8 @@ public class MySqlChangeEventSourceExampleTest {
 
     private MySqlConnection getConnection() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("database.hostname", MYSQL_CONTAINER.getHost());
-        properties.put("database.port", String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
+        properties.put("database.hostname", inventoryDatabase.getHost());
+        properties.put("database.port", String.valueOf(inventoryDatabase.getDatabasePort()));
         properties.put("database.user", inventoryDatabase.getUsername());
         properties.put("database.password", inventoryDatabase.getPassword());
         properties.put("database.serverTimezone", ZoneId.of("UTC").toString());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/testutils/UniqueDatabase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/com/ververica/cdc/connectors/base/testutils/UniqueDatabase.java
@@ -16,6 +16,8 @@
 
 package com.ververica.cdc.connectors.base.testutils;
 
+import com.ververica.cdc.connectors.utils.TestEnvUtils;
+
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -48,41 +50,35 @@ public class UniqueDatabase {
             new String[] {"CREATE DATABASE $DBNAME$;", "USE $DBNAME$;"};
     private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)--.*$");
 
+    private static final String TEST_USER = "mysqluser";
+    private static final String TEST_PASSWORD = "mysqlpw";
+
     private final MySqlContainer container;
     private final String databaseName;
     private final String templateName;
-    private final String username;
-    private final String password;
 
-    public UniqueDatabase(
-            MySqlContainer container, String databaseName, String username, String password) {
-        this(
-                container,
-                databaseName,
-                Integer.toUnsignedString(new Random().nextInt(), 36),
-                username,
-                password);
+    public UniqueDatabase(MySqlContainer container, String databaseName) {
+        this(container, databaseName, Integer.toUnsignedString(new Random().nextInt(), 36));
     }
 
-    private UniqueDatabase(
-            MySqlContainer container,
-            String databaseName,
-            final String identifier,
-            String username,
-            String password) {
+    private UniqueDatabase(MySqlContainer container, String databaseName, final String identifier) {
         this.container = container;
         this.databaseName = databaseName + "_" + identifier;
         this.templateName = databaseName;
-        this.username = username;
-        this.password = password;
     }
 
     public String getHost() {
-        return container.getHost();
+        if (TestEnvUtils.useContainer()) {
+            return container.getHost();
+        }
+        return TestEnvUtils.getHost();
     }
 
     public int getDatabasePort() {
-        return container.getDatabasePort();
+        if (TestEnvUtils.useContainer()) {
+            return container.getDatabasePort();
+        }
+        return TestEnvUtils.getPort();
     }
 
     public String getDatabaseName() {
@@ -90,11 +86,24 @@ public class UniqueDatabase {
     }
 
     public String getUsername() {
-        return username;
+        if (TestEnvUtils.useContainer()) {
+            return TEST_USER;
+        }
+        return TestEnvUtils.getUser();
     }
 
     public String getPassword() {
-        return password;
+        if (TestEnvUtils.useContainer()) {
+            return TEST_PASSWORD;
+        }
+        return TestEnvUtils.getPassword();
+    }
+
+    protected String getJdbcUrl(String databaseName) {
+        if (TestEnvUtils.useContainer()) {
+            return container.getJdbcUrl(databaseName);
+        }
+        return "jdbc:mysql://" + getHost() + ":" + getDatabasePort() + "/" + databaseName;
     }
 
     /** @return Fully qualified table name <code>&lt;databaseName&gt;.&lt;tableName&gt;</code> */
@@ -110,7 +119,7 @@ public class UniqueDatabase {
         try {
             try (Connection connection =
                             DriverManager.getConnection(
-                                    container.getJdbcUrl(), username, password);
+                                    getJdbcUrl(""), getUsername(), getPassword());
                     Statement statement = connection.createStatement()) {
                 final List<String> statements =
                         Arrays.stream(
@@ -142,7 +151,7 @@ public class UniqueDatabase {
     }
 
     public Connection getJdbcConnection() throws SQLException {
-        return DriverManager.getConnection(container.getJdbcUrl(databaseName), username, password);
+        return DriverManager.getConnection(getJdbcUrl(databaseName), getUsername(), getPassword());
     }
 
     private String convertSQL(final String sql) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceExampleTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceExampleTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class LegacyMySqlSourceExampleTest extends LegacyMySqlTestBase {
 
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     @Test
     @Ignore("Test ignored because it won't stop and is used for manual test")
@@ -36,8 +36,8 @@ public class LegacyMySqlSourceExampleTest extends LegacyMySqlTestBase {
         inventoryDatabase.createAndInitialize();
         SourceFunction<String> sourceFunction =
                 MySqlSource.<String>builder()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
                         // monitor all tables under inventory database
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .username(inventoryDatabase.getUsername())

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceITCase.java
@@ -51,7 +51,7 @@ import static org.junit.Assert.assertTrue;
 public class LegacyMySqlSourceITCase extends LegacyMySqlTestBase {
 
     private final UniqueDatabase fullTypesDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test");
 
     @Test
     public void testConsumingAllEventsWithJsonFormatIncludeSchema() throws Exception {
@@ -84,8 +84,8 @@ public class LegacyMySqlSourceITCase extends LegacyMySqlTestBase {
                                 includeSchema, customConverterConfigs);
         SourceFunction<String> sourceFunction =
                 MySqlSource.<String>builder()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .hostname(fullTypesDatabase.getHost())
+                        .port(fullTypesDatabase.getDatabasePort())
                         // monitor all tables under column_type_test database
                         .databaseList(fullTypesDatabase.getDatabaseName())
                         .username(fullTypesDatabase.getUsername())

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlSourceTest.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.jayway.jsonpath.JsonPath;
 import com.ververica.cdc.connectors.mysql.MySqlTestUtils.TestingListState;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
-import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import com.ververica.cdc.connectors.utils.TestSourceContext;
 import com.ververica.cdc.debezium.DebeziumSourceFunction;
@@ -82,8 +81,7 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
 
-    private final UniqueDatabase database =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", "mysqluser", "mysqlpw");
+    private final UniqueDatabase database = new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     @Override
     public String getTempFilePath(String fileName) throws IOException {
@@ -593,8 +591,7 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
         }
 
         Tuple2<String, Integer> offset =
-                currentMySqlLatestOffset(
-                        MYSQL_CONTAINER, database, "products", 10, useLegacyImplementation);
+                currentMySqlLatestOffset(database, "products", 10, useLegacyImplementation);
         final String offsetFile = offset.f0;
         final int offsetPos = offset.f1;
         final TestingListState<byte[]> offsetState = new TestingListState<>();
@@ -1061,7 +1058,6 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
 
     /** Gets the latest offset of current MySQL server. */
     public static Tuple2<String, Integer> currentMySqlLatestOffset(
-            MySqlContainer container,
             UniqueDatabase database,
             String table,
             int expectedRecordCount,
@@ -1069,12 +1065,12 @@ public class LegacyMySqlSourceTest extends LegacyMySqlTestBase {
             throws Exception {
         DebeziumSourceFunction<SourceRecord> source =
                 MySqlSource.<SourceRecord>builder()
-                        .hostname(container.getHost())
-                        .port(container.getDatabasePort())
+                        .hostname(database.getHost())
+                        .port(database.getDatabasePort())
                         .databaseList(database.getDatabaseName())
                         .tableList(database.getDatabaseName() + "." + table)
-                        .username(container.getUsername())
-                        .password(container.getPassword())
+                        .username(database.getUsername())
+                        .password(database.getPassword())
                         .deserializer(new MySqlTestUtils.ForwardDeserializeSchema())
                         .debeziumProperties(createDebeziumProperties(useLegacyImplementation))
                         .build();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/LegacyMySqlTestBase.java
@@ -19,11 +19,11 @@ package com.ververica.cdc.connectors.mysql;
 import org.apache.flink.test.util.AbstractTestBase;
 
 import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
+import com.ververica.cdc.connectors.mysql.testutils.MySqlVersion;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 
 import java.util.stream.Stream;
@@ -37,14 +37,7 @@ public abstract class LegacyMySqlTestBase extends AbstractTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(LegacyMySqlTestBase.class);
 
     protected static final MySqlContainer MYSQL_CONTAINER =
-            (MySqlContainer)
-                    new MySqlContainer()
-                            .withConfigurationOverride("docker/server/my.cnf")
-                            .withSetupSQL("docker/setup.sql")
-                            .withDatabaseName("flink-test")
-                            .withUsername("flinkuser")
-                            .withPassword("flinkpw")
-                            .withLogConsumer(new Slf4jLogConsumer(LOG));
+            MySqlTestUtils.createMySqlContainer(MySqlVersion.V5_7, "docker/server/my.cnf");
 
     @BeforeClass
     public static void startContainers() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlTestUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlTestUtils.java
@@ -34,11 +34,16 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.SupplierWithException;
 
+import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
+import com.ververica.cdc.connectors.mysql.testutils.MySqlVersion;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
 import com.ververica.cdc.connectors.utils.TestSourceContext;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import com.ververica.cdc.debezium.DebeziumSourceFunction;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +58,20 @@ import static org.junit.Assert.assertTrue;
 
 /** Utils to help test. */
 public class MySqlTestUtils {
+
+    protected static final Logger LOG = LoggerFactory.getLogger(MySqlTestUtils.class);
+
+    @SuppressWarnings("unchecked")
+    public static MySqlContainer createMySqlContainer(MySqlVersion version, String configPath) {
+        return (MySqlContainer)
+                new MySqlContainer(version)
+                        .withConfigurationOverride(configPath)
+                        .withSetupSQL("docker/setup.sql")
+                        .withDatabaseName("flink-test")
+                        .withUsername("flinkuser")
+                        .withPassword("flinkpw")
+                        .withLogConsumer(new Slf4jLogConsumer(LOG));
+    }
 
     public static MySqlSource.Builder<SourceRecord> basicSourceBuilder(
             UniqueDatabase database, String serverTimezone, boolean useLegacyImplementation) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlValidatorTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/MySqlValidatorTest.java
@@ -148,19 +148,13 @@ public class MySqlValidatorTest {
     }
 
     private void doValidate(MySqlVersion version, String configPath, String exceptionMessage) {
-        try (MySqlContainer container =
-                new MySqlContainer(version).withConfigurationOverride(configPath)) {
+        try (MySqlContainer container = MySqlTestUtils.createMySqlContainer(version, configPath)) {
 
             LOG.info("Starting containers...");
             Startables.deepStart(Stream.of(container)).join();
             LOG.info("Containers are started.");
 
-            UniqueDatabase database =
-                    new UniqueDatabase(
-                            container,
-                            "inventory",
-                            container.getUsername(),
-                            container.getPassword());
+            UniqueDatabase database = new UniqueDatabase(container, "inventory");
 
             try {
                 startSource(database);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -57,10 +57,10 @@ import static org.junit.Assert.fail;
 public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
 
     private static final UniqueDatabase customerDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "customer");
 
     private static final UniqueDatabase customer3_0Database =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer3.0", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "customer3.0");
 
     private static BinaryLogClient binaryLogClient;
     private static MySqlConnection mySqlConnection;
@@ -662,8 +662,8 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                 .databaseList(database.getDatabaseName())
                 .tableList(captureTableIds)
                 .serverId("1001-1002")
-                .hostname(MYSQL_CONTAINER.getHost())
-                .port(MYSQL_CONTAINER.getDatabasePort())
+                .hostname(database.getHost())
+                .port(database.getDatabasePort())
                 .username(database.getUsername())
                 .splitSize(splitSize)
                 .fetchSize(2)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceExampleTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceExampleTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class MySqlSourceExampleTest extends MySqlSourceTestBase {
 
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     @Test
     @Ignore("Test ignored because it won't stop and is used for manual test")
@@ -36,8 +36,8 @@ public class MySqlSourceExampleTest extends MySqlSourceTestBase {
         inventoryDatabase.createAndInitialize();
         MySqlSource<String> mySqlSource =
                 MySqlSource.<String>builder()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(inventoryDatabase.getDatabaseName() + ".products")
                         .username(inventoryDatabase.getUsername())

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
@@ -103,8 +103,7 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
     @Rule public final Timeout timeoutPerTest = Timeout.seconds(300);
 
     private static final String DEFAULT_SCAN_STARTUP_MODE = "initial";
-    private final UniqueDatabase customDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
+    private final UniqueDatabase customDatabase = new UniqueDatabase(MYSQL_CONTAINER, "customer");
 
     /** Initial changelogs in string of table "customers" in database "customer". */
     private final List<String> initialChanges =
@@ -661,8 +660,8 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
         // Build source
         MySqlSource<RowData> mySqlSource =
                 MySqlSource.<RowData>builder()
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
+                        .hostname(customDatabase.getHost())
+                        .port(customDatabase.getDatabasePort())
                         .databaseList(customDatabase.getDatabaseName())
                         .serverTimeZone("UTC")
                         .tableList(tableId)
@@ -712,8 +711,8 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
                                 .build(),
                         1000L);
         return MySqlSource.<RowData>builder()
-                .hostname(MYSQL_CONTAINER.getHost())
-                .port(MYSQL_CONTAINER.getDatabasePort())
+                .hostname(customDatabase.getHost())
+                .port(customDatabase.getDatabasePort())
                 .databaseList(customDatabase.getDatabaseName())
                 .tableList(getTableId())
                 .username(customDatabase.getUsername())
@@ -822,8 +821,8 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s'"
                                 + " %s"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customDatabase.getHost(),
+                        customDatabase.getDatabasePort(),
                         customDatabase.getUsername(),
                         customDatabase.getPassword(),
                         customDatabase.getDatabaseName(),
@@ -1062,8 +1061,8 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
 
     private MySqlConnection getConnection() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("database.hostname", MYSQL_CONTAINER.getHost());
-        properties.put("database.port", String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
+        properties.put("database.hostname", customDatabase.getHost());
+        properties.put("database.port", String.valueOf(customDatabase.getDatabasePort()));
         properties.put("database.user", customDatabase.getUsername());
         properties.put("database.password", customDatabase.getPassword());
         properties.put("database.serverTimezone", ZoneId.of("UTC").toString());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceTestBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
 
+import com.ververica.cdc.connectors.mysql.MySqlTestUtils;
 import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
 import com.ververica.cdc.connectors.mysql.testutils.MySqlVersion;
 import org.junit.AfterClass;
@@ -32,7 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.lifecycle.Startables;
 
 import java.util.List;
@@ -77,18 +77,7 @@ public abstract class MySqlSourceTestBase extends TestLogger {
     }
 
     protected static MySqlContainer createMySqlContainer(MySqlVersion version) {
-        return createMySqlContainer(version, "docker/server-gtids/my.cnf");
-    }
-
-    protected static MySqlContainer createMySqlContainer(MySqlVersion version, String configPath) {
-        return (MySqlContainer)
-                new MySqlContainer(version)
-                        .withConfigurationOverride(configPath)
-                        .withSetupSQL("docker/setup.sql")
-                        .withDatabaseName("flink-test")
-                        .withUsername("flinkuser")
-                        .withPassword("flinkpw")
-                        .withLogConsumer(new Slf4jLogConsumer(LOG));
+        return MySqlTestUtils.createMySqlContainer(version, "docker/server-gtids/my.cnf");
     }
 
     // ------------------------------------------------------------------------

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/NewlyAddedTableITCase.java
@@ -85,8 +85,7 @@ public class NewlyAddedTableITCase extends MySqlSourceTestBase {
 
     @Rule public final Timeout timeoutPerTest = Timeout.seconds(300);
 
-    private final UniqueDatabase customDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
+    private final UniqueDatabase customDatabase = new UniqueDatabase(MYSQL_CONTAINER, "customer");
 
     private final ScheduledExecutorService mockBinlogExecutor = Executors.newScheduledThreadPool(1);
 
@@ -407,8 +406,8 @@ public class NewlyAddedTableITCase extends MySqlSourceTestBase {
             // Build source
             MySqlSource<RowData> mySqlSource =
                     MySqlSource.<RowData>builder()
-                            .hostname(MYSQL_CONTAINER.getHost())
-                            .port(MYSQL_CONTAINER.getDatabasePort())
+                            .hostname(customDatabase.getHost())
+                            .port(customDatabase.getDatabasePort())
                             .databaseList(customDatabase.getDatabaseName())
                             .serverTimeZone("UTC")
                             .tableList(
@@ -897,8 +896,8 @@ public class NewlyAddedTableITCase extends MySqlSourceTestBase {
                         + " 'scan.newly-added-table.enabled' = 'true'"
                         + " %s"
                         + ")",
-                MYSQL_CONTAINER.getHost(),
-                MYSQL_CONTAINER.getDatabasePort(),
+                customDatabase.getHost(),
+                customDatabase.getDatabasePort(),
                 customDatabase.getUsername(),
                 customDatabase.getPassword(),
                 customDatabase.getDatabaseName(),
@@ -1066,8 +1065,8 @@ public class NewlyAddedTableITCase extends MySqlSourceTestBase {
 
     private MySqlConnection getConnection() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("database.hostname", MYSQL_CONTAINER.getHost());
-        properties.put("database.port", String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
+        properties.put("database.hostname", customDatabase.getHost());
+        properties.put("database.port", String.valueOf(customDatabase.getDatabasePort()));
         properties.put("database.user", customDatabase.getUsername());
         properties.put("database.password", customDatabase.getPassword());
         properties.put("database.serverTimezone", ZoneId.of("UTC").toString());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertTrue;
 public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
 
     private static final UniqueDatabase customerDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "customer");
 
     @BeforeClass
     public static void init() {
@@ -192,8 +192,8 @@ public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
                 .startupOptions(startupOptions)
                 .databaseList(customerDatabase.getDatabaseName())
                 .tableList(captureTableIds)
-                .hostname(MYSQL_CONTAINER.getHost())
-                .port(MYSQL_CONTAINER.getDatabasePort())
+                .hostname(customerDatabase.getHost())
+                .port(customerDatabase.getDatabasePort())
                 .username(customerDatabase.getUsername())
                 .password(customerDatabase.getPassword())
                 .serverTimeZone(ZoneId.of("UTC").toString())

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.fail;
 public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
 
     private static final UniqueDatabase customerDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "customer");
 
     @BeforeClass
     public static void init() {
@@ -632,8 +632,8 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
                 .startupOptions(StartupOptions.initial())
                 .databaseList(database.getDatabaseName())
                 .tableList(fullNames)
-                .hostname(MYSQL_CONTAINER.getHost())
-                .port(MYSQL_CONTAINER.getDatabasePort())
+                .hostname(database.getHost())
+                .port(database.getDatabasePort())
                 .splitSize(splitSize)
                 .fetchSize(2)
                 .distributionFactorUpper(distributionFactorUpper)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -107,10 +107,9 @@ import static org.junit.Assert.fail;
 /** Tests for {@link MySqlSourceReader}. */
 public class MySqlSourceReaderTest extends MySqlSourceTestBase {
 
-    private final UniqueDatabase customerDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", "mysqluser", "mysqlpw");
+    private final UniqueDatabase customerDatabase = new UniqueDatabase(MYSQL_CONTAINER, "customer");
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", "mysqluser", "mysqlpw");
+            new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     @After
     public void clear() {
@@ -296,10 +295,10 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(getTableNameRegex(tableNames.toArray(new String[0])))
                         .includeSchemaChanges(false)
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
-                        .username(customerDatabase.getUsername())
-                        .password(customerDatabase.getPassword())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
+                        .username(inventoryDatabase.getUsername())
+                        .password(inventoryDatabase.getPassword())
                         .serverTimeZone(ZoneId.of("UTC").toString())
                         .createConfig(0);
         final MySqlSnapshotSplitAssigner assigner =
@@ -326,10 +325,10 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                         .tableList(
                                 getTableNameRegex(tableNames.subList(0, 1).toArray(new String[0])))
                         .includeSchemaChanges(false)
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
-                        .username(customerDatabase.getUsername())
-                        .password(customerDatabase.getPassword())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
+                        .username(inventoryDatabase.getUsername())
+                        .password(inventoryDatabase.getPassword())
                         .serverTimeZone(ZoneId.of("UTC").toString())
                         .createConfig(0);
         MySqlSourceReader<SourceRecord> reader = createReader(sourceConfig4Reader, 1);
@@ -351,10 +350,10 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                         .databaseList(inventoryDatabase.getDatabaseName())
                         .tableList(tableName)
                         .includeSchemaChanges(false)
-                        .hostname(MYSQL_CONTAINER.getHost())
-                        .port(MYSQL_CONTAINER.getDatabasePort())
-                        .username(customerDatabase.getUsername())
-                        .password(customerDatabase.getPassword())
+                        .hostname(inventoryDatabase.getHost())
+                        .port(inventoryDatabase.getDatabasePort())
+                        .username(inventoryDatabase.getUsername())
+                        .password(inventoryDatabase.getPassword())
                         .serverTimeZone(ZoneId.of("UTC").toString())
                         .createConfig(0);
         final MySqlSnapshotSplitAssigner assigner =
@@ -517,8 +516,8 @@ public class MySqlSourceReaderTest extends MySqlSourceTestBase {
                 .databaseList(customerDatabase.getDatabaseName())
                 .tableList(captureTableIds)
                 .includeSchemaChanges(false)
-                .hostname(MYSQL_CONTAINER.getHost())
-                .port(MYSQL_CONTAINER.getDatabasePort())
+                .hostname(customerDatabase.getHost())
+                .port(customerDatabase.getDatabasePort())
                 .splitSize(10)
                 .fetchSize(2)
                 .username(customerDatabase.getUsername())

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlConnectorITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MySqlConnectorITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.ExceptionUtils;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
+import com.ververica.cdc.connectors.mysql.MySqlTestUtils;
 import com.ververica.cdc.connectors.mysql.debezium.DebeziumUtils;
 import com.ververica.cdc.connectors.mysql.source.MySqlSourceTestBase;
 import com.ververica.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
@@ -78,36 +79,30 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlConnectorITCase.class);
 
-    private static final String TEST_USER = "mysqluser";
-    private static final String TEST_PASSWORD = "mysqlpw";
-
     private static final MySqlContainer MYSQL8_CONTAINER =
-            createMySqlContainer(MySqlVersion.V8_0, "docker/server-gtids/expire-seconds/my.cnf");
+            MySqlTestUtils.createMySqlContainer(
+                    MySqlVersion.V8_0, "docker/server-gtids/expire-seconds/my.cnf");
 
     private final UniqueDatabase inventoryDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "inventory", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "inventory");
 
     private final UniqueDatabase fullTypesMySql57Database =
-            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "column_type_test");
     private final UniqueDatabase fullTypesMySql8Database =
-            new UniqueDatabase(
-                    MYSQL8_CONTAINER, "column_type_test_mysql8", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL8_CONTAINER, "column_type_test_mysql8");
 
-    private final UniqueDatabase customerDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer", TEST_USER, TEST_PASSWORD);
+    private final UniqueDatabase customerDatabase = new UniqueDatabase(MYSQL_CONTAINER, "customer");
     private static final UniqueDatabase customer3_0Database =
-            new UniqueDatabase(MYSQL_CONTAINER, "customer3.0", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "customer3.0");
 
-    private final UniqueDatabase userDatabase1 =
-            new UniqueDatabase(MYSQL_CONTAINER, "user_1", TEST_USER, TEST_PASSWORD);
-    private final UniqueDatabase userDatabase2 =
-            new UniqueDatabase(MYSQL_CONTAINER, "user_2", TEST_USER, TEST_PASSWORD);
+    private final UniqueDatabase userDatabase1 = new UniqueDatabase(MYSQL_CONTAINER, "user_1");
+    private final UniqueDatabase userDatabase2 = new UniqueDatabase(MYSQL_CONTAINER, "user_2");
 
     private final UniqueDatabase inventoryDatabase8 =
-            new UniqueDatabase(MYSQL8_CONTAINER, "inventory", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL8_CONTAINER, "inventory");
 
     private final UniqueDatabase binlogDatabase =
-            new UniqueDatabase(MYSQL8_CONTAINER, "binlog_metadata_test", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL8_CONTAINER, "binlog_metadata_test");
 
     private final StreamExecutionEnvironment env =
             StreamExecutionEnvironment.getExecutionEnvironment();
@@ -189,10 +184,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + " %s"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         incrementalSnapshot,
@@ -315,10 +310,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.incremental.snapshot.chunk.size' = '2'"
                                 + " %s"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         getServerId(),
                         otherTableOptions);
@@ -445,10 +440,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         incrementalSnapshot,
@@ -504,16 +499,15 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
 
     @Test
     public void testMysql57AllDataTypes() throws Throwable {
-        testAllDataTypes(MYSQL_CONTAINER, fullTypesMySql57Database);
+        testAllDataTypes(fullTypesMySql57Database);
     }
 
     @Test
     public void testMySql8AllDataTypes() throws Throwable {
-        testAllDataTypes(MYSQL8_CONTAINER, fullTypesMySql8Database);
+        testAllDataTypes(fullTypesMySql8Database);
     }
 
-    public void testAllDataTypes(MySqlContainer mySqlContainer, UniqueDatabase database)
-            throws Throwable {
+    public void testAllDataTypes(UniqueDatabase database) throws Throwable {
         database.createAndInitialize();
         String sourceDDL =
                 String.format(
@@ -590,8 +584,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        mySqlContainer.getHost(),
-                        mySqlContainer.getDatabasePort(),
+                        database.getHost(),
+                        database.getDatabasePort(),
                         database.getUsername(),
                         database.getPassword(),
                         database.getDatabaseName(),
@@ -799,8 +793,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        fullTypesMySql57Database.getHost(),
+                        fullTypesMySql57Database.getDatabasePort(),
                         fullTypesMySql57Database.getUsername(),
                         fullTypesMySql57Database.getPassword(),
                         fullTypesMySql57Database.getDatabaseName(),
@@ -874,8 +868,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'server-id' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        fullTypesMySql57Database.getHost(),
+                        fullTypesMySql57Database.getDatabasePort(),
                         fullTypesMySql57Database.getUsername(),
                         fullTypesMySql57Database.getPassword(),
                         fullTypesMySql57Database.getDatabaseName(),
@@ -954,8 +948,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        userDatabase1.getHost(),
+                        userDatabase1.getDatabasePort(),
                         userDatabase1.getUsername(),
                         userDatabase1.getPassword(),
                         userDatabase1.getDatabaseName(),
@@ -1052,10 +1046,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'server-id' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         incrementalSnapshot,
@@ -1126,10 +1120,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "varbinary_pk_table",
                         getServerId(),
@@ -1201,8 +1195,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customerDatabase.getHost(),
+                        customerDatabase.getDatabasePort(),
                         customerDatabase.getUsername(),
                         customerDatabase.getPassword(),
                         customerDatabase.getDatabaseName(),
@@ -1271,8 +1265,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customer3_0Database.getHost(),
+                        customer3_0Database.getDatabasePort(),
                         customer3_0Database.getUsername(),
                         customer3_0Database.getPassword(),
                         customer3_0Database.getDatabaseName(),
@@ -1336,8 +1330,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customerDatabase.getHost(),
+                        customerDatabase.getDatabasePort(),
                         customerDatabase.getUsername(),
                         customerDatabase.getPassword(),
                         // The regular regex from database-name and table-name will be
@@ -1412,8 +1406,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customerDatabase.getHost(),
+                        customerDatabase.getDatabasePort(),
                         customerDatabase.getUsername(),
                         customerDatabase.getPassword(),
                         customerDatabase.getDatabaseName(),
@@ -1550,8 +1544,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customerDatabase.getHost(),
+                        customerDatabase.getDatabasePort(),
                         customerDatabase.getUsername(),
                         customerDatabase.getPassword(),
                         customerDatabase.getDatabaseName(),
@@ -1618,8 +1612,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        userDatabase1.getHost(),
+                        userDatabase1.getDatabasePort(),
                         userDatabase1.getUsername(),
                         userDatabase1.getPassword(),
                         String.format(
@@ -1674,7 +1668,7 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
             statement.execute("UPDATE products SET weight='5.1' WHERE id=107;");
         }
         Tuple2<String, Integer> offset =
-                currentMySqlLatestOffset(MYSQL_CONTAINER, inventoryDatabase, "products", 9, false);
+                currentMySqlLatestOffset(inventoryDatabase, "products", 9, false);
 
         String sourceDDL =
                 String.format(
@@ -1698,10 +1692,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.startup.specific-offset.pos' = '%s',"
                                 + " 'scan.incremental.snapshot.enabled' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         offset.f0,
@@ -1770,10 +1764,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                     DebeziumUtils.currentBinlogOffset(
                             DebeziumUtils.createMySqlConnection(
                                     new MySqlSourceConfigFactory()
-                                            .hostname(MYSQL_CONTAINER.getHost())
-                                            .port(MYSQL_CONTAINER.getDatabasePort())
-                                            .username(TEST_USER)
-                                            .password(TEST_PASSWORD)
+                                            .hostname(inventoryDatabase.getHost())
+                                            .port(inventoryDatabase.getDatabasePort())
+                                            .username(inventoryDatabase.getUsername())
+                                            .password(inventoryDatabase.getPassword())
                                             .databaseList(inventoryDatabase.getDatabaseName())
                                             .tableList("products")
                                             .createConfig(0)));
@@ -1800,10 +1794,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.startup.specific-offset.gtid-set' = '%s',"
                                 + " 'scan.incremental.snapshot.enabled' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         offset.getGtidSet(),
@@ -1873,10 +1867,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.startup.mode' = 'earliest-offset',"
                                 + " 'scan.incremental.snapshot.enabled' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         incrementalSnapshot);
@@ -1959,10 +1953,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.startup.timestamp-millis' = '%s',"
                                 + " 'scan.incremental.snapshot.enabled' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "products",
                         System.currentTimeMillis(),
@@ -2029,8 +2023,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        customerDatabase.getHost(),
+                        customerDatabase.getDatabasePort(),
                         customerDatabase.getUsername(),
                         customerDatabase.getPassword(),
                         customerDatabase.getDatabaseName(),
@@ -2086,10 +2080,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-time-zone' = 'UTC',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "multi_max_table",
                         getServerId(),
@@ -2155,8 +2149,8 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                         + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                         + ")",
                                 i,
-                                MYSQL_CONTAINER.getHost(),
-                                MYSQL_CONTAINER.getDatabasePort(),
+                                customerDatabase.getHost(),
+                                customerDatabase.getDatabasePort(),
                                 customerDatabase.getUsername(),
                                 customerDatabase.getPassword(),
                                 customerDatabase.getDatabaseName(),
@@ -2221,10 +2215,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'server-id' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
-                        MYSQL8_CONTAINER.getHost(),
-                        MYSQL8_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        binlogDatabase.getHost(),
+                        binlogDatabase.getDatabasePort(),
+                        binlogDatabase.getUsername(),
+                        binlogDatabase.getPassword(),
                         binlogDatabase.getDatabaseName(),
                         "binlog_metadata",
                         getServerId(),
@@ -2371,10 +2365,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s',"
                                 + " 'debezium.binary.handling.mode' = 'base64'"
                                 + ")",
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
-                        TEST_USER,
-                        TEST_PASSWORD,
+                        inventoryDatabase.getHost(),
+                        inventoryDatabase.getDatabasePort(),
+                        inventoryDatabase.getUsername(),
+                        inventoryDatabase.getPassword(),
                         inventoryDatabase.getDatabaseName(),
                         "varbinary_base64_table",
                         getServerId(),

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MysqlConnectorCharsetITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/table/MysqlConnectorCharsetITCase.java
@@ -44,11 +44,8 @@ import java.util.Random;
 @RunWith(Parameterized.class)
 public class MysqlConnectorCharsetITCase extends MySqlSourceTestBase {
 
-    private static final String TEST_USER = "mysqluser";
-    private static final String TEST_PASSWORD = "mysqlpw";
-
     private static final UniqueDatabase charsetTestDatabase =
-            new UniqueDatabase(MYSQL_CONTAINER, "charset_test", TEST_USER, TEST_PASSWORD);
+            new UniqueDatabase(MYSQL_CONTAINER, "charset_test");
 
     private final StreamExecutionEnvironment env =
             StreamExecutionEnvironment.getExecutionEnvironment();
@@ -360,8 +357,8 @@ public class MysqlConnectorCharsetITCase extends MySqlSourceTestBase {
                                 + " 'scan.incremental.snapshot.chunk.size' = '%s'"
                                 + ")",
                         testName,
-                        MYSQL_CONTAINER.getHost(),
-                        MYSQL_CONTAINER.getDatabasePort(),
+                        charsetTestDatabase.getHost(),
+                        charsetTestDatabase.getDatabasePort(),
                         charsetTestDatabase.getUsername(),
                         charsetTestDatabase.getPassword(),
                         charsetTestDatabase.getDatabaseName(),

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqlContainer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/testutils/MySqlContainer.java
@@ -16,6 +16,7 @@
 
 package com.ververica.cdc.connectors.mysql.testutils;
 
+import com.ververica.cdc.connectors.utils.TestEnvUtils;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -49,6 +50,20 @@ public class MySqlContainer extends JdbcDatabaseContainer {
     public MySqlContainer(MySqlVersion version) {
         super(DockerImageName.parse(IMAGE + ":" + version.getVersion()));
         addExposedPort(MYSQL_PORT);
+    }
+
+    @Override
+    public void start() {
+        if (TestEnvUtils.useContainer()) {
+            super.start();
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (TestEnvUtils.useContainer()) {
+            super.stop();
+        }
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-test-util/src/main/java/com/ververica/cdc/connectors/utils/TestEnvUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-test-util/src/main/java/com/ververica/cdc/connectors/utils/TestEnvUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.cdc.connectors.utils;
+
+/** Utilities to get environment variables for testing. */
+public class TestEnvUtils {
+
+    private static final String ENV_MODE_KEY = "test.mode";
+    private static final String ENV_HOST_KEY = "test.host";
+    private static final String ENV_PORT_KEY = "test.port";
+    private static final String ENV_USER_KEY = "test.user";
+    private static final String ENV_PASSWORD_KEY = "test.password";
+
+    enum TestMode {
+        CONTAINER,
+        LOCAL;
+
+        public static TestMode parse(String text) {
+            if (text != null && text.trim().equalsIgnoreCase("local")) {
+                return LOCAL;
+            }
+            return CONTAINER;
+        }
+    }
+
+    public static boolean useContainer() {
+        return TestMode.parse(System.getenv(ENV_MODE_KEY)).equals(TestMode.CONTAINER);
+    }
+
+    public static String getHost() {
+        return System.getenv(ENV_HOST_KEY);
+    }
+
+    public static int getPort() {
+        return Integer.parseInt(System.getenv(ENV_PORT_KEY));
+    }
+
+    public static String getUser() {
+        return System.getenv(ENV_USER_KEY);
+    }
+
+    public static String getPassword() {
+        return System.getenv(ENV_PASSWORD_KEY);
+    }
+}

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/Db2E2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/Db2E2eITCase.java
@@ -153,8 +153,8 @@ public class Db2E2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO products_sink",
                         "SELECT * FROM products_source;");
@@ -184,11 +184,15 @@ public class Db2E2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/MongoE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/MongoE2eITCase.java
@@ -170,8 +170,8 @@ public class MongoE2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'mongodb_products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO mongodb_products_sink",
                         "SELECT * FROM products_source;");
@@ -210,11 +210,15 @@ public class MongoE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "100000000000000000000101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/MySqlE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/MySqlE2eITCase.java
@@ -60,8 +60,8 @@ public class MySqlE2eITCase extends FlinkContainerTestEnvironment {
                         " 'connector' = 'mysql-cdc',",
                         " 'hostname' = '" + INTER_CONTAINER_MYSQL_ALIAS + "',",
                         " 'port' = '3306',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "',",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "',",
                         " 'database-name' = '" + mysqlInventoryDatabase.getDatabaseName() + "',",
                         " 'table-name' = 'products_source',",
                         " 'server-time-zone' = 'UTC',",
@@ -87,8 +87,8 @@ public class MySqlE2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO products_sink",
                         "SELECT * FROM products_source;");
@@ -100,11 +100,14 @@ public class MySqlE2eITCase extends FlinkContainerTestEnvironment {
         String jdbcUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         try (Connection conn =
-                        DriverManager.getConnection(jdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+                        DriverManager.getConnection(
+                                jdbcUrl,
+                                mysqlInventoryDatabase.getUsername(),
+                                mysqlInventoryDatabase.getPassword());
                 Statement stat = conn.createStatement()) {
             stat.execute(
                     "UPDATE products_source SET description='18oz carpenter hammer' WHERE id=106;");
@@ -124,7 +127,11 @@ public class MySqlE2eITCase extends FlinkContainerTestEnvironment {
 
         // assert final results
         JdbcProxy proxy =
-                new JdbcProxy(jdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        jdbcUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14,red,{\"key1\": \"value1\"},{\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/OceanBaseE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/OceanBaseE2eITCase.java
@@ -157,8 +157,8 @@ public class OceanBaseE2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'ob_products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO ob_products_sink",
                         "SELECT * FROM products_source;");
@@ -186,11 +186,15 @@ public class OceanBaseE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14,red,{\"key1\": \"value1\"}",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/OracleE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/OracleE2eITCase.java
@@ -120,8 +120,8 @@ public class OracleE2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO products_sink",
                         "SELECT * FROM products_source;");
@@ -157,11 +157,15 @@ public class OracleE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/PostgresE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/PostgresE2eITCase.java
@@ -126,8 +126,8 @@ public class PostgresE2eITCase extends FlinkContainerTestEnvironment {
                             " 'url' = 'jdbc:mysql://%s:3306/%s',",
                             INTER_CONTAINER_MYSQL_ALIAS, mysqlInventoryDatabase.getDatabaseName()),
                     " 'table-name' = 'products_sink',",
-                    " 'username' = '" + MYSQL_TEST_USER + "',",
-                    " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                    " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                    " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                     ");",
                     "INSERT INTO products_sink",
                     "SELECT * FROM products_source;");
@@ -233,11 +233,15 @@ public class PostgresE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/SqlServerE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/SqlServerE2eITCase.java
@@ -136,8 +136,8 @@ public class SqlServerE2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO products_sink",
                         "SELECT * FROM products_source;");
@@ -169,11 +169,15 @@ public class SqlServerE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/TiDBE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/TiDBE2eITCase.java
@@ -171,8 +171,8 @@ public class TiDBE2eITCase extends FlinkContainerTestEnvironment {
                                 INTER_CONTAINER_MYSQL_ALIAS,
                                 mysqlInventoryDatabase.getDatabaseName()),
                         " 'table-name' = 'products_sink',",
-                        " 'username' = '" + MYSQL_TEST_USER + "',",
-                        " 'password' = '" + MYSQL_TEST_PASSWORD + "'",
+                        " 'username' = '" + mysqlInventoryDatabase.getUsername() + "',",
+                        " 'password' = '" + mysqlInventoryDatabase.getPassword() + "'",
                         ");",
                         "INSERT INTO products_sink",
                         "SELECT * FROM tidb_source;");
@@ -210,12 +210,15 @@ public class TiDBE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlJdbcUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
                 new JdbcProxy(
-                        mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                        mysqlJdbcUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/VitessE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/VitessE2eITCase.java
@@ -121,8 +121,8 @@ public class VitessE2eITCase extends FlinkContainerTestEnvironment {
                                 + ");",
                         INTER_CONTAINER_MYSQL_ALIAS,
                         mysqlInventoryDatabase.getDatabaseName(),
-                        MYSQL_TEST_USER,
-                        MYSQL_TEST_PASSWORD);
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword());
         List<String> sqlLines =
                 Arrays.asList(
                         sourceDDL,
@@ -161,11 +161,15 @@ public class VitessE2eITCase extends FlinkContainerTestEnvironment {
         String mysqlUrl =
                 String.format(
                         "jdbc:mysql://%s:%s/%s",
-                        MYSQL.getHost(),
-                        MYSQL.getDatabasePort(),
+                        mysqlInventoryDatabase.getHost(),
+                        mysqlInventoryDatabase.getDatabasePort(),
                         mysqlInventoryDatabase.getDatabaseName());
         JdbcProxy proxy =
-                new JdbcProxy(mysqlUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD, MYSQL_DRIVER_CLASS);
+                new JdbcProxy(
+                        mysqlUrl,
+                        mysqlInventoryDatabase.getUsername(),
+                        mysqlInventoryDatabase.getPassword(),
+                        MYSQL_DRIVER_CLASS);
         List<String> expectResult =
                 Arrays.asList(
                         "101,scooter,Small 2-wheel scooter,3.14",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/utils/FlinkContainerTestEnvironment.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/com/ververica/cdc/connectors/tests/utils/FlinkContainerTestEnvironment.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.util.TestLogger;
 
 import com.github.dockerjava.api.DockerClient;
+import com.ververica.cdc.connectors.mysql.MySqlTestUtils;
 import com.ververica.cdc.connectors.mysql.testutils.MySqlContainer;
 import com.ververica.cdc.connectors.mysql.testutils.MySqlVersion;
 import com.ververica.cdc.connectors.mysql.testutils.UniqueDatabase;
@@ -93,8 +94,6 @@ public abstract class FlinkContainerTestEnvironment extends TestLogger {
     // ------------------------------------------------------------------------------------------
     // MySQL Variables (we always use MySQL as the sink for easier verifying)
     // ------------------------------------------------------------------------------------------
-    protected static final String MYSQL_TEST_USER = "mysqluser";
-    protected static final String MYSQL_TEST_PASSWORD = "mysqlpw";
     protected static final String MYSQL_DRIVER_CLASS = "com.mysql.cj.jdbc.Driver";
     protected static final String INTER_CONTAINER_MYSQL_ALIAS = "mysql";
 
@@ -107,19 +106,13 @@ public abstract class FlinkContainerTestEnvironment extends TestLogger {
     @ClassRule
     public static final MySqlContainer MYSQL =
             (MySqlContainer)
-                    new MySqlContainer(
-                                    MySqlVersion.V8_0) // v8 support both ARM and AMD architectures
-                            .withConfigurationOverride("docker/mysql/my.cnf")
+                    MySqlTestUtils.createMySqlContainer(MySqlVersion.V8_0, "docker/mysql/my.cnf")
                             .withSetupSQL("docker/mysql/setup.sql")
-                            .withDatabaseName("flink-test")
-                            .withUsername("flinkuser")
-                            .withPassword("flinkpw")
                             .withNetwork(NETWORK)
-                            .withNetworkAliases(INTER_CONTAINER_MYSQL_ALIAS)
-                            .withLogConsumer(new Slf4jLogConsumer(LOG));
+                            .withNetworkAliases(INTER_CONTAINER_MYSQL_ALIAS);
 
     protected final UniqueDatabase mysqlInventoryDatabase =
-            new UniqueDatabase(MYSQL, "mysql_inventory", MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+            new UniqueDatabase(MYSQL, "mysql_inventory");
     protected Path jdbcJar;
 
     private GenericContainer<?> jobManager;


### PR DESCRIPTION
Modifications:
- Add `TestEnvUtils` to get environment variables for testing.
- Always using `MySqlTestUtils.createMySqlContainer` to create `MySqlContainer` instances, which ensures that the same configurations (init sql, user and password) are used.
- Modified the `MySqlContainer` and overrided the `start` and `stop` method for local testing.
- Moved the `mysqluser`/`mysqlpw` consts to `UniqueDatabase`, and mocked the getters by environment variables.
- Always using `UniqueDatabase` instance instead of using `MySqlContainer` directly in test cases, which ensures the mocked getters works properly. 

Env usage:
```
test.mode=local
test.host=
test.port=
test.user=
test.password=
```

Close #2922 

