### PR TITLE
[FLINK-35301][cdc] fix deadlock when loading driver classes

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/relational/connection/JdbcConnectionPoolFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/relational/connection/JdbcConnectionPoolFactory.java
@@ -23,6 +23,8 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.debezium.jdbc.JdbcConfiguration;
 
+import java.sql.DriverManager;
+
 /** A connection pool factory to create pooled DataSource {@link HikariDataSource}. */
 public abstract class JdbcConnectionPoolFactory {
 
@@ -43,6 +45,7 @@ public abstract class JdbcConnectionPoolFactory {
         config.setMinimumIdle(MINIMUM_POOL_SIZE);
         config.setMaximumPoolSize(sourceConfig.getConnectionPoolSize());
         config.setConnectionTimeout(sourceConfig.getConnectTimeout().toMillis());
+        DriverManager.getDrivers();
         config.setDriverClassName(sourceConfig.getDriverClassName());
 
         // note: the following properties should be optional (only applied to MySQL)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlConnection.java
@@ -26,6 +26,7 @@ import io.debezium.util.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
@@ -622,6 +623,7 @@ public class MySqlConnection extends JdbcConnection {
             this.jdbcConfig = JdbcConfiguration.adapt(jdbcConfigBuilder.build());
             String driverClassName = this.jdbcConfig.getString(MySqlConnectorConfig.JDBC_DRIVER);
             this.urlPattern = formatJdbcUrl(jdbcProperties);
+            DriverManager.getDrivers();
             factory =
                     JdbcConnection.patternBasedFactory(
                             urlPattern, driverClassName, getClass().getClassLoader());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/connection/PooledDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/connection/PooledDataSourceFactory.java
@@ -23,6 +23,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 
+import java.sql.DriverManager;
 import java.util.Properties;
 
 /** A connection pool factory to create pooled DataSource {@link HikariDataSource}. */
@@ -52,6 +53,7 @@ public class PooledDataSourceFactory {
         config.setMaximumPoolSize(sourceConfig.getConnectionPoolSize());
         config.setConnectionTimeout(sourceConfig.getConnectTimeout().toMillis());
         config.addDataSourceProperty(SERVER_TIMEZONE_KEY, sourceConfig.getServerTimeZone());
+        DriverManager.getDrivers();
         config.setDriverClassName(
                 sourceConfig.getDbzConfiguration().getString(MySqlConnectorConfig.JDBC_DRIVER));
 


### PR DESCRIPTION
In JDK 8 and earlier version, if multiple threads invoke `Class.forName("com.xx.Driver")` simultaneously, it may cause jdbc driver deadlock.

[FLINK-19435](https://issues.apache.org/jira/browse/FLINK-19435)  analyzes this problem.