### PR TITLE
[FLINK-34689][MySQL][Feature] check  binlog_row_value_options

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/MySqlValidator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/MySqlValidator.java
@@ -175,9 +175,9 @@ public class MySqlValidator implements Validator {
         if (!rowValueOptions.equals(BINLOG_ROW_VALUE_OPTIONS)) {
             throw new ValidationException(
                     String.format(
-                            "The MySQL server is configured with binlog_row_value_options %s rather than %s, which is "
-                                    + "required for this connector to work properly. Change the MySQL configuration to use a "
-                                    + "binlog_row_image='' and restart the connector.",
+                            "The MySQL server is configured with binlog_row_value_options=%s, which is possible to cause losing some binlog events"
+                                    + "for the mysql cdc connector. Please remove the binlog_row_value_options setting in the MySQL server and rerun the job."
+                                    + "See more details at https://dev.mysql.com/doc/refman/8.0/en/replication-features-json.html.",
                             rowValueOptions, BINLOG_ROW_VALUE_OPTIONS));
         }
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/MySqlValidator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/MySqlValidator.java
@@ -50,7 +50,7 @@ public class MySqlValidator implements Validator {
 
     private static final String BINLOG_FORMAT_ROW = "ROW";
     private static final String BINLOG_FORMAT_IMAGE_FULL = "FULL";
-    private static final String BINLOG_ROW_VALUE_OPTIONS = "";
+    private static final String DEFAULT_BINLOG_ROW_VALUE_OPTIONS = "";
 
     private final Properties dbzProperties;
     private final MySqlSourceConfig sourceConfig;
@@ -167,18 +167,21 @@ public class MySqlValidator implements Validator {
                 connection
                         .queryAndMap(
                                 "SHOW GLOBAL VARIABLES LIKE 'binlog_row_value_options'",
-                                rs -> rs.next() ? rs.getString(2) : "")
+                                rs ->
+                                        rs.next()
+                                                ? rs.getString(2)
+                                                : DEFAULT_BINLOG_ROW_VALUE_OPTIONS)
                         .trim()
                         .toUpperCase();
         // This setting was introduced in MySQL 8.0+ with default of empty string ''
         // For older versions, assume empty string ''
-        if (!rowValueOptions.equals(BINLOG_ROW_VALUE_OPTIONS)) {
+        if (!DEFAULT_BINLOG_ROW_VALUE_OPTIONS.equals(rowValueOptions)) {
             throw new ValidationException(
                     String.format(
-                            "The MySQL server is configured with binlog_row_value_options=%s, which is possible to cause losing some binlog events"
+                            "The MySQL server is configured with binlog_row_value_options=%s, which is possible to cause losing some binlog events "
                                     + "for the mysql cdc connector. Please remove the binlog_row_value_options setting in the MySQL server and rerun the job."
                                     + "See more details at https://dev.mysql.com/doc/refman/8.0/en/replication-features-json.html.",
-                            rowValueOptions, BINLOG_ROW_VALUE_OPTIONS));
+                            rowValueOptions));
         }
     }
 


### PR DESCRIPTION
Implemented functino to check `binlog_row_value_optoins` within MySqlValidator.

When `binlog_row_value_optoins` is set to `PARTIAL_JSON`,  
the update operator remains as `Update_rows_partial`.
<img width="778" alt="pasted_image_at_2024-03-07T03_21_08 548Z" src="https://github.com/apache/flink-cdc/assets/13589283/5e81fb31-07ff-49bb-a0b1-f18f5955e5ee">

Flink CDC does not parse this event because `Update_row_partial` binlog event is mapped to `PARTIAL_UPDATE_ROWS_EVENT` and Flink CDC do not handle that event type. Therefore, some update query-related binary logs are lost.

So, we have to check `binlog_row_value_optoins` before starting.

### Implemented checkBinlogRowValueOptions
```java
private final MySqlSourceConfig sourceConfig;
    public void validate() {
        checkVersion(connection);
        checkBinlogFormat(connection);
        checkBinlogRowImage(connection);
        checkBinlogRowValueOptions(connection);
        checkTimeZone(connection);
    } catch (SQLException ex) {
        throw new TableException(
    }
}

/** Check whether the binlog row value options is empty. */
private void checkBinlogRowValueOptions(JdbcConnection connection) throws SQLException {
    String rowValueOptions =
           connection
                    .queryAndMap(
                            "SHOW GLOBAL VARIABLES LIKE 'binlog_row_value_options'",
                            rs -> rs.next() ? rs.getString(2) : "")
                    .trim()
                    .toUpperCase();
    // This setting was introduced in MySQL 8.0+ with default of empty string ''
    // For older versions, assume empty string ''
    if (!rowValueOptions.equals(BINLOG_ROW_VALUE_OPTIONS)) {
        throw new ValidationException(
                String.format(
                       "The MySQL server is configured with binlog_row_value_options %s rather than %s, which is "
                                + "required for this connector to work properly. Change the MySQL configuration to use a "
                                + "binlog_row_image='' and restart the connector.",
                        rowValueOptions, BINLOG_ROW_VALUE_OPTIONS));
    }
}
```