### PR TITLE
[FLINK-35467][cdc-dist][bin] Respect externally set FLINK_CONF_DIR for CDC task configuration.

### DIFF
--- a/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
+++ b/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
@@ -37,8 +37,12 @@ fi
 # Setup Flink related configurations
 # Setting _FLINK_HOME_DETERMINED in order to avoid config.sh to overwrite it
 _FLINK_HOME_DETERMINED=1
-# FLINK_CONF_DIR is required by config.sh
-FLINK_CONF_DIR=$FLINK_HOME/conf
+
+# Before modifying FLINK_CONF_DIR, check if it's already set externally.
+if [ -z "$FLINK_CONF_DIR" ]; then
+    FLINK_CONF_DIR=$FLINK_HOME/conf
+fi
+
 # Use config.sh to setup Flink related configurations
 . $FLINK_HOME/bin/config.sh
 


### PR DESCRIPTION
Refer to: https://issues.apache.org/jira/browse/FLINK-35467

Respect externally set FLINK_CONF_DIR for CDC task configuration

The script has been modified to check if the FLINK_CONF_DIR environment variable is set externally before defaulting to $FLINK_HOME/conf. This change allows users to specify a custom configuration directory for Flink, ensuring that CDC tasks read from the correct flink-conf.yaml file.