### PR TITLE
[BP-3.1][FLINK-35235][pipeline-connector][kafka] Fix missing dependencies in the uber jar of Kafka pipeline sink.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
@@ -83,6 +83,12 @@ limitations under the License.
                         </goals>
                         <configuration>
                             <shadeTestJar>false</shadeTestJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.kafka:*</include>
+                                    <include>org.apache.flink:flink-connector-kafka</include>
+                                </includes>
+                            </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.kafka</pattern>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
@@ -94,6 +94,10 @@ limitations under the License.
                                     <pattern>org.apache.kafka</pattern>
                                     <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.kafka</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.connector.kafka</pattern>
+                                    <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.flink.connector.kafka</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
cherry pick of https://github.com/apache/flink-cdc/pull/3262.