### PR TITLE
[hotfix][ci] Migrate to Docker Compose V2

### DIFF
--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -297,14 +297,14 @@ jobs:
         run: FLINK_HOME=./flink-1.18.1/ ruby misc/patch_flink_conf.rb
         working-directory: ./tools/mig-test
       - name: Start containers
-        run: cd conf && docker-compose up -d
+        run: cd conf && docker compose up -d
         working-directory: ./tools/mig-test
       - name: Run migration tests
         run: FLINK_HOME=./flink-1.18.1/ ruby run_migration_test.rb
         working-directory: ./tools/mig-test
       - name: Stop containers
         if: always()
-        run: cd conf && docker-compose down
+        run: cd conf && docker compose down
         working-directory: ./tools/mig-test
 
   data_stream_migration_test:
@@ -340,12 +340,12 @@ jobs:
         run: cd datastream && ruby compile_jobs.rb
         working-directory: ./tools/mig-test
       - name: Start containers
-        run: cd conf && docker-compose up -d
+        run: cd conf && docker compose up -d
         working-directory: ./tools/mig-test
       - name: Run migration tests
         run: cd datastream && FLINK_HOME=../flink-1.18.1/ ruby run_migration_test.rb
         working-directory: ./tools/mig-test
       - name: Stop containers
         if: always()
-        run: cd conf && docker-compose down
+        run: cd conf && docker compose down
         working-directory: ./tools/mig-test


### PR DESCRIPTION
As mentioned in https://github.com/actions/runner-images/issues/9557, https://github.com/actions/runner-images/issues/9692, GHA has deprecated Docker Compose V1 (`docker-compose` command), which will be removed soon. We should migrate to Docker Compose V2 (`docker compose`) before it got removed from runner images.