### PR TITLE
[FLINK-35654][docs] Add CDC release verification & Installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ full database synchronization, sharding table synchronization, schema evolution 
 
 * Flink CDC tar could be downloaded from [Apache Flink Website](https://flink.apache.org/downloads/#apache-flink-cdc) or [GitHub Release Page](https://github.com/apache/flink-cdc/releases).
 * Pipeline and source connectors could be downloaded from [Maven Central Repository](https://mvnrepository.com/artifact/org.apache.flink) or [GitHub Release Page](https://github.com/apache/flink-cdc/releases).
-* If you're using Linux or macOS, you may install Flink CDC and connectors with Homebrew:
+* If you're using macOS, you may install Flink CDC and connectors with Homebrew:
 
 ```bash
 brew install apache-flink-cdc

--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ full database synchronization, sharding table synchronization, schema evolution 
 
 ![Flink CDC framework desigin](docs/static/fig/architecture.png)
 
+### Installation
 
+* Flink CDC tar could be downloaded from [Apache Flink Website](https://flink.apache.org/downloads/#apache-flink-cdc) or [GitHub Release Page](https://github.com/apache/flink-cdc/releases).
+* Pipeline and source connectors could be downloaded from [Maven Central Repository](https://mvnrepository.com/artifact/org.apache.flink) or [GitHub Release Page](https://github.com/apache/flink-cdc/releases).
+* If you're using Linux or macOS, you may install Flink CDC and connectors with Homebrew:
+
+```bash
+brew install apache-flink-cdc
+```
 
 ### Getting Started
 

--- a/docs/content.zh/docs/developer-guide/contribute-to-flink-cdc.md
+++ b/docs/content.zh/docs/developer-guide/contribute-to-flink-cdc.md
@@ -145,10 +145,10 @@ gpg --verify flink-cdc-3.1.0-src.tgz.asc flink-cdc-3.1.0-src.tgz
 4. 执行迁移测试。
 
 Flink CDC 尽力确保状态向后兼容性，即使用旧版本 CDC 保存的作业状态（Checkpoint / Savepoint）能够用于新版本的作业恢复。
-您可以通过 [Flink CDC Migration Test Utils](https://github.com/yuxiqian/migration-test) 脚本执行 CDC 迁移验证。
+您可以通过 [Flink CDC Migration Test Utils](https://github.com/apache/flink-cdc/tree/master/tools/mig-test) 脚本执行 CDC 迁移验证。
 
-* [Pipeline 作业迁移测试指南](https://github.com/yuxiqian/migration-test/blob/main/README.md)
-* [DataStream 作业迁移测试指南](https://github.com/yuxiqian/migration-test/blob/main/datastream/README.md)
+* [Pipeline 作业迁移测试指南](https://github.com/apache/flink-cdc/blob/master/tools/mig-test/README.md)
+* [DataStream 作业迁移测试指南](https://github.com/apache/flink-cdc/blob/master/tools/mig-test/datastream/README.md)
 
 5. 执行端到端测试。
 

--- a/docs/content.zh/docs/developer-guide/contribute-to-flink-cdc.md
+++ b/docs/content.zh/docs/developer-guide/contribute-to-flink-cdc.md
@@ -33,13 +33,14 @@ Bug报告，提议新的功能，加入社区邮件列表的讨论，贡献代�
 
 Flink CDC 社区的贡献不仅限于为项目贡献代码，下面列举了一些可以在社区贡献的内容。
 
-| 贡献方式  | 更多信息                                                                                                                                                                            |
-|:------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 提交BUG | 为了提交问题，您需要首先在 [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) 建立对应的issue，并在`Component/s`选择`Flink CDC`。然后在问题描述中详细描述遇到的问题的信息，如果可能的话，最好提供一下能够复现问题的操作步骤。         |
-| 贡献代码  | 请阅读 <a href="#code-contribution-guide">贡献代码指导</a>                                                                                                                               |
-| 代码评审  | 请阅读 <a href="#code-review-guide">代码评审指导</a>                                                                                                                                     |
-| 版本验证  | 请阅读 <a href="#release-validation-guide">版本验证指导</a>                                                                                                                              |                                                                                     |
-| 用户支持  | 通过 [Flink 用户邮件列表](https://flink.apache.org/what-is-flink/community/#mailing-lists) 来帮助回复用户问题，在 [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) 可以查询到最新的已知问题。 |
+| 贡献方式      | 更多信息                                                                                                                                                                            |
+|:----------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 提交BUG     | 为了提交问题，您需要首先在 [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) 建立对应的issue，并在`Component/s`选择`Flink CDC`。然后在问题描述中详细描述遇到的问题的信息，如果可能的话，最好提供一下能够复现问题的操作步骤。         |
+| 贡献代码      | 请阅读 <a href="#code-contribution-guide">贡献代码指导</a>                                                                                                                               |
+| 代码评审      | 请阅读 <a href="#code-review-guide">代码评审指导</a>                                                                                                                                     |
+| 版本验证      | 请阅读 <a href="#release-validation-guide">版本验证指导</a>                                                                                                                              |                                                            |
+| 用户支持      | 通过 [Flink 用户邮件列表](https://flink.apache.org/what-is-flink/community/#mailing-lists) 来帮助回复用户问题，在 [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) 可以查询到最新的已知问题。 |
+| 加入开发者邮件列表 | 关注 [Flink 开发者邮件列表](https://lists.apache.org/list.html?dev@flink.apache.org) 来参与设计方案讨论。                                                                                          |
 
 如果还有其他问题，可以通过 Flink Dev 邮件列表寻求帮助。
 
@@ -83,8 +84,8 @@ Flink CDC 项目通过众多贡献者的代码贡献来维护，改进和拓展�
 
 我们会定期发布新版本的 Flink CDC。
 
-根据 Apache Software Foundation 版本发布规则，
-我们会在每次发布前制作发布候选（Release Candidate）版本，
+根据 [Apache Software Foundation 版本发布规则](https://www.apache.org/legal/release-policy.html)，
+我们会在每次发布前制作发布候选（Release Candidate, RC）版本，
 并邀请社区成员对这一预发布版本进行测试与投票。
 
 欢迎您在 `dev@flink.apache.org` 邮件列表中参与版本验证工作。
@@ -106,6 +107,36 @@ Flink CDC 项目通过众多贡献者的代码贡献来维护，改进和拓展�
 * Windows (PowerShell): `Get-FileHash flink-cdc-*-bin.tar.gz -Algorithm SHA512 | Format-List`
 
 并验证结果是否与发布页面上的哈希值一致。
+
+为了验证软件包签名，您需要先安装 gpg（2.4 及更高版本）。
+
+首先，从 [KEYS](https://dist.apache.org/repos/dist/release/flink/KEYS) 下载负责发布的项目 PMC / Committer 的 GPG 公钥并导入：
+
+```bash
+gpg --import <releaser-public-key>
+```
+
+例如：
+
+```bash
+gpg  --import leonard-xu.pub
+```
+
+这里，`leonard-xu.pub` 文件即为之前下载的 @leonardBang 的公钥。
+
+然后，我们就可以使用 gpg 命令来验证签名：
+
+```bash
+gpg --verify flink-cdc-<VERSION>-src.tgz.asc flink-cdc-<VERSION>-src.tgz
+```
+
+例如，使用以下命令来验证 3.1.0 的源码包是否被正确签名：
+
+```bash
+gpg --verify flink-cdc-3.1.0-src.tgz.asc flink-cdc-3.1.0-src.tgz
+```
+
+正常情况下应该打印出 Good signature from "Leonard Xu ..."。
 
 3. 验证二进制包是否使用 JDK 8 进行编译。
 

--- a/docs/content.zh/docs/developer-guide/contribute-to-flink-cdc.md
+++ b/docs/content.zh/docs/developer-guide/contribute-to-flink-cdc.md
@@ -34,10 +34,11 @@ Bug报告，提议新的功能，加入社区邮件列表的讨论，贡献代�
 Flink CDC 社区的贡献不仅限于为项目贡献代码，下面列举了一些可以在社区贡献的内容。
 
 | 贡献方式  | 更多信息                                                                                                                                                                            |
-|:------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|:------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 提交BUG | 为了提交问题，您需要首先在 [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) 建立对应的issue，并在`Component/s`选择`Flink CDC`。然后在问题描述中详细描述遇到的问题的信息，如果可能的话，最好提供一下能够复现问题的操作步骤。         |
-| 贡献代码  | 请阅读 <a href="#code-contribution-guide">贡献代码指导</a>                                                                                                                                    |
-| 代码评审  | 请阅读 <a href="#code-review-guide">代码评审指导</a>                                                                                                                                          |
+| 贡献代码  | 请阅读 <a href="#code-contribution-guide">贡献代码指导</a>                                                                                                                               |
+| 代码评审  | 请阅读 <a href="#code-review-guide">代码评审指导</a>                                                                                                                                     |
+| 版本验证  | 请阅读 <a href="#release-validation-guide">版本验证指导</a>                                                                                                                              |                                                                                     |
 | 用户支持  | 通过 [Flink 用户邮件列表](https://flink.apache.org/what-is-flink/community/#mailing-lists) 来帮助回复用户问题，在 [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) 可以查询到最新的已知问题。 |
 
 如果还有其他问题，可以通过 Flink Dev 邮件列表寻求帮助。
@@ -77,3 +78,57 @@ Flink CDC 项目通过众多贡献者的代码贡献来维护，改进和拓展�
 3. 文档是否需要更新？
 
 如果代码提交加入了新的功能，这个新功能需要同时更新到文档中。
+
+<h2 id="release-validation-guide">版本验证指导</h2>
+
+我们会定期发布新版本的 Flink CDC。
+
+根据 Apache Software Foundation 版本发布规则，
+我们会在每次发布前制作发布候选（Release Candidate）版本，
+并邀请社区成员对这一预发布版本进行测试与投票。
+
+欢迎您在 `dev@flink.apache.org` 邮件列表中参与版本验证工作。
+验证内容可能包括以下方面：
+
+1. 验证源代码是否可以正常编译。
+
+目前，Flink CDC 使用 [Maven](https://maven.apache.org/) 3 作为构建工具，并在 JDK 8 平台上进行编译。
+您可以下载 RC 版本的源代码包，并使用 `mvn clean package -Dfast` 命令进行编译，
+并留意任何意料之外的错误或警告。
+
+2. 验证二进制包签名是否一致。
+
+为了确保发布的预编译包没有被篡改，在发布任何二进制 tar 包时总会附上对应文件的哈希值，以便用户进行完整性校验。
+您可以下载 RC 版本的二进制 tar 包，并使用以下命令计算其 SHA512 哈希值：
+
+* Linux: `sha512sum flink-cdc-*-bin.tar.gz`
+* macOS: `shasum -a 512 flink-cdc-*-bin.tar.gz`
+* Windows (PowerShell): `Get-FileHash flink-cdc-*-bin.tar.gz -Algorithm SHA512 | Format-List`
+
+并验证结果是否与发布页面上的哈希值一致。
+
+3. 验证二进制包是否使用 JDK 8 进行编译。
+
+解压预编译的二进制 jar 包，并检查其中的 `META-INF\MANIFEST.MF` 文件的 `Build-Jdk` 条目是否正确。
+
+4. 执行迁移测试。
+
+Flink CDC 尽力确保状态向后兼容性，即使用旧版本 CDC 保存的作业状态（Checkpoint / Savepoint）能够用于新版本的作业恢复。
+您可以通过 [Flink CDC Migration Test Utils](https://github.com/yuxiqian/migration-test) 脚本执行 CDC 迁移验证。
+
+* [Pipeline 作业迁移测试指南](https://github.com/yuxiqian/migration-test/blob/main/README.md)
+* [DataStream 作业迁移测试指南](https://github.com/yuxiqian/migration-test/blob/main/datastream/README.md)
+
+5. 执行端到端测试。
+
+您可以使用 RC 版本的 Flink CDC 与受支持的 Flink 版本一起，
+尝试编写一些 Pipeline / SQL / DataStream 作业，
+观察作业工作状况是否正常。
+
+6. 检查许可协议。
+
+Flink CDC 依赖许多第三方开源软件，我们需要确保这些依赖的许可证信息被正确地包含在 NOTICE 文件中。
+
+此外，一些许可协议与 Flink CDC 采用的 Apache 2.0 许可证不兼容，
+使用这些协议的软件不能被打包到 Flink CDC 中。
+您可以在 [ASF 3RD PARTY LICENSE POLICY](https://www.apache.org/legal/resolved.html) 获取更多信息。

--- a/docs/content/docs/developer-guide/contribute-to-flink-cdc.md
+++ b/docs/content/docs/developer-guide/contribute-to-flink-cdc.md
@@ -36,12 +36,13 @@ improving website, testing release candidates and writing corresponding blog etc
 Contributing to Flink CDC goes beyond writing code for the project. Here are different opportunities to help the 
 project as follows.
 
-| Area            | Further information                                                                                                                                                                                                                                                                                                                                 |
-|:----------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Report Bug      | To report a problem, open an issue in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) and select `Flink CDC` in `Component/s`. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem.                                                       |
-| Contribute Code | Read the <a href="#code-contribution-guide">Code Contribution Guide</a>                                                                                                                                                                                                                                                                             |
-| Code Reviews    | Read the <a href="#code-review-guide">Code Review Guide</a>                                                                                                                                                                                                                                                                                         |
-| Support Users   | Reply to questions on the [flink user mailing list](https://flink.apache.org/what-is-flink/community/#mailing-lists), check the latest issues in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) for tickets which are actually user questions.                                                                                  |
+| Area                 | Further information                                                                                                                                                                                                                                                                           |
+|:---------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Report Bug           | To report a problem, open an issue in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) and select `Flink CDC` in `Component/s`. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem. |
+| Contribute Code      | Read the <a href="#code-contribution-guide">Code Contribution Guide</a>                                                                                                                                                                                                                       |
+| Code Reviews         | Read the <a href="#code-review-guide">Code Review Guide</a>                                                                                                                                                                                                                                   |
+| Release Verification | Read the <a href="#release-validation-guide">Code Review Guide</a>                                                                                                                                                                                                                            |
+| Support Users        | Reply to questions on the [flink user mailing list](https://flink.apache.org/what-is-flink/community/#mailing-lists), check the latest issues in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) for tickets which are actually user questions.                            |
 
 Any other question? Reach out to the Dev mail list to get help!
 
@@ -82,3 +83,56 @@ not need a long description.
 3. Are the Documentation Updated?
 
 If the pull request introduces a new feature, the feature should be documented.
+
+<h2 id="release-validation-guide">Release Verification Guide</h2>
+
+We will prepare for new releases of Flink CDC regularly.
+
+According to the Apache Software Foundation releasing SOP,
+we will make a release candidate version before each release,
+and invite community members to test and vote on this pre-release version.
+
+Everyone is welcomed to participate in the version verification work in `dev@flink.apache.org` mailing list.
+The verification content may include the following aspects:
+
+1. Verify if source code could be compiled successfully.
+
+Currently, Flink CDC uses [Maven](https://maven.apache.org/) 3 as the build tool and compiles on the JDK 8 platform.
+You can download the RC version of the source code package and compile it using the `mvn clean package -Dfast` command,
+and check if there's any unexpected errors or warnings.
+
+2. Verify if tarball checksum matches.
+
+To ensure the genuinity and integrity of released binary packages, a SHA512 hash value of the corresponding file is attached to any released binary tarball so that users can verify the integrity.
+You can download the binary tarball of the RC version and calculate its SHA512 hash value with the following command:
+
+* Linux: `sha512sum flink-cdc-*-bin.tar.gz`
+* macOS: `shasum -a 512 flink-cdc-*-bin.tar.gz`
+* Windows (PowerShell): `Get-FileHash flink-cdc-*-bin.tar.gz -Algorithm SHA512 | Format-List`
+
+3. Verify that the binary package was compiled with JDK 8.
+
+Unpack the precompiled binary jar package and check if the `Build-Jdk` entry in the `META-INF\MANIFEST.MF` file is correct.
+
+4. Run migration tests.
+
+Flink CDC tries to ensure backward compatibility of state, that is, the job state (Checkpoint/Savepoint) saved with previous CDC version should be usable in the new version.
+You can run CDC migration verification locally with [Flink CDC Migration Test Utils](https://github.com/yuxiqian/migration-test) script.
+
+* [Pipeline Job Migration Test Guide](https://github.com/yuxiqian/migration-test/blob/main/README.md)
+* [DataStream Job Migration Test Guide](https://github.com/yuxiqian/migration-test/blob/main/datastream/README.md)
+
+5. Run end-to-end tests.
+
+You may configure the RC version of Flink CDC together with a supported Flink version,
+try running some Pipeline/SQL/DataStream jobs,
+and observe if jobs are working properly.
+
+6. Check third-party software licenses.
+
+Flink CDC depends on a few third-party open source software, 
+we need to ensure their licenses are correctly included in the NOTICE file.
+
+In addition, some license agreements are incompatible with the Apache 2.0 license used by Flink CDC,
+and any software licensed under these agreements cannot be packaged into Flink CDC.
+You can get more information at [ASF 3RD PARTY LICENSE POLICY](https://www.apache.org/legal/resolved.html).

--- a/docs/content/docs/developer-guide/contribute-to-flink-cdc.md
+++ b/docs/content/docs/developer-guide/contribute-to-flink-cdc.md
@@ -149,10 +149,10 @@ Unpack the precompiled binary jar package and check if the `Build-Jdk` entry in 
 4. Run migration tests.
 
 Flink CDC tries to ensure backward compatibility of state, that is, the job state (Checkpoint/Savepoint) saved with previous CDC version should be usable in the new version.
-You can run CDC migration verification locally with [Flink CDC Migration Test Utils](https://github.com/yuxiqian/migration-test) script.
+You can run CDC migration verification locally with [Flink CDC Migration Test Utils](https://github.com/apache/flink-cdc/tree/master/tools/mig-test) script.
 
-* [Pipeline Job Migration Test Guide](https://github.com/yuxiqian/migration-test/blob/main/README.md)
-* [DataStream Job Migration Test Guide](https://github.com/yuxiqian/migration-test/blob/main/datastream/README.md)
+* [Pipeline Job Migration Test Guide](https://github.com/apache/flink-cdc/blob/master/tools/mig-test/README.md)
+* [DataStream Job Migration Test Guide](https://github.com/apache/flink-cdc/blob/master/tools/mig-test/datastream/README.md)
 
 5. Run end-to-end tests.
 

--- a/docs/content/docs/developer-guide/contribute-to-flink-cdc.md
+++ b/docs/content/docs/developer-guide/contribute-to-flink-cdc.md
@@ -36,13 +36,14 @@ improving website, testing release candidates and writing corresponding blog etc
 Contributing to Flink CDC goes beyond writing code for the project. Here are different opportunities to help the 
 project as follows.
 
-| Area                 | Further information                                                                                                                                                                                                                                                                           |
-|:---------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Report Bug           | To report a problem, open an issue in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) and select `Flink CDC` in `Component/s`. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem. |
-| Contribute Code      | Read the <a href="#code-contribution-guide">Code Contribution Guide</a>                                                                                                                                                                                                                       |
-| Code Reviews         | Read the <a href="#code-review-guide">Code Review Guide</a>                                                                                                                                                                                                                                   |
-| Release Verification | Read the <a href="#release-validation-guide">Code Review Guide</a>                                                                                                                                                                                                                            |
-| Support Users        | Reply to questions on the [flink user mailing list](https://flink.apache.org/what-is-flink/community/#mailing-lists), check the latest issues in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) for tickets which are actually user questions.                            |
+| Area                       | Further information                                                                                                                                                                                                                                                                           |
+|:---------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Report Bug                 | To report a problem, open an issue in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) and select `Flink CDC` in `Component/s`. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem. |
+| Contribute Code            | Read the <a href="#code-contribution-guide">Code Contribution Guide</a>                                                                                                                                                                                                                       |
+| Code Reviews               | Read the <a href="#code-review-guide">Code Review Guide</a>                                                                                                                                                                                                                                   |
+| Release Verification       | Read the <a href="#release-validation-guide">Code Review Guide</a>                                                                                                                                                                                                                            |
+| Support Users              | Reply to questions on the [Flink user mailing list](https://flink.apache.org/what-is-flink/community/#mailing-lists), check the latest issues in [Flink jira](https://issues.apache.org/jira/projects/FLINK/issues) for tickets about user questions.                                         |
+| Join Developer Discussions | Be informed with developers' discussions by subscribing to [Flink dev mailing list](https://lists.apache.org/list.html?dev@flink.apache.org).                                                                                                                                                 | 
 
 Any other question? Reach out to the Dev mail list to get help!
 
@@ -86,20 +87,20 @@ If the pull request introduces a new feature, the feature should be documented.
 
 <h2 id="release-validation-guide">Release Verification Guide</h2>
 
-We will prepare for new releases of Flink CDC regularly.
+We will prepare new releases of Flink CDC regularly.
 
-According to the Apache Software Foundation releasing SOP,
-we will make a release candidate version before each release,
+According to official [Apache Software Foundation Releasing policy](https://www.apache.org/legal/release-policy.html),
+we will make a release candidate (RC) version before each release,
 and invite community members to test and vote on this pre-release version.
 
-Everyone is welcomed to participate in the version verification work in `dev@flink.apache.org` mailing list.
-The verification content may include the following aspects:
+Everyone is welcome to participate in the version verification work in `dev@flink.apache.org` mailing list.
+The verification process may include the following aspects:
 
 1. Verify if source code could be compiled successfully.
 
 Currently, Flink CDC uses [Maven](https://maven.apache.org/) 3 as the build tool and compiles on the JDK 8 platform.
 You can download the RC version of the source code package and compile it using the `mvn clean package -Dfast` command,
-and check if there's any unexpected errors or warnings.
+and check if there are any unexpected errors or warnings.
 
 2. Verify if tarball checksum matches.
 
@@ -109,6 +110,37 @@ You can download the binary tarball of the RC version and calculate its SHA512 h
 * Linux: `sha512sum flink-cdc-*-bin.tar.gz`
 * macOS: `shasum -a 512 flink-cdc-*-bin.tar.gz`
 * Windows (PowerShell): `Get-FileHash flink-cdc-*-bin.tar.gz -Algorithm SHA512 | Format-List`
+
+To verify tarball signature, ensure that you have gpg (version 2.4+) is installed.
+
+First, download the releasing PMC/Committer's GPG public key from KEYS location, 
+and import one of the release manager's public key:
+
+```bash
+gpg --import <releaser-public-key>
+```
+
+For example:
+
+```bash
+gpg  --import leonard-xu.pub
+```
+
+The file leonard-xu.pub contains the @leonardBang 's public key from the [KEYS](https://dist.apache.org/repos/dist/release/flink/KEYS) list above.
+
+Verify the tarball signature is genuine:
+
+```bash
+gpg --verify flink-cdc-<VERSION>-src.tgz.asc flink-cdc-<VERSION>-src.tgz
+```
+
+For example, verify version 3.1.0 tarball signature:
+
+```bash
+gpg --verify flink-cdc-3.1.0-src.tgz.asc flink-cdc-3.1.0-src.tgz
+```
+
+It should print Good signature from "Leonard Xu ...".
 
 3. Verify that the binary package was compiled with JDK 8.
 


### PR DESCRIPTION
This closes FLINK-35654.

Currently, ASF voting process requires vast quality verification before releasing any new versions, including:

* Tarball checksum verification
* Compile from source code
* Run pipeline E2e tests
* Run migration tests
* Check if jar was packaged with correct JDK version
* ...

Adding verification SOP in "Contribution guide" of Flink CDC docs should help developers verify future releases more easily.