### PR TITLE
[FLINK-34952][cdc-composer][sink] Flink CDC pipeline supports SinkFunction

### DIFF
--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslator.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslator.java
@@ -27,7 +27,7 @@ import org.apache.flink.cdc.common.sink.EventSinkProvider;
 import org.apache.flink.cdc.common.sink.FlinkSinkFunctionProvider;
 import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
 import org.apache.flink.cdc.composer.definition.SinkDef;
-import org.apache.flink.cdc.runtime.operators.sink.DataSinkOperator;
+import org.apache.flink.cdc.runtime.operators.sink.DataSinkFunctionOperator;
 import org.apache.flink.cdc.runtime.operators.sink.DataSinkWriterOperatorFactory;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
@@ -97,7 +97,7 @@ public class DataSinkTranslator {
             SinkFunction<Event> sinkFunction,
             String sinkName,
             OperatorID schemaOperatorID) {
-        DataSinkOperator sinkOperator = new DataSinkOperator(sinkFunction, schemaOperatorID);
+        DataSinkFunctionOperator sinkOperator = new DataSinkFunctionOperator(sinkFunction, schemaOperatorID);
         final StreamExecutionEnvironment executionEnvironment = input.getExecutionEnvironment();
         PhysicalTransformation<Event> transformation =
                 new LegacySinkTransformation<>(

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslator.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslator.java
@@ -97,7 +97,8 @@ public class DataSinkTranslator {
             SinkFunction<Event> sinkFunction,
             String sinkName,
             OperatorID schemaOperatorID) {
-        DataSinkFunctionOperator sinkOperator = new DataSinkFunctionOperator(sinkFunction, schemaOperatorID);
+        DataSinkFunctionOperator sinkOperator =
+                new DataSinkFunctionOperator(sinkFunction, schemaOperatorID);
         final StreamExecutionEnvironment executionEnvironment = input.getExecutionEnvironment();
         PhysicalTransformation<Event> transformation =
                 new LegacySinkTransformation<>(

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -96,8 +96,8 @@ class FlinkPipelineComposerITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testSingleSplitSingleTable(boolean useLegacySink) throws Exception {
+    @ValueSource(strings = {"SinkFunction", "SinkV2"})
+    void testSingleSplitSingleTable(String sinkType) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -111,7 +111,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
-        sinkConfig.set(ValuesDataSinkOptions.LEGACY_ENABLED, useLegacySink);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_TYPE, sinkType);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline
@@ -152,8 +152,8 @@ class FlinkPipelineComposerITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testSingleSplitMultipleTables(boolean useLegacySink) throws Exception {
+    @ValueSource(strings = {"SinkFunction", "SinkV2"})
+    void testSingleSplitMultipleTables(String sinkType) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -167,7 +167,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
-        sinkConfig.set(ValuesDataSinkOptions.LEGACY_ENABLED, useLegacySink);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_TYPE, sinkType);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline
@@ -218,8 +218,8 @@ class FlinkPipelineComposerITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void testMultiSplitsSingleTable(boolean useLegacySink) throws Exception {
+    @ValueSource(strings = {"SinkFunction", "SinkV2"})
+    void testMultiSplitsSingleTable(String sinkType) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -233,7 +233,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
-        sinkConfig.set(ValuesDataSinkOptions.LEGACY_ENABLED, useLegacySink);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_TYPE, sinkType);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -34,8 +34,9 @@ import org.apache.flink.test.junit5.MiniClusterExtension;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -94,8 +95,9 @@ class FlinkPipelineComposerITCase {
         System.setOut(standardOut);
     }
 
-    @Test
-    void testSingleSplitSingleTable() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSingleSplitSingleTable(boolean useLegacySink) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -109,6 +111,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.LEGACY_ENABLED, useLegacySink);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline
@@ -148,8 +151,9 @@ class FlinkPipelineComposerITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[2, ], after=[2, x], op=UPDATE, meta=()}");
     }
 
-    @Test
-    void testSingleSplitMultipleTables() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testSingleSplitMultipleTables(boolean useLegacySink) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -163,6 +167,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.LEGACY_ENABLED, useLegacySink);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline
@@ -212,8 +217,9 @@ class FlinkPipelineComposerITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[2, 2], after=[2, x], op=UPDATE, meta=()}");
     }
 
