### PR TITLE
[hotfix] run mvn spotless to fix code style violations.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -305,10 +305,15 @@ public class StarRocksUtils {
                 builder.setDecimalDigits(decimalType.getScale());
             } else {
                 builder.setDataType(VARCHAR);
-                // For a DecimalType with precision N, we may need N + 1 or N + 2 characters to store it as a
+                // For a DecimalType with precision N, we may need N + 1 or N + 2 characters to
+                // store it as a
                 // string (one for negative sign, and one for decimal point)
-                builder.setColumnSize(Math.min(
-                        decimalType.getScale() != 0? decimalType.getPrecision() + 2:decimalType.getPrecision() + 1, MAX_VARCHAR_SIZE));
+                builder.setColumnSize(
+                        Math.min(
+                                decimalType.getScale() != 0
+                                        ? decimalType.getPrecision() + 2
+                                        : decimalType.getPrecision() + 1,
+                                MAX_VARCHAR_SIZE));
             }
             builder.setNullable(decimalType.isNullable());
             return builder;


### PR DESCRIPTION
Currently, there is no spotless violation in ` flink-cdc-pipeline-connectors `. When run `mvn spotless:apply ` locally , will throw Exception.