### PR TITLE
[FLINK-35071][cdc-connector][cdc-base] Shade guava31 to avoid dependency conflict with flink below 1.18

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/datastream-api-package-guidance.md
+++ b/docs/content.zh/docs/connectors/flink-sources/datastream-api-package-guidance.md
@@ -104,18 +104,6 @@ This guide provides a simple `pom.xml` example for packaging DataStream job JARs
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Checked the dependencies of the Flink project and below is a feasible reference. -->
-        <!--  Use flink shaded guava  18.0-13.0 for flink 1.13   -->
-        <!--  Use flink shaded guava  30.1.1-jre-14.0 for flink-1.14  -->
-        <!--  Use flink shaded guava  30.1.1-jre-15.0 for flink-1.15  -->
-        <!--  Use flink shaded guava  30.1.1-jre-15.0 for flink-1.16  -->
-        <!--  Use flink shaded guava  30.1.1-jre-16.1 for flink-1.17  -->
-        <!--  Use flink shaded guava  31.1-jre-17.0   for flink-1.18  -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-shaded-guava</artifactId>
-            <version>30.1.1-jre-16.1</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-mysql-cdc</artifactId>
@@ -178,8 +166,6 @@ This guide provides a simple `pom.xml` example for packaging DataStream job JARs
                                     <include>com.google.guava:*</include>
                                     <include>com.esri.geometry:esri-geometry-api</include>
                                     <include>com.zaxxer:HikariCP</include>
-                                    <!--  Include fixed version 30.1.1-jre-16.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/docs/content/docs/connectors/flink-sources/datastream-api-package-guidance.md
+++ b/docs/content/docs/connectors/flink-sources/datastream-api-package-guidance.md
@@ -104,18 +104,6 @@ This guide provides a simple `pom.xml` example for packaging DataStream job JARs
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Checked the dependencies of the Flink project and below is a feasible reference. -->
-        <!--  Use flink shaded guava  18.0-13.0 for flink 1.13   -->
-        <!--  Use flink shaded guava  30.1.1-jre-14.0 for flink-1.14  -->
-        <!--  Use flink shaded guava  30.1.1-jre-15.0 for flink-1.15  -->
-        <!--  Use flink shaded guava  30.1.1-jre-15.0 for flink-1.16  -->
-        <!--  Use flink shaded guava  30.1.1-jre-16.1 for flink-1.17  -->
-        <!--  Use flink shaded guava  31.1-jre-17.0   for flink-1.18  -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-shaded-guava</artifactId>
-            <version>30.1.1-jre-16.1</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-mysql-cdc</artifactId>
@@ -178,8 +166,6 @@ This guide provides a simple `pom.xml` example for packaging DataStream job JARs
                                     <include>com.google.guava:*</include>
                                     <include>com.esri.geometry:esri-geometry-api</include>
                                     <include>com.zaxxer:HikariCP</include>
