### PR TITLE
[cdc-connector][mysql][hotfix] Avoid mysql source to read data after high_watermark in backfill phase

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlBinlogSplitReadTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/debezium/task/MySqlBinlogSplitReadTask.java
@@ -90,7 +90,7 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
         if (!eventFilter.test(event)) {
             return;
         }
-        super.handleEvent(partition, offsetContext, event);
+
         // check do we need to stop for read binlog for snapshot split.
         if (isBoundedRead()) {
             final BinlogOffset currentBinlogOffset = getBinlogPosition(offsetContext.getOffset());
@@ -109,8 +109,10 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
                 }
                 // tell reader the binlog task finished
                 ((StoppableChangeEventSourceContext) context).stopChangeEventSource();
+                return;
             }
         }
+        super.handleEvent(partition, offsetContext, event);
     }
 
     private boolean isBoundedRead() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlSourceITCase.java
@@ -354,9 +354,10 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
 
     @Test
     public void testSnapshotOnlyModeWithDMLPostHighWaterMark() throws Exception {
+        // The data number is 21, set fetchSize = 22 to test the job is bounded.
         List<String> records =
                 testBackfillWhenWritingEvents(
-                        false, 21, USE_POST_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
+                        false, 22, USE_POST_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
         List<String> expectedRecords =
                 Arrays.asList(
                         "+I[101, user_1, Shanghai, 123567891234]",
@@ -385,9 +386,10 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
 
     @Test
     public void testSnapshotOnlyModeWithDMLPreHighWaterMark() throws Exception {
+        // The data number is 21, set fetchSize = 22 to test the job is bounded.
         List<String> records =
                 testBackfillWhenWritingEvents(
-                        false, 21, USE_PRE_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
+                        false, 22, USE_PRE_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
         List<String> expectedRecords =
                 Arrays.asList(
                         "+I[101, user_1, Shanghai, 123567891234]",


### PR DESCRIPTION
### Reason
Current, we emit record first then determine whether is after out of bound. So it may emit data after high_watermark.

### Minimal reproduce step
```java
    @Test
    public void testSnapshotOnlyModeWithDMLPostHighWaterMark() throws Exception {
        // The data num is 21, set fetchSize = 22 to test the job is bounded.
        List<String> records =
                testBackfillWhenWritingEvents(
                        false, 22, USE_POST_HIGHWATERMARK_HOOK, StartupOptions.snapshot());
        List<String> expectedRecords =
                Arrays.asList(
                        "+I[101, user_1, Shanghai, 123567891234]",
                        "+I[102, user_2, Shanghai, 123567891234]",
                        "+I[103, user_3, Shanghai, 123567891234]",
                        "+I[109, user_4, Shanghai, 123567891234]",
                        "+I[110, user_5, Shanghai, 123567891234]",
                        "+I[111, user_6, Shanghai, 123567891234]",
                        "+I[118, user_7, Shanghai, 123567891234]",
                        "+I[121, user_8, Shanghai, 123567891234]",
                        "+I[123, user_9, Shanghai, 123567891234]",
                        "+I[1009, user_10, Shanghai, 123567891234]",
                        "+I[1010, user_11, Shanghai, 123567891234]",
                        "+I[1011, user_12, Shanghai, 123567891234]",
                        "+I[1012, user_13, Shanghai, 123567891234]",
                        "+I[1013, user_14, Shanghai, 123567891234]",
                        "+I[1014, user_15, Shanghai, 123567891234]",
                        "+I[1015, user_16, Shanghai, 123567891234]",
                        "+I[1016, user_17, Shanghai, 123567891234]",
                        "+I[1017, user_18, Shanghai, 123567891234]",
                        "+I[1018, user_19, Shanghai, 123567891234]",
                        "+I[1019, user_20, Shanghai, 123567891234]",
                        "+I[2000, user_21, Shanghai, 123567891234]");
        assertEqualsInAnyOrder(expectedRecords, records);
    }
```
But it return 22 value which contain one update after high_watermark.