### PR TITLE
[FLINK-36027][cdc-connector][mysql] numRecordsOut/numRecordsOutRate metrics for each OperationType

### DIFF
--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -1139,10 +1139,13 @@ The example for different spatial data types mapping is as follows:
 </div>
 
 ## Metrics 
-The mysql-cdc connector offers three additional metrics for each type of data change records.
-- `numRecordsOutByDataChangeRecordInsert`: The number of data change records of INSERT.
-- `numRecordsOutByDataChangeRecordUpdate`: The number of data change records of UPDATE.
-- `numRecordsOutByDataChangeRecordDelete`: The number of data change records of DELETE.
+The mysql-cdc connector offers six additional metrics for each type of data change record.
+- `numRecordsOutByDataChangeRecordInsert`: The number of `INSERT` data change records.
+- `numRecordsOutByDataChangeRecordUpdate`: The number of `UPDATE` data change records.
+- `numRecordsOutByDataChangeRecordDelete`: The number of `DELETE` data change records.
+- `numRecordsOutByRateDataChangeRecordInsert`: The number of `INSERT` data change records per second.
+- `numRecordsOutByRateDataChangeRecordUpdate`: The number of `UPDATE` data change records per second.
+- `numRecordsOutByRateDataChangeRecordDelete`: The number of `DELETE` data change records per second.
 
 
 {{< top >}}

--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -1138,4 +1138,11 @@ The example for different spatial data types mapping is as follows:
 </table>
 </div>
 
+## Metrics 
+The mysql-cdc connector offers three additional metrics for each type of data change records.
+- `numRecordsOutByDataChangeRecordInsert`: The number of data change records of INSERT.
+- `numRecordsOutByDataChangeRecordUpdate`: The number of data change records of UPDATE.
+- `numRecordsOutByDataChangeRecordDelete`: The number of data change records of DELETE.
+
+
 {{< top >}}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -22,6 +22,7 @@ import org.apache.flink.cdc.common.event.OperationType;
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReader;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
 
@@ -47,10 +48,16 @@ public class MySqlSourceReaderMetrics {
             new ConcurrentHashMap();
     public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_RECORD_INSERT =
             "numRecordsOutByDataChangeRecordInsert";
+    public static final String IO_NUM_RECORDS_OUT_RATE_DATA_CHANGE_RECORD_INSERT =
+            "numRecordsOutByPerSecondDataChangeRecordInsert";
     public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_RECORD_UPDATE =
             "numRecordsOutByDataChangeRecordUpdate";
+    public static final String IO_NUM_RECORDS_OUT_RATE_DATA_CHANGE_RECORD_UPDATE =
+            "numRecordsOutByPerSecondDataChangeRecordUpdate";
     public static final String IO_NUM_RECORDS_OUT_DATA_CHANGE_RECORD_DELETE =
             "numRecordsOutByDataChangeRecordDelete";
+    public static final String IO_NUM_RECORDS_OUT_RATE_DATA_CHANGE_RECORD_DELETE =
+            "numRecordsOutByPerSecondDataChangeRecordDelete";
 
     public MySqlSourceReaderMetrics(MetricGroup metricGroup) {
         this.metricGroup = metricGroup;
@@ -59,6 +66,15 @@ public class MySqlSourceReaderMetrics {
     public void registerMetrics() {
         metricGroup.gauge(
                 MetricNames.CURRENT_FETCH_EVENT_TIME_LAG, (Gauge<Long>) this::getFetchDelay);
+        this.metricGroup.meter(
+                IO_NUM_RECORDS_OUT_RATE_DATA_CHANGE_RECORD_INSERT,
+                new MeterView(metricGroup.counter(IO_NUM_RECORDS_OUT_DATA_CHANGE_RECORD_INSERT)));
+        this.metricGroup.meter(
+                IO_NUM_RECORDS_OUT_RATE_DATA_CHANGE_RECORD_UPDATE,
+                new MeterView(metricGroup.counter(IO_NUM_RECORDS_OUT_DATA_CHANGE_RECORD_UPDATE)));
+        this.metricGroup.meter(
+                IO_NUM_RECORDS_OUT_RATE_DATA_CHANGE_RECORD_DELETE,
+                new MeterView(metricGroup.counter(IO_NUM_RECORDS_OUT_DATA_CHANGE_RECORD_DELETE)));
     }
 
     public long getFetchDelay() {


### PR DESCRIPTION
Added numRecordsOut/numRecordsOutRate metrics for each OperationType `INSERT`, `UPDATE`, `DELETE`.

Removed table identifier from metrics name. With monitoring tools such as prometheus, we can distinguish flink job, db, and table using metric attributes.

Don't support this metrics for snapshot phase. Because, the value will be same with `numRecodsOut`, `numRecordsOutRate` in Flink.


related pr: [feature/add-metric-num-records-out-by-data-change-event](https://github.com/apache/flink-cdc/pull/3456)
