### PR TITLE
[FLINK-35245][cdc-connector][tidb] Add metrics for flink-connector-tidb-cdc

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2022 Ververica Inc.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,71 +14,72 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.cdc.connectors.tidb.metrics;
 
+import org.apache.flink.cdc.connectors.tidb.TiKVRichParallelSourceFunction;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
-import org.apache.flink.cdc.connectors.tidb.TiKVRichParallelSourceFunction ;
 
 /** A collection class for handling metrics in {@link TiKVRichParallelSourceFunction}. */
 public class TiDBSourceMetrics {
 
-  private final MetricGroup metricGroup;
+    private final MetricGroup metricGroup;
 
-  /**
-   * The last record processing time, which is updated after {@link
-   * TiKVRichParallelSourceFunction} fetches a batch of data. It's mainly used to report metrics
-   * sourceIdleTime for sourceIdleTime = System.currentTimeMillis() - processTime.
-   */
-  private long processTime = 0L;
+    /**
+     * The last record processing time, which is updated after {@link
+     * TiKVRichParallelSourceFunction} fetches a batch of data. It's mainly used to report metrics
+     * sourceIdleTime for sourceIdleTime = System.currentTimeMillis() - processTime.
+     */
+    private long processTime = 0L;
 
-  /**
-   * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
-   * record fetched into the source operator.
-   */
-  private long fetchDelay = 0L;
+    /**
+     * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
+     * record fetched into the source operator.
+     */
+    private long fetchDelay = 0L;
 
-  /**
-   * currentEmitEventTimeLag = EmitTime - messageTimestamp, where the EmitTime is the time the
-   * record leaves the source operator.
-   */
-  private long emitDelay = 0L;
+    /**
+     * currentEmitEventTimeLag = EmitTime - messageTimestamp, where the EmitTime is the time the
+     * record leaves the source operator.
+     */
+    private long emitDelay = 0L;
 
-  public TiDBSourceMetrics(MetricGroup metricGroup) {
-    this.metricGroup = metricGroup;
-  }
-
-  public void registerMetrics() {
-    metricGroup.gauge("currentFetchEventTimeLag", (Gauge<Long>) this::getFetchDelay);
-    metricGroup.gauge("currentEmitEventTimeLag", (Gauge<Long>) this::getEmitDelay);
-    metricGroup.gauge("sourceIdleTime", (Gauge<Long>) this::getIdleTime);
-  }
-
-  public long getFetchDelay() {
-    return fetchDelay;
-  }
-
-  public long getEmitDelay() {
-    return emitDelay;
-  }
-
-  public long getIdleTime() {
-    // no previous process time at the beginning, return 0 as idle time
-    if (processTime == 0) {
-      return 0;
+    public TiDBSourceMetrics(MetricGroup metricGroup) {
+        this.metricGroup = metricGroup;
     }
-    return System.currentTimeMillis() - processTime;
-  }
 
-  public void recordProcessTime(long processTime) {
-    this.processTime = processTime;
-  }
+    public void registerMetrics() {
+        metricGroup.gauge("currentFetchEventTimeLag", (Gauge<Long>) this::getFetchDelay);
+        metricGroup.gauge("currentEmitEventTimeLag", (Gauge<Long>) this::getEmitDelay);
+        metricGroup.gauge("sourceIdleTime", (Gauge<Long>) this::getIdleTime);
+    }
 
-  public void recordFetchDelay(long fetchDelay) {
-    this.fetchDelay = fetchDelay;
-  }
+    public long getFetchDelay() {
+        return fetchDelay;
+    }
 
-  public void recordEmitDelay(long emitDelay) {
-    this.emitDelay = emitDelay;
-  }
+    public long getEmitDelay() {
+        return emitDelay;
+    }
+
+    public long getIdleTime() {
+        // no previous process time at the beginning, return 0 as idle time
+        if (processTime == 0) {
+            return 0;
+        }
+        return System.currentTimeMillis() - processTime;
+    }
+
+    public void recordProcessTime(long processTime) {
+        this.processTime = processTime;
+    }
+
+    public void recordFetchDelay(long fetchDelay) {
+        this.fetchDelay = fetchDelay;
+    }
+
+    public void recordEmitDelay(long emitDelay) {
+        this.emitDelay = emitDelay;
+    }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.cdc.connectors.tidb.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.cdc.connectors.tidb.TiKVRichParallelSourceFunction ;
+
+/** A collection class for handling metrics in {@link TiKVRichParallelSourceFunction}. */
+public class TiDBSourceMetrics {
+
+  private final MetricGroup metricGroup;
+
+  /**
+   * The last record processing time, which is updated after {@link
+   * TiKVRichParallelSourceFunction} fetches a batch of data. It's mainly used to report metrics
+   * sourceIdleTime for sourceIdleTime = System.currentTimeMillis() - processTime.
+   */
+  private long processTime = 0L;
+
+  /**
+   * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
+   * record fetched into the source operator.
+   */
+  private long fetchDelay = 0L;
+
+  /**
+   * currentEmitEventTimeLag = EmitTime - messageTimestamp, where the EmitTime is the time the
+   * record leaves the source operator.
+   */
+  private long emitDelay = 0L;
+
+  public TiDBSourceMetrics(MetricGroup metricGroup) {
+    this.metricGroup = metricGroup;
+  }
+
+  public void registerMetrics() {
+    metricGroup.gauge("currentFetchEventTimeLag", (Gauge<Long>) this::getFetchDelay);
+    metricGroup.gauge("currentEmitEventTimeLag", (Gauge<Long>) this::getEmitDelay);
+    metricGroup.gauge("sourceIdleTime", (Gauge<Long>) this::getIdleTime);
+  }
+
+  public long getFetchDelay() {
+    return fetchDelay;
+  }
+
+  public long getEmitDelay() {
+    return emitDelay;
+  }
+
+  public long getIdleTime() {
+    // no previous process time at the beginning, return 0 as idle time
+    if (processTime == 0) {
+      return 0;
+    }
+    return System.currentTimeMillis() - processTime;
+  }
+
+  public void recordProcessTime(long processTime) {
+    this.processTime = processTime;
+  }
+
+  public void recordFetchDelay(long fetchDelay) {
+    this.fetchDelay = fetchDelay;
+  }
+
+  public void recordEmitDelay(long emitDelay) {
+    this.emitDelay = emitDelay;
+  }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
@@ -17,12 +17,13 @@
 
 package org.apache.flink.cdc.connectors.tidb.metrics;
 
-import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_EMIT_EVENT_TIME_LAG;
-import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_FETCH_EVENT_TIME_LAG;
-import static org.apache.flink.runtime.metrics.MetricNames.SOURCE_IDLE_TIME;
 import org.apache.flink.cdc.connectors.tidb.TiKVRichParallelSourceFunction;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
+
+import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_EMIT_EVENT_TIME_LAG;
+import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_FETCH_EVENT_TIME_LAG;
+import static org.apache.flink.runtime.metrics.MetricNames.SOURCE_IDLE_TIME;
 
 /** A collection class for handling metrics in {@link TiKVRichParallelSourceFunction}. */
 public class TiDBSourceMetrics {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetrics.java
@@ -17,6 +17,9 @@
 
 package org.apache.flink.cdc.connectors.tidb.metrics;
 
+import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_EMIT_EVENT_TIME_LAG;
+import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_FETCH_EVENT_TIME_LAG;
+import static org.apache.flink.runtime.metrics.MetricNames.SOURCE_IDLE_TIME;
 import org.apache.flink.cdc.connectors.tidb.TiKVRichParallelSourceFunction;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
@@ -50,9 +53,10 @@ public class TiDBSourceMetrics {
     }
 
     public void registerMetrics() {
-        metricGroup.gauge("currentFetchEventTimeLag", (Gauge<Long>) this::getFetchDelay);
-        metricGroup.gauge("currentEmitEventTimeLag", (Gauge<Long>) this::getEmitDelay);
-        metricGroup.gauge("sourceIdleTime", (Gauge<Long>) this::getIdleTime);
+
+        metricGroup.gauge(CURRENT_FETCH_EVENT_TIME_LAG, (Gauge<Long>) this::getFetchDelay);
+        metricGroup.gauge(CURRENT_EMIT_EVENT_TIME_LAG, (Gauge<Long>) this::getEmitDelay);
+        metricGroup.gauge(SOURCE_IDLE_TIME, (Gauge<Long>) this::getIdleTime);
     }
 
     public long getFetchDelay() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetricsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetricsTest.java
@@ -25,13 +25,13 @@ import org.junit.Test;
 
 import java.util.Optional;
 
+import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_EMIT_EVENT_TIME_LAG;
+import static org.apache.flink.runtime.metrics.MetricNames.CURRENT_FETCH_EVENT_TIME_LAG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** Unit test for {@link TiDBSourceMetrics}. */
 public class TiDBSourceMetricsTest {
-    private static final String FETCH_EVENTTIME_LAG = "currentFetchEventTimeLag";
-    private static final String EMIT_EVENTTIME_LAG = "currentEmitEventTimeLag";
     private MetricListener metricListener;
     private TiDBSourceMetrics sourceMetrics;
 
@@ -45,13 +45,13 @@ public class TiDBSourceMetricsTest {
     @Test
     public void testFetchEventTimeLagTracking() {
         sourceMetrics.recordFetchDelay(5L);
-        assertGauge(metricListener, FETCH_EVENTTIME_LAG, 5L);
+        assertGauge(metricListener, CURRENT_FETCH_EVENT_TIME_LAG, 5L);
     }
 
     @Test
     public void testEmitEventTimeLagTracking() {
         sourceMetrics.recordEmitDelay(3L);
-        assertGauge(metricListener, EMIT_EVENTTIME_LAG, 3L);
+        assertGauge(metricListener, CURRENT_EMIT_EVENT_TIME_LAG, 3L);
     }
 
     private void assertGauge(MetricListener metricListener, String identifier, long expected) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetricsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetricsTest.java
@@ -1,11 +1,12 @@
 /*
- * Copyright 2022 Ververica Inc.
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,33 +30,33 @@ import static org.junit.Assert.assertTrue;
 
 /** Unit test for {@link TiDBSourceMetrics}. */
 public class TiDBSourceMetricsTest {
-  private static final String FETCH_EVENTTIME_LAG = "currentFetchEventTimeLag";
-  private static final String EMIT_EVENTTIME_LAG = "currentEmitEventTimeLag";
-  private MetricListener metricListener;
-  private TiDBSourceMetrics sourceMetrics;
+    private static final String FETCH_EVENTTIME_LAG = "currentFetchEventTimeLag";
+    private static final String EMIT_EVENTTIME_LAG = "currentEmitEventTimeLag";
+    private MetricListener metricListener;
+    private TiDBSourceMetrics sourceMetrics;
 
-  @Before
-  public void setUp() {
-    metricListener = new MetricListener();
-    sourceMetrics = new TiDBSourceMetrics(metricListener.getMetricGroup());
-    sourceMetrics.registerMetrics();
-  }
+    @Before
+    public void setUp() {
+        metricListener = new MetricListener();
+        sourceMetrics = new TiDBSourceMetrics(metricListener.getMetricGroup());
+        sourceMetrics.registerMetrics();
+    }
 
-  @Test
-  public void testFetchEventTimeLagTracking() {
-    sourceMetrics.recordFetchDelay(5L);
-    assertGauge(metricListener, FETCH_EVENTTIME_LAG, 5L);
-  }
+    @Test
+    public void testFetchEventTimeLagTracking() {
+        sourceMetrics.recordFetchDelay(5L);
+        assertGauge(metricListener, FETCH_EVENTTIME_LAG, 5L);
+    }
 
-  @Test
-  public void testEmitEventTimeLagTracking() {
-    sourceMetrics.recordEmitDelay(3L);
-    assertGauge(metricListener, EMIT_EVENTTIME_LAG, 3L);
-  }
+    @Test
+    public void testEmitEventTimeLagTracking() {
+        sourceMetrics.recordEmitDelay(3L);
+        assertGauge(metricListener, EMIT_EVENTTIME_LAG, 3L);
+    }
 
-  private void assertGauge(MetricListener metricListener, String identifier, long expected) {
-    Optional<Gauge<Object>> gauge = metricListener.getGauge(identifier);
-    assertTrue(gauge.isPresent());
-    assertEquals(expected, (long) gauge.get().getValue());
-  }
+    private void assertGauge(MetricListener metricListener, String identifier, long expected) {
+        Optional<Gauge<Object>> gauge = metricListener.getGauge(identifier);
+        assertTrue(gauge.isPresent());
+        assertEquals(expected, (long) gauge.get().getValue());
+    }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetricsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/test/java/org/apache/flink/cdc/connectors/tidb/metrics/TiDBSourceMetricsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Ververica Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.tidb.metrics;
+
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.testutils.MetricListener;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Unit test for {@link TiDBSourceMetrics}. */
+public class TiDBSourceMetricsTest {
+  private static final String FETCH_EVENTTIME_LAG = "currentFetchEventTimeLag";
+  private static final String EMIT_EVENTTIME_LAG = "currentEmitEventTimeLag";
+  private MetricListener metricListener;
+  private TiDBSourceMetrics sourceMetrics;
+
+  @Before
+  public void setUp() {
+    metricListener = new MetricListener();
+    sourceMetrics = new TiDBSourceMetrics(metricListener.getMetricGroup());
+    sourceMetrics.registerMetrics();
+  }
+
+  @Test
+  public void testFetchEventTimeLagTracking() {
+    sourceMetrics.recordFetchDelay(5L);
+    assertGauge(metricListener, FETCH_EVENTTIME_LAG, 5L);
+  }
+
+  @Test
+  public void testEmitEventTimeLagTracking() {
+    sourceMetrics.recordEmitDelay(3L);
+    assertGauge(metricListener, EMIT_EVENTTIME_LAG, 3L);
+  }
+
+  private void assertGauge(MetricListener metricListener, String identifier, long expected) {
+    Optional<Gauge<Object>> gauge = metricListener.getGauge(identifier);
+    assertTrue(gauge.isPresent());
+    assertEquals(expected, (long) gauge.get().getValue());
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-35245

add metrcis: currentFetchEventTimeLag, currentEmitEventTimeLag, sourceIdleTime for TiKVRichParallelSourceFunction