### PR TITLE
[hotfix][cdc][build] Include cdc-common module when shaded for module flink-sql-connector-mysql-cdc

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mysql-cdc/pom.xml
@@ -57,6 +57,7 @@ limitations under the License.
                                     <include>io.debezium:debezium-core</include>
                                     <include>io.debezium:debezium-ddl-parser</include>
                                     <include>io.debezium:debezium-connector-mysql</include>
+                                    <include>com.ververica:flink-cdc-common</include>
                                     <include>com.ververica:flink-connector-debezium</include>
                                     <include>com.ververica:flink-connector-mysql-cdc</include>
                                     <include>org.antlr:antlr4-runtime</include>

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/org/apache/flink/cdc/connectors/tests/MySqlE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/org/apache/flink/cdc/connectors/tests/MySqlE2eITCase.java
@@ -119,6 +119,8 @@ public class MySqlE2eITCase extends FlinkContainerTestEnvironment {
                     "UPDATE products_source SET description='new water resistent white wind breaker', weight='0.5' WHERE id=110;");
             stat.execute("UPDATE products_source SET weight='5.17' WHERE id=111;");
             stat.execute("DELETE FROM products_source WHERE id=111;");
+            // add schema change event in the last.
+            stat.execute("CREATE TABLE new_table (id int, age int);");
         } catch (SQLException e) {
             LOG.error("Update table for CDC failed.", e);
             throw e;


### PR DESCRIPTION
`flink-cdc-source-connectors` module is depended on `flink-cdc-common`, but `flink-sql-connector-mysql-cdc` is not included `flink-cdc-common` when packaging.