### PR TITLE
[FLINK-34690] Cast decimal to VARCHAR as primary key in starrocks sink

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -297,10 +297,17 @@ public class StarRocksUtils {
 
         @Override
         public StarRocksColumn.Builder visit(DecimalType decimalType) {
-            builder.setDataType(DECIMAL);
+            // StarRocks does not support Decimal as primary key, so decimal should be cast to
+            // VARCHAR.
+            if (!isPrimaryKeys) {
+                builder.setDataType(DECIMAL);
+                builder.setColumnSize(decimalType.getPrecision());
+                builder.setDecimalDigits(decimalType.getScale());
+            } else {
+                builder.setDataType(VARCHAR);
+                builder.setColumnSize(Math.min(decimalType.getPrecision(), MAX_VARCHAR_SIZE));
+            }
             builder.setNullable(decimalType.isNullable());
-            builder.setColumnSize(decimalType.getPrecision());
-            builder.setDecimalDigits(decimalType.getScale());
             return builder;
         }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -305,7 +305,9 @@ public class StarRocksUtils {
                 builder.setDecimalDigits(decimalType.getScale());
             } else {
                 builder.setDataType(VARCHAR);
-                builder.setColumnSize(Math.min(decimalType.getPrecision(), MAX_VARCHAR_SIZE));
+                // For a DecimalType with precision N, we may need N + 2 characters to store it as a
+                // string (one for negative sign, and one for decimal point)
+                builder.setColumnSize(Math.min(decimalType.getPrecision() + 2, MAX_VARCHAR_SIZE));
             }
             builder.setNullable(decimalType.isNullable());
             return builder;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -305,9 +305,10 @@ public class StarRocksUtils {
                 builder.setDecimalDigits(decimalType.getScale());
             } else {
                 builder.setDataType(VARCHAR);
-                // For a DecimalType with precision N, we may need N + 2 characters to store it as a
+                // For a DecimalType with precision N, we may need N + 1 or N + 2 characters to store it as a
                 // string (one for negative sign, and one for decimal point)
-                builder.setColumnSize(Math.min(decimalType.getPrecision() + 2, MAX_VARCHAR_SIZE));
+                builder.setColumnSize(Math.min(
+                        decimalType.getScale() != 0? decimalType.getPrecision() + 2:decimalType.getPrecision() + 1, MAX_VARCHAR_SIZE));
             }
             builder.setNullable(decimalType.isNullable());
             return builder;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/CdcDataTypeTransformerTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/CdcDataTypeTransformerTest.java
@@ -116,7 +116,7 @@ public class CdcDataTypeTransformerTest {
         assertEquals("primary_key", unsignedBigIntColumn.getColumnName());
         assertEquals(1, unsignedBigIntColumn.getOrdinalPosition());
         assertEquals(StarRocksUtils.VARCHAR, unsignedBigIntColumn.getDataType());
-        assertEquals(Integer.valueOf(22), unsignedBigIntColumn.getColumnSize().orElse(null));
+        assertEquals(Integer.valueOf(21), unsignedBigIntColumn.getColumnSize().orElse(null));
         assertTrue(!unsignedBigIntColumn.isNullable());
     }
 


### PR DESCRIPTION
### What's the problem
Flink only have bigint type, if mysql data is unsigned bigint , maybe out of range, so cast to DECIMAL(20, 0).

If starrocks supports unsigned bigint, maybe can transform DECIMAL(20, 0) to unsigned bigint in sink. To be honest, unsigned bigint is not in SQL standard, thus many databases maybe not support it. https://docs.starrocks.io/zh/docs/sql-reference/sql-statements/data-types/data-type-list/

And starrock not support DECIMAL as primary key, thus should be transformed to VARHCAR.

### How to solve
StarRocks is not support Decimal as primary key, so decimal should be cast to  VARHCAR.
