### PR TITLE
[hotfix][runtime] Invalidate cache correctly to avoid classloader leakage

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionCompiler.java
@@ -39,7 +39,10 @@ public class TransformExpressionCompiler {
 
     /** Triggers internal garbage collection of expired cache entries. */
     public static void cleanUp() {
-        COMPILED_EXPRESSION_CACHE.cleanUp();
+        // com.google.common.cache.Cache from Guava isn't guaranteed to clear all cached records
+        // when invoking Cache#cleanUp, which may cause classloader leakage. Use #invalidateAll
+        // instead to ensure all key / value pairs to be correctly discarded.
+        COMPILED_EXPRESSION_CACHE.invalidateAll();
     }
 
     /** Compiles an expression code to a janino {@link ExpressionEvaluator}. */


### PR DESCRIPTION
Occasionally, CDC composer ITcase will fail when running test cases consecutively, with the following error message:

```
Caused by: java.lang.IllegalStateException: Trying to access closed classloader. Please check if you store classloaders directly or indirectly in static fields. If the stacktrace suggests that the leak occurs in a third party library and cannot be fixed immediately, you can disable this check with the configuration 'classloader.check-leaked-classloader'.
	at org.apache.flink.util.FlinkUserCodeClassLoaders$SafetyNetWrapperClassLoader.ensureInner(FlinkUserCodeClassLoaders.java:184)
	at org.apache.flink.util.FlinkUserCodeClassLoaders$SafetyNetWrapperClassLoader.loadClass(FlinkUserCodeClassLoaders.java:198)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:411)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at sun.misc.Unsafe.defineClass(Native Method)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.janino.ExpressionEvaluator.evaluate(ExpressionEvaluator.java:541)
	at org.codehaus.janino.ExpressionEvaluator.evaluate(ExpressionEvaluator.java:533)
	at org.apache.flink.cdc.runtime.operators.transform.TransformFilterProcessor.process(TransformFilterProcessor.java:78)
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processFilter(PostTransformOperator.java:393)
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processDataChangeEvent(PostTransformOperator.java:335)
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElement(PostTransformOperator.java:227)
	at org.apache.flink.streaming.runtime.tasks.OneInputStreamTask$StreamTaskNetworkOutput.emitRecord(OneInputStreamTask.java:237)
	at org.apache.flink.streaming.runtime.io.AbstractStreamTaskNetworkInput.processElement(AbstractStreamTaskNetworkInput.java:146)
	at org.apache.flink.streaming.runtime.io.AbstractStreamTaskNetworkInput.emitNext(AbstractStreamTaskNetworkInput.java:110)
	at org.apache.flink.streaming.runtime.io.StreamOneInputProcessor.processInput(StreamOneInputProcessor.java:65)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.processInput(StreamTask.java:562)
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:231)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:858)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:807)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:953)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:932)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:746)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:562)
	at java.lang.Thread.run(Thread.java:748)
```

Turns out it was caused by the static field `COMPILED_EXPRESSION_CACHE` used for caching transform expression evaluators. `PostTransformOperator` tried to invalidate cache by calling `Cache#cleanUp`, which doesn't have a well-defined behavior. Whether clearing cache or not is implementation-dependent[1]. Since `Cache#invalidateAll` will discard all entries immediately,  it should resolve such exception.

[1] https://guava.dev/releases/21.0/api/docs/com/google/common/cache/Cache.html