### PR TITLE
[FLINK-35102][doris] Fix Doris connector type mapping issues

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.doris</groupId>
             <artifactId>flink-doris-connector-${flink.major.version}</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This closes [FLINK-35102](https://issues.apache.org/jira/browse/FLINK-35102).

According to Flink CDC Doris connector docs, CHAR and VARCHAR are mapped to 3-bytes since Doris uses UTF-8 variable-length encoding internally.

<img width="786" alt="截圖 2024-04-15 11 23 10" src="https://github.com/apache/flink-cdc/assets/34335406/517d7841-cfec-404a-bb94-f9ed3126a420">


However, in current type mapping implementation (based on `flink-doris-connector:1.5.0`), it was implemented differently, mapping `CHAR(n)` to `CHAR(n)`, and `VARCHAR(n)` to `VARCHAR(n * 4)`.

```java
public String visit(CharType charType) {
    return String.format("%s(%s)", "CHAR", charType.getLength());
}

public String visit(VarCharType varCharType) {
    long length = (long)varCharType.getLength();
    return length * 4L >= 65533L ? "STRING" : String.format("%s(%s)", "VARCHAR", length * 4L);
}
```

In latest 1.6.0 version, this issue was fixed and are types correctly mapped. Updating dependencies should fix this problem.