### PR TITLE
[minor][cdc-runtime]The processedTableIds add is executed twice

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkWriterOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkWriterOperator.java
@@ -172,7 +172,6 @@ public class DataSinkWriterOperator<CommT> extends AbstractStreamOperator<Commit
             emitLatestSchema(changeEvent.tableId());
             processedTableIds.add(changeEvent.tableId());
         }
-        processedTableIds.add(changeEvent.tableId());
         this.<OneInputStreamOperator<Event, CommittableMessage<CommT>>>getFlinkWriterOperator()
                 .processElement(element);
     }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1e01a59e-5cb8-4844-bc83-2a366277fe7c)

The processedTableIds add is executed twice
