### PR TITLE
[FLINK-35781][cli] Provide a default parallelism (1) for pipeline jobs

### DIFF
--- a/docs/content.zh/docs/core-concept/data-pipeline.md
+++ b/docs/content.zh/docs/core-concept/data-pipeline.md
@@ -98,5 +98,5 @@ The following config options of Data Pipeline level are supported:
 | parameter       | meaning                                                                                 | optional/required |
 |-----------------|-----------------------------------------------------------------------------------------|-------------------|
 | name            | The name of the pipeline, which will be submitted to the Flink cluster as the job name. | optional          |
-| parallelism     | The global parallelism of the pipeline.                                                 | required          |
+| parallelism     | The global parallelism of the pipeline.                                                 | optional          |
 | local-time-zone | The local time zone defines current session time zone id.                               | optional          |

--- a/docs/content.zh/docs/core-concept/data-pipeline.md
+++ b/docs/content.zh/docs/core-concept/data-pipeline.md
@@ -98,5 +98,5 @@ The following config options of Data Pipeline level are supported:
 | parameter       | meaning                                                                                 | optional/required |
 |-----------------|-----------------------------------------------------------------------------------------|-------------------|
 | name            | The name of the pipeline, which will be submitted to the Flink cluster as the job name. | optional          |
-| parallelism     | The global parallelism of the pipeline.                                                 | optional          |
+| parallelism     | The global parallelism of the pipeline. Defaults to 1.                                  | optional          |
 | local-time-zone | The local time zone defines current session time zone id.                               | optional          |

--- a/docs/content/docs/core-concept/data-pipeline.md
+++ b/docs/content/docs/core-concept/data-pipeline.md
@@ -98,5 +98,5 @@ The following config options of Data Pipeline level are supported:
 | parameter       | meaning                                                                                 | optional/required |
 |-----------------|-----------------------------------------------------------------------------------------|-------------------|
 | name            | The name of the pipeline, which will be submitted to the Flink cluster as the job name. | optional          |
-| parallelism     | The global parallelism of the pipeline.                                                 | required          |
+| parallelism     | The global parallelism of the pipeline.                                                 | optional          |
 | local-time-zone | The local time zone defines current session time zone id.                               | optional          |

--- a/docs/content/docs/core-concept/data-pipeline.md
+++ b/docs/content/docs/core-concept/data-pipeline.md
@@ -98,5 +98,5 @@ The following config options of Data Pipeline level are supported:
 | parameter       | meaning                                                                                 | optional/required |
 |-----------------|-----------------------------------------------------------------------------------------|-------------------|
 | name            | The name of the pipeline, which will be submitted to the Flink cluster as the job name. | optional          |
-| parallelism     | The global parallelism of the pipeline.                                                 | optional          |
+| parallelism     | The global parallelism of the pipeline. Defaults to 1.                                  | optional          |
 | local-time-zone | The local time zone defines current session time zone id.                               | optional          |

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/pipeline/PipelineOptions.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/pipeline/PipelineOptions.java
@@ -42,7 +42,7 @@ public class PipelineOptions {
     public static final ConfigOption<Integer> PIPELINE_PARALLELISM =
             ConfigOptions.key("parallelism")
                     .intType()
-                    .noDefaultValue()
+                    .defaultValue(1)
                     .withDescription("Parallelism of the pipeline");
 
     public static final ConfigOption<SchemaChangeBehavior> PIPELINE_SCHEMA_CHANGE_BEHAVIOR =


### PR DESCRIPTION
This closes FLINK-35781.

Currently, Flink CDC `PIPELINE_PARALLELISM` option is forcefully required in pipeline definition, which turns out to be unnecessary since Flink already has a fallback parallelism option.

This PR adds a default value (1, same as Flink's default parallelism) in CDC CLI to resolve this issue.