### PR TITLE
[FLINK-35968][cdc-connector] Remove dependency of flink-cdc-runtime from flink-cdc-source-connector

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
@@ -58,22 +58,6 @@ limitations under the License.
             <artifactId>flink-cdc-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-cdc-runtime</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.janino</groupId>
-                    <artifactId>janino</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.calcite</groupId>
-                    <artifactId>calcite-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Current, flink-cdc-source-connectors  depends on flink-cdc-runtime, which is not ideal for design and is redundant.

This issue is aimed to remove it.