### PR TITLE
[FLINK-34959] Update old flink-cdc-connectors artifactId

### DIFF
--- a/flink-cdc-cli/pom.xml
+++ b/flink-cdc-cli/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-common/pom.xml
+++ b/flink-cdc-common/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-composer/pom.xml
+++ b/flink-cdc-composer/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-connect/pom.xml
+++ b/flink-cdc-connect/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-dist/pom.xml
+++ b/flink-cdc-dist/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-runtime/pom.xml
+++ b/flink-cdc-runtime/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc-connectors</artifactId>
+        <artifactId>flink-cdc</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.flink</groupId>
-    <artifactId>flink-cdc-connectors</artifactId>
+    <artifactId>flink-cdc</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Update old `flink-cdc-connectors` artifactId to `flink-cdc`.

![image](https://github.com/apache/flink-cdc/assets/95013770/5a27075f-0d07-4dc7-afd8-57e5fd3d75c5)
