### PR TITLE
[FLINK-34715][cdc-connector][mysql] Fix mysql ut about closing BinlogSplitReader

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -987,8 +987,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
         }
         binlogReader.close();
 
-        assertNotNull(snapshotSplitReader.getExecutorService());
-        assertTrue(snapshotSplitReader.getExecutorService().isTerminated());
+        assertNotNull(binlogReader.getExecutorService());
+        assertTrue(binlogReader.getExecutorService().isTerminated());
 
         return actual;
     }


### PR DESCRIPTION
BinlogSplitReaderTest#readBinlogSplitsFromSnapshotSplits should test binlog reader is closed after binlog reader close. But code always test snapshot split reader is closed.
```java
binlogReader.close();
assertNotNull(snapshotSplitReader.getExecutorService());
assertTrue(snapshotSplitReader.getExecutorService().isTerminated());
```

We shoud change code to 
```java
binlogReader.close();
assertNotNull(binlogReader.getExecutorService());
assertTrue(binlogReader.getExecutorService().isTerminated());  
```