### PR TITLE
[hotfix][ci] Clean up disk space

### DIFF
--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -149,6 +149,23 @@ jobs:
     steps:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 
+      - name: Clean up disk space
+        run: |
+          set -euo pipefail
+          
+          echo "Disk space before cleanup"
+          df -h 
+          
+          echo "Cleaning up disk space"
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          
+          echo "Disk space after cleanup"
+          df -h
+
       - name: Check out repository code
         uses: actions/checkout@v4
         with:

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
@@ -357,9 +357,6 @@ public class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
                         .set(JDBC_URL, STARROCKS_CONTAINER.getJdbcUrl())
                         .set(USERNAME, StarRocksContainer.STARROCKS_USERNAME)
                         .set(PASSWORD, StarRocksContainer.STARROCKS_PASSWORD);
-        config.addAll(
-                Configuration.fromMap(
-                        Collections.singletonMap("table.create.properties.replication_num", "1")));
 
         DataSink starRocksSink = createStarRocksDataSink(config);
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksPipelineITCase.java
@@ -43,7 +43,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.cdc.connectors.starrocks.sink.StarRocksDataSinkOptions.JDBC_URL;
@@ -163,10 +162,6 @@ public class StarRocksPipelineITCase extends StarRocksSinkTestBase {
                         .set(JDBC_URL, STARROCKS_CONTAINER.getJdbcUrl())
                         .set(USERNAME, StarRocksContainer.STARROCKS_USERNAME)
                         .set(PASSWORD, StarRocksContainer.STARROCKS_PASSWORD);
-
-        config.addAll(
-                Configuration.fromMap(
-                        Collections.singletonMap("table.create.properties.replication_num", "1")));
 
         Sink<Event> starRocksSink =
                 ((FlinkSinkProvider) createStarRocksDataSink(config).getEventSinkProvider())

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksContainer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksContainer.java
@@ -32,11 +32,7 @@ import java.util.List;
 /** Docker container for StarRocks. */
 public class StarRocksContainer extends JdbcDatabaseContainer<StarRocksContainer> {
 
-    // NOTE: StarRocks 3.x introduces free space check (> 5GB) during FE node startup
-    // (https://github.com/StarRocks/starrocks/pull/34813), which will fail on a typical GitHub
-    // runner environment. Downgraded to 2.x series for now to avoid blocking CI, and upgrade this
-    // after StarRocks provide a workaround for this.
-    private static final String DOCKER_IMAGE_NAME = "starrocks/allin1-ubuntu:2.5.21";
+    private static final String DOCKER_IMAGE_NAME = "starrocks/allin1-ubuntu:3.2.6";
 
     // exposed ports
     public static final int FE_HTTP_SERVICE_PORT = 8080;


### PR DESCRIPTION
### Summary

Due to the extensive use of Docker images by our CDC unit tests, GitHub runners are running low on disk space, with only `19 GB` remaining. To address this issue and free up additional disk space, we propose removing unnecessary packages from the GitHub runners.

### Details

- **Issue**: The frequent downloading of Docker images for CDC unit tests has significantly reduced the available disk space on our GitHub runners.
- **Action**: This merge request aims to delete outdated or unused packages to reclaim disk space and ensure that the runners operate efficiently.

By implementing these changes, we anticipate improved performance and reduced risk of disk space-related issues during CI/CD processes.

### Reject
We can see `/mnt` has `66 GB` disk space, flink ci https://github.com/apache/flink/blob/master/.github/workflows/template.flink-ci.yml#L177 use this space by docker volume mount. But It's  has some concern ahout this disk space. You can refer this issue: https://github.com/easimon/maximize-build-space/issues/48.

### Refer

- https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh#L45
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md

@leonardBang @yuxiqian PTAL