### PR TITLE
[FLINK-35674][cdc-connector][mysql]Fix blocking caused by searching for timestamp in binlog file

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -193,7 +193,9 @@ public class StatefulTaskContext {
                 mySqlSplit.isSnapshotSplit()
                         ? BinlogOffset.ofEarliest()
                         : initializeEffectiveOffset(
-                                mySqlSplit.asBinlogSplit().getStartingOffset(), connection);
+                                mySqlSplit.asBinlogSplit().getStartingOffset(),
+                                connection,
+                                sourceConfig);
 
         LOG.info("Starting offset is initialized to {}", offset);
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffsetUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffsetUtils.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.mysql.source.offset;
 
 import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
 import org.apache.flink.cdc.connectors.mysql.debezium.task.context.StatefulTaskContext;
+import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 
 import io.debezium.connector.mysql.MySqlConnection;
 
@@ -45,13 +46,14 @@ public class BinlogOffsetUtils {
      * </ul>
      */
     public static BinlogOffset initializeEffectiveOffset(
-            BinlogOffset offset, MySqlConnection connection) {
+            BinlogOffset offset, MySqlConnection connection, MySqlSourceConfig mySqlSourceConfig) {
         BinlogOffsetKind offsetKind = offset.getOffsetKind();
         switch (offsetKind) {
             case EARLIEST:
                 return BinlogOffset.ofBinlogFilePosition("", 0);
             case TIMESTAMP:
-                return DebeziumUtils.findBinlogOffset(offset.getTimestampSec() * 1000, connection);
+                return DebeziumUtils.findBinlogOffset(
+                        offset.getTimestampSec() * 1000, connection, mySqlSourceConfig);
             case LATEST:
                 return DebeziumUtils.currentBinlogOffset(connection);
             default:

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -1262,7 +1262,8 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                             ? BinlogOffset.ofEarliest()
                             : initializeEffectiveOffset(
                                     mySqlSplit.asBinlogSplit().getStartingOffset(),
-                                    getConnection());
+                                    getConnection(),
+                                    getSourceConfig());
 
             LOG.info("Starting offset is initialized to {}", offset);
 


### PR DESCRIPTION
# Issue Description

1. If the binaryLogClient does not have a registered server-id, the binaryLogClient will use the default 65535 parameter. If there is only one source in a Flink job, it will be normal.
2. If multiple sources register binaryLogClients using the default 65535 in a Flink job, registration may fail because one of the sources is searching for the timestamp of the binlog file and has not yet released the client registered using 65535 as the server-id.
3. If registration fails. BlockingQueue will always be empty and waiting without doing nothing.

# Changes
When registering the binaryLogClient to search timestamp , use the server-id unique to each source for registration.