### PR TITLE
[FLINK-35386][cdc][docs] Build release-3.1 documentation and mark it as stable

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -55,6 +55,7 @@ jobs:
         branch:
           - master
           - release-3.0
+          - release-3.1
 
     steps:
       - uses: actions/checkout@v3
@@ -69,7 +70,7 @@ jobs:
           
           if [ "${currentBranch}" = "master" ]; then
           echo "flink_alias=release-3.2" >> ${GITHUB_ENV}
-          elif [ "${currentBranch}" = "release-3.0" ]; then
+          elif [ "${currentBranch}" = "release-3.1" ]; then
           echo "flink_alias=stable" >> ${GITHUB_ENV}
           fi
 


### PR DESCRIPTION
This pull request configures GitHub Action to build release-3.1 documentation and mark it as stable.