### PR TITLE
[FLINK-35762] Cache hashCode for TableID & Transform descriptors

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/TableId.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/TableId.java
@@ -51,6 +51,9 @@ public class TableId implements Serializable {
     @Nullable private final String schemaName;
     private final String tableName;
 
+    // Cache immutable objects' hash code for optimization.
+    private transient volatile int hashCode;
+
     private TableId(@Nullable String namespace, @Nullable String schemaName, String tableName) {
         this.namespace = namespace;
         this.schemaName = schemaName;
@@ -125,7 +128,10 @@ public class TableId implements Serializable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(namespace, schemaName, tableName);
+        if (hashCode == 0) {
+            hashCode = Objects.hash(namespace, schemaName, tableName);
+        }
+        return hashCode;
     }
 
     @Override

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperator.java
@@ -315,7 +315,7 @@ public class PostTransformOperator extends AbstractStreamOperator<Event>
                 Optional<TransformFilter> transformFilterOptional = transform.getFilter();
 
                 if (transformFilterOptional.isPresent()
-                        && transformFilterOptional.get().isVaild()) {
+                        && transformFilterOptional.get().isValid()) {
                     TransformFilter transformFilter = transformFilterOptional.get();
                     if (!transformFilterProcessorMap.containsKey(
                             Tuple2.of(tableId, transformFilter))) {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformFilter.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformFilter.java
@@ -22,6 +22,7 @@ import org.apache.flink.cdc.runtime.parser.TransformParser;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -41,6 +42,9 @@ public class TransformFilter implements Serializable {
     private final String expression;
     private final String scriptExpression;
     private final List<String> columnNames;
+
+    // Cache immutable objects' hash code for optimization.
+    private transient volatile int hashCode;
 
     public TransformFilter(String expression, String scriptExpression, List<String> columnNames) {
         this.expression = expression;
@@ -72,7 +76,29 @@ public class TransformFilter implements Serializable {
         return Optional.of(new TransformFilter(filterExpression, scriptExpression, columnNames));
     }
 
-    public boolean isVaild() {
+    public boolean isValid() {
         return !columnNames.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TransformFilter that = (TransformFilter) o;
+        return Objects.equals(expression, that.expression)
+                && Objects.equals(scriptExpression, that.scriptExpression)
+                && Objects.equals(columnNames, that.columnNames);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == 0) {
+            hashCode = Objects.hash(expression, scriptExpression, columnNames);
+        }
+        return hashCode;
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformProjection.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformProjection.java
@@ -23,6 +23,7 @@ import org.apache.flink.cdc.common.utils.StringUtils;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -41,6 +42,9 @@ public class TransformProjection implements Serializable {
     private static final long serialVersionUID = 1L;
     private String projection;
     private List<ProjectionColumn> projectionColumns;
+
+    // Cache immutable objects' hash code for optimization.
+    private transient volatile int hashCode;
 
     public TransformProjection(String projection, List<ProjectionColumn> projectionColumns) {
         this.projection = projection;
@@ -74,5 +78,26 @@ public class TransformProjection implements Serializable {
         return projectionColumns.stream()
                 .map(ProjectionColumn::getColumn)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TransformProjection that = (TransformProjection) o;
+        return Objects.equals(projection, that.projection)
+                && Objects.equals(projectionColumns, that.projectionColumns);
+    }
+
+    @Override
+    public int hashCode() {
+        if (hashCode == 0) {
+            hashCode = Objects.hash(projection, projectionColumns);
+        }
+        return hashCode;
     }
 }


### PR DESCRIPTION
This closes FLINK-35762.

As previously discussed offline with @lvyanquan, HashMap lookup could be slow since we must calculate key hash code every time, though most key objects are immutable.

A common practice in Java world is caching object hash code in a transient field, just like what `java.lang.String` does. In CDC code, `TableId` & transform rule types are frequently used as HashMap key type, and their hash code could be safely cached since their instances are immutable.