### PR TITLE
[docs] Add schema evolution type supporting status for pipeline sink connectors

### DIFF
--- a/docs/content.zh/docs/connectors/pipeline-connectors/doris.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/doris.md
@@ -281,4 +281,17 @@ pipeline:
 </table>
 </div>
 
+## 支持的表结构变更事件
+
+目前，Doris Pipeline 连接器支持应用以下表结构变更事件：
+
+| 类型                   | 是否支持 | 附注                   |
+|----------------------|------|----------------------|
+| AddColumnEvent       | ✅    |                      |
+| AlterColumnTypeEvent | ✅    | 只支持部分列类型转换。可能造成精度损失。 |
+| CreateTableEvent     | ✅    |                      |
+| DropColumnEvent      | ✅    | 不可以删除分区列。            |
+| RenameColumnEvent    | ✅    |                      |
+
+
 {{< top >}}

--- a/docs/content.zh/docs/connectors/pipeline-connectors/kafka.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/kafka.md
@@ -221,4 +221,8 @@ Pipeline 连接器配置项
 </table>
 </div>
 
+## 支持的表结构变更事件
+
+Kafka Pipeline 连接器不维护任何表结构信息。
+
 {{< top >}}

--- a/docs/content.zh/docs/connectors/pipeline-connectors/paimon.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/paimon.md
@@ -229,4 +229,16 @@ Pipeline 连接器配置项
 </table>
 </div>
 
+## 支持的表结构变更事件
+
+目前，Paimon Pipeline 连接器支持应用以下表结构变更事件：
+
+| 类型                   | 是否支持 | 附注 |
+|----------------------|------|----|
+| AddColumnEvent       | ✅    |    |
+| AlterColumnTypeEvent | ✅    |    |
+| CreateTableEvent     | ✅    |    |
+| DropColumnEvent      | ✅    |    |
+| RenameColumnEvent    | ✅    |    |
+
 {{< top >}}

--- a/docs/content.zh/docs/connectors/pipeline-connectors/starrocks.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/starrocks.md
@@ -322,4 +322,17 @@ pipeline:
 </table>
 </div>
 
+
+## 支持的表结构变更事件
+
+目前，StarRocks Pipeline 连接器支持应用以下表结构变更事件：
+
+| 类型                   | 是否支持 | 附注            |
+|----------------------|------|---------------|
+| AddColumnEvent       | ✅    | 不可以在主键列前插入新列。 |
+| AlterColumnTypeEvent | ❌    |               |
+| CreateTableEvent     | ✅    |               |
+| DropColumnEvent      | ✅    | 不可以删除分区列。     |
+| RenameColumnEvent    | ❌    |               |
+
 {{< top >}}

--- a/docs/content/docs/connectors/pipeline-connectors/doris.md
+++ b/docs/content/docs/connectors/pipeline-connectors/doris.md
@@ -281,4 +281,16 @@ pipeline:
 </table>
 </div>
 
+## Supported Schema Evolution Types
+
+Currently, Doris pipeline connector supports the following schema evolution types.
+
+| Type                 | Supported | Notes                                                                                         |
+|----------------------|-----------|-----------------------------------------------------------------------------------------------|
+| AddColumnEvent       | ✅         |                                                                                               |
+| AlterColumnTypeEvent | ✅         | Limited type conversions are supported. User is responsible for any potential precision loss. |
+| CreateTableEvent     | ✅         |                                                                                               |
+| DropColumnEvent      | ✅         | Partition columns cannot be dropped.                                                          |
+| RenameColumnEvent    | ✅         |                                                                                               |
+
 {{< top >}}

--- a/docs/content/docs/connectors/pipeline-connectors/kafka.md
+++ b/docs/content/docs/connectors/pipeline-connectors/kafka.md
@@ -219,4 +219,8 @@ Data Type Mapping
 </table>
 </div>
 
+## Supported Schema Evolution Types
+
+Kafka Pipeline connector doesn't maintain any schema information.
+
 {{< top >}}

--- a/docs/content/docs/connectors/pipeline-connectors/paimon.md
+++ b/docs/content/docs/connectors/pipeline-connectors/paimon.md
@@ -229,4 +229,16 @@ Data Type Mapping
 </table>
 </div>
 
+## Supported Schema Evolution Types
+
+Currently, Paimon pipeline connector supports the following schema evolution types.
+
+| Type                 | Supported | Notes |
+|----------------------|-----------|-------|
+| AddColumnEvent       | ✅         |       |
+| AlterColumnTypeEvent | ✅         |       |
+| CreateTableEvent     | ✅         |       |
+| DropColumnEvent      | ✅         |       |
+| RenameColumnEvent    | ✅         |       |
+
 {{< top >}}

--- a/docs/content/docs/connectors/pipeline-connectors/starrocks.md
+++ b/docs/content/docs/connectors/pipeline-connectors/starrocks.md
@@ -333,4 +333,16 @@ pipeline:
 </table>
 </div>
 
+## Supported Schema Evolution Types
+
+Currently, StarRocks pipeline connector supports the following schema evolution types.
+
+| Type                 | Supported | Notes                                                      |
+|----------------------|-----------|------------------------------------------------------------|
+| AddColumnEvent       | ✅         | New columns could not be inserted before any primary keys. |
+| AlterColumnTypeEvent | ❌         |                                                            |
+| CreateTableEvent     | ✅         |                                                            |
+| DropColumnEvent      | ✅         | Partition columns cannot be dropped.                       |
+| RenameColumnEvent    | ❌         |                                                            |
+
 {{< top >}}


### PR DESCRIPTION
Currently, not all pipeline sink connectors support every schema change events, and some have extra limitations when applying schema evolution events. Explicitly stating them in documentations should be helpful for users.