### PR TITLE
[FLINK-35072][doris] Support applying AlterColumnTypeEvent to Doris sink

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
@@ -44,7 +44,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.doris</groupId>
             <artifactId>flink-doris-connector-${flink.major.version}</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.2</version>
         </dependency>
 
         <dependency>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
@@ -26,6 +26,10 @@ limitations under the License.
     <artifactId>flink-cdc-pipeline-connector-doris</artifactId>
     <name>flink-cdc-pipeline-connector-doris</name>
 
+    <properties>
+        <doris.connector.version>1.6.2</doris.connector.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -44,7 +48,7 @@ limitations under the License.
         <dependency>
             <groupId>org.apache.doris</groupId>
             <artifactId>flink-doris-connector-${flink.major.version}</artifactId>
-            <version>1.6.2</version>
+            <version>${doris.connector.version}</version>
         </dependency>
 
         <dependency>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
@@ -45,7 +45,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -367,7 +366,6 @@ public class DorisMetadataApplierITCase extends DorisSinkTestBase {
     }
 
     @Test
-    @Ignore("AlterColumnType is yet to be supported until we close FLINK-35072.")
     public void testDorisAlterColumnType() throws Exception {
         TableId tableId =
                 TableId.tableId(


### PR DESCRIPTION
This closes FLINK-35072.

Thanks to @qg-lin's great work, doris-flink-connector 1.6.2 has implemented column type modification API, so Flink CDC could implement this ticket more easily.

~~Notice that this PR isn't ready for merge yet, since doris-flink-connector 1.6.2 artifact has not been released. Local compilation & tests are required to verify this change for now.~~