### PR TITLE
[FLINK-35128][cdc-connector][cdc-base] Re-calculate the starting changelog offset after the new table added

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/StreamSplit.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/StreamSplit.java
@@ -174,7 +174,7 @@ public class StreamSplit extends SourceSplitBase {
 
         return new StreamSplit(
                 streamSplit.splitId,
-                streamSplit.getStartingOffset(),
+                startingOffset,
                 streamSplit.getEndingOffset(),
                 splitInfos,
                 streamSplit.getTableSchemas(),

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/StreamSplit.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/StreamSplit.java
@@ -163,7 +163,15 @@ public class StreamSplit extends SourceSplitBase {
     // -------------------------------------------------------------------
     public static StreamSplit appendFinishedSplitInfos(
             StreamSplit streamSplit, List<FinishedSnapshotSplitInfo> splitInfos) {
+        // re-calculate the starting changelog offset after the new table added
+        Offset startingOffset = streamSplit.getStartingOffset();
+        for (FinishedSnapshotSplitInfo splitInfo : splitInfos) {
+            if (splitInfo.getHighWatermark().isBefore(startingOffset)) {
+                startingOffset = splitInfo.getHighWatermark();
+            }
+        }
         splitInfos.addAll(streamSplit.getFinishedSnapshotSplitInfos());
+
         return new StreamSplit(
                 streamSplit.splitId,
                 streamSplit.getStartingOffset(),


### PR DESCRIPTION
In mysql cdc, re-calculate the starting binlog offset after the new table added in MySqlBinlogSplit#appendFinishedSplitInfos, while there lack of same action in StreamSplit#appendFinishedSplitInfos. This will cause data loss if any newly added table snapshot split's high_watermark is smaller.

Some unstable test problem occurs because of it.