### PR TITLE
[BP-3.1][FLINK-35128][cdc-connector][cdc-base] Re-calculate the starting changelog offset after the new table added (#3230)

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-baseURL = '//nightlies.apache.org/flink/flink-cdc-docs-master'
+baseURL = '//nightlies.apache.org/flink/flink-cdc-docs-release-3.1'
 languageCode = 'en-us'
 title = 'Apache Flink CDC'
 enableGitInfo = false
@@ -24,7 +24,7 @@ pygmentsUseClasses = true
 [params]
   # Flag whether this is a stable version or not.
   # Used for the quickstart page.
-  IsStable = false
+  IsStable = true
 
   # Flag to indicate whether an outdated warning should be shown.
   ShowOutDatedWarning = false
@@ -34,14 +34,14 @@ pygmentsUseClasses = true
   # we change the version for the complete docs when forking of a release branch
   # etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "3.1-SNAPSHOT"
+  Version = "3.1.0"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "3.1-SNAPSHOT"
+  VersionTitle = "3.1"
 
   # The branch for this version of Apache Flink CDC
-  Branch = "master"
+  Branch = "release-3.1"
 
   # The GitHub repository for Apache Flink CDC
   Repo = "//github.com/apache/flink-cdc"
@@ -54,7 +54,7 @@ pygmentsUseClasses = true
   # of the menu
   MenuLinks = [
     ["Project Homepage", "//flink.apache.org"],
-    ["JavaDocs", "//nightlies.apache.org/flink/flink-cdc-docs-master/api/java/"],
+    ["JavaDocs", "//nightlies.apache.org/flink/flink-cdc-docs-release-3.1/api/java/"],
   ]
 
   PreviousDocs = [

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/StreamSplit.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/StreamSplit.java
@@ -163,10 +163,18 @@ public class StreamSplit extends SourceSplitBase {
     // -------------------------------------------------------------------
     public static StreamSplit appendFinishedSplitInfos(
             StreamSplit streamSplit, List<FinishedSnapshotSplitInfo> splitInfos) {
+        // re-calculate the starting changelog offset after the new table added
+        Offset startingOffset = streamSplit.getStartingOffset();
+        for (FinishedSnapshotSplitInfo splitInfo : splitInfos) {
+            if (splitInfo.getHighWatermark().isBefore(startingOffset)) {
+                startingOffset = splitInfo.getHighWatermark();
+            }
+        }
         splitInfos.addAll(streamSplit.getFinishedSnapshotSplitInfos());
+
         return new StreamSplit(
                 streamSplit.splitId,
-                streamSplit.getStartingOffset(),
+                startingOffset,
                 streamSplit.getEndingOffset(),
                 splitInfos,
                 streamSplit.getTableSchemas(),


### PR DESCRIPTION
BP FLINK-35128 to release 3.1.