-    @Test
-    void testMultiSplitsSingleTable() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testMultiSplitsSingleTable(boolean useLegacySink) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -227,6 +233,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.LEGACY_ENABLED, useLegacySink);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -261,8 +261,9 @@ class FlinkPipelineComposerITCase {
                         "default_namespace.default_schema.table1:col1=5;col2=5;col3=");
     }
 
-    @Test
-    void testTransform() throws Exception {
+    @ParameterizedTest
+    @EnumSource
+    void testTransform(ValuesDataSink.SinkApi sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -276,6 +277,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup transform
@@ -318,8 +320,9 @@ class FlinkPipelineComposerITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[2, , 20], after=[2, x, 20], op=UPDATE, meta=()}");
     }
 
-    @Test
-    void testTransformTwice() throws Exception {
+    @ParameterizedTest
+    @EnumSource
+    void testTransformTwice(ValuesDataSink.SinkApi sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -333,6 +336,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup transform

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.cdc.composer.definition.SourceDef;
 import org.apache.flink.cdc.composer.definition.TransformDef;
 import org.apache.flink.cdc.connectors.values.ValuesDatabase;
 import org.apache.flink.cdc.connectors.values.factory.ValuesDataFactory;
+import org.apache.flink.cdc.connectors.values.sink.ValuesDataSink;
 import org.apache.flink.cdc.connectors.values.sink.ValuesDataSinkOptions;
 import org.apache.flink.cdc.connectors.values.source.ValuesDataSourceHelper;
 import org.apache.flink.cdc.connectors.values.source.ValuesDataSourceOptions;
@@ -36,7 +37,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -96,8 +97,8 @@ class FlinkPipelineComposerITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"SinkFunction", "SinkV2"})
-    void testSingleSplitSingleTable(String sinkApi) throws Exception {
+    @EnumSource
+    void testSingleSplitSingleTable(ValuesDataSink.SinkApi sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -152,8 +153,8 @@ class FlinkPipelineComposerITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"SinkFunction", "SinkV2"})
-    void testSingleSplitMultipleTables(String sinkApi) throws Exception {
+    @EnumSource
+    void testSingleSplitMultipleTables(ValuesDataSink.SinkApi sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -218,8 +219,8 @@ class FlinkPipelineComposerITCase {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"SinkFunction", "SinkV2"})
-    void testMultiSplitsSingleTable(String sinkApi) throws Exception {
+    @EnumSource
+    void testMultiSplitsSingleTable(ValuesDataSink.SinkApi sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -97,7 +97,7 @@ class FlinkPipelineComposerITCase {
 
     @ParameterizedTest
     @ValueSource(strings = {"SinkFunction", "SinkV2"})
-    void testSingleSplitSingleTable(String sinkType) throws Exception {
+    void testSingleSplitSingleTable(String sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -111,7 +111,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
-        sinkConfig.set(ValuesDataSinkOptions.SINK_TYPE, sinkType);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline
@@ -153,7 +153,7 @@ class FlinkPipelineComposerITCase {
 
     @ParameterizedTest
     @ValueSource(strings = {"SinkFunction", "SinkV2"})
-    void testSingleSplitMultipleTables(String sinkType) throws Exception {
+    void testSingleSplitMultipleTables(String sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -167,7 +167,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
-        sinkConfig.set(ValuesDataSinkOptions.SINK_TYPE, sinkType);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline
@@ -219,7 +219,7 @@ class FlinkPipelineComposerITCase {
 
     @ParameterizedTest
     @ValueSource(strings = {"SinkFunction", "SinkV2"})
-    void testMultiSplitsSingleTable(String sinkType) throws Exception {
+    void testMultiSplitsSingleTable(String sinkApi) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -233,7 +233,7 @@ class FlinkPipelineComposerITCase {
         // Setup value sink
         Configuration sinkConfig = new Configuration();
         sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
-        sinkConfig.set(ValuesDataSinkOptions.SINK_TYPE, sinkType);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
         SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
 
         // Setup pipeline

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
@@ -54,7 +54,7 @@ public class ValuesDataFactory implements DataSourceFactory, DataSinkFactory {
         return new ValuesDataSink(
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY),
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.PRINT_ENABLED),
-                context.getFactoryConfiguration().get(ValuesDataSinkOptions.SINK_TYPE));
+                context.getFactoryConfiguration().get(ValuesDataSinkOptions.SINK_API));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
@@ -54,7 +54,7 @@ public class ValuesDataFactory implements DataSourceFactory, DataSinkFactory {
         return new ValuesDataSink(
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY),
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.PRINT_ENABLED),
-                context.getFactoryConfiguration().get(ValuesDataSinkOptions.LEGACY_ENABLED));
+                context.getFactoryConfiguration().get(ValuesDataSinkOptions.SINK_TYPE));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
@@ -53,7 +53,8 @@ public class ValuesDataFactory implements DataSourceFactory, DataSinkFactory {
     public DataSink createDataSink(Context context) {
         return new ValuesDataSink(
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY),
-                context.getFactoryConfiguration().get(ValuesDataSinkOptions.PRINT_ENABLED));
+                context.getFactoryConfiguration().get(ValuesDataSinkOptions.PRINT_ENABLED),
+                context.getFactoryConfiguration().get(ValuesDataSinkOptions.LEGACY_ENABLED));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
@@ -30,6 +30,7 @@ import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.sink.DataSink;
 import org.apache.flink.cdc.common.sink.EventSinkProvider;
+import org.apache.flink.cdc.common.sink.FlinkSinkFunctionProvider;
 import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
 import org.apache.flink.cdc.common.utils.SchemaUtils;
@@ -49,14 +50,22 @@ public class ValuesDataSink implements DataSink, Serializable {
 
     private final boolean print;
 
-    public ValuesDataSink(boolean materializedInMemory, boolean print) {
+    private final boolean legacy;
+
+    public ValuesDataSink(boolean materializedInMemory, boolean print, boolean lagacy) {
         this.materializedInMemory = materializedInMemory;
         this.print = print;
+        this.legacy = lagacy;
     }
 
     @Override
     public EventSinkProvider getEventSinkProvider() {
-        return FlinkSinkProvider.of(new ValuesSink(materializedInMemory, print));
+        if (!legacy) {
+            return FlinkSinkProvider.of(new ValuesSink(materializedInMemory, print));
+        } else {
+            return FlinkSinkFunctionProvider.of(
+                    new ValuesDataSinkFunction(materializedInMemory, print));
+        }
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
@@ -35,7 +35,6 @@ import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
 import org.apache.flink.cdc.common.utils.SchemaUtils;
 import org.apache.flink.cdc.connectors.values.ValuesDatabase;
-import org.apache.flink.table.api.ValidationException;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -51,9 +50,9 @@ public class ValuesDataSink implements DataSink, Serializable {
 
     private final boolean print;
 
-    private final String sinkApi;
+    private final SinkApi sinkApi;
 
-    public ValuesDataSink(boolean materializedInMemory, boolean print, String sinkApi) {
+    public ValuesDataSink(boolean materializedInMemory, boolean print, SinkApi sinkApi) {
         this.materializedInMemory = materializedInMemory;
         this.print = print;
         this.sinkApi = sinkApi;
@@ -61,7 +60,7 @@ public class ValuesDataSink implements DataSink, Serializable {
 
     @Override
     public EventSinkProvider getEventSinkProvider() {
-        if (SinkApiEnum.SINK_V2.equals(SinkApiEnum.getSinkApi(sinkApi))) {
+        if (SinkApi.SINK_V2.equals(sinkApi)) {
             return FlinkSinkProvider.of(new ValuesSink(materializedInMemory, print));
         } else {
             return FlinkSinkFunctionProvider.of(
@@ -168,28 +167,12 @@ public class ValuesDataSink implements DataSink, Serializable {
         public void close() {}
     }
 
-    public enum SinkApiEnum{
-        /**
-         * Sink based on SinkFunction
-         */
+    /** SinkApi which sink based on. */
+    public enum SinkApi {
+        /** Sink based on SinkFunction. */
         SINK_FUNCTION,
 
-        /**
-         * Sink based on SinkV2
-         */
+        /** Sink based on SinkV2. */
         SINK_V2;
-
-
-        static SinkApiEnum getSinkApi(String sinkApi) {
-            switch (sinkApi.toLowerCase()) {
-                case "sinkfunction":
-                    return SINK_FUNCTION;
-                case "sinkv2":
-                    return SINK_V2;
-                default:
-                    throw new ValidationException(
-                            String.format("Invalid sink api '%s'.", sinkApi));
-            }
-        }
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
@@ -51,17 +51,17 @@ public class ValuesDataSink implements DataSink, Serializable {
 
     private final boolean print;
 
-    private final String sinkType;
+    private final String sinkApi;
 
-    public ValuesDataSink(boolean materializedInMemory, boolean print, String sinkType) {
+    public ValuesDataSink(boolean materializedInMemory, boolean print, String sinkApi) {
         this.materializedInMemory = materializedInMemory;
         this.print = print;
-        this.sinkType = sinkType;
+        this.sinkApi = sinkApi;
     }
 
     @Override
     public EventSinkProvider getEventSinkProvider() {
-        if (SinkType.SINK_V2.equals(SinkType.getSinkType(sinkType))) {
+        if (SinkApiEnum.SINK_V2.equals(SinkApiEnum.getSinkApi(sinkApi))) {
             return FlinkSinkProvider.of(new ValuesSink(materializedInMemory, print));
         } else {
             return FlinkSinkFunctionProvider.of(
@@ -168,7 +168,7 @@ public class ValuesDataSink implements DataSink, Serializable {
         public void close() {}
     }
 
-    public enum SinkType{
+    public enum SinkApiEnum{
         /**
          * Sink based on SinkFunction
          */
@@ -180,15 +180,15 @@ public class ValuesDataSink implements DataSink, Serializable {
         SINK_V2;
 
 
-        static SinkType getSinkType(String sinkType) {
-            switch (sinkType.toLowerCase()) {
+        static SinkApiEnum getSinkApi(String sinkApi) {
+            switch (sinkApi.toLowerCase()) {
                 case "sinkfunction":
                     return SINK_FUNCTION;
                 case "sinkv2":
                     return SINK_V2;
                 default:
                     throw new ValidationException(
-                            String.format("Invalid sink type '%s'.", sinkType));
+                            String.format("Invalid sink api '%s'.", sinkApi));
             }
         }
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkFunction.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkFunction.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.values.sink;
+
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.cdc.common.data.RecordData;
+import org.apache.flink.cdc.common.event.ChangeEvent;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.utils.SchemaUtils;
+import org.apache.flink.cdc.connectors.values.ValuesDatabase;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** An e2e {@link SinkFunction} implementation that print all {@link DataChangeEvent} out. */
+public class ValuesDataSinkFunction implements SinkFunction<Event> {
+    private final boolean materializedInMemory;
+
+    private final boolean print;
+
+    /**
+     * keep the relationship of TableId and Schema as write method may rely on the schema
+     * information of DataChangeEvent.
+     */
+    private final Map<TableId, Schema> schemaMaps;
+
+    private final Map<TableId, List<RecordData.FieldGetter>> fieldGetterMaps;
+
+    public ValuesDataSinkFunction(boolean materializedInMemory, boolean print) {
+        this.materializedInMemory = materializedInMemory;
+        this.print = print;
+        schemaMaps = new HashMap<>();
+        fieldGetterMaps = new HashMap<>();
+    }
+
+    @Override
+    public void invoke(Event event, Context context) throws Exception {
+        if (event instanceof SchemaChangeEvent) {
+            SchemaChangeEvent schemaChangeEvent = (SchemaChangeEvent) event;
+            TableId tableId = schemaChangeEvent.tableId();
+            if (event instanceof CreateTableEvent) {
+                Schema schema = ((CreateTableEvent) event).getSchema();
+                schemaMaps.put(tableId, schema);
+                fieldGetterMaps.put(tableId, SchemaUtils.createFieldGetters(schema));
+            } else {
+                if (!schemaMaps.containsKey(tableId)) {
+                    throw new RuntimeException("schema of " + tableId + " is not existed.");
+                }
+                Schema schema =
+                        SchemaUtils.applySchemaChangeEvent(
+                                schemaMaps.get(tableId), schemaChangeEvent);
+                schemaMaps.put(tableId, schema);
+                fieldGetterMaps.put(tableId, SchemaUtils.createFieldGetters(schema));
+            }
+        } else if (materializedInMemory && event instanceof DataChangeEvent) {
+            ValuesDatabase.applyDataChangeEvent((DataChangeEvent) event);
+        }
+
+        if (print) {
+            // print the detail message to console for verification.
+            System.out.println(
+                    ValuesDataSinkHelper.convertEventToStr(
+                            event, fieldGetterMaps.get(((ChangeEvent) event).tableId())));
+        }
+    }
+
+    @Override
+    public void writeWatermark(Watermark watermark) throws Exception {
+        SinkFunction.super.writeWatermark(watermark);
+    }
+
+    @Override
+    public void finish() throws Exception {
+        SinkFunction.super.finish();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
@@ -35,4 +35,10 @@ public class ValuesDataSinkOptions {
                     .booleanType()
                     .defaultValue(true)
                     .withDescription("True if the Event should be print to console.");
+
+    public static final ConfigOption<Boolean> LEGACY_ENABLED =
+            ConfigOptions.key("legacy.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("False if use SinkFunction, while true if use Sink V2");
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
@@ -36,9 +36,10 @@ public class ValuesDataSinkOptions {
                     .defaultValue(true)
                     .withDescription("True if the Event should be print to console.");
 
-    public static final ConfigOption<String> SINK_API =
+    public static final ConfigOption<ValuesDataSink.SinkApi> SINK_API =
             ConfigOptions.key("sink.api")
-                    .stringType()
-                    .defaultValue("SinkV2")
-                    .withDescription("The sink api on which the sink is based: SinkFunction or SinkV2.");
+                    .enumType(ValuesDataSink.SinkApi.class)
+                    .defaultValue(ValuesDataSink.SinkApi.SINK_V2)
+                    .withDescription(
+                            "The sink api on which the sink is based: SinkFunction or SinkV2.");
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
@@ -36,9 +36,9 @@ public class ValuesDataSinkOptions {
                     .defaultValue(true)
                     .withDescription("True if the Event should be print to console.");
 
-    public static final ConfigOption<Boolean> LEGACY_ENABLED =
-            ConfigOptions.key("legacy.enabled")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription("False if use SinkFunction, while true if use Sink V2");
+    public static final ConfigOption<String> SINK_TYPE =
+            ConfigOptions.key("sinkType")
+                    .stringType()
+                    .defaultValue("SinkV2")
+                    .withDescription("The sink type on which the sink is based: SinkFunction or SinkV2.");
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
@@ -36,9 +36,9 @@ public class ValuesDataSinkOptions {
                     .defaultValue(true)
                     .withDescription("True if the Event should be print to console.");
 
-    public static final ConfigOption<String> SINK_TYPE =
-            ConfigOptions.key("sinkType")
+    public static final ConfigOption<String> SINK_API =
+            ConfigOptions.key("sink.api")
                     .stringType()
                     .defaultValue("SinkV2")
-                    .withDescription("The sink type on which the sink is based: SinkFunction or SinkV2.");
+                    .withDescription("The sink api on which the sink is based: SinkFunction or SinkV2.");
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkFunctionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkFunctionOperator.java
@@ -48,14 +48,14 @@ import java.util.Set;
  * <p>The operator is always part of a sink pipeline and is the first operator.
  */
 @Internal
-public class DataSinkOperator extends StreamSink<Event> {
+public class DataSinkFunctionOperator extends StreamSink<Event> {
 
     private SchemaEvolutionClient schemaEvolutionClient;
     private final OperatorID schemaOperatorID;
     /** A set of {@link TableId} that already processed {@link CreateTableEvent}. */
     private final Set<TableId> processedTableIds;
 
-    public DataSinkOperator(SinkFunction<Event> userFunction, OperatorID schemaOperatorID) {
+    public DataSinkFunctionOperator(SinkFunction<Event> userFunction, OperatorID schemaOperatorID) {
         super(userFunction);
         this.schemaOperatorID = schemaOperatorID;
         processedTableIds = new HashSet<>();

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkOperator.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.runtime.operators.sink;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.event.ChangeEvent;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.FlushEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.graph.StreamConfig;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.Output;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * An operator that processes records to be written into a {@link
+ * org.apache.flink.streaming.api.functions.sink.SinkFunction}.
+ *
+ * <p>The operator is a proxy of {@link org.apache.flink.streaming.api.operators.StreamSink} in
+ * Flink.
+ *
+ * <p>The operator is always part of a sink pipeline and is the first operator.
+ */
+@Internal
+public class DataSinkOperator extends StreamSink<Event> {
+
+    private SchemaEvolutionClient schemaEvolutionClient;
+    private final OperatorID schemaOperatorID;
+    /** A set of {@link TableId} that already processed {@link CreateTableEvent}. */
+    private final Set<TableId> processedTableIds;
+
+    public DataSinkOperator(SinkFunction<Event> userFunction, OperatorID schemaOperatorID) {
+        super(userFunction);
+        this.schemaOperatorID = schemaOperatorID;
+        processedTableIds = new HashSet<>();
+        this.chainingStrategy = ChainingStrategy.ALWAYS;
+    }
+
+    @Override
+    public void setup(
+            StreamTask<?, ?> containingTask,
+            StreamConfig config,
+            Output<StreamRecord<Object>> output) {
+        super.setup(containingTask, config, output);
+        schemaEvolutionClient =
+                new SchemaEvolutionClient(
+                        containingTask.getEnvironment().getOperatorCoordinatorEventGateway(),
+                        schemaOperatorID);
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        schemaEvolutionClient.registerSubtask(getRuntimeContext().getIndexOfThisSubtask());
+        super.initializeState(context);
+    }
+
+    @Override
+    public void processElement(StreamRecord<Event> element) throws Exception {
+        Event event = element.getValue();
+
+        // FlushEvent triggers flush
+        if (event instanceof FlushEvent) {
+            handleFlushEvent(((FlushEvent) event));
+            return;
+        }
+
+        // CreateTableEvent marks the table as processed directly
+        if (event instanceof CreateTableEvent) {
+            processedTableIds.add(((CreateTableEvent) event).tableId());
+            super.processElement(element);
+            return;
+        }
+
+        // Check if the table is processed before emitting all other events, because we have to make
+        // sure that sink have a view of the full schema before processing any change events,
+        // including schema changes.
+        ChangeEvent changeEvent = (ChangeEvent) event;
+        if (!processedTableIds.contains(changeEvent.tableId())) {
+            emitLatestSchema(changeEvent.tableId());
+            processedTableIds.add(changeEvent.tableId());
+        }
+        processedTableIds.add(changeEvent.tableId());
+        super.processElement(element);
+    }
+
+    // ----------------------------- Helper functions -------------------------------
+    private void handleFlushEvent(FlushEvent event) throws Exception {
+        userFunction.finish();
+        schemaEvolutionClient.notifyFlushSuccess(
+                getRuntimeContext().getIndexOfThisSubtask(), event.getTableId());
+    }
+
+    private void emitLatestSchema(TableId tableId) throws Exception {
+        Optional<Schema> schema = schemaEvolutionClient.getLatestSchema(tableId);
+        if (schema.isPresent()) {
+            // request and process CreateTableEvent because SinkFunction need to retrieve
+            // Schema to deserialize RecordData after resuming job.
+            super.processElement(new StreamRecord<>(new CreateTableEvent(tableId, schema.get())));
+            processedTableIds.add(tableId);
+        } else {
+            throw new RuntimeException(
+                    "Could not find schema message from SchemaRegistry for " + tableId);
+        }
+    }
+}


### PR DESCRIPTION
### What's the problem
Though current Flink CDC pipeline define com.ververica.cdc.common.sink.FlinkSinkFunctionProvider to to provide a Flink SinkFunction for writing events to external systems. However, com.ververica.cdc.runtime.operators.sink.DataSinkWriterOperator don't support SouceFunction, which means sink implement SinkFunction cannot use CDC pipeline.
Why not support  SourceFunction in Flink CDC pipeline ?

### How to solve
Add An operator `DataSinkOperator` that processes records to be written into a {@link org.apache.flink.streaming.api.functions.sink.SinkFunction}.
