### PR TITLE
[FLINK-35090][cdc][doris] Add database auto-creating support for Doris sink pipeline connector

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -40,6 +40,7 @@ import org.apache.doris.flink.catalog.doris.DataModel;
 import org.apache.doris.flink.catalog.doris.DorisSystem;
 import org.apache.doris.flink.catalog.doris.FieldSchema;
 import org.apache.doris.flink.catalog.doris.TableSchema;
+import org.apache.doris.flink.cfg.DorisConnectionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.exception.IllegalArgumentException;
 import org.apache.doris.flink.sink.schema.SchemaChangeManager;
@@ -67,7 +68,16 @@ public class DorisMetadataApplier implements MetadataApplier {
         this.dorisOptions = dorisOptions;
         this.schemaChangeManager = new SchemaChangeManager(dorisOptions);
         this.config = config;
-        this.dorisSystem = new DorisSystem(dorisOptions);
+
+        DorisConnectionOptions.DorisConnectionOptionsBuilder builder =
+                new DorisConnectionOptions.DorisConnectionOptionsBuilder();
+
+        config.getOptional(DorisDataSinkOptions.FENODES).ifPresent(builder::withFenodes);
+        config.getOptional(DorisDataSinkOptions.JDBC_URL).ifPresent(builder::withJdbcUrl);
+        config.getOptional(DorisDataSinkOptions.USERNAME).ifPresent(builder::withUsername);
+        config.getOptional(DorisDataSinkOptions.PASSWORD).ifPresent(builder::withPassword);
+
+        this.dorisSystem = new DorisSystem(builder.build());
     }
 
     @Override
@@ -87,7 +97,7 @@ public class DorisMetadataApplier implements MetadataApplier {
             }
         } catch (Exception ex) {
             throw new RuntimeException(
-                    "Failed to schema change, " + event + ", reason: " + ex.getMessage());
+                    "Failed to schema change, " + event + ", reason: " + ex.getMessage(), ex);
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
@@ -59,6 +59,7 @@ import java.util.List;
 import static org.apache.flink.cdc.common.pipeline.PipelineOptions.DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.BENODES;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.FENODES;
+import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.JDBC_URL;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.PASSWORD;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.SINK_ENABLE_BATCH_MODE;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.SINK_ENABLE_DELETE;
@@ -402,6 +403,7 @@ public class DorisMetadataApplierITCase extends DorisSinkTestBase {
                 new Configuration()
                         .set(FENODES, DORIS_CONTAINER.getFeNodes())
                         .set(BENODES, DORIS_CONTAINER.getBeNodes())
+                        .set(JDBC_URL, DORIS_CONTAINER.getJdbcUrl())
                         .set(USERNAME, DorisContainer.DORIS_USERNAME)
                         .set(PASSWORD, DorisContainer.DORIS_PASSWORD)
                         .set(SINK_ENABLE_BATCH_MODE, batchMode)

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisPipelineITCase.java
@@ -48,6 +48,7 @@ import java.util.List;
 
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.BENODES;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.FENODES;
+import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.JDBC_URL;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.PASSWORD;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.SINK_ENABLE_BATCH_MODE;
 import static org.apache.flink.cdc.connectors.doris.sink.DorisDataSinkOptions.SINK_ENABLE_DELETE;
@@ -185,6 +186,7 @@ public class DorisPipelineITCase extends DorisSinkTestBase {
                 new Configuration()
                         .set(FENODES, DORIS_CONTAINER.getFeNodes())
                         .set(BENODES, DORIS_CONTAINER.getBeNodes())
+                        .set(JDBC_URL, DORIS_CONTAINER.getJdbcUrl())
                         .set(USERNAME, DorisContainer.DORIS_USERNAME)
                         .set(PASSWORD, DorisContainer.DORIS_PASSWORD)
                         .set(SINK_ENABLE_BATCH_MODE, batchMode)


### PR DESCRIPTION
Currently, Doris sink supports auto-creating table only. When specified database does not exist, connector will panic with a Doris internal error. By ensuring database exists before creating any table should fix this problem.