### PR TITLE
[FLINK-35647][route] Allow symbol replacement to simplify routing rules

### DIFF
--- a/docs/content.zh/docs/core-concept/route.md
+++ b/docs/content.zh/docs/core-concept/route.md
@@ -30,12 +30,12 @@ under the License.
 # Parameters
 To describe a route, the follows are required:  
 
-| parameter      | meaning                                            | optional/required |
-|----------------|----------------------------------------------------|-------------------|
-| source-table   | Source table id, supports regular expressions      | required          |
-| sink-table     | Sink table id, supports regular expressions        | required          |
-| replace-symbol | Special symbol in sink-table for pattern replacing | optional          |
-| description    | Routing rule description(a default value provided) | optional          |
+| parameter      | meaning                                                                                     | optional/required |
+|----------------|---------------------------------------------------------------------------------------------|-------------------|
+| source-table   | Source table id, supports regular expressions                                               | required          |
+| sink-table     | Sink table id, supports regular expressions                                                 | required          |
+| replace-symbol | Special symbol in sink-table for pattern replacing, will be replaced by original table name | optional          |
+| description    | Routing rule description(a default value provided)                                          | optional          |
 
 A route module can contain a list of source-table/sink-table rules.
 

--- a/docs/content.zh/docs/core-concept/route.md
+++ b/docs/content.zh/docs/core-concept/route.md
@@ -33,7 +33,7 @@ To describe a route, the follows are required:
 | parameter      | meaning                                                                                     | optional/required |
 |----------------|---------------------------------------------------------------------------------------------|-------------------|
 | source-table   | Source table id, supports regular expressions                                               | required          |
-| sink-table     | Sink table id, supports regular expressions                                                 | required          |
+| sink-table     | Sink table id, supports symbol replacement                                                  | required          |
 | replace-symbol | Special symbol in sink-table for pattern replacing, will be replaced by original table name | optional          |
 | description    | Routing rule description(a default value provided)                                          | optional          |
 

--- a/docs/content.zh/docs/core-concept/route.md
+++ b/docs/content.zh/docs/core-concept/route.md
@@ -30,11 +30,12 @@ under the License.
 # Parameters
 To describe a route, the follows are required:  
 
-| parameter    | meaning                                            | optional/required |
-|--------------|----------------------------------------------------|-------------------|
-| source-table | Source table id, supports regular expressions      | required          |
-| sink-table   | Sink table id, supports regular expressions        | required          |
-| description  | Routing rule description(a default value provided) | optional          |
+| parameter      | meaning                                            | optional/required |
+|----------------|----------------------------------------------------|-------------------|
+| source-table   | Source table id, supports regular expressions      | required          |
+| sink-table     | Sink table id, supports regular expressions        | required          |
+| replace-symbol | Special symbol in sink-table for pattern replacing | optional          |
+| description    | Routing rule description(a default value provided) | optional          |
 
 A route module can contain a list of source-table/sink-table rules.
 
