### PR TITLE
[FLINK-35627][pepeline-connector][paimon] store MultiTableCommittable…

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonCommitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonCommitter.java
@@ -47,7 +47,7 @@ public class PaimonCommitter implements Committer<MultiTableCommittable> {
 
     @Override
     public void commit(Collection<CommitRequest<MultiTableCommittable>> commitRequests)
-            throws IOException, InterruptedException {
+            throws IOException {
         if (commitRequests.isEmpty()) {
             return;
         }
@@ -58,7 +58,7 @@ public class PaimonCommitter implements Committer<MultiTableCommittable> {
         long checkpointId = committables.get(0).checkpointId();
         WrappedManifestCommittable wrappedManifestCommittable =
                 storeMultiCommitter.combine(checkpointId, 1L, committables);
-        storeMultiCommitter.commit(Collections.singletonList(wrappedManifestCommittable));
+        storeMultiCommitter.filterAndCommit(Collections.singletonList(wrappedManifestCommittable));
     }
 
     @Override


### PR DESCRIPTION
… in state to avoid conflict when job restarted.

Refer to [RestoreAndFailCommittableStateManager](https://github.com/apache/paimon/blob/f2c87287666e0e77859f85b43abdc30b1845cf14/paimon-flink/paimon-flink-common/src/main/java/org/apache/paimon/flink/sink/RestoreAndFailCommittableStateManager.java#L46) in Paimon repo.

Paimon relies on a retry mechanism to resolve conflicts and requires saving commit information to a state for multiple attempts.


