### PR TITLE
[FLINK-34634]Fix that Restarting the job will not read the changelog anymore if it stops before the synchronization of meta information is complete and some table is removed

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -39,10 +39,10 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -92,7 +92,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                 currentParallelism,
                 new ArrayList<>(),
                 new ArrayList<>(),
-                new HashMap<>(),
+                new LinkedHashMap<>(),
                 new HashMap<>(),
                 new HashMap<>(),
                 INITIAL_ASSIGNING,
@@ -143,7 +143,17 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
         this.currentParallelism = currentParallelism;
         this.alreadyProcessedTables = alreadyProcessedTables;
         this.remainingSplits = remainingSplits;
-        this.assignedSplits = assignedSplits;
+        // When job restore from savepoint, sort the existing tables and newly added tables
+        // to let enumerator only send newly added tables' StreamSplitMetaEvent
+        this.assignedSplits =
+                assignedSplits.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .collect(
+                                Collectors.toMap(
+                                        Map.Entry::getKey,
+                                        Map.Entry::getValue,
+                                        (o, o2) -> o,
+                                        LinkedHashMap::new));
         this.tableSchemas = tableSchemas;
         this.splitFinishedOffsets = splitFinishedOffsets;
         this.assignerStatus = assignerStatus;
@@ -303,9 +313,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                     "The assigner is not ready to offer finished split information, this should not be called");
         }
         final List<SchemalessSnapshotSplit> assignedSnapshotSplit =