@@ -72,3 +73,17 @@ route:
     sink-table: ods_db.ods_products
     description: sync products table to ods_products
 ```
+
+## Pattern Replacement in routing rules
+
+If you'd like to route source tables and rename them to sink tables with specific patterns, `replace-symbol` could be used to resemble source table names like this:
+
+```yaml
+route:
+  - source-table: source_db.\.*
+    sink-table: sink_db.<>
+    replace-symbol: <>
+    description: route all tables in source_db to sink_db
+```
+
+Then, all tables including `source_db.XXX` will be routed to `sink_db.XXX` without hassle.

--- a/docs/content/docs/core-concept/route.md
+++ b/docs/content/docs/core-concept/route.md
@@ -30,12 +30,12 @@ under the License.
 # Parameters
 To describe a route, the follows are required:  
 
-| parameter      | meaning                                            | optional/required |
-|----------------|----------------------------------------------------|-------------------|
-| source-table   | Source table id, supports regular expressions      | required          |
-| sink-table     | Sink table id, supports regular expressions        | required          |
-| replace-symbol | Special symbol in sink-table for pattern replacing | optional          |
-| description    | Routing rule description(a default value provided) | optional          |
+| parameter      | meaning                                                                                     | optional/required |
+|----------------|---------------------------------------------------------------------------------------------|-------------------|
+| source-table   | Source table id, supports regular expressions                                               | required          |
+| sink-table     | Sink table id, supports regular expressions                                                 | required          |
+| replace-symbol | Special symbol in sink-table for pattern replacing, will be replaced by original table name | optional          |
+| description    | Routing rule description(a default value provided)                                          | optional          |
 
 A route module can contain a list of source-table/sink-table rules.
 

--- a/docs/content/docs/core-concept/route.md
+++ b/docs/content/docs/core-concept/route.md
@@ -33,7 +33,7 @@ To describe a route, the follows are required:
 | parameter      | meaning                                                                                     | optional/required |
 |----------------|---------------------------------------------------------------------------------------------|-------------------|
 | source-table   | Source table id, supports regular expressions                                               | required          |
-| sink-table     | Sink table id, supports regular expressions                                                 | required          |
+| sink-table     | Sink table id, supports symbol replacement                                                  | required          |
 | replace-symbol | Special symbol in sink-table for pattern replacing, will be replaced by original table name | optional          |
 | description    | Routing rule description(a default value provided)                                          | optional          |
 

--- a/docs/content/docs/core-concept/route.md
+++ b/docs/content/docs/core-concept/route.md
@@ -30,11 +30,12 @@ under the License.
 # Parameters
 To describe a route, the follows are required:  
 
-| parameter    | meaning                                            | optional/required |
-|--------------|----------------------------------------------------|-------------------|
-| source-table | Source table id, supports regular expressions      | required          |
-| sink-table   | Sink table id, supports regular expressions        | required          |
-| description  | Routing rule description(a default value provided) | optional          |
+| parameter      | meaning                                            | optional/required |
+|----------------|----------------------------------------------------|-------------------|
+| source-table   | Source table id, supports regular expressions      | required          |
+| sink-table     | Sink table id, supports regular expressions        | required          |
+| replace-symbol | Special symbol in sink-table for pattern replacing | optional          |
+| description    | Routing rule description(a default value provided) | optional          |
 
 A route module can contain a list of source-table/sink-table rules.
 
@@ -72,3 +73,17 @@ route:
     sink-table: ods_db.ods_products
     description: sync products table to ods_products
 ```
+
+## Pattern Replacement in routing rules
+
+If you'd like to route source tables and rename them to sink tables with specific patterns, `replace-symbol` could be used to resemble source table names like this:
+
+```yaml
+route:
+  - source-table: source_db.\.*
+    sink-table: sink_db.<>
+    replace-symbol: <>
+    description: route all tables in source_db to sink_db
+```
+
+Then, all tables including `source_db.XXX` will be routed to `sink_db.XXX` without hassle.

--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -55,6 +55,7 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
     // Route keys
     private static final String ROUTE_SOURCE_TABLE_KEY = "source-table";
     private static final String ROUTE_SINK_TABLE_KEY = "sink-table";
+    private static final String ROUTE_REPLACE_SYMBOL = "replace-symbol";
     private static final String ROUTE_DESCRIPTION_KEY = "description";
 
     // Transform keys
@@ -164,11 +165,15 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
                                 "Missing required field \"%s\" in route configuration",
                                 ROUTE_SINK_TABLE_KEY)
                         .asText();
+        String replaceSymbol =
+                Optional.ofNullable(routeNode.get(ROUTE_REPLACE_SYMBOL))
+                        .map(JsonNode::asText)
+                        .orElse(null);
         String description =
                 Optional.ofNullable(routeNode.get(ROUTE_DESCRIPTION_KEY))
                         .map(JsonNode::asText)
                         .orElse(null);
