### PR TITLE
[minor][cdc] Suppress false alarm in flink config loader

### DIFF
--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/utils/FlinkEnvironmentUtils.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/utils/FlinkEnvironmentUtils.java
@@ -24,7 +24,6 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -38,13 +37,9 @@ public class FlinkEnvironmentUtils {
 
     public static Configuration loadFlinkConfiguration(Path flinkHome) throws Exception {
         Path flinkConfPath = flinkHome.resolve(FLINK_CONF_DIR).resolve(FLINK_CONF_FILENAME);
-        try {
+        if (flinkConfPath.toFile().exists()) {
             return ConfigurationUtils.loadConfigFile(flinkConfPath);
-        } catch (FileNotFoundException e) {
-            LOG.warn(
-                    "Failed to load the configuration file from {}. Trying to use legacy YAML parser to load flink configuration file from {}.",
-                    FLINK_CONF_FILENAME,
-                    LEGACY_FLINK_CONF_FILENAME);
+        } else {
             return ConfigurationUtils.loadConfigFile(
                     flinkHome.resolve(FLINK_CONF_DIR).resolve(LEGACY_FLINK_CONF_FILENAME), true);
         }


### PR DESCRIPTION
Currently, Flink CDC supports both new Flink config file `config.yaml` and fallback legacy config file `flink-conf.yaml`.

However, a false-alarm "File Not Found" exception will be printed in legacy compatible mode. Using `if - else` control flow to replace `try - catch` clause should fix this problem.