### PR TITLE
[minor][cdc-connector][mysql] catch all exceptions to display the table info

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -38,7 +38,6 @@ import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
-import io.debezium.text.ParsingException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -134,7 +133,7 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
         String ddlStatement = showCreateTable(jdbc, tableId);
         try {
             return parseDDL(ddlStatement, tableId);
-        } catch (ParsingException pe) {
+        } catch (Exception pe) {
             LOG.warn(
                     "Failed to parse DDL: \n{}\nWill try parsing by describing table.",
                     ddlStatement,


### PR DESCRIPTION
parseDDL doesn't always throw ParsingException, and table info will be missed in this case.
![image](https://github.com/user-attachments/assets/5d053c50-3b80-4a9b-9994-a86a8c9a6be9)
