### PR TITLE
[FLINK-35072][cdc][doris] Support applying compatible `AlterColumnTypeEvent` to Doris sink

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.doris.sink;
+
+import org.apache.doris.flink.catalog.doris.FieldSchema;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.exception.IllegalArgumentException;
+import org.apache.doris.flink.sink.schema.SchemaChangeManager;
+
+import java.io.IOException;
+
+/** Provides schema change operations based on {@link SchemaChangeManager}. */
+public class DorisSchemaChangeManager extends SchemaChangeManager {
+    public DorisSchemaChangeManager(DorisOptions dorisOptions) {
+        super(dorisOptions);
+    }
+
+    private static final String MODIFY_COLUMN_DDL = "ALTER TABLE %s MODIFY COLUMN %s %s";
+
+    public boolean alterColumn(
+            String database, String table, String columnName, String newColumnType)
+            throws IOException, IllegalArgumentException {
+        String tableIdentifier = String.format("%s.%s", database, table);
+        FieldSchema alterFieldSchema = new FieldSchema(columnName, newColumnType, "");
+
+        String alterColumnDDL =
+                String.format(
+                        MODIFY_COLUMN_DDL,
+                        tableIdentifier,
+                        columnName,
+                        alterFieldSchema.getTypeString());
+
+        try {
+            return this.schemaChange(
+                    database, table, buildRequestParam(true, columnName), alterColumnDDL);
+        } catch (RuntimeException ex) {
+            if (ex.getMessage().contains("Nothing is changed. please check your alter stmt.")) {
+                // Doris doesn't allow ALTER statement without effects.
+                // We should ignore such exception since upstream connector
+                // might emit redundant AlterColumnTypeEvents.
+                return false;
+            } else {
+                throw ex;
+            }
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
@@ -33,6 +33,10 @@ public class DorisSchemaChangeManager extends SchemaChangeManager {
 
     private static final String MODIFY_COLUMN_DDL = "ALTER TABLE %s MODIFY COLUMN %s %s";
 
+    // Error message response from Doris server when no alter change is applied.
+    private static final String ALTER_NO_CHANGE_ERROR_MESSAGE =
+            "Nothing is changed. please check your alter stmt.";
+
     public boolean alterColumn(
             String database, String table, String columnName, String newColumnType)
             throws IOException, IllegalArgumentException {
@@ -50,7 +54,7 @@ public class DorisSchemaChangeManager extends SchemaChangeManager {
             return this.schemaChange(
                     database, table, buildRequestParam(true, columnName), alterColumnDDL);
         } catch (DorisSchemaChangeException ex) {
-            if (ex.getMessage().contains("Nothing is changed. please check your alter stmt.")) {
+            if (ex.getMessage().contains(ALTER_NO_CHANGE_ERROR_MESSAGE)) {
                 // Doris doesn't allow ALTER statement without effects.
                 // We should ignore such exception since upstream connector
                 // might emit redundant AlterColumnTypeEvents.

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.doris.sink;
 
 import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.exception.DorisSchemaChangeException;
 import org.apache.doris.flink.exception.IllegalArgumentException;
 import org.apache.doris.flink.sink.schema.SchemaChangeManager;
 
@@ -48,7 +49,7 @@ public class DorisSchemaChangeManager extends SchemaChangeManager {
         try {
             return this.schemaChange(
                     database, table, buildRequestParam(true, columnName), alterColumnDDL);
-        } catch (RuntimeException ex) {
+        } catch (DorisSchemaChangeException ex) {
             if (ex.getMessage().contains("Nothing is changed. please check your alter stmt.")) {
                 // Doris doesn't allow ALTER statement without effects.
                 // We should ignore such exception since upstream connector


### PR DESCRIPTION
According to [Doris documentation](https://doris.apache.org/docs/sql-manual/sql-reference/Data-Definition-Statements/Alter/ALTER-TABLE-COLUMN/), altering column types dynamically is supported (via `ALTER TABLE ... MODIFY COLUMN` statement) when lossless conversion is available. However, now Doris pipeline connector has no support for any `AlterColumnTypeEvent`s, and raises RuntimeException all the time.

This PR adds `alterColumn` method which is not provided by Doris' `SchemaChangeManager` to apply `AlterColumnTypeEvent` to Doris sink. Only lossless conversions that were accepted by Doris will be allowed, and a `RuntimeException` will be raised for any incompatible narrowing casts.