-        return new RouteDef(sourceTable, sinkTable, description);
+        return new RouteDef(sourceTable, sinkTable, replaceSymbol, description);
     }
 
     private TransformDef toTransformDef(JsonNode transformNode) {

--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
@@ -373,12 +373,12 @@ class YamlPipelineDefinitionParserTest {
                     Arrays.asList(
                             new RouteDef(
                                     "mydb.default.app_order_.*",
-                                    "odsdb.default.app_order",
+                                    "odsdb.default.app_order_<>",
                                     "<>",
                                     "sync all sharding tables to one"),
                             new RouteDef(
                                     "mydb.default.web_order",
-                                    "odsdb.default.ods_web_order",
+                                    "odsdb.default.ods_web_order_>_<",
                                     ">_<",
                                     "sync table to with given prefix ods_")),
                     Arrays.asList(

--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
@@ -166,6 +166,15 @@ class YamlPipelineDefinitionParserTest {
                                 + "Or use 'UTC' without time zone and daylight saving time.");
     }
 
+    @Test
+    void testRouteWithReplacementSymbol() throws Exception {
+        URL resource =
+                Resources.getResource("definitions/pipeline-definition-full-with-repsym.yaml");
+        YamlPipelineDefinitionParser parser = new YamlPipelineDefinitionParser();
+        PipelineDef pipelineDef = parser.parse(Paths.get(resource.toURI()), new Configuration());
+        assertThat(pipelineDef).isEqualTo(fullDefWithRouteRepSym);
+    }
+
     private final PipelineDef fullDef =
             new PipelineDef(
                     new SourceDef(
@@ -197,10 +206,12 @@ class YamlPipelineDefinitionParserTest {
                             new RouteDef(
                                     "mydb.default.app_order_.*",
                                     "odsdb.default.app_order",
+                                    null,
                                     "sync all sharding tables to one"),
                             new RouteDef(
                                     "mydb.default.web_order",
                                     "odsdb.default.ods_web_order",
+                                    null,
                                     "sync table to with given prefix ods_")),
                     Arrays.asList(
                             new TransformDef(
@@ -258,10 +269,12 @@ class YamlPipelineDefinitionParserTest {
                             new RouteDef(
                                     "mydb.default.app_order_.*",
                                     "odsdb.default.app_order",
+                                    null,
                                     "sync all sharding tables to one"),
                             new RouteDef(
                                     "mydb.default.web_order",
                                     "odsdb.default.ods_web_order",
+                                    null,
                                     "sync table to with given prefix ods_")),
                     Arrays.asList(
                             new TransformDef(
@@ -312,7 +325,10 @@ class YamlPipelineDefinitionParserTest {
                                             .build())),
                     Collections.singletonList(
                             new RouteDef(
-                                    "mydb.default.app_order_.*", "odsdb.default.app_order", null)),
+                                    "mydb.default.app_order_.*",
+                                    "odsdb.default.app_order",
+                                    null,
+                                    null)),
                     Collections.emptyList(),
                     Configuration.fromMap(
                             ImmutableMap.<String, String>builder()
@@ -326,4 +342,67 @@ class YamlPipelineDefinitionParserTest {
                     Collections.emptyList(),
                     Collections.emptyList(),
                     Configuration.fromMap(Collections.singletonMap("parallelism", "1")));
+
+    private final PipelineDef fullDefWithRouteRepSym =
+            new PipelineDef(
+                    new SourceDef(
+                            "mysql",
+                            "source-database",
+                            Configuration.fromMap(
+                                    ImmutableMap.<String, String>builder()
+                                            .put("host", "localhost")
+                                            .put("port", "3306")
+                                            .put("username", "admin")
+                                            .put("password", "pass")
+                                            .put(
+                                                    "tables",
+                                                    "adb.*, bdb.user_table_[0-9]+, [app|web]_order_.*")
+                                            .put(
+                                                    "chunk-column",
+                                                    "app_order_.*:id,web_order:product_id")
+                                            .put("capture-new-tables", "true")
+                                            .build())),
+                    new SinkDef(
+                            "kafka",
+                            "sink-queue",
+                            Configuration.fromMap(
+                                    ImmutableMap.<String, String>builder()
+                                            .put("bootstrap-servers", "localhost:9092")
+                                            .put("auto-create-table", "true")
+                                            .build())),
+                    Arrays.asList(
+                            new RouteDef(
+                                    "mydb.default.app_order_.*",
+                                    "odsdb.default.app_order",
+                                    "<>",
+                                    "sync all sharding tables to one"),
+                            new RouteDef(
+                                    "mydb.default.web_order",
+                                    "odsdb.default.ods_web_order",
+                                    ">_<",
+                                    "sync table to with given prefix ods_")),
+                    Arrays.asList(
+                            new TransformDef(
+                                    "mydb.app_order_.*",
+                                    "id, order_id, TO_UPPER(product_name)",
+                                    "id > 10 AND order_id > 100",
+                                    "id",
+                                    "product_name",
+                                    "comment=app order",
+                                    "project fields from source table"),
+                            new TransformDef(
+                                    "mydb.web_order_.*",
+                                    "CONCAT(id, order_id) as uniq_id, *",
+                                    "uniq_id > 10",
+                                    null,
+                                    null,
+                                    null,
+                                    "add new uniq_id for each row")),
+                    Configuration.fromMap(
+                            ImmutableMap.<String, String>builder()
+                                    .put("name", "source-database-sync-pipe")
+                                    .put("parallelism", "4")
+                                    .put("schema.change.behavior", "evolve")
+                                    .put("schema-operator.rpc-timeout", "1 h")
+                                    .build()));
 }

--- a/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full-with-repsym.yaml
+++ b/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full-with-repsym.yaml
@@ -1,0 +1,61 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+source:
+  type: mysql
+  name: source-database
+  host: localhost
+  port: 3306
+  username: admin
+  password: pass
+  tables: adb.*, bdb.user_table_[0-9]+, [app|web]_order_.*
+  chunk-column: app_order_.*:id,web_order:product_id
+  capture-new-tables: true
+
+sink:
+  type: kafka
+  name: sink-queue
+  bootstrap-servers: localhost:9092
+  auto-create-table: true
+
+route:
+  - source-table: mydb.default.app_order_.*
+    sink-table: odsdb.default.app_order
+    replace-symbol: "<>"
+    description: sync all sharding tables to one
+  - source-table: mydb.default.web_order
+    sink-table: odsdb.default.ods_web_order
+    replace-symbol: ">_<"
+    description: sync table to with given prefix ods_
+
+transform:
+  - source-table: mydb.app_order_.*
+    projection: id, order_id, TO_UPPER(product_name)
+    filter: id > 10 AND order_id > 100
+    primary-keys: id
+    partition-keys: product_name
+    table-options: comment=app order
+    description: project fields from source table
+  - source-table: mydb.web_order_.*
+    projection: CONCAT(id, order_id) as uniq_id, *
+    filter: uniq_id > 10
+    description: add new uniq_id for each row
+
+pipeline:
+  name: source-database-sync-pipe
+  parallelism: 4
+  schema.change.behavior: evolve
+  schema-operator.rpc-timeout: 1 h

--- a/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full-with-repsym.yaml
+++ b/flink-cdc-cli/src/test/resources/definitions/pipeline-definition-full-with-repsym.yaml
@@ -33,11 +33,11 @@ sink:
 
 route:
   - source-table: mydb.default.app_order_.*
-    sink-table: odsdb.default.app_order
+    sink-table: odsdb.default.app_order_<>
     replace-symbol: "<>"
     description: sync all sharding tables to one
   - source-table: mydb.default.web_order
-    sink-table: odsdb.default.ods_web_order
+    sink-table: odsdb.default.ods_web_order_>_<
     replace-symbol: ">_<"
     description: sync table to with given prefix ods_
 

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/route/RouteRule.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/route/RouteRule.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 /** Definition of a routing rule with replacement symbol. */
 public class RouteRule implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     public RouteRule(String sourceTable, String sinkTable, String replaceSymbol) {
         this.sourceTable = sourceTable;
         this.sinkTable = sinkTable;

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/route/RouteRule.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/route/RouteRule.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.route;
+
+import java.io.Serializable;
+
+/** Definition of a routing rule with replacement symbol. */
+public class RouteRule implements Serializable {
+
+    public RouteRule(String sourceTable, String sinkTable, String replaceSymbol) {
+        this.sourceTable = sourceTable;
+        this.sinkTable = sinkTable;
+        this.replaceSymbol = replaceSymbol;
+    }
+
+    public String sourceTable;
+    public String sinkTable;
+    public String replaceSymbol;
+}

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/RouteDef.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/RouteDef.java
@@ -36,11 +36,17 @@ import java.util.Optional;
 public class RouteDef {
     private final String sourceTable;
     private final String sinkTable;
+    private final String replaceSymbol;
     @Nullable private final String description;
 
-    public RouteDef(String sourceTable, String sinkTable, @Nullable String description) {
+    public RouteDef(
+            String sourceTable,
+            String sinkTable,
+            @Nullable String replaceSymbol,
+            @Nullable String description) {
         this.sourceTable = sourceTable;
         this.sinkTable = sinkTable;
+        this.replaceSymbol = replaceSymbol;
         this.description = description;
     }
 
@@ -50,6 +56,10 @@ public class RouteDef {
 
     public String getSinkTable() {
         return sinkTable;
+    }
+
+    public Optional<String> getReplaceSymbol() {
+        return Optional.ofNullable(replaceSymbol);
     }
 
     public Optional<String> getDescription() {
@@ -63,6 +73,8 @@ public class RouteDef {
                 + sourceTable
                 + ", sinkTable="
                 + sinkTable
+                + ", replaceSymbol="
+                + replaceSymbol
                 + ", description='"
                 + description
                 + '\''
@@ -80,11 +92,12 @@ public class RouteDef {
         RouteDef routeDef = (RouteDef) o;
         return Objects.equals(sourceTable, routeDef.sourceTable)
                 && Objects.equals(sinkTable, routeDef.sinkTable)
+                && Objects.equals(replaceSymbol, routeDef.replaceSymbol)
                 && Objects.equals(description, routeDef.description);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceTable, sinkTable, description);
+        return Objects.hash(sourceTable, sinkTable, replaceSymbol, description);
     }
 }

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/SchemaOperatorTranslator.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/SchemaOperatorTranslator.java
@@ -17,12 +17,11 @@
 
 package org.apache.flink.cdc.composer.flink.translator;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
-import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
+import org.apache.flink.cdc.common.route.RouteRule;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
 import org.apache.flink.cdc.composer.definition.RouteDef;
 import org.apache.flink.cdc.runtime.operators.schema.SchemaOperator;
@@ -80,10 +79,13 @@ public class SchemaOperatorTranslator {
             int parallelism,
             MetadataApplier metadataApplier,
             List<RouteDef> routes) {
-        List<Tuple2<String, TableId>> routingRules = new ArrayList<>();
+        List<RouteRule> routingRules = new ArrayList<>();
         for (RouteDef route : routes) {
             routingRules.add(
-                    Tuple2.of(route.getSourceTable(), TableId.parse(route.getSinkTable())));
+                    new RouteRule(
+                            route.getSourceTable(),
+                            route.getSinkTable(),
+                            route.getReplaceSymbol().orElse(null)));
         }
         SingleOutputStreamOperator<Event> stream =
                 input.transform(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -101,6 +101,11 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
     private transient TaskOperatorEventGateway toCoordinator;
     private transient SchemaEvolutionClient schemaEvolutionClient;
     private transient LoadingCache<TableId, Schema> cachedSchemas;
+
+    /**
+     * Storing mapping relations between upstream tableId (source table) mapping to downstream
+     * tableIds (sink tables).
+     */
     private transient LoadingCache<TableId, List<TableId>> tableIdMappingCache;
 
     private final long rpcTimeOutInMillis;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -91,7 +91,12 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
 
     private final List<RouteRule> routingRules;
 
+    /**
+     * Storing route source table selector, sink table name (before symbol replacement), and replace
+     * symbol in a tuple.
+     */
     private transient List<Tuple3<Selectors, String, String>> routes;
+
     private transient TaskOperatorEventGateway toCoordinator;
     private transient SchemaEvolutionClient schemaEvolutionClient;
     private transient LoadingCache<TableId, Schema> cachedSchemas;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorFactory.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorFactory.java
@@ -17,10 +17,9 @@
 
 package org.apache.flink.cdc.runtime.operators.schema;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.event.Event;
-import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.route.RouteRule;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
 import org.apache.flink.cdc.runtime.operators.schema.coordinator.SchemaRegistryProvider;
 import org.apache.flink.runtime.jobgraph.OperatorID;
@@ -40,12 +39,10 @@ public class SchemaOperatorFactory extends SimpleOperatorFactory<Event>
     private static final long serialVersionUID = 1L;
 
     private final MetadataApplier metadataApplier;
-    private final List<Tuple2<String, TableId>> routingRules;
+    private final List<RouteRule> routingRules;
 
     public SchemaOperatorFactory(
-            MetadataApplier metadataApplier,
-            List<Tuple2<String, TableId>> routingRules,
-            Duration rpcTimeOut) {
+            MetadataApplier metadataApplier, List<RouteRule> routingRules, Duration rpcTimeOut) {
         super(new SchemaOperator(routingRules, rpcTimeOut));
         this.metadataApplier = metadataApplier;
         this.routingRules = routingRules;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.cdc.runtime.operators.schema.coordinator;
 
-import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
@@ -25,6 +25,7 @@ import org.apache.flink.cdc.common.event.DropColumnEvent;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.route.RouteRule;
 import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.schema.PhysicalColumn;
 import org.apache.flink.cdc.common.schema.Schema;
@@ -48,19 +49,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /** Derive schema changes based on the routing rules. */
 public class SchemaDerivation {
     private final SchemaManager schemaManager;
-    private final List<Tuple2<Selectors, TableId>> routes;
     private final Map<TableId, Set<TableId>> derivationMapping;
+    private transient List<Tuple3<Selectors, String, String>> routes;
 
     public SchemaDerivation(
             SchemaManager schemaManager,
-            List<Tuple2<Selectors, TableId>> routes,
+            List<RouteRule> routeRules,
             Map<TableId, Set<TableId>> derivationMapping) {
         this.schemaManager = schemaManager;
-        this.routes = routes;
+        this.routes =
+                routeRules.stream()
+                        .map(
+                                rule -> {
+                                    String tableInclusions = rule.sourceTable;
+                                    Selectors selectors =
+                                            new Selectors.SelectorsBuilder()
+                                                    .includeTables(tableInclusions)
+                                                    .build();
+                                    return new Tuple3<>(
+                                            selectors, rule.sinkTable, rule.replaceSymbol);
+                                })
+                        .collect(Collectors.toList());
         this.derivationMapping = derivationMapping;
     }
 
@@ -69,7 +83,7 @@ public class SchemaDerivation {
         TableId originalTable = schemaChangeEvent.tableId();
         boolean noRouteMatched = true;
 
-        for (Tuple2<Selectors, TableId> route : routes) {
+        for (Tuple3<Selectors, String, String> route : routes) {
             // Check routing table
             if (!route.f0.isMatch(originalTable)) {
                 continue;
@@ -78,7 +92,7 @@ public class SchemaDerivation {
             noRouteMatched = false;
 
             // Matched a routing rule
-            TableId derivedTable = route.f1;
+            TableId derivedTable = resolveReplacement(originalTable, route);
             Set<TableId> originalTables =
                     derivationMapping.computeIfAbsent(derivedTable, t -> new HashSet<>());
             originalTables.add(originalTable);
@@ -132,6 +146,14 @@ public class SchemaDerivation {
         } else {
             return events;
         }
+    }
+
+    private TableId resolveReplacement(
+            TableId originalTable, Tuple3<Selectors, String, String> route) {
+        if (route.f2 != null) {
+            return TableId.parse(route.f1.replace(route.f2, originalTable.getTableName()));
+        }
+        return TableId.parse(route.f1);
     }
 
     public Map<TableId, Set<TableId>> getDerivationMapping() {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
@@ -55,6 +55,11 @@ import java.util.stream.Collectors;
 public class SchemaDerivation {
     private final SchemaManager schemaManager;
     private final Map<TableId, Set<TableId>> derivationMapping;
+
+    /**
+     * Storing route source table selector, sink table name (before symbol replacement), and replace
+     * symbol in a tuple.
+     */
     private transient List<Tuple3<Selectors, String, String>> routes;
 
     public SchemaDerivation(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
@@ -17,9 +17,8 @@
 
 package org.apache.flink.cdc.runtime.operators.schema.coordinator;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.event.TableId;
-import org.apache.flink.cdc.common.schema.Selectors;
+import org.apache.flink.cdc.common.route.RouteRule;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
 import org.apache.flink.cdc.runtime.operators.schema.SchemaOperator;
 import org.apache.flink.cdc.runtime.operators.schema.event.FlushSuccessEvent;
@@ -90,7 +89,7 @@ public class SchemaRegistry implements OperatorCoordinator, CoordinationRequestH
     /** Metadata applier for applying schema changes to external system. */
     private final MetadataApplier metadataApplier;
 
-    private final List<Tuple2<Selectors, TableId>> routes;
+    private final List<RouteRule> routes;
 
     /** The request handler that handle all requests and events. */
     private SchemaRegistryRequestHandler requestHandler;
@@ -104,7 +103,7 @@ public class SchemaRegistry implements OperatorCoordinator, CoordinationRequestH
             String operatorName,
             OperatorCoordinator.Context context,
             MetadataApplier metadataApplier,
-            List<Tuple2<Selectors, TableId>> routes) {
+            List<RouteRule> routes) {
         this.context = context;
         this.operatorName = operatorName;
         this.failedReasons = new HashMap<>();

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivationTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivationTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.cdc.runtime.operators.schema.coordinator;
 
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
@@ -25,10 +24,10 @@ import org.apache.flink.cdc.common.event.DropColumnEvent;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.route.RouteRule;
 import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.schema.PhysicalColumn;
 import org.apache.flink.cdc.common.schema.Schema;
-import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 
@@ -81,13 +80,9 @@ class SchemaDerivationTest {
                     .column(Column.physicalColumn("gender", DataTypes.STRING()))
                     .build();
 
-    private static final List<Tuple2<Selectors, TableId>> ROUTES =
+    private static final List<RouteRule> ROUTES =
             Collections.singletonList(
-                    Tuple2.of(
-                            new Selectors.SelectorsBuilder()
-                                    .includeTables("mydb.myschema.mytable[0-9]")
-                                    .build(),
-                            MERGED_TABLE));
+                    new RouteRule("mydb.myschema.mytable[0-9]", MERGED_TABLE.toString(), null));
 
     @Test
     void testOneToOneMapping() {


### PR DESCRIPTION
This closes FLINK-35647, inspired by #2908 and #2947. Credit goes to @icchux and @WholeWorld-Timothy.

---

Currently, we must provide explicit sink-table in pipeline route rules, which means if we'd like to route all tables in specific database and change names in pattern, there's no choice but write all rules separately, which is a chore.

This PR allows specifying a special "replacement symbol" to resemble original table name in route rules like this:

```yaml
route:
  - source-table: db.\.*
    sink-table: new_db.<>
    replace-symbol: <>
```

Now, `<>` will be replaced by upstream table name, so any tables like `db.tableX` will be routed to `new_db.tableX` automatically.
