### PR TITLE
[FLINK-35251][cdc][runtime] Fix bug of serializing derivation mapping in SchemaDerivation

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
@@ -123,7 +123,7 @@ public class SchemaDerivation {
         TableIdSerializer tableIdSerializer = TableIdSerializer.INSTANCE;
         // Serialize derivation mapping in SchemaDerivation
         Map<TableId, Set<TableId>> derivationMapping = schemaDerivation.getDerivationMapping();
-        out.write(derivationMapping.size());
+        out.writeInt(derivationMapping.size());
         for (Map.Entry<TableId, Set<TableId>> entry : derivationMapping.entrySet()) {
             // Routed table ID
             TableId routedTableId = entry.getKey();


### PR DESCRIPTION
This PR fixes bug of serializing derivation mapping in SchemaDerivation that mistakenly uses `out.write` instead of `out.writeInt` when serializing the size of the mapping, and also add a test case for validating serde of SchemaDerivation.