### PR TITLE
[hotfix][docs] Use the download link of the release version instead of a snapshot version

### DIFF
--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/db2-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/db2-cdc.md
@@ -50,12 +50,8 @@ using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR
 
 ```Download link is available only for stable releases.```
 
-Download flink-sql-connector-db2-cdc-3.0-SNAPSHOT.jar and 
+Download [flink-sql-connector-db2-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-db2-cdc) and 
 put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-db2-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as
-[flink-sql-connector-db2-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-db2-cdc),
-the released version will be available in the Maven central warehouse.
 
 Setup Db2 server
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/mongodb-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/mongodb-cdc.md
@@ -47,9 +47,7 @@ MongoDB CDC 连接器允许从 MongoDB 读取快照数据和增量数据。 本�
 
 ```下载链接仅适用于稳定版本。```
 
-下载 [flink-sql-connector-mongodb-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-connector-mongodb-cdc/3.0.0/flink-connector-mongodb-cdc-3.0.0.jar) 把它放在 `<FLINK_HOME>/lib/`.
-
-**注意:** flink-sql-connector-mongodb-cdc-XXX-SNAPSHOT 版本是与开发分支相对应的代码。 用户需要下载源代码并编译相应的jar。 用户应使用已发布的版本，例如 [flink-sql-connector-mongodb-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mongodb-cdc), 发布的版本将在 Maven 中央仓库中提供。
+下载 [flink-sql-connector-mongodb-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mongodb-cdc) 把它放在`<FLINK_HOME>/lib/`。
 
 设置 MongoDB
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
@@ -54,9 +54,7 @@ MySQL CDC 连接器允许从 MySQL 数据库读取快照数据和增量数据。
 
 ```下载链接仅在已发布版本可用，请在文档网站左下角选择浏览已发布的版本。```
 
