### PR TITLE
[FLINK-36023][cdc-composer] Hotfix: Flink CDC K8S Native Application …

### DIFF
--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/utils/FactoryDiscoveryUtils.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/utils/FactoryDiscoveryUtils.java
@@ -94,9 +94,10 @@ public class FactoryDiscoveryUtils {
             T factory = getFactoryByIdentifier(identifier, factoryClass);
             URL url = factory.getClass().getProtectionDomain().getCodeSource().getLocation();
             String urlString = url.toString();
-            if (urlString.contains("usrlib")) {
-                String flinkHome = System.getenv("FLINK_HOME");
-                urlString = urlString.replace("usrlib", flinkHome + "/usrlib");
+            // if already in usr lib of k8s, the jar has been added into classpath.Thus, no need to
+            // upload jar anymore.
+            if (urlString.startsWith("local:///opt/flink/usrlib/")) {
+                return Optional.empty();
             }
             url = new URL(urlString);
             if (Files.isDirectory(Paths.get(url.toURI()))) {


### PR DESCRIPTION
As shown in https://issues.apache.org/jira/browse/FLINK-36023, there is some problem:
* if user summit job not in Flink K8S Native Application Mode, and put jar in /mypackage/usrlib will be casted to &{FLINK_HOME}/usrlib.
* if user summit job in Flink K8S Native Application Mode , jar in local:///opt/flink/usrlib/ have already been added to classpath of JM and TM, thus no need to add jar anymore.