### PR TITLE
[minor][paimon] Remove duplicates implements.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSink.java
@@ -20,7 +20,6 @@ package org.apache.flink.cdc.connectors.paimon.sink.v2;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.Sink;
-import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessageTypeInfo;
@@ -36,9 +35,7 @@ import org.apache.paimon.table.sink.CommitMessageSerializer;
 /**
  * A {@link Sink} for Paimon. Maintain this package until Paimon has it own sinkV2 implementation.
  */
-public class PaimonSink<InputT>
-        implements TwoPhaseCommittingSink<InputT, MultiTableCommittable>,
-                WithPreCommitTopology<InputT, MultiTableCommittable> {
+public class PaimonSink<InputT> implements WithPreCommitTopology<InputT, MultiTableCommittable> {
 
     // provided a default commit user.
     public static final String DEFAULT_COMMIT_USER = "admin";


### PR DESCRIPTION
Because WithPreCommitTopology has extended TwoPhaseCommittingSink, there is no need to implement the TwoPhaseCommittingSink interface separately.