### PR TITLE
[FLINK-34948][cdc-common] Fix cdc `RowType` can not convert to flink type

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/DataField.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/DataField.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.common.types;
 
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.common.types.utils.DataTypeUtils;
 import org.apache.flink.cdc.common.utils.Preconditions;
 
 import javax.annotation.Nullable;
@@ -115,5 +116,13 @@ public class DataField implements Serializable {
                     typeString,
                     escapeSingleQuotes(description));
         }
+    }
+
+    public org.apache.flink.table.api.DataTypes.Field toFlinkDataTypeField() {
+        return description == null
+                ? org.apache.flink.table.api.DataTypes.FIELD(
+                        name, DataTypeUtils.toFlinkDataType(type))
+                : org.apache.flink.table.api.DataTypes.FIELD(
+                        name, DataTypeUtils.toFlinkDataType(type), description);
     }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** Utilities for handling {@link DataType}s. */
-class DataTypeUtils {
+public class DataTypeUtils {
     /**
      * Returns the conversion class for the given {@link DataType} that is used by the table runtime
      * as internal data structure.

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
@@ -24,6 +24,7 @@ import org.apache.flink.cdc.common.data.RecordData;
 import org.apache.flink.cdc.common.data.StringData;
 import org.apache.flink.cdc.common.data.TimestampData;
 import org.apache.flink.cdc.common.data.ZonedTimestampData;
+import org.apache.flink.cdc.common.types.DataField;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.types.RowType;
@@ -139,26 +140,22 @@ public class DataTypeUtils {
                 RowType rowType = (RowType) type;
                 List<org.apache.flink.table.api.DataTypes.Field> fields =
                         rowType.getFields().stream()
-                                .map(
-                                        dataField ->
-                                                dataField.getDescription() == null
-                                                        ? org.apache.flink.table.api.DataTypes
-                                                                .FIELD(
-                                                                        dataField.getName(),
-                                                                        toFlinkDataType(
-                                                                                dataField
-                                                                                        .getType()))
-                                                        : org.apache.flink.table.api.DataTypes
-                                                                .FIELD(
-                                                                        dataField.getName(),
-                                                                        toFlinkDataType(
-                                                                                dataField
-                                                                                        .getType()),
-                                                                        dataField.getDescription()))
+                                .map(DataTypeUtils::toFlinkDataTypeField)
                                 .collect(Collectors.toList());
                 return org.apache.flink.table.api.DataTypes.ROW(fields);
             default:
                 throw new IllegalArgumentException("Illegal type: " + type);
         }
+    }
+
+    private static org.apache.flink.table.api.DataTypes.Field toFlinkDataTypeField(
+            DataField dataField) {
+        return dataField.getDescription() == null
+                ? org.apache.flink.table.api.DataTypes.FIELD(
+                        dataField.getName(), toFlinkDataType(dataField.getType()))
+                : org.apache.flink.table.api.DataTypes.FIELD(
+                        dataField.getName(),
+                        toFlinkDataType(dataField.getType()),
+                        dataField.getDescription());
     }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
@@ -140,22 +140,11 @@ public class DataTypeUtils {
                 RowType rowType = (RowType) type;
                 List<org.apache.flink.table.api.DataTypes.Field> fields =
                         rowType.getFields().stream()
-                                .map(DataTypeUtils::toFlinkDataTypeField)
+                                .map(DataField::toFlinkDataTypeField)
                                 .collect(Collectors.toList());
                 return org.apache.flink.table.api.DataTypes.ROW(fields);
             default:
                 throw new IllegalArgumentException("Illegal type: " + type);
         }
-    }
-
-    private static org.apache.flink.table.api.DataTypes.Field toFlinkDataTypeField(
-            DataField dataField) {
-        return dataField.getDescription() == null
-                ? org.apache.flink.table.api.DataTypes.FIELD(
-                        dataField.getName(), toFlinkDataType(dataField.getType()))
-                : org.apache.flink.table.api.DataTypes.FIELD(
-                        dataField.getName(),
-                        toFlinkDataType(dataField.getType()),
-                        dataField.getDescription());
     }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/types/utils/DataTypeUtils.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /** Utilities for handling {@link DataType}s. */
-public class DataTypeUtils {
+class DataTypeUtils {
     /**
      * Returns the conversion class for the given {@link DataType} that is used by the table runtime
      * as internal data structure.

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -88,7 +88,7 @@ public class DataTypeUtilsTest {
             };
 
     @Test
-    public void testToFlinkDataType() {
+    void testToFlinkDataType() {
         List<DataField> list =
                 IntStream.range(0, allTypes.length)
                         .mapToObj(i -> DataTypes.FIELD("f" + i, allTypes[i]))

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -88,16 +88,16 @@ public class DataTypeUtilsTest {
             };
 
     @Test
-    void testToFlinkDataType() {
+    public void testToFlinkDataType() {
         List<DataField> list =
-                IntStream.range(0, allTypes.length)
-                        .mapToObj(i -> DataTypes.FIELD("f" + i, allTypes[i]))
+                IntStream.range(0, ALL_TYPES.length)
+                        .mapToObj(i -> DataTypes.FIELD("f" + i, ALL_TYPES[i]))
                         .collect(Collectors.toList());
 
         org.apache.flink.table.types.DataType dataType =
                 DataTypeUtils.toFlinkDataType(new RowType(list));
 
-        org.apache.flink.table.types.DataType targetDataType =
+        org.apache.flink.table.types.DataType expectedDataType =
                 ROW(
                         FIELD("f0", BOOLEAN()),
                         FIELD("f1", BYTES()),
@@ -127,6 +127,6 @@ public class DataTypeUtilsTest {
                         FIELD("f25", ROW(FIELD("f1", STRING()), FIELD("f2", STRING(), "desc"))),
                         FIELD("f26", ROW(SMALLINT(), STRING())));
 
-        assertEquals(dataType, targetDataType);
+        assertThat(dataType).isEqualTo(expectedDataType);
     }
 }

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.types.RowType;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -53,7 +53,7 @@ import static org.apache.flink.table.api.DataTypes.VARCHAR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** A test for the {@link org.apache.flink.cdc.common.types.utils.DataTypeUtils}. */
-public class DataTypeUtilsTest {
+class DataTypeUtilsTest {
     private static final DataType[] ALL_TYPES =
             new DataType[] {
                 DataTypes.BOOLEAN(),
@@ -88,7 +88,7 @@ public class DataTypeUtilsTest {
             };
 
     @Test
-    public void testToFlinkDataType() {
+    void testToFlinkDataType() {
         List<DataField> list =
                 IntStream.range(0, ALL_TYPES.length)
                         .mapToObj(i -> DataTypes.FIELD("f" + i, ALL_TYPES[i]))

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.types.utils;
+
+import org.apache.flink.cdc.common.types.DataField;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.types.RowType;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.api.DataTypes.ARRAY;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.BINARY;
+import static org.apache.flink.table.api.DataTypes.BOOLEAN;
+import static org.apache.flink.table.api.DataTypes.BYTES;
+import static org.apache.flink.table.api.DataTypes.CHAR;
+import static org.apache.flink.table.api.DataTypes.DATE;
+import static org.apache.flink.table.api.DataTypes.DECIMAL;
+import static org.apache.flink.table.api.DataTypes.DOUBLE;
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.FLOAT;
+import static org.apache.flink.table.api.DataTypes.INT;
+import static org.apache.flink.table.api.DataTypes.MAP;
+import static org.apache.flink.table.api.DataTypes.ROW;
+import static org.apache.flink.table.api.DataTypes.SMALLINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.DataTypes.TIME;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP_LTZ;
+import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE;
+import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.apache.flink.table.api.DataTypes.VARBINARY;
+import static org.apache.flink.table.api.DataTypes.VARCHAR;
+import static org.junit.Assert.assertEquals;
+
+/** A test for the {@link org.apache.flink.cdc.common.types.utils.DataTypeUtils}. */
+public class DataTypeUtilsTest {
+    private final DataType[] allTypes =
+            new DataType[] {
+                DataTypes.BOOLEAN(),
+                DataTypes.BYTES(),
+                DataTypes.BINARY(10),
+                DataTypes.VARBINARY(10),
+                DataTypes.CHAR(10),
+                DataTypes.VARCHAR(10),
+                DataTypes.STRING(),
+                DataTypes.INT(),
+                DataTypes.TINYINT(),
+                DataTypes.SMALLINT(),
+                DataTypes.BIGINT(),
+                DataTypes.DOUBLE(),
+                DataTypes.FLOAT(),
+                DataTypes.DECIMAL(6, 3),
+                DataTypes.DATE(),
+                DataTypes.TIME(),
+                DataTypes.TIME(6),
+                DataTypes.TIMESTAMP(),
+                DataTypes.TIMESTAMP(6),
+                DataTypes.TIMESTAMP_LTZ(),
+                DataTypes.TIMESTAMP_LTZ(6),
+                DataTypes.TIMESTAMP_TZ(),
+                DataTypes.TIMESTAMP_TZ(6),
+                DataTypes.ARRAY(DataTypes.BIGINT()),
+                DataTypes.MAP(DataTypes.SMALLINT(), DataTypes.STRING()),
+                DataTypes.ROW(
+                        DataTypes.FIELD("f1", DataTypes.STRING()),
+                        DataTypes.FIELD("f2", DataTypes.STRING(), "desc")),
+                DataTypes.ROW(DataTypes.SMALLINT(), DataTypes.STRING())
+            };
+
+    @Test
+    public void testToFlinkDataType() {
+        List<DataField> list =
+                IntStream.range(0, allTypes.length)
+                        .mapToObj(i -> DataTypes.FIELD("f" + i, allTypes[i]))
+                        .collect(Collectors.toList());
+
+        org.apache.flink.table.types.DataType dataType =
+                DataTypeUtils.toFlinkDataType(new RowType(list));
+
+        org.apache.flink.table.types.DataType targetDataType =
+                ROW(
+                        FIELD("f0", BOOLEAN()),
+                        FIELD("f1", BYTES()),
+                        FIELD("f2", BINARY(10)),
+                        FIELD("f3", VARBINARY(10)),
+                        FIELD("f4", CHAR(10)),
+                        FIELD("f5", VARCHAR(10)),
+                        FIELD("f6", STRING()),
+                        FIELD("f7", INT()),
+                        FIELD("f8", TINYINT()),
+                        FIELD("f9", SMALLINT()),
+                        FIELD("f10", BIGINT()),
+                        FIELD("f11", DOUBLE()),
+                        FIELD("f12", FLOAT()),
+                        FIELD("f13", DECIMAL(6, 3)),
+                        FIELD("f14", DATE()),
+                        FIELD("f15", TIME()),
+                        FIELD("f16", TIME(6)),
+                        FIELD("f17", TIMESTAMP_WITH_TIME_ZONE()),
+                        FIELD("f18", TIMESTAMP_WITH_TIME_ZONE(6)),
+                        FIELD("f19", TIMESTAMP_LTZ()),
+                        FIELD("f20", TIMESTAMP_LTZ(6)),
+                        FIELD("f21", TIMESTAMP_WITH_TIME_ZONE()),
+                        FIELD("f22", TIMESTAMP_WITH_TIME_ZONE(6)),
+                        FIELD("f23", ARRAY(BIGINT())),
+                        FIELD("f24", MAP(SMALLINT(), STRING())),
+                        FIELD("f25", ROW(FIELD("f1", STRING()), FIELD("f2", STRING(), "desc"))),
+                        FIELD("f26", ROW(SMALLINT(), STRING())));
+
+        assertEquals(dataType, targetDataType);
+    }
+}

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -50,11 +50,11 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** A test for the {@link org.apache.flink.cdc.common.types.utils.DataTypeUtils}. */
 public class DataTypeUtilsTest {
-    private final DataType[] allTypes =
+    private static final DataType[] allTypes =
             new DataType[] {
                 DataTypes.BOOLEAN(),
                 DataTypes.BYTES(),

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** A test for the {@link org.apache.flink.cdc.common.types.utils.DataTypeUtils}. */
 public class DataTypeUtilsTest {
-    private static final DataType[] allTypes =
+    private static final DataType[] ALL_TYPES =
             new DataType[] {
                 DataTypes.BOOLEAN(),
                 DataTypes.BYTES(),

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/types/utils/DataTypeUtilsTest.java
@@ -50,7 +50,7 @@ import static org.apache.flink.table.api.DataTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static org.apache.flink.table.api.DataTypes.TINYINT;
 import static org.apache.flink.table.api.DataTypes.VARBINARY;
 import static org.apache.flink.table.api.DataTypes.VARCHAR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** A test for the {@link org.apache.flink.cdc.common.types.utils.DataTypeUtils}. */
 public class DataTypeUtilsTest {

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -27,7 +27,8 @@ import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,13 +36,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /** A test for the {@link org.apache.flink.cdc.common.utils.SchemaUtils}. */
-class SchemaUtilsTest {
+public class SchemaUtilsTest {
 
     @Test
-    void testApplySchemaChangeEvent() {
+    public void testApplySchemaChangeEvent() {
         TableId tableId = TableId.parse("default.default.table1");
         Schema schema =
                 Schema.newBuilder()
@@ -56,13 +55,13 @@ class SchemaUtilsTest {
                         Column.physicalColumn("col3", DataTypes.STRING())));
         AddColumnEvent addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("col2", DataTypes.STRING())
-                                .physicalColumn("col3", DataTypes.STRING())
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("col2", DataTypes.STRING())
+                        .physicalColumn("col3", DataTypes.STRING())
+                        .build());
 
         // add new column before existed column
         addedColumns = new ArrayList<>();
@@ -73,14 +72,14 @@ class SchemaUtilsTest {
                         "col3"));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("col2", DataTypes.STRING())
-                                .physicalColumn("col4", DataTypes.STRING())
-                                .physicalColumn("col3", DataTypes.STRING())
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("col2", DataTypes.STRING())
+                        .physicalColumn("col4", DataTypes.STRING())
+                        .physicalColumn("col3", DataTypes.STRING())
+                        .build());
 
         // add new column after existed column
         addedColumns = new ArrayList<>();
@@ -91,15 +90,15 @@ class SchemaUtilsTest {
                         "col4"));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("col2", DataTypes.STRING())
-                                .physicalColumn("col4", DataTypes.STRING())
-                                .physicalColumn("col5", DataTypes.STRING())
-                                .physicalColumn("col3", DataTypes.STRING())
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("col2", DataTypes.STRING())
+                        .physicalColumn("col4", DataTypes.STRING())
+                        .physicalColumn("col5", DataTypes.STRING())
+                        .physicalColumn("col3", DataTypes.STRING())
+                        .build());
 
         // add column in first position
         addedColumns = new ArrayList<>();
@@ -110,29 +109,29 @@ class SchemaUtilsTest {
                         null));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col0", DataTypes.STRING())
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("col2", DataTypes.STRING())
-                                .physicalColumn("col4", DataTypes.STRING())
-                                .physicalColumn("col5", DataTypes.STRING())
-                                .physicalColumn("col3", DataTypes.STRING())
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col0", DataTypes.STRING())
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("col2", DataTypes.STRING())
+                        .physicalColumn("col4", DataTypes.STRING())
+                        .physicalColumn("col5", DataTypes.STRING())
+                        .physicalColumn("col3", DataTypes.STRING())
+                        .build());
 
         // drop columns
         DropColumnEvent dropColumnEvent =
                 new DropColumnEvent(tableId, Arrays.asList("col3", "col5"));
         schema = SchemaUtils.applySchemaChangeEvent(schema, dropColumnEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col0", DataTypes.STRING())
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("col2", DataTypes.STRING())
-                                .physicalColumn("col4", DataTypes.STRING())
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col0", DataTypes.STRING())
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("col2", DataTypes.STRING())
+                        .physicalColumn("col4", DataTypes.STRING())
+                        .build());
 
         // rename columns
         Map<String, String> nameMapping = new HashMap<>();
@@ -140,14 +139,14 @@ class SchemaUtilsTest {
         nameMapping.put("col4", "newCol4");
         RenameColumnEvent renameColumnEvent = new RenameColumnEvent(tableId, nameMapping);
         schema = SchemaUtils.applySchemaChangeEvent(schema, renameColumnEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col0", DataTypes.STRING())
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("newCol2", DataTypes.STRING())
-                                .physicalColumn("newCol4", DataTypes.STRING())
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col0", DataTypes.STRING())
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("newCol2", DataTypes.STRING())
+                        .physicalColumn("newCol4", DataTypes.STRING())
+                        .build());
 
         // alter column types
         Map<String, DataType> typeMapping = new HashMap<>();
@@ -155,13 +154,13 @@ class SchemaUtilsTest {
         typeMapping.put("newCol4", DataTypes.VARCHAR(10));
         AlterColumnTypeEvent alterColumnTypeEvent = new AlterColumnTypeEvent(tableId, typeMapping);
         schema = SchemaUtils.applySchemaChangeEvent(schema, alterColumnTypeEvent);
-        assertThat(schema)
-                .isEqualTo(
-                        Schema.newBuilder()
-                                .physicalColumn("col0", DataTypes.STRING())
-                                .physicalColumn("col1", DataTypes.STRING())
-                                .physicalColumn("newCol2", DataTypes.VARCHAR(10))
-                                .physicalColumn("newCol4", DataTypes.VARCHAR(10))
-                                .build());
+        Assert.assertEquals(
+                schema,
+                Schema.newBuilder()
+                        .physicalColumn("col0", DataTypes.STRING())
+                        .physicalColumn("col1", DataTypes.STRING())
+                        .physicalColumn("newCol2", DataTypes.VARCHAR(10))
+                        .physicalColumn("newCol4", DataTypes.VARCHAR(10))
+                        .build());
     }
 }

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -27,8 +27,7 @@ import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,11 +35,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** A test for the {@link org.apache.flink.cdc.common.utils.SchemaUtils}. */
-public class SchemaUtilsTest {
+class SchemaUtilsTest {
 
     @Test
-    public void testApplySchemaChangeEvent() {
+    void testApplySchemaChangeEvent() {
         TableId tableId = TableId.parse("default.default.table1");
         Schema schema =
                 Schema.newBuilder()
@@ -55,13 +56,13 @@ public class SchemaUtilsTest {
                         Column.physicalColumn("col3", DataTypes.STRING())));
         AddColumnEvent addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("col2", DataTypes.STRING())
-                        .physicalColumn("col3", DataTypes.STRING())
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col3", DataTypes.STRING())
+                                .build());
 
         // add new column before existed column
         addedColumns = new ArrayList<>();
@@ -72,14 +73,14 @@ public class SchemaUtilsTest {
                         "col3"));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("col2", DataTypes.STRING())
-                        .physicalColumn("col4", DataTypes.STRING())
-                        .physicalColumn("col3", DataTypes.STRING())
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col4", DataTypes.STRING())
+                                .physicalColumn("col3", DataTypes.STRING())
+                                .build());
 
         // add new column after existed column
         addedColumns = new ArrayList<>();
@@ -90,15 +91,15 @@ public class SchemaUtilsTest {
                         "col4"));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("col2", DataTypes.STRING())
-                        .physicalColumn("col4", DataTypes.STRING())
-                        .physicalColumn("col5", DataTypes.STRING())
-                        .physicalColumn("col3", DataTypes.STRING())
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col4", DataTypes.STRING())
+                                .physicalColumn("col5", DataTypes.STRING())
+                                .physicalColumn("col3", DataTypes.STRING())
+                                .build());
 
         // add column in first position
         addedColumns = new ArrayList<>();
@@ -109,29 +110,29 @@ public class SchemaUtilsTest {
                         null));
         addColumnEvent = new AddColumnEvent(tableId, addedColumns);
         schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col0", DataTypes.STRING())
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("col2", DataTypes.STRING())
-                        .physicalColumn("col4", DataTypes.STRING())
-                        .physicalColumn("col5", DataTypes.STRING())
-                        .physicalColumn("col3", DataTypes.STRING())
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col0", DataTypes.STRING())
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col4", DataTypes.STRING())
+                                .physicalColumn("col5", DataTypes.STRING())
+                                .physicalColumn("col3", DataTypes.STRING())
+                                .build());
 
         // drop columns
         DropColumnEvent dropColumnEvent =
                 new DropColumnEvent(tableId, Arrays.asList("col3", "col5"));
         schema = SchemaUtils.applySchemaChangeEvent(schema, dropColumnEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col0", DataTypes.STRING())
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("col2", DataTypes.STRING())
-                        .physicalColumn("col4", DataTypes.STRING())
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col0", DataTypes.STRING())
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col4", DataTypes.STRING())
+                                .build());
 
         // rename columns
         Map<String, String> nameMapping = new HashMap<>();
@@ -139,14 +140,14 @@ public class SchemaUtilsTest {
         nameMapping.put("col4", "newCol4");
         RenameColumnEvent renameColumnEvent = new RenameColumnEvent(tableId, nameMapping);
         schema = SchemaUtils.applySchemaChangeEvent(schema, renameColumnEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col0", DataTypes.STRING())
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("newCol2", DataTypes.STRING())
-                        .physicalColumn("newCol4", DataTypes.STRING())
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col0", DataTypes.STRING())
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("newCol2", DataTypes.STRING())
+                                .physicalColumn("newCol4", DataTypes.STRING())
+                                .build());
 
         // alter column types
         Map<String, DataType> typeMapping = new HashMap<>();
@@ -154,13 +155,13 @@ public class SchemaUtilsTest {
         typeMapping.put("newCol4", DataTypes.VARCHAR(10));
         AlterColumnTypeEvent alterColumnTypeEvent = new AlterColumnTypeEvent(tableId, typeMapping);
         schema = SchemaUtils.applySchemaChangeEvent(schema, alterColumnTypeEvent);
-        Assert.assertEquals(
-                schema,
-                Schema.newBuilder()
-                        .physicalColumn("col0", DataTypes.STRING())
-                        .physicalColumn("col1", DataTypes.STRING())
-                        .physicalColumn("newCol2", DataTypes.VARCHAR(10))
-                        .physicalColumn("newCol4", DataTypes.VARCHAR(10))
-                        .build());
+        assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col0", DataTypes.STRING())
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("newCol2", DataTypes.VARCHAR(10))
+                                .physicalColumn("newCol4", DataTypes.VARCHAR(10))
+                                .build());
     }
 }


### PR DESCRIPTION
Fix cdc `RowType` can not convert to flink type

I meet the follow exception:
```
java.lang.ArrayStoreException
	at java.lang.System.arraycopy(Native Method)
	at java.util.Arrays.copyOf(Arrays.java:3213)
	at java.util.ArrayList.toArray(ArrayList.java:413)
	at java.util.Collections$UnmodifiableCollection.toArray(Collections.java:1036)
```