### PR TITLE
[hotfix][tests] Separate Pipeline and Source E2e tests

### DIFF
--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -94,8 +94,10 @@ env:
   flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc,\
   flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-vitess-cdc"
   
-  MODULES_E2E: "\
-  flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests,\
+  MODULES_PIPELINE_E2E: "\
+  flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests"
+
+  MODULES_SOURCE_E2E: "\
   flink-cdc-e2e-tests/flink-cdc-source-e2e-tests"
 
 jobs:
@@ -145,7 +147,8 @@ jobs:
                   "oceanbase",
                   "db2",
                   "vitess",
-                  "e2e"
+                  "pipeline_e2e",
+                  "source_e2e"
         ]
     timeout-minutes: 120
     env:
@@ -216,13 +219,17 @@ jobs:
               ("vitess")
                modules=${{ env.MODULES_VITESS }}
               ;;
-              ("e2e")
-               compile_modules="${{ env.MODULES_CORE }},${{ env.MODULES_PIPELINE_CONNECTORS }},${{ env.MODULES_MYSQL }},${{ env.MODULES_POSTGRES }},${{ env.MODULES_ORACLE }},${{ env.MODULES_MONGODB }},${{ env.MODULES_SQLSERVER }},${{ env.MODULES_TIDB }},${{ env.MODULES_OCEANBASE }},${{ env.MODULES_DB2 }},${{ env.MODULES_VITESS }},${{ env.MODULES_E2E }}"
-               modules=${{ env.MODULES_E2E }}
+              ("pipeline_e2e")
+               compile_modules="${{ env.MODULES_CORE }},${{ env.MODULES_PIPELINE_CONNECTORS }},${{ env.MODULES_MYSQL }},${{ env.MODULES_POSTGRES }},${{ env.MODULES_ORACLE }},${{ env.MODULES_MONGODB }},${{ env.MODULES_SQLSERVER }},${{ env.MODULES_TIDB }},${{ env.MODULES_OCEANBASE }},${{ env.MODULES_DB2 }},${{ env.MODULES_VITESS }},${{ env.MODULES_PIPELINE_E2E }}"
+               modules=${{ env.MODULES_PIPELINE_E2E }}
+              ;;
+              ("source_e2e")
+               compile_modules="${{ env.MODULES_CORE }},${{ env.MODULES_PIPELINE_CONNECTORS }},${{ env.MODULES_MYSQL }},${{ env.MODULES_POSTGRES }},${{ env.MODULES_ORACLE }},${{ env.MODULES_MONGODB }},${{ env.MODULES_SQLSERVER }},${{ env.MODULES_TIDB }},${{ env.MODULES_OCEANBASE }},${{ env.MODULES_DB2 }},${{ env.MODULES_VITESS }},${{ env.MODULES_SOURCE_E2E }}"
+               modules=${{ env.MODULES_SOURCE_E2E }}
               ;;
           esac
 
-          if [ ${{ matrix.module }} != "e2e" ]; then
+          if [ ${{ matrix.module }} != "pipeline_e2e" ] && [ ${{ matrix.module }} != "source_e2e" ]; then
             compile_modules=$modules
           fi
 


### PR DESCRIPTION
After #3489 got merged, a regular E2e CI run requires approximately 1h 15min to run, and JUnit will not execute pipeline E2e cases until all source E2e cases complete successfully.

Considering pipeline connectors are under active development now, this PR changes workflow jobs, allowing pipeline e2e tests to be executed independently.