### PR TITLE
[minor][cdc-connector][mongo] Fix warning during MongoDB tests

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/resources/ddl/chunk_test.js
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/resources/ddl/chunk_test.js
@@ -19,7 +19,7 @@ sh.shardCollection(db.getName() + ".shopping_cart", { "user_id": 1, "product_no"
 var shoppingCarts = [];
 for (var i = 1; i <= 20480; i++) {
     shoppingCarts.push({
-        "product_no": NumberLong(i),
+        "product_no": NumberLong(i.toString()),
         "product_kind": 'KIND_' + i,
         "user_id": 'user_' + i,
         "description": 'my shopping cart ' + i


### PR DESCRIPTION
Currently, when running `MongoDBStreamSplitReaderTest` and `MongoDBSnapshotSplitReaderTest`, tons of warning messages were be printed:

```
Warning: NumberLong: specifying a number as argument is deprecated and may lead to loss of precision, pass a string instead
... (repeated lines)
```

<img width="858" alt="Console output" src="https://github.com/apache/flink-cdc/assets/34335406/5cc61ba2-0fa4-44e5-ae16-f23ec021b43c">

The problem lies in `chunk_test.js:22`, where `NumberLong` was called with a plain number instead of string, which has been deprecated by MongoDB engine due to precision loss concerns, though here `i` would never be greater than `20480`.

Converting it to string before passing it to `NumberLong` should fix this problem.