-                assignedSplits.values().stream()
-                        .sorted(Comparator.comparing(SourceSplitBase::splitId))
-                        .collect(Collectors.toList());
+                new ArrayList<>(assignedSplits.values());
         List<FinishedSnapshotSplitInfo> finishedSnapshotSplitInfos = new ArrayList<>();
         for (SchemalessSnapshotSplit split : assignedSnapshotSplit) {
             Offset finishedOffset = splitFinishedOffsets.get(split.splitId());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -240,6 +240,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
                     tableSchemas
                             .entrySet()
                             .removeIf(schema -> tablesToRemove.contains(schema.getKey()));
+                    LOG.info("Enumerator remove tables after restart: {}", tablesToRemove);
                     remainingSplits.removeIf(split -> tablesToRemove.contains(split.getTableId()));
                     remainingTables.removeAll(tablesToRemove);
                     alreadyProcessedTables.removeIf(tableId -> tablesToRemove.contains(tableId));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/enumerator/IncrementalSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/enumerator/IncrementalSourceEnumerator.java
@@ -310,6 +310,11 @@ public class IncrementalSourceEnumerator
         final int totalFinishedSplitSizeOfReader = requestEvent.getTotalFinishedSplitSize();
         final int totalFinishedSplitSizeOfEnumerator = splitAssigner.getFinishedSplitInfos().size();
         if (totalFinishedSplitSizeOfReader > totalFinishedSplitSizeOfEnumerator) {
+            LOG.warn(
+                    "Total finished split size of subtask {} is {}, while total finished split size of enumerator is only {}. Try to truncate it",
+                    subTask,
+                    totalFinishedSplitSizeOfReader,
+                    totalFinishedSplitSizeOfEnumerator);
             StreamSplitMetaEvent metadataEvent =
                     new StreamSplitMetaEvent(
                             requestEvent.getSplitId(),

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/enumerator/IncrementalSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/enumerator/IncrementalSourceEnumerator.java
@@ -307,8 +307,17 @@ public class IncrementalSourceEnumerator
                             finishedSnapshotSplitInfos, sourceConfig.getSplitMetaGroupSize());
         }
         final int requestMetaGroupId = requestEvent.getRequestMetaGroupId();
-
-        if (finishedSnapshotSplitMeta.size() > requestMetaGroupId) {
+        final int totalFinishedSplitSizeOfReader = requestEvent.getTotalFinishedSplitSize();
+        final int totalFinishedSplitSizeOfEnumerator = splitAssigner.getFinishedSplitInfos().size();
+        if (totalFinishedSplitSizeOfReader > totalFinishedSplitSizeOfEnumerator) {
+            StreamSplitMetaEvent metadataEvent =
+                    new StreamSplitMetaEvent(
+                            requestEvent.getSplitId(),
+                            requestMetaGroupId,
+                            null,
+                            totalFinishedSplitSizeOfEnumerator);
+            context.sendEventToSourceReader(subTask, metadataEvent);
+        } else if (finishedSnapshotSplitMeta.size() > requestMetaGroupId) {
             List<FinishedSnapshotSplitInfo> metaToSend =
                     finishedSnapshotSplitMeta.get(requestMetaGroupId);
             StreamSplitMetaEvent metadataEvent =
@@ -317,13 +326,17 @@ public class IncrementalSourceEnumerator
                             requestMetaGroupId,
                             metaToSend.stream()
                                     .map(FinishedSnapshotSplitInfo::serialize)
-                                    .collect(Collectors.toList()));
+                                    .collect(Collectors.toList()),
+                            totalFinishedSplitSizeOfEnumerator);
             context.sendEventToSourceReader(subTask, metadataEvent);
         } else {
-            LOG.error(
-                    "Received invalid request meta group id {}, the invalid meta group id range is [0, {}]",
-                    requestMetaGroupId,
-                    finishedSnapshotSplitMeta.size() - 1);
+            throw new FlinkRuntimeException(
+                    String.format(
+                            "The enumerator received invalid request meta group id %s, the valid meta group id range is [0, %s]. Total finished split size of reader is %s, while the total finished split size of enumerator is %s.",
+                            requestMetaGroupId,
+                            finishedSnapshotSplitMeta.size() - 1,
+                            totalFinishedSplitSizeOfReader,
+                            totalFinishedSplitSizeOfEnumerator));
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitMetaEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitMetaEvent.java
@@ -43,10 +43,14 @@ public class StreamSplitMetaEvent implements SourceEvent {
      */
     private final List<byte[]> metaGroup;
 
-    public StreamSplitMetaEvent(String splitId, int metaGroupId, List<byte[]> metaGroup) {
+    private final int totalFinishedSplitSize;
+
+    public StreamSplitMetaEvent(
+            String splitId, int metaGroupId, List<byte[]> metaGroup, int totalFinishedSplitSize) {
         this.splitId = splitId;
         this.metaGroupId = metaGroupId;
         this.metaGroup = metaGroup;
+        this.totalFinishedSplitSize = totalFinishedSplitSize;
     }
 
     public String getSplitId() {
@@ -59,5 +63,9 @@ public class StreamSplitMetaEvent implements SourceEvent {
 
     public List<byte[]> getMetaGroup() {
         return metaGroup;
+    }
+
+    public int getTotalFinishedSplitSize() {
+        return totalFinishedSplitSize;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitMetaEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitMetaEvent.java
@@ -22,6 +22,8 @@ import org.apache.flink.cdc.connectors.base.source.enumerator.IncrementalSourceE
 import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo;
 import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReader;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -46,7 +48,10 @@ public class StreamSplitMetaEvent implements SourceEvent {
     private final int totalFinishedSplitSize;
 
     public StreamSplitMetaEvent(
-            String splitId, int metaGroupId, List<byte[]> metaGroup, int totalFinishedSplitSize) {
+            String splitId,
+            int metaGroupId,
+            @Nullable List<byte[]> metaGroup,
+            int totalFinishedSplitSize) {
         this.splitId = splitId;
         this.metaGroupId = metaGroupId;
         this.metaGroup = metaGroup;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitMetaRequestEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitMetaRequestEvent.java
@@ -33,9 +33,13 @@ public class StreamSplitMetaRequestEvent implements SourceEvent {
     private final String splitId;
     private final int requestMetaGroupId;
 
-    public StreamSplitMetaRequestEvent(String splitId, int requestMetaGroupId) {
+    private final int totalFinishedSplitSize;
+
+    public StreamSplitMetaRequestEvent(
+            String splitId, int requestMetaGroupId, int totalFinishedSplitSize) {
         this.splitId = splitId;
         this.requestMetaGroupId = requestMetaGroupId;
+        this.totalFinishedSplitSize = totalFinishedSplitSize;
     }
 
     public String getSplitId() {
@@ -44,5 +48,9 @@ public class StreamSplitMetaRequestEvent implements SourceEvent {
 
     public int getRequestMetaGroupId() {
         return requestMetaGroupId;
+    }
+
+    public int getTotalFinishedSplitSize() {
+        return totalFinishedSplitSize;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceReader.java
@@ -418,11 +418,19 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
         StreamSplit streamSplit = uncompletedStreamSplits.get(metadataEvent.getSplitId());
         if (streamSplit != null) {
             final int receivedMetaGroupId = metadataEvent.getMetaGroupId();
+            final int receivedTotalFinishedSplitSize = metadataEvent.getTotalFinishedSplitSize();
             final int expectedMetaGroupId =
                     getNextMetaGroupId(
                             streamSplit.getFinishedSnapshotSplitInfos().size(),
                             sourceConfig.getSplitMetaGroupSize());
-            if (receivedMetaGroupId == expectedMetaGroupId) {
+            if (receivedTotalFinishedSplitSize < streamSplit.getTotalFinishedSplitSize()) {
+                LOG.info(
+                        "Update total finished split size from {} to {}",
+                        streamSplit.getTotalFinishedSplitSize(),
+                        receivedTotalFinishedSplitSize);
+                streamSplit = toNormalStreamSplit(streamSplit, receivedTotalFinishedSplitSize);
+                uncompletedStreamSplits.put(streamSplit.splitId(), streamSplit);
+            } else if (receivedMetaGroupId == expectedMetaGroupId) {
                 Set<String> existedSplitsOfLastGroup =
                         getExistedSplitsOfLastGroup(
                                 streamSplit.getFinishedSnapshotSplitInfos(),
@@ -461,7 +469,8 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
                             streamSplit.getFinishedSnapshotSplitInfos().size(),
                             sourceConfig.getSplitMetaGroupSize());
             StreamSplitMetaRequestEvent splitMetaRequestEvent =
-                    new StreamSplitMetaRequestEvent(splitId, nextMetaGroupId);
+                    new StreamSplitMetaRequestEvent(
+                            splitId, nextMetaGroupId, streamSplit.getTotalFinishedSplitSize());
             context.sendSourceEventToCoordinator(splitMetaRequestEvent);
         } else {
             LOG.info("The meta of stream split {} has been collected success", splitId);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceReader.java
@@ -424,10 +424,11 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
                             streamSplit.getFinishedSnapshotSplitInfos().size(),
                             sourceConfig.getSplitMetaGroupSize());
             if (receivedTotalFinishedSplitSize < streamSplit.getTotalFinishedSplitSize()) {
-                LOG.info(
-                        "Update total finished split size from {} to {}",
-                        streamSplit.getTotalFinishedSplitSize(),
-                        receivedTotalFinishedSplitSize);
+                LOG.warn(
+                        "Source reader {} receives out of bound finished split size. The received finished split size is {}, but expected is {}, truncate it",
+                        subtaskId,
+                        receivedTotalFinishedSplitSize,
+                        streamSplit.getTotalFinishedSplitSize());
                 streamSplit = toNormalStreamSplit(streamSplit, receivedTotalFinishedSplitSize);
                 uncompletedStreamSplits.put(streamSplit.splitId(), streamSplit);
             } else if (receivedMetaGroupId == expectedMetaGroupId) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/NewlyAddedTableITCase.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
 
-import java.lang.reflect.Field;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -948,20 +947,11 @@ public class NewlyAddedTableITCase extends MongoDBSourceTestBase {
         // Close sink upsert materialize to show more clear test output.
         Configuration tableConfig = new Configuration();
         tableConfig.setString("table.exec.sink.upsert-materialize", "none");
+        if (finishedSavePointPath != null) {
+            tableConfig.setString(SavepointConfigOptions.SAVEPOINT_PATH, finishedSavePointPath);
+        }
         StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(tableConfig);
-        if (finishedSavePointPath != null) {
-            // restore from savepoint
-            // hack for test to visit protected TestStreamEnvironment#getConfiguration() method
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            Class<?> clazz =
-                    classLoader.loadClass(
-                            "org.apache.flink.streaming.api.environment.StreamExecutionEnvironment");
-            Field field = clazz.getDeclaredField("configuration");
-            field.setAccessible(true);
-            Configuration configuration = (Configuration) field.get(env);
-            configuration.setString(SavepointConfigOptions.SAVEPOINT_PATH, finishedSavePointPath);
-        }
         env.setParallelism(parallelism);
         env.enableCheckpointing(200L);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(3, 100L));
@@ -987,6 +977,7 @@ public class NewlyAddedTableITCase extends MongoDBSourceTestBase {
                         + " 'password' = '%s',"
                         + " 'database' = '%s',"
                         + " 'collection' = '%s',"
+                        + " 'chunk-meta.group.size' = '2',"
                         + " 'heartbeat.interval.ms' = '100',"
                         + " 'scan.full-changelog' = 'true',"
                         + " 'scan.newly-added-table.enabled' = 'true'"

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -253,6 +253,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                             .entrySet()
                             .removeIf(schema -> tablesToRemove.contains(schema.getKey()));
                     remainingSplits.removeIf(split -> tablesToRemove.contains(split.getTableId()));
+                    LOG.info("Enumerator remove tables after restart: {}", tablesToRemove);
                     remainingTables.removeAll(tablesToRemove);
                     alreadyProcessedTables.removeIf(tableId -> tablesToRemove.contains(tableId));
                 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -298,8 +298,17 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                             finishedSnapshotSplitInfos, sourceConfig.getSplitMetaGroupSize());
         }
         final int requestMetaGroupId = requestEvent.getRequestMetaGroupId();
-
-        if (binlogSplitMeta.size() > requestMetaGroupId) {
+        final int totalFinishedSplitSizeOfReader = requestEvent.getTotalFinishedSplitSize();
+        final int totalFinishedSplitSizeOfEnumerator = splitAssigner.getFinishedSplitInfos().size();
+        if (totalFinishedSplitSizeOfReader > totalFinishedSplitSizeOfEnumerator) {
+            BinlogSplitMetaEvent metadataEvent =
+                    new BinlogSplitMetaEvent(
+                            requestEvent.getSplitId(),
+                            requestMetaGroupId,
+                            null,
+                            totalFinishedSplitSizeOfEnumerator);
+            context.sendEventToSourceReader(subTask, metadataEvent);
+        } else if (binlogSplitMeta.size() > requestMetaGroupId) {
             List<FinishedSnapshotSplitInfo> metaToSend = binlogSplitMeta.get(requestMetaGroupId);
             BinlogSplitMetaEvent metadataEvent =
                     new BinlogSplitMetaEvent(
@@ -307,13 +316,17 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
                             requestMetaGroupId,
                             metaToSend.stream()
                                     .map(FinishedSnapshotSplitInfo::serialize)
-                                    .collect(Collectors.toList()));
+                                    .collect(Collectors.toList()),
+                            totalFinishedSplitSizeOfEnumerator);
             context.sendEventToSourceReader(subTask, metadataEvent);
         } else {
-            LOG.error(
-                    "The enumerator received invalid request meta group id {}, the valid meta group id range is [0, {}]",
-                    requestMetaGroupId,
-                    binlogSplitMeta.size() - 1);
+            throw new FlinkRuntimeException(
+                    String.format(
+                            "The enumerator received invalid request meta group id %s, the valid meta group id range is [0, %s]. Total finished split size of reader is %s, while the total finished split size of enumerator is %s.",
+                            requestMetaGroupId,
+                            binlogSplitMeta.size() - 1,
+                            totalFinishedSplitSizeOfReader,
+                            totalFinishedSplitSizeOfEnumerator));
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -301,6 +301,11 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
         final int totalFinishedSplitSizeOfReader = requestEvent.getTotalFinishedSplitSize();
         final int totalFinishedSplitSizeOfEnumerator = splitAssigner.getFinishedSplitInfos().size();
         if (totalFinishedSplitSizeOfReader > totalFinishedSplitSizeOfEnumerator) {
+            LOG.warn(
+                    "Total finished split size of subtask {} is {}, while total finished split size of Enumerator is only {}. Try to truncate it",
+                    subTask,
+                    totalFinishedSplitSizeOfReader,
+                    totalFinishedSplitSizeOfEnumerator);
             BinlogSplitMetaEvent metadataEvent =
                     new BinlogSplitMetaEvent(
                             requestEvent.getSplitId(),

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/events/BinlogSplitMetaEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/events/BinlogSplitMetaEvent.java
@@ -22,6 +22,8 @@ import org.apache.flink.cdc.connectors.mysql.source.enumerator.MySqlSourceEnumer
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReader;
 import org.apache.flink.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 
 /**
@@ -46,7 +48,10 @@ public class BinlogSplitMetaEvent implements SourceEvent {
     private final int totalFinishedSplitSize;
 
     public BinlogSplitMetaEvent(
-            String splitId, int metaGroupId, List<byte[]> metaGroup, int totalFinishedSplitSize) {
+            String splitId,
+            int metaGroupId,
+            @Nullable List<byte[]> metaGroup,
+            int totalFinishedSplitSize) {
         this.splitId = splitId;
         this.metaGroupId = metaGroupId;
         this.metaGroup = metaGroup;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/events/BinlogSplitMetaEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/events/BinlogSplitMetaEvent.java
@@ -43,10 +43,14 @@ public class BinlogSplitMetaEvent implements SourceEvent {
      */
     private final List<byte[]> metaGroup;
 
-    public BinlogSplitMetaEvent(String splitId, int metaGroupId, List<byte[]> metaGroup) {
+    private final int totalFinishedSplitSize;
+
+    public BinlogSplitMetaEvent(
+            String splitId, int metaGroupId, List<byte[]> metaGroup, int totalFinishedSplitSize) {
         this.splitId = splitId;
         this.metaGroupId = metaGroupId;
         this.metaGroup = metaGroup;
+        this.totalFinishedSplitSize = totalFinishedSplitSize;
     }
 
     public String getSplitId() {
@@ -59,5 +63,9 @@ public class BinlogSplitMetaEvent implements SourceEvent {
 
     public List<byte[]> getMetaGroup() {
         return metaGroup;
+    }
+
+    public int getTotalFinishedSplitSize() {
+        return totalFinishedSplitSize;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/events/BinlogSplitMetaRequestEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/events/BinlogSplitMetaRequestEvent.java
@@ -32,9 +32,13 @@ public class BinlogSplitMetaRequestEvent implements SourceEvent {
     private final String splitId;
     private final int requestMetaGroupId;
 
-    public BinlogSplitMetaRequestEvent(String splitId, int requestMetaGroupId) {
+    private final int totalFinishedSplitSize;
+
+    public BinlogSplitMetaRequestEvent(
+            String splitId, int requestMetaGroupId, int totalFinishedSplitSize) {
         this.splitId = splitId;
         this.requestMetaGroupId = requestMetaGroupId;
+        this.totalFinishedSplitSize = totalFinishedSplitSize;
     }
 
     public String getSplitId() {
@@ -43,5 +47,9 @@ public class BinlogSplitMetaRequestEvent implements SourceEvent {
 
     public int getRequestMetaGroupId() {
         return requestMetaGroupId;
+    }
+
+    public int getTotalFinishedSplitSize() {
+        return totalFinishedSplitSize;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
@@ -402,6 +402,11 @@ public class MySqlSourceReader<T>
                             binlogSplit.getFinishedSnapshotSplitInfos().size(),
                             sourceConfig.getSplitMetaGroupSize());
             if (receivedTotalFinishedSplitSize < binlogSplit.getTotalFinishedSplitSize()) {
+                LOG.warn(
+                        "Source reader {} receives out of bound finished split size. The received finished split size is {}, but expected is {}, truncate it",
+                        subtaskId,
+                        receivedTotalFinishedSplitSize,
+                        binlogSplit.getTotalFinishedSplitSize());
                 binlogSplit =
                         MySqlBinlogSplit.toNormalBinlogSplit(
                                 binlogSplit, receivedTotalFinishedSplitSize);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
@@ -383,7 +383,8 @@ public class MySqlSourceReader<T>
                             binlogSplit.getFinishedSnapshotSplitInfos().size(),
                             sourceConfig.getSplitMetaGroupSize());
             BinlogSplitMetaRequestEvent splitMetaRequestEvent =
-                    new BinlogSplitMetaRequestEvent(splitId, nextMetaGroupId);
+                    new BinlogSplitMetaRequestEvent(
+                            splitId, nextMetaGroupId, binlogSplit.getTotalFinishedSplitSize());
             context.sendSourceEventToCoordinator(splitMetaRequestEvent);
         } else {
             LOG.info("Source reader {} collects meta of binlog split success", subtaskId);
@@ -395,11 +396,17 @@ public class MySqlSourceReader<T>
         MySqlBinlogSplit binlogSplit = uncompletedBinlogSplits.get(metadataEvent.getSplitId());
         if (binlogSplit != null) {
             final int receivedMetaGroupId = metadataEvent.getMetaGroupId();
+            final int receivedTotalFinishedSplitSize = metadataEvent.getTotalFinishedSplitSize();
             final int expectedMetaGroupId =
                     ChunkUtils.getNextMetaGroupId(
                             binlogSplit.getFinishedSnapshotSplitInfos().size(),
                             sourceConfig.getSplitMetaGroupSize());
-            if (receivedMetaGroupId == expectedMetaGroupId) {
+            if (receivedTotalFinishedSplitSize < binlogSplit.getTotalFinishedSplitSize()) {
+                binlogSplit =
+                        MySqlBinlogSplit.toNormalBinlogSplit(
+                                binlogSplit, receivedTotalFinishedSplitSize);
+                uncompletedBinlogSplits.put(binlogSplit.splitId(), binlogSplit);
+            } else if (receivedMetaGroupId == expectedMetaGroupId) {
                 List<FinishedSnapshotSplitInfo> newAddedMetadataGroup;
                 Set<String> existedSplitsOfLastGroup =
                         getExistedSplitsOfLastGroup(


### PR DESCRIPTION
### What's the problem
Once, I removed a table from the option and then restarted the job from the savepoint, but the job couldn't read the binlog anymore. When I checked the logs, I found an Error level log stating: ' The enumerator received invalid request meta group id 6, the valid meta group id range is [0, 4].'

It appears that the Reader is requesting more splits than the Enumerator is aware of.
However, the code should indeed remove redundant split information from the Reader as seen in https://github.com/ververica/flink-cdc-connectors/pull/2292. So why does this issue occur?

### why occurs
![image](https://github.com/apache/flink-cdc/assets/125648852/ab12311f-94a4-4e2d-aff4-02891ad1e668)
Upon examining the code, I discovered the cause. If the job stops before completing all the split meta information and then restarts, this issue occurs. Suppose that the totalFinishedSplitSize of binlogSplit in the Reader is 6, and no meta information has been synchronized, leaving the finishedSnapshotSplitInfos of binlogSplit in the Reader empty. After restarting, the totalFinishedSplitSize of binlogSplit in the Reader equals (6 - (0 - 0)) which is still 6, but in the Enumerator, it is only 4(the removed table have two split). This could lead to an out-of-range request.
![image](https://github.com/apache/flink-cdc/assets/125648852/ef027a32-93f9-452f-b0a4-2527f482385c)
### How to reproduce

-  Add Thread.sleep(1000L) in com.ververica.cdc.connectors.mysql.source.reader.MySqlSourceReader#handleSourceEvents to postpone split meta infos synchronization.

```java
public void handleSourceEvents(SourceEvent sourceEvent) {
else if (sourceEvent instanceof BinlogSplitMetaEvent) {
    LOG.debug(
            "Source reader {} receives binlog meta with group id {}.",
            subtaskId,
            ((BinlogSplitMetaEvent) sourceEvent).getMetaGroupId());
    try {
        Thread.sleep(1000L);
    } catch (InterruptedException e) {
        throw new RuntimeException(e);
    }
    fillMetadataForBinlogSplit((BinlogSplitMetaEvent) sourceEvent);
} 
```

- Add Thread.sleep(500L) in com.ververica.cdc.connectors.mysql.source.NewlyAddedTableITCase#testRemoveTablesOneByOne to trigger savepoint before meta infos synchronization finishes.
```java
// step 2: execute insert and trigger savepoint with all tables added
{
    // ..ingore 

    waitForSinkSize("sink", fetchedDataList.size());
    Thread.sleep(500L);
    assertEqualsInAnyOrder(fetchedDataList, TestValuesTableFactory.getRawResults("sink"));
    finishedSavePointPath = triggerSavepointWithRetry(jobClient, savepointDirectory);
    jobClient.cancel().get();
}

// test removing table one by one, note that there should be at least one table remaining
for (int round = 0; round < captureAddressTables.length - 1; round++) {
...
}
```

- Add chunk-meta.group.size  =2 in com.ververica.cdc.connectors.mysql.source.NewlyAddedTableITCase#getCreateTableStatement

Finally, run test(com.ververica.cdc.connectors.mysql.source.NewlyAddedTableITCase#testJobManagerFailoverForRemoveTable), the error log will occur.



