### PR TITLE
[hotfix][doris] DorisMetadataApplier fails to reject unsupported schema change events

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -82,7 +82,7 @@ public class DorisMetadataApplier implements MetadataApplier {
                 applyRenameColumnEvent((RenameColumnEvent) event);
             } else if (event instanceof AlterColumnTypeEvent) {
                 applyAlterColumnTypeEvent((AlterColumnTypeEvent) event);
-            } else if (event instanceof AlterColumnTypeEvent) {
+            } else {
                 throw new RuntimeException("Unsupported schema change event, " + event);
             }
         } catch (Exception ex) {


### PR DESCRIPTION
This fixed `DorisMetadataApplier` failed to throw exceptions for an unsupported SchemaChangeEvent, which was introduced in #3473.