### PR TITLE
[Bug][pipeline]Set default values for the parallelism.

### DIFF
--- a/flink-cdc-common/src/main/java/com/ververica/cdc/common/pipeline/PipelineOptions.java
+++ b/flink-cdc-common/src/main/java/com/ververica/cdc/common/pipeline/PipelineOptions.java
@@ -37,7 +37,7 @@ public class PipelineOptions {
     public static final ConfigOption<Integer> PIPELINE_PARALLELISM =
             ConfigOptions.key("parallelism")
                     .intType()
-                    .noDefaultValue()
+                    .defaultValue(1)
                     .withDescription("Parallelism of the pipeline");
 
     public static final ConfigOption<SchemaChangeBehavior> PIPELINE_SCHEMA_CHANGE_BEHAVIOR =


### PR DESCRIPTION
Set default values for the parallelism. parameter to prevent NPE caused by not setting it.
https://github.com/apache/flink-cdc/blob/96888b2ce0a7981ebe5917b6c27deb4015d845d2/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/FlinkPipelineComposer.java#L95
https://github.com/apache/flink-cdc/blob/96888b2ce0a7981ebe5917b6c27deb4015d845d2/flink-cdc-composer/src/main/java/com/ververica/cdc/composer/flink/translator/DataSourceTranslator.java#L65
<img width="1042" alt="image" src="https://github.com/apache/flink-cdc/assets/40714172/2c031c99-24ee-48c3-8105-a918f5a63f84">
