### PR TITLE
[minor][cdc][docs] Fix outdated StarRocks quickstart guide

### DIFF
--- a/docs/content.zh/docs/get-started/quickstart/mysql-to-starrocks.md
+++ b/docs/content.zh/docs/get-started/quickstart/mysql-to-starrocks.md
@@ -65,7 +65,7 @@ under the License.
    version: '2.1'
    services:
      StarRocks:
-       image: starrocks/allin1-ubuntu:3.1.10
+       image: starrocks/allin1-ubuntu:3.2.6
        ports:
          - "8080:8080"
          - "9030:9030"

--- a/docs/content.zh/docs/get-started/quickstart/mysql-to-starrocks.md
+++ b/docs/content.zh/docs/get-started/quickstart/mysql-to-starrocks.md
@@ -65,10 +65,9 @@ under the License.
    version: '2.1'
    services:
      StarRocks:
-       image: registry.starrocks.io/starrocks/allin1-ubuntu
+       image: starrocks/allin1-ubuntu:3.1.10
        ports:
-         - "8030:8030"
-         - "8040:8040"
+         - "8080:8080"
          - "9030:9030"
      MySQL:
        image: debezium/example-mysql:1.1
@@ -95,7 +94,7 @@ under the License.
 1. 进入 MySQL 容器
 
    ```shell
-   docker-compose exec mysql mysql -uroot -p123456
+   docker-compose exec MySQL mysql -uroot -p123456
    ```
 
 2. 创建数据库 `app_db` 和表 `orders`,`products`,`shipments`，并插入数据
@@ -172,7 +171,7 @@ under the License.
      type: starrocks
      name: StarRocks Sink
      jdbc-url: jdbc:mysql://127.0.0.1:9030
-     load-url: 127.0.0.1:8030
+     load-url: 127.0.0.1:8080
      username: root
      password: ""
      table.create.properties.replication_num: 1

--- a/docs/content/docs/get-started/quickstart/mysql-to-starrocks.md
+++ b/docs/content/docs/get-started/quickstart/mysql-to-starrocks.md
@@ -68,10 +68,9 @@ Create a `docker-compose.yml` file using the content provided below:
    version: '2.1'
    services:
       StarRocks:
-         image: registry.starrocks.io/starrocks/allin1-ubuntu
+         image: starrocks/allin1-ubuntu:3.1.10
          ports:
-            - "8030:8030"
-            - "8040:8040"
+            - "8080:8080"
             - "9030:9030"
       MySQL:
          image: debezium/example-mysql:1.1
@@ -98,7 +97,7 @@ This command automatically starts all the containers defined in the Docker Compo
 1. Enter MySQL container
 
    ```shell
-   docker-compose exec mysql mysql -uroot -p123456
+   docker-compose exec MySQL mysql -uroot -p123456
    ```
 
 2. create `app_db` database and `orders`,`products`,`shipments` tables, then insert records
@@ -175,7 +174,7 @@ This command automatically starts all the containers defined in the Docker Compo
      type: starrocks
      name: StarRocks Sink
      jdbc-url: jdbc:mysql://127.0.0.1:9030
-     load-url: 127.0.0.1:8030
+     load-url: 127.0.0.1:8080
      username: root
      password: ""
      table.create.properties.replication_num: 1

--- a/docs/content/docs/get-started/quickstart/mysql-to-starrocks.md
+++ b/docs/content/docs/get-started/quickstart/mysql-to-starrocks.md
@@ -68,7 +68,7 @@ Create a `docker-compose.yml` file using the content provided below:
    version: '2.1'
    services:
       StarRocks:
-         image: starrocks/allin1-ubuntu:3.1.10
+         image: starrocks/allin1-ubuntu:3.2.6
          ports:
             - "8080:8080"
             - "9030:9030"


### PR DESCRIPTION
StarRocks refactored its all-in-one docker image in [this PR](https://github.com/StarRocks/starrocks/pull/28240/), which adds a `feproxy` layer exposing 8080 as the unified FE http service port. The previous quickstar guide is outdated since the container doesn't expose port 8030 and connection attempt would fail.

This PR:
* uses fixed docker image tag to make the process reproducible
* changed exposed port & `load-url` to follow latest StarRocks image
* fixed `docker-compose exec` command case-insensitive issue

Local tests have been done to ensure the guide feasible.