### PR TITLE
[hotfix][cdc-composor] adjust test of cdc composer from junit4 to junit5

### DIFF
--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerTest.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerTest.java
@@ -27,14 +27,14 @@ import org.apache.flink.cdc.composer.utils.factory.DataSinkFactory1;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** A test for the {@link FlinkPipelineComposer}. */
-public class FlinkPipelineComposerTest {
+class FlinkPipelineComposerTest {
 
     @Test
-    public void testCreateDataSinkFromSinkDef() {
+    void testCreateDataSinkFromSinkDef() {
         SinkDef sinkDef =
                 new SinkDef(
                         "data-sink-factory-1",
@@ -55,7 +55,7 @@ public class FlinkPipelineComposerTest {
                                 new Configuration(),
                                 Thread.currentThread().getContextClassLoader()));
 
-        Assert.assertTrue(dataSink instanceof DataSinkFactory1.TestDataSink);
-        Assert.assertEquals("0.0.0.0", ((DataSinkFactory1.TestDataSink) dataSink).getHost());
+        Assertions.assertTrue(dataSink instanceof DataSinkFactory1.TestDataSink);
+        Assertions.assertEquals("0.0.0.0", ((DataSinkFactory1.TestDataSink) dataSink).getHost());
     }
 }

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslatorTest.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslatorTest.java
@@ -29,17 +29,17 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Lists;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
 
 /** A test for {@link DataSinkTranslator}. */
-public class DataSinkTranslatorTest {
+class DataSinkTranslatorTest {
 
     @Test
-    public void testPreWriteWithoutCommitSink() {
+    void testPreWriteWithoutCommitSink() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         ArrayList<Event> mockEvents = Lists.newArrayList(new EmptyEvent(), new EmptyEvent());
         DataStreamSource<Event> inputStream = env.fromCollection(mockEvents);
@@ -60,7 +60,7 @@ public class DataSinkTranslatorTest {
         OneInputTransformation<Event, Event> oneInputTransformation =
                 (OneInputTransformation) env.getTransformations().get(0);
         Transformation<?> reblanceTransformation = oneInputTransformation.getInputs().get(0);
-        Assert.assertEquals(uid, reblanceTransformation.getUserProvidedNodeHash());
+        Assertions.assertEquals(uid, reblanceTransformation.getUserProvidedNodeHash());
     }
 
     private static class EmptyEvent implements Event {}

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/translator/DataSourceTranslatorTest.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/translator/DataSourceTranslatorTest.java
@@ -27,14 +27,14 @@ import org.apache.flink.cdc.composer.utils.factory.DataSourceFactory1;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** A test for the {@link DataSourceTranslator}. */
-public class DataSourceTranslatorTest {
+class DataSourceTranslatorTest {
 
     @Test
-    public void testCreateDataSourceFromSourceDef() {
+    void testCreateDataSourceFromSourceDef() {
         SourceDef sourceDef =
                 new SourceDef(
                         "data-source-factory-1",
@@ -55,7 +55,8 @@ public class DataSourceTranslatorTest {
                                 new Configuration(),
                                 Thread.currentThread().getContextClassLoader()));
 
-        Assert.assertTrue(dataSource instanceof DataSourceFactory1.TestDataSource);
-        Assert.assertEquals("0.0.0.0", ((DataSourceFactory1.TestDataSource) dataSource).getHost());
+        Assertions.assertTrue(dataSource instanceof DataSourceFactory1.TestDataSource);
+        Assertions.assertEquals(
+                "0.0.0.0", ((DataSourceFactory1.TestDataSource) dataSource).getHost());
     }
 }


### PR DESCRIPTION
As shown in https://github.com/apache/flink-cdc/pull/3387, adjust test of cdc composer from junit4 to junit5.