### PR TITLE
[MySQL] Fix for DBZ-7037 and 2217 to not clear tableMapEventByTableId for fake Rotates Event

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -268,7 +268,8 @@ public class MySqlStreamingChangeEventSource
 
                             // DBZ-5126 Clean cache on rotate event to prevent it from growing
                             // indefinitely.
-                            if (event.getHeader().getEventType() == EventType.ROTATE && event.getHeader().getTimestamp() != 0) {
+                            if (event.getHeader().getEventType() == EventType.ROTATE
+                                    && event.getHeader().getTimestamp() != 0) {
                                 tableMapEventByTableId.clear();
                             }
                             return event;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -268,7 +268,7 @@ public class MySqlStreamingChangeEventSource
 
                             // DBZ-5126 Clean cache on rotate event to prevent it from growing
                             // indefinitely.
-                            if (event.getHeader().getEventType() == EventType.ROTATE) {
+                            if (event.getHeader().getEventType() == EventType.ROTATE && event.getHeader().getTimestamp() != 0) {
                                 tableMapEventByTableId.clear();
                             }
                             return event;


### PR DESCRIPTION
Event log  
`Caused by: com.github.shyiko.mysql.binlog.event.deserialization.MissingTableMapEventException`
would occur as explained in issue #2217  whereby client is restarted during the consumption process, leading to a Rotate Event that clears the tableMapEventByTableId. 

This has been fixed in [DBZ](https://github.com/debezium/debezium/pull/4959) discussing the same issue. This PR tries to port that fix over since Flink CDC clones the MySqlStreamingChangeEventSource.
