### PR TITLE
[cdc-connector][mysql][hotfix] Fix NullPointerException when currentReader is null.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/reader/MySqlSplitReader.java
@@ -103,7 +103,7 @@ public class MySqlSplitReader implements SplitReader<SourceRecords, MySqlSplit> 
     }
 
     private MySqlRecords pollSplitRecords() throws InterruptedException {
-        Iterator<SourceRecords> dataIt;
+        Iterator<SourceRecords> dataIt = null;
         if (currentReader == null) {
             // (1) Reads binlog split firstly and then read snapshot split
             if (binlogSplits.size() > 0) {
@@ -122,7 +122,11 @@ public class MySqlSplitReader implements SplitReader<SourceRecords, MySqlSplit> 
             } else {
                 LOG.info("No available split to read.");
             }
-            dataIt = currentReader.pollSplitRecords();
+            if (currentReader != null) {
+                dataIt = currentReader.pollSplitRecords();
+            } else {
+                currentSplitId = null;
+            }
             return dataIt == null ? finishedSplit() : forRecords(dataIt);
         } else if (currentReader instanceof SnapshotSplitReader) {
             // (2) try to switch to binlog split reading util current snapshot split finished


### PR DESCRIPTION
In current com.ververica.cdc.connectors.mysql.source.reader.MySqlSplitReader#pollSplitRecords, if currentReader == null(for example, there is no split), NullPointerException will be thrown here:
```java
 private MySqlRecords pollSplitRecords() throws InterruptedException {
        Iterator<SourceRecords> dataIt;
        if (currentReader == null) {
            // (1) Reads binlog split firstly and then read snapshot split
            if (binlogSplits.size() > 0) {
                // the binlog split may come from:
                // (a) the initial binlog split
                // (b) added back binlog-split in newly added table process
                MySqlSplit nextSplit = binlogSplits.poll();
                currentSplitId = nextSplit.splitId();
                currentReader = getBinlogSplitReader();
                currentReader.submitSplit(nextSplit);
            } else if (snapshotSplits.size() > 0) {
                MySqlSplit nextSplit = snapshotSplits.poll();
                currentSplitId = nextSplit.splitId();
                currentReader = getSnapshotSplitReader();
                currentReader.submitSplit(nextSplit);
            } else {
                LOG.info("No available split to read.");
            }
            dataIt = currentReader.pollSplitRecords();
          
}
```