### PR TITLE
[FLINK-35802][mysql] clean ChangeEventQueue to avoid deadlock when calling BinaryLogClient#disconnect method.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -179,6 +179,9 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
                 statefulTaskContext.getConnection().close();
             }
             if (statefulTaskContext.getBinaryLogClient() != null) {
+                // BinaryLogClient still tries to enqueue records, if this queue is full, it will
+                // lead to deadlock.
+                statefulTaskContext.getQueue().poll();
                 statefulTaskContext.getBinaryLogClient().disconnect();
             }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/FLINK-35802 for more details.