### PR TITLE
[FLINK-35244][cdc-connector][tidb] Move package for flink-connector-tidb-cdc test

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/TiDBTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/TiDBTestBase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cdc.connectors;
+package org.apache.flink.cdc.connectors.tidb;
 
 import org.apache.flink.test.util.AbstractTestBase;
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/table/TiDBConnectorITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/table/TiDBConnectorITCase.java
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cdc.connectors.table;
+package org.apache.flink.cdc.connectors.tidb.table;
 
-import org.apache.flink.cdc.connectors.TiDBTestBase;
+import org.apache.flink.cdc.connectors.tidb.TiDBTestBase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/table/TiDBConnectorRegionITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/table/TiDBConnectorRegionITCase.java
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cdc.connectors.table;
+package org.apache.flink.cdc.connectors.tidb.table;
 
-import org.apache.flink.cdc.connectors.TiDBTestBase;
+import org.apache.flink.cdc.connectors.tidb.TiDBTestBase;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableResult;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/table/TiDBTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/table/TiDBTableSourceFactoryTest.java
@@ -15,10 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.flink.cdc.connectors.table;
+package org.apache.flink.cdc.connectors.tidb.table;
 
-import org.apache.flink.cdc.connectors.tidb.table.StartupOptions;
-import org.apache.flink.cdc.connectors.tidb.table.TiDBTableSource;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/FLINK-35244

test case for flink-connector-tidb-cdc should under
`org.apache.flink.cdc.connectors.tidb` package
instead of `org.apache.flink.cdc.connectors`