### PR TITLE
Update oracle-cdc.md

### DIFF
--- a/docs/content/docs/connectors/cdc-connectors/oracle-cdc.md
+++ b/docs/content/docs/connectors/cdc-connectors/oracle-cdc.md
@@ -522,7 +522,7 @@ public class OracleParallelSourceExample {
 
     public static void main(String[] args) throws Exception {
         Properties debeziumProperties = new Properties();
-        debeziumProperties.setProperty("log.mining.strategy", "online_catalog");
+        debeziumProperties.setProperty("debezium.log.mining.strategy", "online_catalog");
 
         JdbcIncrementalSource<String> oracleChangeEventSource =
                 new OracleSourceBuilder()


### PR DESCRIPTION
fix error the "log.mining.strategy" should be start with prefix "debezium." according to https://nightlies.apache.org/flink/flink-cdc-docs-release-3.0/zh/docs/connectors/cdc-connectors/oracle-cdc/#connector-options and the help from @e-mhui with the link https://github.com/apache/flink-cdc/pull/2315#issuecomment-1999166980