### PR TITLE
add ignore no primary key table param

### DIFF
--- a/docs/content/pipelines/mysql-pipeline(ZH).md
+++ b/docs/content/pipelines/mysql-pipeline(ZH).md
@@ -210,6 +210,13 @@ Pipeline 连接器选项
       <td>是否在快照结束后关闭空闲的 Reader。 此特性需要 flink 版本大于等于 1.14 并且 'execution.checkpointing.checkpoints-after-tasks-finish.enabled' 需要设置为 true。<br>
           若 flink 版本大于等于 1.15，'execution.checkpointing.checkpoints-after-tasks-finish.enabled' 默认值变更为 true，可以不用显式配置 'execution.checkpointing.checkpoints-after-tasks-finish.enabled' = true。</td>
     </tr>
+    <tr>
+      <td>ignore.noprimarykey.table</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>是否忽略没有主键的表，默认是false，如果设置为true，那么就忽略没有主键的表。</td>
+    </tr>
     </tbody>
 </table>
 </div>

--- a/docs/content/pipelines/mysql-pipeline.md
+++ b/docs/content/pipelines/mysql-pipeline.md
@@ -215,6 +215,13 @@ Pipeline Connector Options
           so it does not need to be explicitly configured 'execution.checkpointing.checkpoints-after-tasks-finish.enabled' = 'true'
       </td>
     </tr>
+    <tr>
+      <td>ignore.noprimarykey.table</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>Whether ignore no primary key table, by default is false. If set to true, will ignore no primary key tables.</td>
+    </tr>
     </tbody>
 </table>
 </div>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -216,6 +217,10 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
     private static String[] getTableList(
             MySqlSourceConfig sourceConfig, Selectors selectors, boolean ignorePrimaryKeyTable) {
         if (ignorePrimaryKeyTable) {
+            List<TableId> noPrimaryKeyTables =
+                    MySqlSchemaUtils.listNoPrimaryKeyTables(sourceConfig, null);
+            LOG.info("\t List of tables ignored without primary keys are: {}", noPrimaryKeyTables);
+
             return MySqlSchemaUtils.listPrimaryKeyTables(sourceConfig, null).stream()
                     .filter(selectors::isMatch)
                     .map(TableId::toString)

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceOptions.java
@@ -230,4 +230,11 @@ public class MySqlDataSourceOptions {
                     .defaultValue(true)
                     .withDescription(
                             "Whether send schema change events, by default is true. If set to false, the schema changes will not be sent.");
+
+    public static final ConfigOption<Boolean> IGNORE_NOPRIMARYKEY_TABLE =
+            ConfigOptions.key("ignore.noprimarykey.table")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether ignore no primary key table, by default is false. If set to true, will ignore no primary key tables.");
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/utils/MySqlSchemaUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/utils/MySqlSchemaUtils.java
@@ -154,9 +154,10 @@ public class MySqlSchemaUtils {
         final List<TableId> tableIds = new ArrayList<>();
 
         jdbc.query(
-                "select distinct TABLE_NAME from INFORMATION_SCHEMA.COLUMNS where TABLE_SCHEMA = '"
+                "SELECT DISTINCT TABLE_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS "
+                        + "WHERE CONSTRAINT_TYPE = 'PRIMARY KEY' AND TABLE_SCHEMA = '"
                         + dbName
-                        + "' and COLUMN_KEY = 'PRI'",
+                        + "'",
                 rs -> {
                     while (rs.next()) {
                         tableIds.add(TableId.tableId(dbName, rs.getString(1)));

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/utils/MySqlSchemaUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/com/ververica/cdc/connectors/mysql/utils/MySqlSchemaUtils.java
@@ -198,7 +198,6 @@ public class MySqlSchemaUtils {
      * @param jdbc
      * @param dbName
      * @return
-     * @throws SQLException
      */
     public static List<TableId> listNoPrimaryKeyTables(JdbcConnection jdbc, String dbName)
             throws SQLException {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
@@ -27,11 +27,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.HOSTNAME;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.IGNORE_NOPRIMARYKEY_TABLE;
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.PASSWORD;
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.PORT;
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES;
 import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.USERNAME;
-import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.IGNORE_NOPRIMARYKEY_TABLE;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/com/ververica/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
@@ -26,7 +26,12 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.*;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.HOSTNAME;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.PASSWORD;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.PORT;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.USERNAME;
+import static com.ververica.cdc.connectors.mysql.source.MySqlDataSourceOptions.IGNORE_NOPRIMARYKEY_TABLE;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
 import static com.ververica.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/ddl/inventory.sql
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/ddl/inventory.sql
@@ -67,4 +67,14 @@ VALUES (default, '2016-01-16', 1001, 1, 102),
        (default, '2016-02-19', 1002, 2, 106),
        (default, '16-02-21', 1003, 1, 107);
 
+-- Create a user table which have no primary key
+CREATE TABLE users (
+    user_id int,
+    user_name varchar(255)
+);
+
+INSERT INTO users
+values (1, 'Sally'),
+       (2, 'George');
+
 


### PR DESCRIPTION
add ignore.noprimarykey.table param, default this param is false, but when this param is set to true, it can ignore no primary key tables.
fix #3006 