### PR TITLE
[FLINK-35984][transform] Fix: Job crashes when metadata column names present in transform rules

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumnProcessor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumnProcessor.java
@@ -152,22 +152,22 @@ public class ProjectionColumnProcessor {
                 }
             }
         }
-        if (scriptExpression.contains(TransformParser.DEFAULT_NAMESPACE_NAME)
-                && !argumentNames.contains(TransformParser.DEFAULT_NAMESPACE_NAME)) {
-            argumentNames.add(TransformParser.DEFAULT_NAMESPACE_NAME);
-            paramTypes.add(String.class);
-        }
 
-        if (scriptExpression.contains(TransformParser.DEFAULT_SCHEMA_NAME)
-                && !argumentNames.contains(TransformParser.DEFAULT_SCHEMA_NAME)) {
-            argumentNames.add(TransformParser.DEFAULT_SCHEMA_NAME);
-            paramTypes.add(String.class);
-        }
-
-        if (scriptExpression.contains(TransformParser.DEFAULT_TABLE_NAME)
-                && !argumentNames.contains(TransformParser.DEFAULT_TABLE_NAME)) {
-            argumentNames.add(TransformParser.DEFAULT_TABLE_NAME);
-            paramTypes.add(String.class);
+        for (String originalColumnName : originalColumnNames) {
+            switch (originalColumnName) {
+                case TransformParser.DEFAULT_NAMESPACE_NAME:
+                    argumentNames.add(TransformParser.DEFAULT_NAMESPACE_NAME);
+                    paramTypes.add(String.class);
+                    break;
+                case TransformParser.DEFAULT_SCHEMA_NAME:
+                    argumentNames.add(TransformParser.DEFAULT_SCHEMA_NAME);
+                    paramTypes.add(String.class);
+                    break;
+                case TransformParser.DEFAULT_TABLE_NAME:
+                    argumentNames.add(TransformParser.DEFAULT_TABLE_NAME);
+                    paramTypes.add(String.class);
+                    break;
+            }
         }
 
         argumentNames.add(JaninoCompiler.DEFAULT_TIME_ZONE);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
@@ -499,7 +499,7 @@ public class TransformParser {
     }
 
     private static List<Column> copyFillMetadataColumn(List<Column> columns) {
-        // Add meteColumn for SQLValidater.validate
+        // Add metaColumn for SQLValidater.validate
         List<Column> columnsWithMetadata = new ArrayList<>(columns);
         columnsWithMetadata.add(Column.physicalColumn(DEFAULT_NAMESPACE_NAME, DataTypes.STRING()));
         columnsWithMetadata.add(Column.physicalColumn(DEFAULT_SCHEMA_NAME, DataTypes.STRING()));

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
@@ -499,7 +499,7 @@ public class TransformParser {
     }
 
     private static List<Column> copyFillMetadataColumn(List<Column> columns) {
-        // Add metaColumn for SQLValidater.validate
+        // Add metaColumn for SQLValidator.validate
         List<Column> columnsWithMetadata = new ArrayList<>(columns);
         columnsWithMetadata.add(Column.physicalColumn(DEFAULT_NAMESPACE_NAME, DataTypes.STRING()));
         columnsWithMetadata.add(Column.physicalColumn(DEFAULT_SCHEMA_NAME, DataTypes.STRING()));

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
@@ -109,7 +109,7 @@ public class TransformParser {
             List<Column> columns,
             SqlNode sqlNode,
             List<UserDefinedFunctionDescriptor> udfDescriptors) {
-        List<Column> columnsWithMetadata = copyFillMetadataColumn(sqlNode.toString(), columns);
+        List<Column> columnsWithMetadata = copyFillMetadataColumn(columns);
         CalciteSchema rootSchema = CalciteSchema.createRootSchema(true);
         SchemaPlus schema = rootSchema.plus();
         Map<String, Object> operand = new HashMap<>();
@@ -498,27 +498,13 @@ public class TransformParser {
         return parseSelect(statement.toString());
     }
 
-    private static List<Column> copyFillMetadataColumn(
-            String transformStatement, List<Column> columns) {
+    private static List<Column> copyFillMetadataColumn(List<Column> columns) {
+        // Add meteColumn for SQLValidater.validate
         List<Column> columnsWithMetadata = new ArrayList<>(columns);
-        if (transformStatement.contains(DEFAULT_NAMESPACE_NAME)
-                && !containsMetadataColumn(columnsWithMetadata, DEFAULT_NAMESPACE_NAME)) {
-            columnsWithMetadata.add(
-                    Column.physicalColumn(DEFAULT_NAMESPACE_NAME, DataTypes.STRING()));
-        }
-        if (transformStatement.contains(DEFAULT_SCHEMA_NAME)
-                && !containsMetadataColumn(columnsWithMetadata, DEFAULT_SCHEMA_NAME)) {
-            columnsWithMetadata.add(Column.physicalColumn(DEFAULT_SCHEMA_NAME, DataTypes.STRING()));
-        }
-        if (transformStatement.contains(DEFAULT_TABLE_NAME)
-                && !containsMetadataColumn(columnsWithMetadata, DEFAULT_TABLE_NAME)) {
-            columnsWithMetadata.add(Column.physicalColumn(DEFAULT_TABLE_NAME, DataTypes.STRING()));
-        }
+        columnsWithMetadata.add(Column.physicalColumn(DEFAULT_NAMESPACE_NAME, DataTypes.STRING()));
+        columnsWithMetadata.add(Column.physicalColumn(DEFAULT_SCHEMA_NAME, DataTypes.STRING()));
+        columnsWithMetadata.add(Column.physicalColumn(DEFAULT_TABLE_NAME, DataTypes.STRING()));
         return columnsWithMetadata;
-    }
-
-    private static boolean containsMetadataColumn(List<Column> columns, String columnName) {
-        return columns.stream().anyMatch(column -> column.getName().equals(columnName));
     }
 
     private static boolean isMetadataColumn(String columnName) {

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/UnifiedTransformOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/UnifiedTransformOperatorTest.java
@@ -918,6 +918,52 @@ public class UnifiedTransformOperatorTest {
     }
 
     @Test
+    public void testMetadataTransformIncludeMetaColumnString() throws Exception {
+        TableId tableId = TableId.tableId("my_company", "my_branch", "schema_nullability");
+        UnifiedTransformTestCase.of(
+                        tableId,
+                        "id, name, age, id + age as computed, __table_name__ as metaCol1, '__table_name__' as metaCol2, '__namespace__name__schema__name__table__name__' as metaCol3, UPPER(__schema_name__) as metaCol4",
+                        "id > 100",
+                        Schema.newBuilder()
+                                .physicalColumn("id", DataTypes.INT())
+                                .physicalColumn("name", DataTypes.STRING().notNull())
+                                .physicalColumn("age", DataTypes.INT().notNull())
+                                .primaryKey("id")
+                                .build(),
+                        Schema.newBuilder()
+                                .physicalColumn("id", DataTypes.INT())
+                                .physicalColumn("name", DataTypes.STRING().notNull())
+                                .physicalColumn("age", DataTypes.INT().notNull())
+                                .primaryKey("id")
+                                .build(),
+                        Schema.newBuilder()
+                                .physicalColumn("id", DataTypes.INT())
+                                .physicalColumn("name", DataTypes.STRING().notNull())
+                                .physicalColumn("age", DataTypes.INT().notNull())
+                                .physicalColumn("computed", DataTypes.INT())
+                                .physicalColumn("metaCol1", DataTypes.STRING())
+                                .physicalColumn("metaCol2", DataTypes.STRING())
+                                .physicalColumn("metaCol3", DataTypes.STRING())
+                                .physicalColumn("metaCol4", DataTypes.STRING())
+                                .primaryKey("id")
+                                .build())
+                .initializeHarness()
+                .insertSource(1000, "Alice", 17)
+                .insertPreTransformed(1000, "Alice", 17)
+                .insertPostTransformed(
+                        1000,
+                        "Alice",
+                        17,
+                        1017,
+                        "schema_nullability",
+                        "__table_name__",
+                        "__namespace__name__schema__name__table__name__",
+                        "MY_BRANCH")
+                .runTests()
+                .destroyHarness();
+    }
+
+    @Test
     public void testTransformWithCast() throws Exception {
         TableId tableId = TableId.tableId("my_company", "my_branch", "transform_with_cast");
         UnifiedTransformTestCase.of(

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/UnifiedTransformOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/UnifiedTransformOperatorTest.java
@@ -922,7 +922,8 @@ public class UnifiedTransformOperatorTest {
         TableId tableId = TableId.tableId("my_company", "my_branch", "schema_nullability");
         UnifiedTransformTestCase.of(
                         tableId,
-                        "id, name, age, id + age as computed, __table_name__ as metaCol1, '__table_name__' as metaCol2, '__namespace__name__schema__name__table__name__' as metaCol3, UPPER(__schema_name__) as metaCol4",
+                        "id, name, age, id + age as computed, __namespace_name__ as metaColNameSpaceName,  __schema_name__ as metaColSchemaName, __table_name__ as metaColNameTableName, "
+                                + "UPPER(__schema_name__) as metaColSchemaNameUpper, '__table_name__' as metaColStr1, '__namespace__name__schema__name__table__name__' as metaColStr2",
                         "id > 100",
                         Schema.newBuilder()
                                 .physicalColumn("id", DataTypes.INT())
@@ -941,10 +942,12 @@ public class UnifiedTransformOperatorTest {
                                 .physicalColumn("name", DataTypes.STRING().notNull())
                                 .physicalColumn("age", DataTypes.INT().notNull())
                                 .physicalColumn("computed", DataTypes.INT())
-                                .physicalColumn("metaCol1", DataTypes.STRING())
-                                .physicalColumn("metaCol2", DataTypes.STRING())
-                                .physicalColumn("metaCol3", DataTypes.STRING())
-                                .physicalColumn("metaCol4", DataTypes.STRING())
+                                .physicalColumn("metaColNameSpaceName", DataTypes.STRING())
+                                .physicalColumn("metaColSchemaName", DataTypes.STRING())
+                                .physicalColumn("metaColNameTableName", DataTypes.STRING())
+                                .physicalColumn("metaColSchemaNameUpper", DataTypes.STRING())
+                                .physicalColumn("metaColStr1", DataTypes.STRING())
+                                .physicalColumn("metaColStr2", DataTypes.STRING())
                                 .primaryKey("id")
                                 .build())
                 .initializeHarness()
@@ -955,10 +958,12 @@ public class UnifiedTransformOperatorTest {
                         "Alice",
                         17,
                         1017,
+                        "my_company",
+                        "my_branch",
                         "schema_nullability",
+                        "MY_BRANCH",
                         "__table_name__",
-                        "__namespace__name__schema__name__table__name__",
-                        "MY_BRANCH")
+                        "__namespace__name__schema__name__table__name__")
                 .runTests()
                 .destroyHarness();
     }


### PR DESCRIPTION
since metadata column existence check was done by searching identifier string in statement, without considering any syntax info

In the transform rule (projection: \*, '_namespace_nameschema_nametable_name_' AS string_literal) mentioned in FLINK-35984, Caused by: java.lang.IllegalArgumentException: wrong number of arguments is thrown because of the "\*" symbol. The PreTransformOperator introduced in FLINK-35272 fixes the "\*" problem, but there are still some scenarios where Caused by: java.lang.IllegalArgumentException: wrong number of arguments is thrown due to metaColumn name conflicts. This PR will fix these bugs.