-下载 [flink-sql-connector-mysql-cdc-3.0.0.jar](https://repo1.maven.org/maven2/com/ververica/flink-connector-mysql-cdc/3.0.0/flink-connector-mysql-cdc-3.0.0.jar) 到 `<FLINK_HOME>/lib/` 目录下。
-
-**注意:** flink-sql-connector-mysql-cdc-XXX-SNAPSHOT 版本是开发分支`release-XXX`对应的快照版本，快照版本用户需要下载源代码并编译相应的 jar。用户应使用已经发布的版本，例如 [flink-sql-connector-mysql-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-mysql-cdc) 当前已发布的所有版本都可以在 Maven 中央仓库获取。
+下载 [flink-sql-connector-mysql-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mysql-cdc) 到 `<FLINK_HOME>/lib/` 目录下。
 
 配置 MySQL 服务器
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/oceanbase-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/oceanbase-cdc.md
@@ -57,9 +57,7 @@ OceanBase CDC 连接器允许从 OceanBase 读取快照数据和增量数据。�
 
 ```下载链接仅在已发布版本可用，请在文档网站左下角选择浏览已发布的版本。```
 
-下载[flink-sql-connector-oceanbase-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/com/ververica/flink-connector-oceanbase-cdc/3.0.0/flink-connector-oceanbase-cdc-3.0.0.jar)  到 `<FLINK_HOME>/lib/` 目录下。
-
-**注意:** flink-sql-connector-oceanbase-cdc-XXX-SNAPSHOT 版本是开发分支`release-XXX`对应的快照版本，快照版本用户需要下载源代码并编译相应的 jar。用户应使用已经发布的版本，例如 [flink-sql-connector-oceanbase-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oceanbase-cdc) 当前已发布的所有版本都可以在 Maven 中央仓库获取。
+下载[flink-sql-connector-oceanbase-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oceanbase-cdc) 到 `<FLINK_HOME>/lib/` 目录下。
 
 对于 JDBC 驱动，上述的 cdc jar 文件中已经包含了我们推荐的 MySQL 驱动版本 5.1.47。由于开源许可证的原因，我们不能在上述 cdc jar 文件中包含 OceanBase 的官方 JDBC 驱动，如果您需要使用它，可以从[这里](https://repo1.maven.org/maven2/com/oceanbase/oceanbase-client/2.4.2/oceanbase-client-2.4.2.jar)下载，然后放到 `<FLINK_HOME>/lib/` 目录下，同时需要将配置项 `jdbc.driver` 设为 `com.oceanbase.jdbc.Driver`。
 

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/oracle-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/oracle-cdc.md
@@ -41,9 +41,7 @@ In order to setup the Oracle CDC connector, the following table provides depende
 
 **Download link is available only for stable releases.**
 
-Download [flink-sql-connector-oracle-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-oracle-cdc/3.0-SNAPSHOT/flink-sql-connector-oracle-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-oracle-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-oracle-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oracle-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-oracle-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oracle-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup Oracle
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/postgres-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/postgres-cdc.md
@@ -41,9 +41,7 @@ In order to setup the Postgres CDC connector, the following table provides depen
 
 ```Download link is available only for stable releases.```
 
-Download flink-sql-connector-postgres-cdc-3.0-SNAPSHOT.jar and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-postgres-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as [flink-sql-connector-postgres-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-postgres-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-postgres-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-postgres-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 How to create a Postgres CDC table
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/sqlserver-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/sqlserver-cdc.md
@@ -41,9 +41,7 @@ In order to setup the SQLServer CDC connector, the following table provides depe
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-sqlserver-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-sqlserver-cdc/3.0-SNAPSHOT/flink-sql-connector-sqlserver-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-sqlserver-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as [flink-sql-connector-sqlserver-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-sqlserver-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-sqlserver-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-sqlserver-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup SQLServer Database
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/tidb-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/tidb-cdc.md
@@ -41,9 +41,7 @@ In order to setup the TiDB CDC connector, the following table provides dependenc
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-tidb-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-tidb-cdc/3.0-SNAPSHOT/flink-sql-connector-tidb-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-tidb-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-tidb-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-tidb-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-tidb-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-tidb-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 How to create a TiDB CDC table
 ----------------

--- a/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/vitess-cdc.md
+++ b/docs/content.zh/docs/connectors/legacy-flink-cdc-sources/vitess-cdc.md
@@ -40,11 +40,7 @@ In order to setup the Vitess CDC connector, the following table provides depende
 
 ### SQL Client JAR
 
-Download [flink-sql-connector-vitess-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-vitess-cdc/3.0-SNAPSHOT/flink-sql-connector-vitess-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-vitess-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as
-[flink-sql-connector-vitess-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-vitess-cdc),
-the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-vitess-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-vitess-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup Vitess server
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/db2-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/db2-cdc.md
@@ -50,12 +50,8 @@ using a build automation tool (such as Maven or SBT) and SQL Client with SQL JAR
 
 ```Download link is available only for stable releases.```
 
-Download flink-sql-connector-db2-cdc-3.0-SNAPSHOT.jar and 
+Download [flink-sql-connector-db2-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-db2-cdc) and 
 put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-db2-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as
-[flink-sql-connector-db2-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-db2-cdc),
-the released version will be available in the Maven central warehouse.
 
 Setup Db2 server
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/mongodb-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/mongodb-cdc.md
@@ -41,9 +41,7 @@ In order to setup the MongoDB CDC connector, the following table provides depend
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-mongodb-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-mongodb-cdc/3.0-SNAPSHOT/flink-sql-connector-mongodb-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-mongodb-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-mongodb-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mongodb-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-mongodb-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mongodb-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup MongoDB
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/mysql-cdc.md
@@ -48,9 +48,7 @@ In order to setup the MySQL CDC connector, the following table provides dependen
 
 ```Download link is available only for stable releases.```
 
-Download flink-sql-connector-mysql-cdc-3.0-SNAPSHOT.jar and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-mysql-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as [flink-sql-connector-mysql-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-mysql-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-mysql-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-mysql-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup MySQL server
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/oceanbase-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/oceanbase-cdc.md
@@ -49,9 +49,7 @@ If you want to use OceanBase JDBC driver to connect to the enterprise edition da
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-oceanbase-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-oceanbase-cdc/3.0-SNAPSHOT/flink-sql-connector-oceanbase-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-oceanbase-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-oceanbase-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oceanbase-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-oceanbase-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oceanbase-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 For JDBC driver, the cdc jar above already contains MySQL JDBC driver 5.1.47, which is our recommended version. Due to the license issue, we can not include the OceanBase JDBC driver in the cdc jar. If you need to use it, you can download it from [here](https://repo1.maven.org/maven2/com/oceanbase/oceanbase-client/2.4.2/oceanbase-client-2.4.2.jar) and put it under `<FLINK_HOME>/lib/`, you also need to set the start option `jdbc.driver` to `com.oceanbase.jdbc.Driver`.
 

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/oracle-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/oracle-cdc.md
@@ -41,9 +41,7 @@ In order to setup the Oracle CDC connector, the following table provides depende
 
 **Download link is available only for stable releases.**
 
-Download [flink-sql-connector-oracle-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-oracle-cdc/3.0-SNAPSHOT/flink-sql-connector-oracle-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-oracle-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-oracle-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oracle-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-oracle-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-oracle-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup Oracle
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/postgres-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/postgres-cdc.md
@@ -41,9 +41,7 @@ In order to setup the Postgres CDC connector, the following table provides depen
 
 ```Download link is available only for stable releases.```
 
-Download flink-sql-connector-postgres-cdc-3.0-SNAPSHOT.jar and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-postgres-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as [flink-sql-connector-postgres-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-postgres-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-postgres-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-postgres-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 How to create a Postgres CDC table
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/sqlserver-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/sqlserver-cdc.md
@@ -41,9 +41,7 @@ In order to setup the SQLServer CDC connector, the following table provides depe
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-sqlserver-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-sqlserver-cdc/3.0-SNAPSHOT/flink-sql-connector-sqlserver-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-sqlserver-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as [flink-sql-connector-sqlserver-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-sqlserver-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-sqlserver-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-sqlserver-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup SQLServer Database
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/tidb-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/tidb-cdc.md
@@ -41,9 +41,7 @@ In order to setup the TiDB CDC connector, the following table provides dependenc
 
 ```Download link is available only for stable releases.```
 
-Download [flink-sql-connector-tidb-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-tidb-cdc/3.0-SNAPSHOT/flink-sql-connector-tidb-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-tidb-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users need to download the source code and compile the corresponding jar. Users should use the released version, such as [flink-sql-connector-tidb-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-tidb-cdc), the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-tidb-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-tidb-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 How to create a TiDB CDC table
 ----------------

--- a/docs/content/docs/connectors/legacy-flink-cdc-sources/vitess-cdc.md
+++ b/docs/content/docs/connectors/legacy-flink-cdc-sources/vitess-cdc.md
@@ -40,11 +40,7 @@ In order to setup the Vitess CDC connector, the following table provides depende
 
 ### SQL Client JAR
 
-Download [flink-sql-connector-vitess-cdc-3.0-SNAPSHOT.jar](https://repo1.maven.org/maven2/org/apache/flink/flink-sql-connector-vitess-cdc/3.0-SNAPSHOT/flink-sql-connector-vitess-cdc-3.0-SNAPSHOT.jar) and put it under `<FLINK_HOME>/lib/`.
-
-**Note:** flink-sql-connector-vitess-cdc-XXX-SNAPSHOT version is the code corresponding to the development branch. Users should use the released version, such as
-[flink-sql-connector-vitess-cdc-3.0.0.jar](https://mvnrepository.com/artifact/com.ververica/flink-connector-vitess-cdc),
-the released version will be available in the Maven central warehouse.
+Download [flink-sql-connector-vitess-cdc-3.0.1.jar](https://mvnrepository.com/artifact/com.ververica/flink-sql-connector-vitess-cdc) and put it under `<FLINK_HOME>/lib/`.
 
 Setup Vitess server
 ----------------


### PR DESCRIPTION
This PR update docs by using the download link of the release version instead of a snapshot version.