### PR TITLE
[FLINK-35874][cdc-connector][mysql] Check pureBinlogPhaseTables set before call getBinlogPosition method

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -215,6 +215,9 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
     private boolean shouldEmit(SourceRecord sourceRecord) {
         if (RecordUtils.isDataChangeRecord(sourceRecord)) {
             TableId tableId = RecordUtils.getTableId(sourceRecord);
+            if (pureBinlogPhaseTables.contains(tableId)) {
+                return true;
+            }
             BinlogOffset position = RecordUtils.getBinlogPosition(sourceRecord);
             if (hasEnterPureBinlogPhase(tableId, position)) {
                 return true;
@@ -254,9 +257,6 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
     }
 
     private boolean hasEnterPureBinlogPhase(TableId tableId, BinlogOffset position) {
-        if (pureBinlogPhaseTables.contains(tableId)) {
-            return true;
-        }
         // the existed tables those have finished snapshot reading
         if (maxSplitHighWatermarkMap.containsKey(tableId)
                 && position.isAtOrAfter(maxSplitHighWatermarkMap.get(tableId))) {


### PR DESCRIPTION
This closes [FLINK-35874]
Optimize and avoid frequent invocations of getBinlogPosition by moving the check pureBinlogPhaseTables.contains(tableId) in the hasEnterPureBinlogPhase method before calling getBinlogPosition. This way, if the SourceRecord belongs to a pure binlog phase table, we can directly return true without the need for the highly performance-consuming getBinlogPosition method.
