### PR TITLE
[FLINK-35294][mysql] Use source config to check if the filter should be applied in timestamp starting mode

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlBinlogSplitReadTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlBinlogSplitReadTask.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.mysql.debezium.task;
 
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
 import org.apache.flink.cdc.connectors.mysql.debezium.dispatcher.EventDispatcherImpl;
 import org.apache.flink.cdc.connectors.mysql.debezium.dispatcher.SignalEventDispatcher;
 import org.apache.flink.cdc.connectors.mysql.debezium.reader.StoppableChangeEventSourceContext;
@@ -118,5 +119,10 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
 
     private boolean isBoundedRead() {
         return !isNonStoppingOffset(binlogSplit.getEndingOffset());
+    }
+
+    @VisibleForTesting
+    public Predicate<Event> getEventFilter() {
+        return eventFilter;
     }
 }


### PR DESCRIPTION
Since MySQL does not support the ability to quickly locate an binlog offset through a timestamp, the current logic for starting from a timestamp is to begin from the earliest binlog offset and then filter out the data before the user-specified position.

If the user restarts the job during the filtering process, this filter will become ineffective.

Use source config to check if the filter should be applied in timestamp starting mode.