### PR TITLE
[fix][cdc-connector][mysql] Fix NoClassDefFoundError when create new table in mysql cdc source

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/utils/RecordUtils.java
@@ -18,7 +18,6 @@ package com.ververica.cdc.connectors.mysql.source.utils;
 
 import org.apache.flink.table.types.logical.RowType;
 
-import com.ververica.cdc.common.utils.StringUtils;
 import com.ververica.cdc.connectors.mysql.debezium.dispatcher.SignalEventDispatcher.WatermarkKind;
 import com.ververica.cdc.connectors.mysql.debezium.reader.DebeziumReader;
 import com.ververica.cdc.connectors.mysql.source.offset.BinlogOffset;
@@ -29,6 +28,7 @@ import io.debezium.document.DocumentReader;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.HistoryRecord;
 import io.debezium.util.SchemaNameAdjuster;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
@@ -392,7 +392,7 @@ public class RecordUtils {
         Struct value = (Struct) dataRecord.value();
         Struct source = value.getStruct(Envelope.FieldName.SOURCE);
         String tableName = source.getString(TABLE_NAME_KEY);
-        return !StringUtils.isNullOrWhitespaceOnly(tableName);
+        return StringUtils.isNotBlank(tableName);
     }
 
     public static Object[] getSplitKey(


### PR DESCRIPTION
### Prepare a Pull Request

Fixes: #3035 

### Motivation
When we package maven jar for flink-cdc-connector-mysql-cdc module, the flink-cdc-common moduel is excluded.
So we can use org.apache.commons.lang3.StringUtils instead of com.ververica.cdc.common.utils.StringUtils and then mysql CDC run correctly when adding new source tables.

Modifications

Change the import of StringUtils from com.ververica.cdc.common.utils to org.apache.commons.lang3