### PR TITLE
use lazy initialization to resolve circular dependency between the `DataFieldSerializer`, `DataTypeSerializer`, and `RowTypeSerializer` classes that causes NPE for certain RowTypes like nested row type

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/schema/DataFieldSerializer.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/schema/DataFieldSerializer.java
@@ -39,7 +39,14 @@ public class DataFieldSerializer extends TypeSerializerSingleton<DataField> {
     public static final DataFieldSerializer INSTANCE = new DataFieldSerializer();
 
     private final StringSerializer stringSerializer = StringSerializer.INSTANCE;
-    private final DataTypeSerializer dataTypeSerializer = new DataTypeSerializer();
+    private DataTypeSerializer dataTypeSerializer;
+
+    private DataTypeSerializer getDataTypeSerializer() {
+        if (dataTypeSerializer == null) {
+            dataTypeSerializer = new DataTypeSerializer();
+        }
+        return dataTypeSerializer;
+    }
 
     @Override
     public boolean isImmutableType() {
@@ -55,7 +62,7 @@ public class DataFieldSerializer extends TypeSerializerSingleton<DataField> {
     public DataField copy(DataField from) {
         return new DataField(
                 stringSerializer.copy(from.getName()),
-                dataTypeSerializer.copy(from.getType()),
+                getDataTypeSerializer().copy(from.getType()),
                 stringSerializer.copy(from.getDescription()));
     }
 
@@ -72,14 +79,14 @@ public class DataFieldSerializer extends TypeSerializerSingleton<DataField> {
     @Override
     public void serialize(DataField record, DataOutputView target) throws IOException {
         stringSerializer.serialize(record.getName(), target);
-        dataTypeSerializer.serialize(record.getType(), target);
+        getDataTypeSerializer().serialize(record.getType(), target);
         stringSerializer.serialize(record.getDescription(), target);
     }
 
     @Override
     public DataField deserialize(DataInputView source) throws IOException {
         String name = stringSerializer.deserialize(source);
-        DataType type = dataTypeSerializer.deserialize(source);
+        DataType type = getDataTypeSerializer().deserialize(source);
         String desc = stringSerializer.deserialize(source);
         return new DataField(name, type, desc);
     }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/schema/DataTypeSerializer.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/schema/DataTypeSerializer.java
@@ -55,7 +55,14 @@ public class DataTypeSerializer extends TypeSerializer<DataType> {
 
     private final EnumSerializer<DataTypeClass> enumSerializer =
             new EnumSerializer<>(DataTypeClass.class);
-    private final RowTypeSerializer rowTypeSerializer = RowTypeSerializer.INSTANCE;
+    private RowTypeSerializer rowTypeSerializer;
+
+    private RowTypeSerializer getRowTypeSerializer() {
+        if (rowTypeSerializer == null) {
+            rowTypeSerializer = RowTypeSerializer.INSTANCE;
+        }
+        return rowTypeSerializer;
+    }
 
     @Override
     public boolean isImmutableType() {
@@ -75,7 +82,7 @@ public class DataTypeSerializer extends TypeSerializer<DataType> {
     @Override
     public DataType copy(DataType from) {
         if (from instanceof RowType) {
-            return rowTypeSerializer.copy((RowType) from);
+            return getRowTypeSerializer().copy((RowType) from);
         }
         return from;
     }
@@ -94,7 +101,7 @@ public class DataTypeSerializer extends TypeSerializer<DataType> {
     public void serialize(DataType record, DataOutputView target) throws IOException {
         if (record instanceof RowType) {
             enumSerializer.serialize(DataTypeClass.ROW, target);
-            rowTypeSerializer.serialize((RowType) record, target);
+            getRowTypeSerializer().serialize((RowType) record, target);
         } else if (record instanceof BinaryType) {
             enumSerializer.serialize(DataTypeClass.BINARY, target);
             target.writeBoolean(record.isNullable());
@@ -178,7 +185,7 @@ public class DataTypeSerializer extends TypeSerializer<DataType> {
     public DataType deserialize(DataInputView source) throws IOException {
         DataTypeClass dataTypeClass = enumSerializer.deserialize(source);
         if (dataTypeClass == DataTypeClass.ROW) {
-            return rowTypeSerializer.deserialize(source);
+            return getRowTypeSerializer().deserialize(source);
         }
         boolean isNullable = source.readBoolean();
         switch (dataTypeClass) {
@@ -255,12 +262,12 @@ public class DataTypeSerializer extends TypeSerializer<DataType> {
         }
         DataTypeSerializer that = (DataTypeSerializer) o;
         return Objects.equals(enumSerializer, that.enumSerializer)
-                && Objects.equals(rowTypeSerializer, that.rowTypeSerializer);
+                && Objects.equals(getRowTypeSerializer(), that.getRowTypeSerializer());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enumSerializer, rowTypeSerializer);
+        return Objects.hash(enumSerializer, getRowTypeSerializer());
     }
 
     @Override

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/schema/DataTypeSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/schema/DataTypeSerializerTest.java
@@ -20,10 +20,22 @@ package org.apache.flink.cdc.runtime.serializer.schema;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.types.RowType;
 import org.apache.flink.cdc.runtime.serializer.SerializerTestBase;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /** A test for the {@link DataTypeSerializer}. */
 public class DataTypeSerializerTest extends SerializerTestBase<DataType> {
@@ -80,4 +92,38 @@ public class DataTypeSerializerTest extends SerializerTestBase<DataType> {
                         Arrays.stream(allTypes), Arrays.stream(allTypes).map(DataType::notNull))
                 .toArray(DataType[]::new);
     }
+
+    @Test
+    void testNestedRow() throws IOException {
+        RowType innerMostRowType = RowType.of(DataTypes.BIGINT());
+        RowType outerRowType = RowType.of(
+                DataTypes.ROW(DataTypes.FIELD("outerRow", innerMostRowType)));
+
+        DataTypeSerializer serializer = new DataTypeSerializer();
+
+        // Log to ensure INSTANCE is initialized
+        assertNotNull(RowTypeSerializer.INSTANCE, "RowTypeSerializer.INSTANCE is null");
+        System.out.println("RowTypeSerializer.INSTANCE is initialized");
+
+        // Copy the RowType
+        RowType copiedRow = (RowType) serializer.copy(outerRowType);
+        assertNotNull(copiedRow, "Copied RowType is null");
+        System.out.println("Copied RowType: " + copiedRow);
+
+        // Serialize the RowType
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        DataOutputView outputView = new DataOutputViewStreamWrapper(byteArrayOutputStream);
+        serializer.serialize(outerRowType, outputView);
+
+        // Deserialize the RowType
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+        DataInputView inputView = new DataInputViewStreamWrapper(byteArrayInputStream);
+        RowType deserializedRow = (RowType) serializer.deserialize(inputView);
+
+        // Assert that the deserialized RowType is not null and equals the original
+        assertNotNull(deserializedRow, "Deserialized RowType is null");
+        assertEquals(outerRowType, deserializedRow, "Deserialized RowType does not match the original");
+        System.out.println("Deserialized RowType: " + deserializedRow);
+    }
+
 }

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/schema/DataTypeSerializerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/serializer/schema/DataTypeSerializerTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
@@ -96,8 +97,8 @@ public class DataTypeSerializerTest extends SerializerTestBase<DataType> {
     @Test
     void testNestedRow() throws IOException {
         RowType innerMostRowType = RowType.of(DataTypes.BIGINT());
-        RowType outerRowType = RowType.of(
-                DataTypes.ROW(DataTypes.FIELD("outerRow", innerMostRowType)));
+        RowType outerRowType =
+                RowType.of(DataTypes.ROW(DataTypes.FIELD("outerRow", innerMostRowType)));
 
         DataTypeSerializer serializer = new DataTypeSerializer();
 
@@ -116,14 +117,15 @@ public class DataTypeSerializerTest extends SerializerTestBase<DataType> {
         serializer.serialize(outerRowType, outputView);
 
         // Deserialize the RowType
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+        ByteArrayInputStream byteArrayInputStream =
+                new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
         DataInputView inputView = new DataInputViewStreamWrapper(byteArrayInputStream);
         RowType deserializedRow = (RowType) serializer.deserialize(inputView);
 
         // Assert that the deserialized RowType is not null and equals the original
         assertNotNull(deserializedRow, "Deserialized RowType is null");
-        assertEquals(outerRowType, deserializedRow, "Deserialized RowType does not match the original");
+        assertEquals(
+                outerRowType, deserializedRow, "Deserialized RowType does not match the original");
         System.out.println("Deserialized RowType: " + deserializedRow);
     }
-
 }


### PR DESCRIPTION
There is a circular dependency between the `DataFieldSerializer`, `DataTypeSerializer`, and `RowTypeSerializer` classes. This circular dependency can lead to incomplete initialization of the serializers, causing a `NullPointerException` when you attempt to use them.

Here's a breakdown of the problem:

1. `DataFieldSerializer` has a `DataTypeSerializer` instance.
2. `DataTypeSerializer` has a `RowTypeSerializer` instance.
3. `RowTypeSerializer` has a `ListSerializer<DataField>` instance, which in turn uses `DataFieldSerializer`.

This circular dependency can cause the serializers to be in an incomplete state when they are first accessed, leading to the `NullPointerException`. 

Code below is enough to re-create this NPE
```
        RowType innerMostRowType = RowType.of(DataTypes.BIGINT());
        RowType outerRowType = RowType.of(
                DataTypes.ROW(DataTypes.FIELD("outerRow", innerMostRowType)));

        DataTypeSerializer serializer = new DataTypeSerializer();


        assertNotNull(RowTypeSerializer.INSTANCE, "RowTypeSerializer.INSTANCE is null");
        RowType copiedRow = (RowType) serializer.copy(outerRowType);

```