### PR TITLE
[hotfix] Fix StarRocks FE startup failure due to insufficient disk space available

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
@@ -357,6 +357,9 @@ public class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
                         .set(JDBC_URL, STARROCKS_CONTAINER.getJdbcUrl())
                         .set(USERNAME, StarRocksContainer.STARROCKS_USERNAME)
                         .set(PASSWORD, StarRocksContainer.STARROCKS_PASSWORD);
+        config.addAll(
+                Configuration.fromMap(
+                        Collections.singletonMap("table.create.properties.replication_num", "1")));
 
         DataSink starRocksSink = createStarRocksDataSink(config);
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksPipelineITCase.java
@@ -43,6 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.cdc.connectors.starrocks.sink.StarRocksDataSinkOptions.JDBC_URL;
@@ -162,6 +163,10 @@ public class StarRocksPipelineITCase extends StarRocksSinkTestBase {
                         .set(JDBC_URL, STARROCKS_CONTAINER.getJdbcUrl())
                         .set(USERNAME, StarRocksContainer.STARROCKS_USERNAME)
                         .set(PASSWORD, StarRocksContainer.STARROCKS_PASSWORD);
+
+        config.addAll(
+                Configuration.fromMap(
+                        Collections.singletonMap("table.create.properties.replication_num", "1")));
 
         Sink<Event> starRocksSink =
                 ((FlinkSinkProvider) createStarRocksDataSink(config).getEventSinkProvider())

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksContainer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksContainer.java
@@ -32,6 +32,10 @@ import java.util.List;
 /** Docker container for StarRocks. */
 public class StarRocksContainer extends JdbcDatabaseContainer<StarRocksContainer> {
 
+    // NOTE: StarRocks 3.x introduces free space check (> 5GB) during FE node startup
+    // (https://github.com/StarRocks/starrocks/pull/34813), which will fail on a typical GitHub
+    // runner environment. Downgraded to 2.x series for now to avoid blocking CI, and upgrade this
+    // after StarRocks provide a workaround for this.
     private static final String DOCKER_IMAGE_NAME = "starrocks/allin1-ubuntu:2.5.21";
 
     // exposed ports

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksContainer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksContainer.java
@@ -32,7 +32,7 @@ import java.util.List;
 /** Docker container for StarRocks. */
 public class StarRocksContainer extends JdbcDatabaseContainer<StarRocksContainer> {
 
-    private static final String DOCKER_IMAGE_NAME = "starrocks/allin1-ubuntu:3.2.6";
+    private static final String DOCKER_IMAGE_NAME = "starrocks/allin1-ubuntu:2.5.21";
 
     // exposed ports
     public static final int FE_HTTP_SERVICE_PORT = 8080;


### PR DESCRIPTION
This fixes recent StarRocks pipeline connector IT case failure ([#10241560412](https://github.com/apache/flink-cdc/actions/runs/10241560412), [#10233853192](https://github.com/apache/flink-cdc/actions/runs/10233853192), ...), which was caused by an exception in FE startup method [here](https://github.com/StarRocks/starrocks/blob/0f2dc86d2a006ede7ad2bfd2d393cb3d70d0ccb0/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java#L171).

Newer version of StarRocks (3.0+) requires at least 5GB free disk space to start FE node (introduced by https://github.com/StarRocks/starrocks/pull/34813), while current GitHub Actions' configuration could not provide sufficient disk space. My guess is the last GitHub Actions runner image upgrade changed disk space usage situation, since neither CDC code nor StarRocks image changed recently.

Running tests on StarRocks 2.5.21 should be fine, since this arbitrary check wasn't back-ported to 2.x series. (Manually specifying `replication_num` config is necessary since auto-configuring replication count feature was not included in this version.)

Other possible options are:

* Pay extra fees to GitHub to run CI on machines with more disk space available
* Run each pipeline connector test in independent CI tasks to reduce disk pressure
* Request @StarRocks to loosen this limitation, or at least provide an option to override this check
* Remove StarRocks IT case entirely, since basically it has been covered by https://github.com/StarRocks/starrocks-connector-for-apache-flink