### PR TITLE
[FLINK-35873][cdc-connector][paimon] Add HashFunctionProvider implementation for PaimonDataSink.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
     <artifactId>flink-cdc-pipeline-connector-paimon</artifactId>
 
     <properties>
-        <paimon.version>0.7.0-incubating</paimon.version>
+        <paimon.version>0.8.2</paimon.version>
         <hadoop.version>2.8.5</hadoop.version>
         <hive.version>2.3.9</hive.version>
         <mockito.version>3.4.6</mockito.version>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSink.java
@@ -17,8 +17,10 @@
 
 package org.apache.flink.cdc.connectors.paimon.sink;
 
+import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.function.HashFunctionProvider;
 import org.apache.flink.cdc.common.sink.DataSink;
 import org.apache.flink.cdc.common.sink.EventSinkProvider;
 import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
@@ -29,6 +31,7 @@ import org.apache.flink.cdc.connectors.paimon.sink.v2.PaimonSink;
 import org.apache.paimon.options.Options;
 
 import java.io.Serializable;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -47,17 +50,21 @@ public class PaimonDataSink implements DataSink, Serializable {
 
     private final PaimonRecordSerializer<Event> serializer;
 
+    private final ZoneId zoneId;
+
     public PaimonDataSink(
             Options options,
             Map<String, String> tableOptions,
             String commitUser,
             Map<TableId, List<String>> partitionMaps,
-            PaimonRecordSerializer<Event> serializer) {
+            PaimonRecordSerializer<Event> serializer,
+            ZoneId zoneId) {
         this.options = options;
         this.tableOptions = tableOptions;
         this.commitUser = commitUser;
         this.partitionMaps = partitionMaps;
         this.serializer = serializer;
+        this.zoneId = zoneId;
     }
 
     @Override
@@ -68,5 +75,10 @@ public class PaimonDataSink implements DataSink, Serializable {
     @Override
     public MetadataApplier getMetadataApplier() {
         return new PaimonMetadataApplier(options, tableOptions, partitionMaps);
+    }
+
+    @Override
+    public HashFunctionProvider<DataChangeEvent> getDataChangeEventHashFunctionProvider() {
+        return new PaimonHashFunctionProvider(options, zoneId);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSinkFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSinkFactory.java
@@ -104,7 +104,8 @@ public class PaimonDataSinkFactory implements DataSinkFactory {
             }
         }
         PaimonRecordSerializer<Event> serializer = new PaimonRecordEventSerializer(zoneId);
-        return new PaimonDataSink(options, tableOptions, commitUser, partitionMaps, serializer);
+        return new PaimonDataSink(
+                options, tableOptions, commitUser, partitionMaps, serializer, zoneId);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunction.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.paimon.sink;
+
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.connectors.paimon.sink.v2.PaimonRecordEventSerializer;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.sink.RowKeyExtractor;
+
+import java.io.Serializable;
+import java.time.ZoneId;
+
+/**
+ * A {@link HashFunction} implementation for {@link PaimonDataSink}. TODO: RowKeyExtractor is not
+ * applicative for DynamicBucketTable, need another way to support it.
+ */
+public class PaimonHashFunction implements HashFunction<DataChangeEvent>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final PaimonRecordEventSerializer eventSerializer;
+
+    private final RowKeyExtractor keyExtractor;
+
+    public PaimonHashFunction(Options options, TableId tableId, Schema schema, ZoneId zoneId) {
+        Catalog catalog = FlinkCatalogFactory.createPaimonCatalog(options);
+        FileStoreTable table;
+        try {
+            table = (FileStoreTable) catalog.getTable(Identifier.fromString(tableId.toString()));
+        } catch (Catalog.TableNotExistException e) {
+            throw new RuntimeException(e);
+        }
+        keyExtractor = table.createRowKeyExtractor();
+
+        eventSerializer = new PaimonRecordEventSerializer(zoneId);
+        eventSerializer.serialize(new CreateTableEvent(tableId, schema));
+    }
+
+    @Override
+    public int hashcode(DataChangeEvent event) {
+        GenericRow genericRow = eventSerializer.serialize(event).getGenericRow();
+        keyExtractor.setRecord(genericRow);
+        return keyExtractor.bucket();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunctionProvider.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunctionProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.paimon.sink;
+
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.function.HashFunctionProvider;
+import org.apache.flink.cdc.common.schema.Schema;
+
+import org.apache.paimon.options.Options;
+
+import javax.annotation.Nullable;
+
+import java.time.ZoneId;
+
+/** A {@link HashFunctionProvider} implementation for {@link PaimonDataSink}. */
+public class PaimonHashFunctionProvider implements HashFunctionProvider<DataChangeEvent> {
+
+    private final Options options;
+
+    private final ZoneId zoneId;
+
+    public PaimonHashFunctionProvider(Options options, ZoneId zoneId) {
+        this.options = options;
+        this.zoneId = zoneId;
+    }
+
+    @Override
+    public HashFunction<DataChangeEvent> getHashFunction(@Nullable TableId tableId, Schema schema) {
+        return new PaimonHashFunction(options, tableId, schema, zoneId);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunctionTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunctionTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.paimon.sink;
+
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
+
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.flink.FlinkCatalogFactory;
+import org.apache.paimon.options.Options;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/** Tests for {@link PaimonHashFunction}. */
+public class PaimonHashFunctionTest {
+
+    @TempDir public static java.nio.file.Path temporaryFolder;
+
+    private Catalog catalog;
+
+    private Options catalogOptions;
+
+    private static final String TEST_DATABASE = "test";
+
+    @BeforeEach
+    public void beforeEach() throws Catalog.DatabaseAlreadyExistException {
+        catalogOptions = new Options();
+        String warehouse =
+                new File(temporaryFolder.toFile(), UUID.randomUUID().toString()).toString();
+        catalogOptions.setString("warehouse", warehouse);
+        catalog = FlinkCatalogFactory.createPaimonCatalog(catalogOptions);
+        catalog.createDatabase(TEST_DATABASE, true);
+    }
+
+    @AfterEach
+    public void afterEach() throws Exception {
+        catalog.dropDatabase(TEST_DATABASE, true, true);
+        catalog.close();
+    }
+
+    @Test
+    public void testHashCodeForFixedBucketTable() {
+        TableId tableId = TableId.tableId(TEST_DATABASE, "test_table");
+        Map<String, String> tableOptions = new HashMap<>();
+        tableOptions.put("bucket", "10");
+        MetadataApplier metadataApplier =
+                new PaimonMetadataApplier(catalogOptions, tableOptions, new HashMap<>());
+        Schema schema =
+                Schema.newBuilder()
+                        .physicalColumn("col1", DataTypes.STRING().notNull())
+                        .physicalColumn("col2", DataTypes.STRING())
+                        .physicalColumn("pt", DataTypes.STRING())
+                        .primaryKey("col1", "pt")
+                        .partitionKey("pt")
+                        .build();
+        CreateTableEvent createTableEvent = new CreateTableEvent(tableId, schema);
+        metadataApplier.applySchemaChange(createTableEvent);
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+        PaimonHashFunction hashFunction =
+                new PaimonHashFunction(catalogOptions, tableId, schema, ZoneId.systemDefault());
+        DataChangeEvent dataChangeEvent1 =
+                DataChangeEvent.insertEvent(
+                        tableId,
+                        generator.generate(
+                                new Object[] {
+                                    BinaryStringData.fromString("1"),
+                                    BinaryStringData.fromString("1"),
+                                    BinaryStringData.fromString("2024")
+                                }));
+        int key1 = hashFunction.hashcode(dataChangeEvent1);
+
+        DataChangeEvent dataChangeEvent2 =
+                DataChangeEvent.updateEvent(
+                        tableId,
+                        generator.generate(
+                                new Object[] {
+                                    BinaryStringData.fromString("1"),
+                                    BinaryStringData.fromString("1"),
+                                    BinaryStringData.fromString("2024")
+                                }),
+                        generator.generate(
+                                new Object[] {
+                                    BinaryStringData.fromString("1"),
+                                    BinaryStringData.fromString("2"),
+                                    BinaryStringData.fromString("2024")
+                                }));
+        int key2 = hashFunction.hashcode(dataChangeEvent2);
+
+        DataChangeEvent dataChangeEvent3 =
+                DataChangeEvent.deleteEvent(
+                        tableId,
+                        generator.generate(
+                                new Object[] {
+                                    BinaryStringData.fromString("1"),
+                                    BinaryStringData.fromString("2"),
+                                    BinaryStringData.fromString("2024")
+                                }));
+        int key3 = hashFunction.hashcode(dataChangeEvent3);
+
+        Assertions.assertEquals(key1, key2, key3);
+    }
+}


### PR DESCRIPTION
A followup of https://github.com/apache/flink-cdc/pull/3414.
Shuffle record by bucket.