### PR TITLE
[FLINK-35447][doc-ci] Flink CDC Document document file had removed but website can access

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,12 +22,6 @@ on:
       - release-*
     paths:
       - 'docs/**'
-  push:
-    paths:
-      - 'docs/**'
-    branches:
-      - master
-      - release-*
   schedule:
     - cron: '0 0 * * *' # Deploy every day
   workflow_dispatch:
@@ -92,7 +86,7 @@ jobs:
       - name: Upload documentation
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: --archive --compress
+          switches: --archive --compress --delete
           path: docs/target/
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/flink/flink-cdc-docs-${{ env.flink_branch }}/
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}
@@ -104,7 +98,7 @@ jobs:
         if: env.flink_alias != ''
         uses: burnett01/rsync-deployments@5.2
         with:
-          switches: --archive --compress
+          switches: --archive --compress --delete
           path: docs/target/
           remote_path: ${{ secrets.NIGHTLIES_RSYNC_PATH }}/flink/flink-cdc-docs-${{ env.flink_alias }}/
           remote_host: ${{ secrets.NIGHTLIES_RSYNC_HOST }}


### PR DESCRIPTION
Solution:
Deletes files from the destination directory that are not present in the source directory.