### PR TITLE
[FLINK-35119][cdc-runtime] Change DataChangeEvent serialization and eserialization

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/DataChangeEvent.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/DataChangeEvent.java
@@ -20,6 +20,8 @@ package org.apache.flink.cdc.common.event;
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.common.data.RecordData;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
@@ -112,7 +114,7 @@ public class DataChangeEvent implements ChangeEvent, Serializable {
 
     /** Creates a {@link DataChangeEvent} instance that describes the update event. */
     public static DataChangeEvent updateEvent(
-            TableId tableId, RecordData before, RecordData after) {
+            TableId tableId, @Nullable RecordData before, RecordData after) {
         return new DataChangeEvent(
                 tableId, before, after, OperationType.UPDATE, Collections.emptyMap());
     }
@@ -121,7 +123,10 @@ public class DataChangeEvent implements ChangeEvent, Serializable {
      * Creates a {@link DataChangeEvent} instance that describes the update event with meta info.
      */
     public static DataChangeEvent updateEvent(
-            TableId tableId, RecordData before, RecordData after, Map<String, String> meta) {
+            TableId tableId,
+            @Nullable RecordData before,
+            RecordData after,
+            Map<String, String> meta) {
         return new DataChangeEvent(tableId, before, after, OperationType.UPDATE, meta);
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/test/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/test/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceITCase.java
@@ -68,6 +68,7 @@ public class ValuesDataSourceITCase {
     private void executeDataStreamJob(ValuesDataSourceHelper.EventSetId type) throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(3000);
+        env.setParallelism(2);
         env.setRestartStrategy(RestartStrategies.noRestart());
         FlinkSourceProvider sourceProvider =
                 (FlinkSourceProvider) new ValuesDataSource(type).getEventSourceProvider();

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/test/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/test/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceITCase.java
@@ -68,7 +68,6 @@ public class ValuesDataSourceITCase {
     private void executeDataStreamJob(ValuesDataSourceHelper.EventSetId type) throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.enableCheckpointing(3000);
-        env.setParallelism(2);
         env.setRestartStrategy(RestartStrategies.noRestart());
         FlinkSourceProvider sourceProvider =
                 (FlinkSourceProvider) new ValuesDataSource(type).getEventSourceProvider();

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/data/RecordDataSerializer.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/data/RecordDataSerializer.java
@@ -63,13 +63,13 @@ public class RecordDataSerializer extends TypeSerializerSingleton<RecordData> {
     @Override
     public RecordData copy(RecordData from) {
         // BinaryRecordData is the only implementation of RecordData
-        return ((BinaryRecordData) from).copy();
+        return from == null ? null : ((BinaryRecordData) from).copy();
     }
 
     @Override
     public RecordData copy(RecordData from, RecordData reuse) {
         // BinaryRecordData is the only implementation of RecordData
-        return ((BinaryRecordData) from).copy((BinaryRecordData) reuse);
+        return from == null ? null : ((BinaryRecordData) from).copy((BinaryRecordData) reuse);
     }
 
     @Override

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/data/binary/BinaryRecordDataSerializer.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/data/binary/BinaryRecordDataSerializer.java
@@ -39,6 +39,8 @@ public class BinaryRecordDataSerializer extends TypeSerializerSingleton<BinaryRe
 
     private static final long serialVersionUID = 1L;
 
+    private static final int NULL_VALUE_IDENTIFIER = 0;
+
     public static final BinaryRecordDataSerializer INSTANCE = new BinaryRecordDataSerializer();
 
     @Override
@@ -68,6 +70,10 @@ public class BinaryRecordDataSerializer extends TypeSerializerSingleton<BinaryRe
 
     @Override
     public void serialize(BinaryRecordData record, DataOutputView target) throws IOException {
+        if (record == null) {
+            target.writeInt(NULL_VALUE_IDENTIFIER);
+            return;
+        }
         target.writeInt(record.getArity());
         target.writeInt(record.getSizeInBytes());
         if (target instanceof MemorySegmentWritable) {
@@ -80,7 +86,11 @@ public class BinaryRecordDataSerializer extends TypeSerializerSingleton<BinaryRe
 
     @Override
     public BinaryRecordData deserialize(DataInputView source) throws IOException {
-        BinaryRecordData row = new BinaryRecordData(source.readInt());
+        int arity = source.readInt();
+        if (arity == NULL_VALUE_IDENTIFIER) {
+            return null;
+        }
+        BinaryRecordData row = new BinaryRecordData(arity);
         int length = source.readInt();
         byte[] bytes = new byte[length];
         source.readFully(bytes);

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/event/DataChangeEventSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/event/DataChangeEventSerializerTest.java
@@ -75,7 +75,11 @@ public class DataChangeEventSerializerTest extends SerializerTestBase<DataChange
             DataChangeEvent.updateEvent(
                     TableId.tableId("namespace", "schema", "table"), before, after),
             DataChangeEvent.updateEvent(
-                    TableId.tableId("namespace", "schema", "table"), before, after, meta)
+                    TableId.tableId("namespace", "schema", "table"), null, after),
+            DataChangeEvent.updateEvent(
+                    TableId.tableId("namespace", "schema", "table"), before, after, meta),
+            DataChangeEvent.updateEvent(
+                    TableId.tableId("namespace", "schema", "table"), null, after, meta)
         };
     }
 }


### PR DESCRIPTION
Resolve [FLINK-35119](https://issues.apache.org/jira/browse/FLINK-35119).

The `before` and `after` of DataChangeEvent participate in serialization in case of null value.