### PR TITLE
[cdc-connector][mysql]Mysql add numRecordsOutBySnapshot and numRecordsOutByIncremental  metrics

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.cdc.connectors.mysql.source.metrics;
 
-import org.apache.flink.cdc.common.event.OperationType;
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReader;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
@@ -26,6 +25,7 @@ import org.apache.flink.runtime.metrics.MetricNames;
 
 import io.debezium.relational.TableId;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** A collection class for handling metrics in {@link MySqlSourceReader}. */
@@ -46,7 +46,13 @@ public class MySqlSourceReaderMetrics {
     public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_UPDATE =
             ".numRecordsOutByDataChangeEventUpdate";
 
-    private final ConcurrentHashMap<String, Counter> numRecordsOutMap = new ConcurrentHashMap();
+    private final Map<TableId, Counter> snapshotNumRecordsOutMap = new ConcurrentHashMap();
+
+    private final Map<TableId, Counter> insertNumRecordsOutMap = new ConcurrentHashMap();
+
+    private final Map<TableId, Counter> updateNumRecordsOutMap = new ConcurrentHashMap();
+
+    private final Map<TableId, Counter> deleteNumRecordsOutMap = new ConcurrentHashMap();
 
     /**
      * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
@@ -65,8 +71,8 @@ public class MySqlSourceReaderMetrics {
 
     public void numRecordsOutSnapshotIncrease(TableId tableId) {
         Counter counter =
-                numRecordsOutMap.computeIfAbsent(
-                        tableId.identifier(),
+                snapshotNumRecordsOutMap.computeIfAbsent(
+                        tableId,
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier() + IO_NUM_RECORDS_OUT_SNAPSHOT));
@@ -75,8 +81,8 @@ public class MySqlSourceReaderMetrics {
 
     public void numRecordsOutInsertIncrease(TableId tableId) {
         Counter counter =
-                numRecordsOutMap.computeIfAbsent(
-                        tableId.identifier() + OperationType.INSERT,
+                insertNumRecordsOutMap.computeIfAbsent(
+                        tableId,
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier()
@@ -86,8 +92,8 @@ public class MySqlSourceReaderMetrics {
 
     public void numRecordsOutUpdateIncrease(TableId tableId) {
         Counter counter =
-                numRecordsOutMap.computeIfAbsent(
-                        tableId.identifier() + OperationType.UPDATE,
+                updateNumRecordsOutMap.computeIfAbsent(
+                        tableId,
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier()
@@ -97,8 +103,8 @@ public class MySqlSourceReaderMetrics {
 
     public void numRecordsOutDeleteIncrease(TableId tableId) {
         Counter counter =
-                numRecordsOutMap.computeIfAbsent(
-                        tableId.identifier() + OperationType.DELETE,
+                deleteNumRecordsOutMap.computeIfAbsent(
+                        tableId,
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier()

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -37,14 +37,14 @@ public class MySqlSourceReaderMetrics {
 
     public static final String IO_NUM_RECORDS_OUT_SNAPSHOT = ".numRecordsOutBySnapshot";
 
-    public static final String IO_NUM_RECORDS_OUT_INCREMENTAL_INSERT =
-            ".numRecordsOutByIncrementalInsert";
+    public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_INSERT =
+            ".numRecordsOutByDataChangeEventInsert";
 
-    public static final String IO_NUM_RECORDS_OUT_INCREMENTAL_DELETE =
-            ".numRecordsOutByIncrementalDelete";
+    public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_DELETE =
+            ".numRecordsOutByDataChangeEventDelete";
 
-    public static final String IO_NUM_RECORDS_OUT_INCREMENTAL_UPDATE =
-            ".numRecordsOutByIncrementalUpdate";
+    public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_UPDATE =
+            ".numRecordsOutByDataChangeEventUpdate";
 
     private final ConcurrentHashMap<String, Counter> numRecordsOutMap = new ConcurrentHashMap();
 
@@ -80,7 +80,7 @@ public class MySqlSourceReaderMetrics {
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier()
-                                                + IO_NUM_RECORDS_OUT_INCREMENTAL_INSERT));
+                                                + IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_INSERT));
         counter.inc();
     }
 
@@ -91,7 +91,7 @@ public class MySqlSourceReaderMetrics {
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier()
-                                                + IO_NUM_RECORDS_OUT_INCREMENTAL_UPDATE));
+                                                + IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_UPDATE));
         counter.inc();
     }
 
@@ -102,7 +102,7 @@ public class MySqlSourceReaderMetrics {
                         k ->
                                 metricGroup.counter(
                                         tableId.identifier()
-                                                + IO_NUM_RECORDS_OUT_INCREMENTAL_DELETE));
+                                                + IO_NUM_RECORDS_OUT_DATA_CHANGE_EVENT_DELETE));
         counter.inc();
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -17,10 +17,16 @@
 
 package org.apache.flink.cdc.connectors.mysql.source.metrics;
 
+import org.apache.flink.cdc.common.event.OperationType;
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReader;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
+
+import io.debezium.relational.TableId;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 /** A collection class for handling metrics in {@link MySqlSourceReader}. */
 public class MySqlSourceReaderMetrics {
@@ -28,6 +34,19 @@ public class MySqlSourceReaderMetrics {
     public static final long UNDEFINED = -1;
 
     private final MetricGroup metricGroup;
+
+    public static final String IO_NUM_RECORDS_OUT_SNAPSHOT = ".numRecordsOutBySnapshot";
+
+    public static final String IO_NUM_RECORDS_OUT_INCREMENTAL_INSERT =
+            ".numRecordsOutByIncrementalInsert";
+
+    public static final String IO_NUM_RECORDS_OUT_INCREMENTAL_DELETE =
+            ".numRecordsOutByIncrementalDelete";
+
+    public static final String IO_NUM_RECORDS_OUT_INCREMENTAL_UPDATE =
+            ".numRecordsOutByIncrementalUpdate";
+
+    private final ConcurrentHashMap<String, Counter> numRecordsOutMap = new ConcurrentHashMap();
 
     /**
      * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
@@ -42,6 +61,49 @@ public class MySqlSourceReaderMetrics {
     public void registerMetrics() {
         metricGroup.gauge(
                 MetricNames.CURRENT_FETCH_EVENT_TIME_LAG, (Gauge<Long>) this::getFetchDelay);
+    }
+
+    public void numRecordsOutSnapshotIncrease(TableId tableId) {
+        Counter counter =
+                numRecordsOutMap.computeIfAbsent(
+                        tableId.identifier(),
+                        k ->
+                                metricGroup.counter(
+                                        tableId.identifier() + IO_NUM_RECORDS_OUT_SNAPSHOT));
+        counter.inc();
+    }
+
+    public void numRecordsOutInsertIncrease(TableId tableId) {
+        Counter counter =
+                numRecordsOutMap.computeIfAbsent(
+                        tableId.identifier() + OperationType.INSERT,
+                        k ->
+                                metricGroup.counter(
+                                        tableId.identifier()
+                                                + IO_NUM_RECORDS_OUT_INCREMENTAL_INSERT));
+        counter.inc();
+    }
+
+    public void numRecordsOutUpdateIncrease(TableId tableId) {
+        Counter counter =
+                numRecordsOutMap.computeIfAbsent(
+                        tableId.identifier() + OperationType.UPDATE,
+                        k ->
+                                metricGroup.counter(
+                                        tableId.identifier()
+                                                + IO_NUM_RECORDS_OUT_INCREMENTAL_UPDATE));
+        counter.inc();
+    }
+
+    public void numRecordsOutDeleteIncrease(TableId tableId) {
+        Counter counter =
+                numRecordsOutMap.computeIfAbsent(
+                        tableId.identifier() + OperationType.DELETE,
+                        k ->
+                                metricGroup.counter(
+                                        tableId.identifier()
+                                                + IO_NUM_RECORDS_OUT_INCREMENTAL_DELETE));
+        counter.inc();
     }
 
     public long getFetchDelay() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -128,23 +128,20 @@ public class MySqlRecordEmitter<T> implements RecordEmitter<SourceRecords, T, My
         if (splitState.isSnapshotSplitState()) {
             sourceReaderMetrics.numRecordsOutSnapshotIncrease(tableId);
         } else if (splitState.isBinlogSplitState()) {
-            if (RecordUtils.isDataChangeRecord(element)) {
-                Struct value = (Struct) element.value();
-                if (value != null) {
-                    Envelope.Operation operation =
-                            Envelope.Operation.forCode(
-                                    value.getString(Envelope.FieldName.OPERATION));
-                    switch (operation) {
-                        case CREATE:
-                            sourceReaderMetrics.numRecordsOutInsertIncrease(tableId);
-                            break;
-                        case UPDATE:
-                            sourceReaderMetrics.numRecordsOutUpdateIncrease(tableId);
-                            break;
-                        case DELETE:
-                            sourceReaderMetrics.numRecordsOutDeleteIncrease(tableId);
-                            break;
-                    }
+            Struct value = (Struct) element.value();
+            if (value != null) {
+                Envelope.Operation operation =
+                        Envelope.Operation.forCode(value.getString(Envelope.FieldName.OPERATION));
+                switch (operation) {
+                    case CREATE:
+                        sourceReaderMetrics.numRecordsOutInsertIncrease(tableId);
+                        break;
+                    case UPDATE:
+                        sourceReaderMetrics.numRecordsOutUpdateIncrease(tableId);
+                        break;
+                    case DELETE:
+                        sourceReaderMetrics.numRecordsOutDeleteIncrease(tableId);
+                        break;
                 }
             }
         }


### PR DESCRIPTION
`numRecordsOutBySnapshot` metrics collects snapshot statistics

`numRecordsOutByIncremental` metrics collects incremental statistics

`numRecordsOutByIncremental` has three metrics, respectively is `numRecordsOutByIncrementalInsert`, `numRecordsOutByIncrementalUpdate`, `numRecordsOutByIncrementalDelete`

![image](https://github.com/apache/flink-cdc/assets/125547374/1d15cf11-f7db-4644-9ae8-56bcec8c0c9f)




2024.7.12 change metrics name，change `numRecordsOutByIncrementalInsert` to  `numRecordsOutByDataChangeEventInsert`
![image](https://github.com/user-attachments/assets/892f1090-58a9-4212-95d1-9816f75e06e8)

