### PR TITLE
[minor][docs] Add user guide about providing extra jar package in quickstart docs

### DIFF
--- a/docs/content.zh/docs/get-started/quickstart/mysql-to-doris.md
+++ b/docs/content.zh/docs/get-started/quickstart/mysql-to-doris.md
@@ -188,6 +188,7 @@ MacOS 由于内部实现容器的方式不同，在部署时宿主机直接修�
    **下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译.**
     - [MySQL pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-mysql/3.0.0/flink-cdc-pipeline-connector-mysql-3.0.0.jar)
     - [Apache Doris pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-doris/3.0.0/flink-cdc-pipeline-connector-doris-3.0.0.jar)
+    - [MySQL Connector Java](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar)
 
 3.编写任务配置 yaml 文件
 下面给出了一个整库同步的示例文件 `mysql-to-doris.yaml`：
@@ -226,7 +227,7 @@ sink 添加 `table.create.properties.replication_num` 参数是由于 Docker 镜
 
 4. 最后，通过命令行提交任务到 Flink Standalone cluster
    ```shell
-   bash bin/flink-cdc.sh mysql-to-doris.yaml
+   bash bin/flink-cdc.sh mysql-to-doris.yaml --jar lib/mysql-connector-java-8.0.27.jar
    ```
 提交成功后，返回信息如：
    ```shell

--- a/docs/content.zh/docs/get-started/quickstart/mysql-to-starrocks.md
+++ b/docs/content.zh/docs/get-started/quickstart/mysql-to-starrocks.md
@@ -149,6 +149,7 @@ under the License.
    **下载链接只对已发布的版本有效, SNAPSHOT 版本需要本地基于 master 或 release- 分支编译**
    - [MySQL pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-mysql/3.0.0/flink-cdc-pipeline-connector-mysql-3.0.0.jar)
    - [StarRocks pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-starrocks/3.0.0/flink-cdc-pipeline-connector-starrocks-3.0.0.jar)
+   - [MySQL Connector Java](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar)
 
 3. 编写任务配置 yaml 文件  
    下面给出了一个整库同步的示例文件 mysql-to-starrocks.yaml：
@@ -189,7 +190,7 @@ under the License.
 4. 最后，通过命令行提交任务到 Flink Standalone cluster
 
    ```shell
-   bash bin/flink-cdc.sh mysql-to-starrocks.yaml
+   bash bin/flink-cdc.sh mysql-to-starrocks.yaml --jar lib/mysql-connector-java-8.0.27.jar
    ```
 
 提交成功后，返回信息如：

--- a/docs/content/docs/get-started/quickstart/mysql-to-doris.md
+++ b/docs/content/docs/get-started/quickstart/mysql-to-doris.md
@@ -190,6 +190,7 @@ This command automatically starts all the containers defined in the Docker Compo
    **Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release branches by yourself.**
     - [MySQL pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-mysql/3.0.0/flink-cdc-pipeline-connector-mysql-3.0.0.jar)
     - [Apache Doris pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-doris/3.0.0/flink-cdc-pipeline-connector-doris-3.0.0.jar)
+    - [MySQL Connector Java](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar)
 
 3. Write task configuration yaml file 
   Here is an example file for synchronizing the entire database `mysql-to-doris.yaml`：
@@ -228,7 +229,7 @@ Notice that:
 
 4. Finally, submit job to Flink Standalone cluster using Cli.
    ```shell
-   bash bin/flink-cdc.sh mysql-to-doris.yaml
+   bash bin/flink-cdc.sh mysql-to-doris.yaml --jar lib/mysql-connector-java-8.0.27.jar
    ```
 After successful submission, the return information is as follows：
    ```shell

--- a/docs/content/docs/get-started/quickstart/mysql-to-starrocks.md
+++ b/docs/content/docs/get-started/quickstart/mysql-to-starrocks.md
@@ -152,6 +152,7 @@ This command automatically starts all the containers defined in the Docker Compo
    **Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on master or release branches by yourself.**
     - [MySQL pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-mysql/3.0.0/flink-cdc-pipeline-connector-mysql-3.0.0.jar)
     - [StarRocks pipeline connector 3.0.0](https://repo1.maven.org/maven2/com/ververica/flink-cdc-pipeline-connector-starrocks/3.0.0/flink-cdc-pipeline-connector-starrocks-3.0.0.jar)
+    - [MySQL Connector Java](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar)
 
 3. Write task configuration yaml file.
    Here is an example file for synchronizing the entire database `mysql-to-starrocks.yaml`：
@@ -192,7 +193,7 @@ Notice that:
 4. Finally, submit job to Flink Standalone cluster using Cli.
 
    ```shell
-   bash bin/flink-cdc.sh mysql-to-starrocks.yaml
+   bash bin/flink-cdc.sh mysql-to-starrocks.yaml --jar lib/mysql-connector-java-8.0.27.jar
    ```
    
 After successful submission, the return information is as follows：


### PR DESCRIPTION
`mysql-connector-java` has been excluded from released jar packages, users must provide it explicitly. Updated quickstart guides to clarify this.