### PR TITLE
[FLINK-36054][cdc][build] Fix Flink CDC parent pom and release scripts

### DIFF
--- a/flink-cdc-cli/pom.xml
+++ b/flink-cdc-cli/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-common/pom.xml
+++ b/flink-cdc-common/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-composer/pom.xml
+++ b/flink-cdc-composer/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-connect/pom.xml
+++ b/flink-cdc-connect/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-dist/pom.xml
+++ b/flink-cdc-dist/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-dist/src/main/assembly/assembly.xml
+++ b/flink-cdc-dist/src/main/assembly/assembly.xml
@@ -32,6 +32,13 @@ limitations under the License.
             <destName>flink-cdc-dist-${revision}.jar</destName>
             <fileMode>0644</fileMode>
         </file>
+
+        <!-- copy license -->
+        <file>
+            <source>../LICENSE</source>
+            <outputDirectory/>
+            <fileMode>0644</fileMode>
+        </file>
     </files>
 
     <fileSets>

--- a/flink-cdc-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/flink-cdc-migration-tests/pom.xml
+++ b/flink-cdc-migration-tests/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/flink-cdc-pipeline-udf-examples/pom.xml
+++ b/flink-cdc-pipeline-udf-examples/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <version>${revision}</version>
     </parent>
 

--- a/flink-cdc-runtime/pom.xml
+++ b/flink-cdc-runtime/pom.xml
@@ -19,7 +19,7 @@ limitations under the License.
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>flink-cdc</artifactId>
+        <artifactId>flink-cdc-parent</artifactId>
         <groupId>org.apache.flink</groupId>
         <version>${revision}</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.apache.flink</groupId>
-    <artifactId>flink-cdc</artifactId>
+    <artifactId>flink-cdc-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,16 +51,11 @@ limitations under the License.
         </license>
     </licenses>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>oss</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-        </snapshotRepository>
-        <repository>
-            <id>oss</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
+    <scm>
+        <url>https://github.com/apache/flink-cdc</url>
+        <connection>git@github.com:apache/flink-cdc.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-cdc.git</developerConnection>
+    </scm>
 
     <properties>
         <revision>3.3-SNAPSHOT</revision>

--- a/pom.xml
+++ b/pom.xml
@@ -722,107 +722,35 @@ limitations under the License.
             </build>
         </profile>
         <profile>
-            <id>release</id>
+            <!--
+              We're reusing the apache-release build profile defined in the Apache Parent POM,
+              with one exclusion: do not run the source-release-assembly execution goal.
+              We have our own scripts to create the source release, which correctly excludes
+              binaries from distribution tarball.
+              The script can be found under tools/releasing/create_source_release.sh.
+            -->
+            <id>apache-release</id>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.apache.apache.resources</groupId>
+                                <artifactId>apache-source-release-assembly-descriptor</artifactId>
+                                <version>1.0.6</version>
+                            </dependency>
+                        </dependencies>
                         <executions>
                             <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-enforcer-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>enforce-java</id>
-                                <goals>
-                                    <goal>enforce</goal>
-                                </goals>
-                                <configuration>
-                                    <rules>
-                                        <requireJavaVersion>
-                                            <version>[1.8,)</version>
-                                        </requireJavaVersion>
-                                    </rules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version><!--$NO-MVN-MAN-VER$-->
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>net.ju-n.maven.plugins</groupId>
-                        <artifactId>checksum-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>artifacts</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <algorithms>
-                                <algorithm>SHA-256</algorithm>
-                            </algorithms>
-                            <failOnError>false</failOnError>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9.1</version><!--$NO-MVN-MAN-VER$-->
-                        <configuration>
-                            <quiet>true</quiet>
-                            <detectOfflineLinks>false</detectOfflineLinks>
-                            <additionalJOptions combine.children="append">
-                                <additionalJOption>-Xdoclint:none</additionalJOption>
-                            </additionalJOptions>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
+                                <id>source-release-assembly</id>
+                                <!-- disable the execution -->
+                                <phase>none</phase>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-release-plugin</artifactId>
-                            <version>2.1</version>
-                            <configuration>
-                                <mavenExecutorId>forked-path</mavenExecutorId>
-                                <useReleaseProfile>false</useReleaseProfile>
-                                <arguments>${arguments} -Psonatype-oss-release</arguments>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
             </build>
         </profile>
     </profiles>

--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -77,10 +77,10 @@ rsync -a \
   --exclude ".travis.yml" \
   . flink-cdc-${RELEASE_VERSION}
 
-tar czf ${RELEASE_DIR}/apache-flink-cdc-${RELEASE_VERSION}-src.tgz flink-cdc-${RELEASE_VERSION}
-gpg --armor --detach-sig ${RELEASE_DIR}/apache-flink-cdc-${RELEASE_VERSION}-src.tgz
+tar czf ${RELEASE_DIR}/flink-cdc-${RELEASE_VERSION}-src.tgz flink-cdc-${RELEASE_VERSION}
+gpg --armor --detach-sig ${RELEASE_DIR}/flink-cdc-${RELEASE_VERSION}-src.tgz
 cd ${RELEASE_DIR}
-${SHASUM} apache-flink-cdc-${RELEASE_VERSION}-src.tgz > apache-flink-cdc-${RELEASE_VERSION}-src.tgz.sha512
+${SHASUM} flink-cdc-${RELEASE_VERSION}-src.tgz > flink-cdc-${RELEASE_VERSION}-src.tgz.sha512
 
 rm -rf ${CLONE_DIR}
 


### PR DESCRIPTION
This pull request fixes several issues in Flink CDC parent pom and release script:

In parent pom:
- Parent pom should use artifact ID `flink-cdc-parent` instead of `flink-cdc`
- Distribution management pointing to Sonatype should be removed, as we should use Apache repository
- Parent pom should include correct SCM information
- Parent pom should use `apache-release` profile for releasing

In release script:
- LICENSE file should be included in the binary release
- Source release prefix should be `flink-cdc` instead of `apache-flink-cdc`