-                                    <!--  Include fixed version 30.1.1-jre-16.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/flink-cdc-cli/pom.xml
+++ b/flink-cdc-cli/pom.xml
@@ -55,6 +55,12 @@ limitations under the License.
             <artifactId>commons-cli</artifactId>
             <version>${commons-cli.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+            <version>31.1-jre-${flink.shaded.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/configuration/description/TextElement.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/configuration/description/TextElement.java
@@ -19,8 +19,6 @@ package org.apache.flink.cdc.common.configuration.description;
 
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 
-import org.apache.flink.shaded.guava31.com.google.common.base.Strings;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -55,11 +53,6 @@ public class TextElement implements BlockElement, InlineElement {
      */
     public static TextElement text(String text) {
         return new TextElement(text, Collections.emptyList());
-    }
-
-    /** Wraps a list of {@link InlineElement}s into a single {@link TextElement}. */
-    public static InlineElement wrap(InlineElement... elements) {
-        return text(Strings.repeat("%s", elements.length), elements);
     }
 
     /**

--- a/flink-cdc-composer/pom.xml
+++ b/flink-cdc-composer/pom.xml
@@ -56,6 +56,59 @@ limitations under the License.
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+            <version>31.1-jre-${flink.shaded.version}</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink-guava</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Shading test jar have bug in some previous version, so close this configuration here,
+                            see https://issues.apache.org/jira/browse/MSHADE-284 -->
+                            <shadeTestJar>false</shadeTestJar>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <filters combine.children="append">
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.flink:flink-shaded-guava</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.flink.shaded.guava</pattern>
+                                    <shadedPattern>org.apache.cdc.flink.shaded.guava</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/pom.xml
@@ -170,8 +170,6 @@ limitations under the License.
                                     <include>com.google.guava:*</include>
                                     <include>com.esri.geometry:esri-geometry-api</include>
                                     <include>com.zaxxer:HikariCP</include>
-                                    <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkFactoryTest.java
@@ -25,10 +25,11 @@ import org.apache.flink.cdc.common.sink.DataSink;
 import org.apache.flink.cdc.composer.utils.FactoryDiscoveryUtils;
 import org.apache.flink.table.api.ValidationException;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
+
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 
 import java.util.HashMap;
 import java.util.List;
@@ -44,14 +45,12 @@ public class StarRocksDataSinkFactoryTest {
                 FactoryDiscoveryUtils.getFactoryByIdentifier("starrocks", DataSinkFactory.class);
         Assertions.assertThat(sinkFactory).isInstanceOf(StarRocksDataSinkFactory.class);
 
-        Configuration conf =
-                Configuration.fromMap(
-                        ImmutableMap.<String, String>builder()
-                                .put("jdbc-url", "jdbc:mysql://127.0.0.1:9030")
-                                .put("load-url", "127.0.0.1:8030")
-                                .put("username", "root")
-                                .put("password", "")
-                                .build());
+        Map configMap = new HashMap<>();
+        configMap.put("jdbc-url", "jdbc:mysql://127.0.0.1:9030");
+        configMap.put("load-url", "127.0.0.1:8030");
+        configMap.put("username", "root");
+        configMap.put("password", "");
+        Configuration conf = Configuration.fromMap(configMap);
         DataSink dataSink =
                 sinkFactory.createDataSink(
                         new FactoryHelper.DefaultContext(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierTest.java
@@ -30,8 +30,6 @@ import org.apache.flink.cdc.common.types.IntType;
 import org.apache.flink.cdc.common.types.SmallIntType;
 import org.apache.flink.cdc.common.types.TimestampType;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
-
 import com.starrocks.connector.flink.catalog.StarRocksColumn;
 import com.starrocks.connector.flink.catalog.StarRocksTable;
 import org.junit.Before;
@@ -40,7 +38,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.cdc.connectors.starrocks.sink.StarRocksDataSinkOptions.TABLE_CREATE_NUM_BUCKETS;
 import static org.apache.flink.cdc.connectors.starrocks.sink.StarRocksDataSinkOptions.TABLE_SCHEMA_CHANGE_TIMEOUT;
@@ -55,13 +55,11 @@ public class StarRocksMetadataApplierTest {
 
     @Before
     public void setup() {
-        Configuration configuration =
-                Configuration.fromMap(
-                        ImmutableMap.<String, String>builder()
-                                .put(TABLE_SCHEMA_CHANGE_TIMEOUT.key(), "100s")
-                                .put(TABLE_CREATE_NUM_BUCKETS.key(), "10")
-                                .put("table.create.properties.replication_num", "5")
-                                .build());
+        Map configMap = new HashMap<>();
+        configMap.put(TABLE_SCHEMA_CHANGE_TIMEOUT.key(), "100s");
+        configMap.put(TABLE_CREATE_NUM_BUCKETS.key(), "10");
+        configMap.put("table.create.properties.replication_num", "5");
+        Configuration configuration = Configuration.fromMap(configMap);
         SchemaChangeConfig schemaChangeConfig = SchemaChangeConfig.from(configuration);
         TableCreateConfig tableCreateConfig = TableCreateConfig.from(configuration);
         this.catalog = new MockStarRocksCatalog();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceStreamFetcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceStreamFetcher.java
@@ -22,9 +22,8 @@ import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSp
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceRecords;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.base.utils.ThreadUtil;
 import org.apache.flink.util.FlinkRuntimeException;
-
-import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.DataChangeEvent;
@@ -69,8 +68,7 @@ public class IncrementalSourceStreamFetcher implements Fetcher<SourceRecords, So
 
     public IncrementalSourceStreamFetcher(FetchTask.Context taskContext, int subTaskId) {
         this.taskContext = taskContext;
-        ThreadFactory threadFactory =
-                new ThreadFactoryBuilder().setNameFormat("debezium-reader-" + subTaskId).build();
+        ThreadFactory threadFactory = ThreadUtil.buildThreadFactory("debezium-reader-" + subTaskId);
         this.executorService = Executors.newSingleThreadExecutor(threadFactory);
         this.currentTaskRunning = true;
         this.pureStreamPhaseTables = new HashSet<>();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/utils/ThreadUtil.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/utils/ThreadUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.utils;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A utility class to help build thread Factory. */
+public class ThreadUtil {
+    private static final AtomicLong count = new AtomicLong(0);
+
+    public static ThreadFactory buildThreadFactory(String nameFormat) {
+        return buildThreadFactory(nameFormat, null);
+    }
+
+    public static ThreadFactory buildThreadFactory(
+            String nameFormat, Thread.UncaughtExceptionHandler eh) {
+        return r -> {
+            Thread t = new Thread(nameFormat + "-" + count.get());
+            if (eh != null) {
+                t.setUncaughtExceptionHandler(eh);
+            }
+            return t;
+        };
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/DebeziumSourceFunction.java
@@ -47,8 +47,6 @@ import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import io.debezium.document.DocumentReader;
 import io.debezium.document.DocumentWriter;
 import io.debezium.embedded.Connect;
@@ -69,7 +67,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.cdc.debezium.internal.Handover.ClosedException.isGentlyClosedException;
@@ -215,9 +212,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
     public void open(Configuration parameters) throws Exception {
         validator.validate();
         super.open(parameters);
-        ThreadFactory threadFactory =
-                new ThreadFactoryBuilder().setNameFormat("debezium-engine").build();
-        this.executor = Executors.newSingleThreadExecutor(threadFactory);
+        this.executor = Executors.newSingleThreadExecutor(r -> new Thread("debezium-engine"));
         this.handover = new Handover();
         this.changeConsumer = new DebeziumChangeConsumer(handover);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -29,10 +29,9 @@ import org.apache.flink.cdc.connectors.mysql.source.utils.ChunkUtils;
 import org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils;
 import org.apache.flink.cdc.connectors.mysql.table.StartupMode;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
+import org.apache.flink.cdc.connectors.mysql.utils.ThreadUtil;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.FlinkRuntimeException;
-
-import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventType;
@@ -89,8 +88,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
 
     public BinlogSplitReader(StatefulTaskContext statefulTaskContext, int subTaskId) {
         this.statefulTaskContext = statefulTaskContext;
-        ThreadFactory threadFactory =
-                new ThreadFactoryBuilder().setNameFormat("binlog-reader-" + subTaskId).build();
+        ThreadFactory threadFactory = ThreadUtil.buildThreadFactory("binlog-reader-" + subTaskId);
         this.executorService = Executors.newSingleThreadExecutor(threadFactory);
         this.currentTaskRunning = true;
         this.pureBinlogPhaseTables = new HashSet<>();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -29,10 +29,9 @@ import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.SourceRecords;
 import org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils;
 import org.apache.flink.cdc.connectors.mysql.source.utils.hooks.SnapshotPhaseHooks;
+import org.apache.flink.cdc.connectors.mysql.utils.ThreadUtil;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
-
-import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.base.ChangeEventQueue;
@@ -97,11 +96,9 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
             StatefulTaskContext statefulTaskContext, int subtaskId, SnapshotPhaseHooks hooks) {
         this.statefulTaskContext = statefulTaskContext;
         ThreadFactory threadFactory =
-                new ThreadFactoryBuilder()
-                        .setNameFormat("debezium-reader-" + subtaskId)
-                        .setUncaughtExceptionHandler(
-                                (thread, throwable) -> setReadException(throwable))
-                        .build();
+                ThreadUtil.buildThreadFactory(
+                        "debezium-reader-" + subtaskId,
+                        (thread, throwable) -> setReadException(throwable));
         this.executorService = Executors.newSingleThreadExecutor(threadFactory);
         this.hooks = hooks;
         this.currentTaskRunning = false;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -31,8 +31,6 @@ import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import io.debezium.connector.mysql.MySqlPartition;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
@@ -57,7 +55,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 import java.util.stream.Collectors;
 
 /**
@@ -283,9 +280,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
     private void startAsynchronouslySplit() {
         if (chunkSplitter.hasNextChunk() || !remainingTables.isEmpty()) {
             if (executor == null) {
-                ThreadFactory threadFactory =
-                        new ThreadFactoryBuilder().setNameFormat("snapshot-splitting").build();
-                this.executor = Executors.newSingleThreadExecutor(threadFactory);
+                this.executor = Executors.newSingleThreadExecutor();
             }
             executor.submit(this::splitChunksForRemainingTables);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/ThreadUtil.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/ThreadUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.utils;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A utility class to help build thread Factory. */
+public class ThreadUtil {
+    private static final AtomicLong count = new AtomicLong(0);
+
+    public static ThreadFactory buildThreadFactory(String nameFormat) {
+        return buildThreadFactory(nameFormat, null);
+    }
+
+    public static ThreadFactory buildThreadFactory(
+            String nameFormat, Thread.UncaughtExceptionHandler eh) {
+        return r -> {
+            Thread t = new Thread(nameFormat + "-" + count.get());
+            if (eh != null) {
+                t.setUncaughtExceptionHandler(eh);
+            }
+            return t;
+        };
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssignerTest.java
@@ -34,8 +34,6 @@ import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
 import io.debezium.relational.TableId;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,6 +41,7 @@ import org.junit.Test;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -76,7 +75,8 @@ public class MySqlHybridSplitAssignerTest extends MySqlSourceTestBase {
         RowType splitKeyType =
                 (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT())).getLogicalType();
 
-        List<TableId> alreadyProcessedTables = Lists.newArrayList(tableId);
+        List<TableId> alreadyProcessedTables = Collections.emptyList();
+        alreadyProcessedTables.add(tableId);
         List<MySqlSchemalessSnapshotSplit> remainingSplits = new ArrayList<>();
 
         Map<String, MySqlSchemalessSnapshotSplit> assignedSplits = new HashMap<>();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlConnectorITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlConnectorITCase.java
@@ -39,8 +39,6 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.ExceptionUtils;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -916,8 +914,10 @@ public class MySqlConnectorITCase extends MySqlSourceTestBase {
             expected.add("+I[" + i + ", " + (i + 200000) + "]");
         }
         // binlog result after upsert into the sink
-        expected.addAll(
-                Lists.newArrayList("+U[0, 1024]", "+U[1, 1025]", "+U[2, 2048]", "+U[3, 2049]"));
+        expected.add("+U[0, 1024]");
+        expected.add("+U[1, 1025]");
+        expected.add("+U[2, 2048]");
+        expected.add("+U[3, 2049]");
 
         List<String> actual = TestValuesTableFactory.getRawResults("sink");
         Collections.sort(actual);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/pom.xml
@@ -164,6 +164,13 @@ limitations under the License.
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+            <version>31.1-jre-${flink.shaded.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/pom.xml
@@ -151,6 +151,12 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+            <version>31.1-jre-${flink.shaded.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -164,6 +170,48 @@ limitations under the License.
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink-guava</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Shading test jar have bug in some previous version, so close this configuration here,
+                            see https://issues.apache.org/jira/browse/MSHADE-284 -->
+                            <shadeTestJar>false</shadeTestJar>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <filters combine.children="append">
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.flink:flink-shaded-guava</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.flink.shaded.guava</pattern>
+                                    <shadedPattern>org.apache.cdc.flink.shaded.guava</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc/src/main/java/org/apache/flink/cdc/connectors/vitess/VitessValidator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc/src/main/java/org/apache/flink/cdc/connectors/vitess/VitessValidator.java
@@ -19,11 +19,11 @@ package org.apache.flink.cdc.connectors.vitess;
 
 import org.apache.flink.cdc.debezium.Validator;
 
-import org.apache.flink.shaded.guava31.com.google.common.collect.Maps;
-
 import io.debezium.connector.vitess.VitessConnector;
 
 import java.io.Serializable;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -35,12 +35,23 @@ public class VitessValidator implements Validator, Serializable {
     private final Map<String, String> configuration;
 
     public VitessValidator(Properties properties) {
-        this.configuration = Maps.fromProperties(properties);
+        this.configuration = fromProperties(properties);
     }
 
     @Override
     public void validate() {
         VitessConnector c = new VitessConnector();
         c.validate(configuration);
+    }
+
+    private Map<String, String> fromProperties(Properties properties) {
+        Map map = new HashMap();
+        Enumeration<?> e = properties.propertyNames();
+
+        while (e.hasMoreElements()) {
+            String key = (String) e.nextElement();
+            map.put(key, properties.getProperty(key));
+        }
+        return map;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
@@ -66,8 +66,6 @@ limitations under the License.
                                     <include>org.apache.kafka:*</include>
                                     <include>com.fasterxml.*:*</include>
                                     <include>com.google.guava:*</include>
-                                    <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
@@ -67,8 +67,6 @@ limitations under the License.
                                     <include>com.google.guava:*</include>
                                     <include>com.esri.geometry:esri-geometry-api</include>
                                     <include>com.zaxxer:HikariCP</include>
-                                    <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
@@ -65,8 +65,6 @@ limitations under the License.
                                     <include>org.apache.kafka:*</include>
                                     <include>org.postgresql:postgresql</include>
                                     <include>com.fasterxml.*:*</include>
-                                    <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
@@ -63,8 +63,6 @@ limitations under the License.
                                     <include>org.apache.kafka:*</include>
                                     <include>com.fasterxml.*:*</include>
                                     <include>com.google.guava:*</include>
-                                    <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-tidb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-tidb-cdc/pom.xml
@@ -57,8 +57,6 @@ limitations under the License.
                                     <include>org.tikv:tikv-client-java</include>
                                     <include>com.google.protobuf:*</include>
                                     <include>io.grpc:*</include>
-                                    <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
-                                    <include>org.apache.flink:flink-shaded-guava</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/flink-cdc-runtime/pom.xml
+++ b/flink-cdc-runtime/pom.xml
@@ -111,6 +111,58 @@ limitations under the License.
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+            <version>31.1-jre-${flink.shaded.version}</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink-guava</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Shading test jar have bug in some previous version, so close this configuration here,
+                            see https://issues.apache.org/jira/browse/MSHADE-284 -->
+                            <shadeTestJar>false</shadeTestJar>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <filters combine.children="append">
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.flink:flink-shaded-guava</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.flink.shaded.guava</pattern>
+                                    <shadedPattern>org.apache.cdc.flink.shaded.guava</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -284,11 +284,6 @@ limitations under the License.
             <version>${slf4j.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-shaded-guava</artifactId>
-            <version>31.1-jre-${flink.shaded.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
As shown in https://github.com/ververica/flink-cdc-connectors/issues/3071, 
Unlike flink-table-common、flink-connector-base 、flink-core whose maven scope is provided , flink-shaded-guava and flink-shaded-force-shading will be included in the final jar package,  so maybe cause dependency conflict.

Now we can see why dependency conflict occurs:

- Since Flink 1.18, version of guava is upgrade from 30 to 31 (using 31.1-jre-17.0)

![image](https://github.com/ververica/flink-cdc-connectors/assets/125648852/5425d959-089a-46bd-9e34-0c262cd04457)

- Since CDC 3.0.1, version of guava is also upgrade from 30 to 31 (using 31.1-jre-17.0)

- So CDC 3.0.1 is compatible with Flink 1.18, CDC 2.x is is compatible with Flink 1.13-1.17. CDC 2.x and Flink 1.18 dependency conflict, CDC 3.0.1 and Flink 1.17(or earlier version) dependency conflict.
(https://maven.apache.org/plugins/maven-shade-plugin/shade-mojo.html#relocations) in pom.xml.
