### PR TITLE
[FLINK-35079] Fallback to timestamp startup mode when resume token has expired

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/offset/ChangeStreamOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/offset/ChangeStreamOffset.java
@@ -73,6 +73,10 @@ public class ChangeStreamOffset extends Offset {
         offset.put(RESUME_TOKEN_FIELD, resumeToken.toJson());
     }
 
+    public void clearResumeToken() {
+        offset.remove(RESUME_TOKEN_FIELD);
+    }
+
     @Nullable
     public BsonDocument getResumeToken() {
         String resumeTokenJson = offset.get(RESUME_TOKEN_FIELD);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/offset/ChangeStreamOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/offset/ChangeStreamOffset.java
@@ -73,10 +73,6 @@ public class ChangeStreamOffset extends Offset {
         offset.put(RESUME_TOKEN_FIELD, resumeToken.toJson());
     }
 
-    public void clearResumeToken() {
-        offset.remove(RESUME_TOKEN_FIELD);
-    }
-
     @Nullable
     public BsonDocument getResumeToken() {
         String resumeTokenJson = offset.get(RESUME_TOKEN_FIELD);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/NewlyAddedTableITCase.java
@@ -459,7 +459,7 @@ public class NewlyAddedTableITCase extends MongoDBSourceTestBase {
             // step 4: make changelog data for all collections before this round(also includes this
             // round),
             // test whether only this round collection's data is captured.
-            for (int i = round; i >= 0; i--) {
+            for (int i = 0; i <= round; i++) {
                 String collection = captureAddressCollections[i];
                 makeOplogForAddressTableInRound(database, collection, round);
             }


### PR DESCRIPTION
Closes [FLINK-35079](https://issues.apache.org/jira/browse/FLINK-35079).

When MongoDB CDC connector tries to create cursor with an expired resuming token during stream task fetching stage, it will crash with a fatal exception: `error due to Command failed with error 280 (ChangeStreamFatalError): cannot resume stream; the resume token was not found.`

This PR added fallback logic to create cursor with timestamp, which only runs when:
* Mongo CDC is in StreamTaskFetch stage
* a `ChangeStreamFatalError` (280) is raised
* Current `ChangeStreamOffset` has a valid timestamp field

Also tweaked @loserwang1024 's test case to cover resume token expiration scenario better.