### PR TITLE
[FLINK-35127] remove HybridSource to avoid CI failure.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSource.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSource.java
@@ -35,7 +35,6 @@ import org.apache.flink.cdc.common.source.EventSourceProvider;
 import org.apache.flink.cdc.common.source.FlinkSourceProvider;
 import org.apache.flink.cdc.common.source.MetadataAccessor;
 import org.apache.flink.cdc.connectors.values.ValuesDatabase;
-import org.apache.flink.connector.base.source.hybrid.HybridSource;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
@@ -73,11 +72,7 @@ public class ValuesDataSource implements DataSource {
     @Override
     public EventSourceProvider getEventSourceProvider() {
         ValuesDataSourceHelper.setSourceEvents(eventSetId);
-        HybridSource<Event> hybridSource =
-                HybridSource.builder(new ValuesSource(failAtPos, eventSetId, true))
-                        .addSource(new ValuesSource(failAtPos, eventSetId, false))
-                        .build();
-        return FlinkSourceProvider.of(hybridSource);
+        return FlinkSourceProvider.of(new ValuesSource(failAtPos, eventSetId, false));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceHelper.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceHelper.java
@@ -73,7 +73,13 @@ public class ValuesDataSourceHelper {
             // use default enum of SINGLE_SPLIT_SINGLE_TABLE
             sourceEvents = singleSplitSingleTable();
         }
-        return sourceEvents;
+        // put all events into one list to avoid CI failure and make sure that SchemaChangeEvent are
+        // sent in order.
+        List<Event> mergeEvents = new ArrayList<>();
+        for (List<Event> events : sourceEvents) {
+            mergeEvents.addAll(events);
+        }
+        return Collections.singletonList(mergeEvents);
     }
 
     /** set sourceEvents using custom events. */


### PR DESCRIPTION
At present, CI testing often causes OOM due to ValuesSource, which may be caused by the use of HybridSource. Considering that this will block other prs, remove it first to restore CI.