### PR TITLE
[hotfix][ci] Add new pipeline connectors into `labeler.yml`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -74,6 +74,10 @@ values-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/**/*
 mysql-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/**/*
+paimon-pipeline-connector:
+  - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/**/*
+kafka-pipeline-connector:
+  - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/**/*
 doris-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/**/*
 starrocks-pipeline-connector:


### PR DESCRIPTION
Flink CDC 3.1 adds two new pipeline connectors (Kafka & Paimon). Added them into auto-labeler to tag PRs more precisely.