### PR TITLE
[FLINK-35421]fixed schema operator blocking when restart

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -46,7 +46,6 @@ import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.TaskOperatorEventGateway;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
-import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -140,16 +140,11 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
                                         return getLatestSchema(tableId);
                                     }
                                 });
-    }
 
-    @Override
-    public void initializeState(StateInitializationContext context) throws Exception {
-        if (context.isRestored()) {
-            // Multiple operators may appear during a restart process,
-            // only clear the pendingSchemaChanges when the first operator starts.
-            if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
-                sendRequestToCoordinator(new RefreshPendingListsRequest());
-            }
+        // Multiple operators may appear during a restart process,
+        // only clear the pendingSchemaChanges when the first operator starts.
+        if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+            sendRequestToCoordinator(new RefreshPendingListsRequest());
         }
     }
 

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorTest.java
@@ -126,6 +126,28 @@ public class SchemaOperatorTest {
     }
 
     @Test
+    void testProcessSchemaChangeEventWithRestart() throws Exception {
+        SchemaOperator schemaOperator =
+            new SchemaOperator(new ArrayList<>(), Duration.ofSeconds(1));
+        EventOperatorTestHarness<SchemaOperator, Event> harness =
+            new EventOperatorTestHarness<>(schemaOperator, 1, Duration.ofSeconds(3));
+        harness.open();
+        Assertions.assertThrowsExactly(
+            TimeoutException.class,
+            () ->
+                schemaOperator.processElement(
+                    new StreamRecord<>(
+                        new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA))));
+        harness.setOperator(new SchemaOperator(new ArrayList<>(), Duration.ofSeconds(1)));
+        harness.open();
+        Assertions.assertDoesNotThrow(
+            () ->
+                schemaOperator.processElement(
+                    new StreamRecord<>(
+                        new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA))));
+    }
+
+    @Test
     void testProcessSchemaChangeEventWithOutTimeOut() throws Exception {
         SchemaOperator schemaOperator =
                 new SchemaOperator(new ArrayList<>(), Duration.ofSeconds(30));

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorTest.java
@@ -128,23 +128,23 @@ public class SchemaOperatorTest {
     @Test
     void testProcessSchemaChangeEventWithRestart() throws Exception {
         SchemaOperator schemaOperator =
-            new SchemaOperator(new ArrayList<>(), Duration.ofSeconds(1));
+                new SchemaOperator(new ArrayList<>(), Duration.ofSeconds(1));
         EventOperatorTestHarness<SchemaOperator, Event> harness =
-            new EventOperatorTestHarness<>(schemaOperator, 1, Duration.ofSeconds(3));
+                new EventOperatorTestHarness<>(schemaOperator, 1, Duration.ofSeconds(3));
         harness.open();
         Assertions.assertThrowsExactly(
-            TimeoutException.class,
-            () ->
-                schemaOperator.processElement(
-                    new StreamRecord<>(
-                        new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA))));
+                TimeoutException.class,
+                () ->
+                        schemaOperator.processElement(
+                                new StreamRecord<>(
+                                        new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA))));
         harness.setOperator(new SchemaOperator(new ArrayList<>(), Duration.ofSeconds(1)));
         harness.open();
         Assertions.assertDoesNotThrow(
-            () ->
-                schemaOperator.processElement(
-                    new StreamRecord<>(
-                        new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA))));
+                () ->
+                        schemaOperator.processElement(
+                                new StreamRecord<>(
+                                        new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA))));
     }
 
     @Test

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/EventOperatorTestHarness.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/EventOperatorTestHarness.java
@@ -67,7 +67,7 @@ public class EventOperatorTestHarness<OP extends AbstractStreamOperator<E>, E ex
 
     public static final OperatorID SINK_OPERATOR_ID = new OperatorID(15214L, 15514L);
 
-    private final OP operator;
+    private OP operator;
     private final int numOutputs;
     private final SchemaRegistry schemaRegistry;
     private final TestingSchemaRegistryGateway schemaRegistryGateway;
@@ -102,6 +102,10 @@ public class EventOperatorTestHarness<OP extends AbstractStreamOperator<E>, E ex
     public void open() throws Exception {
         initializeOperator();
         operator.open();
+    }
+
+    public void setOperator(OP operator) {
+        this.operator = operator;
     }
 
     public LinkedList<StreamRecord<E>> getOutputRecords() {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-35421
1. i move refresh action to the `setup` method and remove checker of whether it restored from checkpoint or not.
2. i add some testing for it to double check when `SchemaOperator` restart, the  new `CreateTableEvent` chould be responsed `SchemaOperator` as expect.