### PR TITLE
[FLINK-36086] Set isSnapshotCompleted only immediately after snapshot

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
@@ -272,6 +272,8 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
                 stoppingOffset,
                 divideMetaToGroups ? new ArrayList<>() : finishedSnapshotSplitInfos,
                 new HashMap<>(),
-                finishedSnapshotSplitInfos.size());
+                finishedSnapshotSplitInfos.size(),
+                false,
+                true);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/offset/OffsetDeserializerSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/offset/OffsetDeserializerSerializer.java
@@ -50,6 +50,7 @@ public interface OffsetDeserializerSerializer extends Serializable {
             case 3:
             case 4:
             case 5:
+            case 6:
                 return readOffsetPosition(in);
             default:
                 throw new IOException("Unknown version: " + offsetVersion);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
@@ -50,7 +50,7 @@ import java.util.Map;
 public abstract class SourceSplitSerializer
         implements SimpleVersionedSerializer<SourceSplitBase>, OffsetDeserializerSerializer {
 
-    private static final int VERSION = 5;
+    private static final int VERSION = 6;
     private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
             ThreadLocal.withInitial(() -> new DataOutputSerializer(64));
 
@@ -126,6 +126,7 @@ public abstract class SourceSplitSerializer
             case 3:
             case 4:
             case 5:
+            case 6:
                 return deserializeSplit(version, serialized);
             default:
                 throw new IOException("Unknown version: " + version);
@@ -175,6 +176,12 @@ public abstract class SourceSplitSerializer
             if (version == 5) {
                 isSuspended = in.readBoolean();
             }
+
+            boolean isSnapshotCompleted = false;
+            if (version >= 6) {
+                isSnapshotCompleted = in.readBoolean();
+            }
+
             in.releaseArrays();
             return new StreamSplit(
                     splitId,
@@ -183,7 +190,8 @@ public abstract class SourceSplitSerializer
                     finishedSplitsInfo,
                     tableChangeMap,
                     totalFinishedSplitSize,
-                    isSuspended);
+                    isSuspended,
+                    isSnapshotCompleted);
         } else {
             throw new IOException("Unknown split kind: " + splitKind);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializerTest.java
@@ -105,7 +105,8 @@ public class SourceSplitSerializerTest {
                 new ArrayList<>(),
                 new HashMap<>(),
                 0,
-                isSuspend);
+                isSuspend,
+                false);
     }
 
     private StreamSplitVersion4 constuctStreamSplitVersion4() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerStreamFetchTask.java
@@ -56,7 +56,9 @@ public class SqlServerStreamFetchTask implements FetchTask<SourceSplitBase> {
     public void execute(Context context) throws Exception {
         SqlServerSourceFetchTaskContext sourceFetchContext =
                 (SqlServerSourceFetchTaskContext) context;
-        sourceFetchContext.getOffsetContext().preSnapshotCompletion();
+        if (split.isSnapshotCompleted()) {
+            sourceFetchContext.getOffsetContext().preSnapshotCompletion();
+        }
         taskRunning = true;
         StreamSplitReadTask redoLogSplitReadTask =
                 new StreamSplitReadTask(


### PR DESCRIPTION
If the SQL Server source connector is restarted while handling updates from a transaction with multiple updates, upon restart, it will skip the non-processed changes and proceed from the next transaction.

This is an analog of [DBZ-1128](https://issues.redhat.com/browse/DBZ-1128) but reproducible only in Flink CDC.

This is a regression introduced in #2176.

### Lower-level details

The `isSnapshotCompleted` offset context flag in Debezium tells the source connector to jump one transaction ahead in the beginning of the streaming phase. This is only necessary during the transition from the initial state snapshot to streaming. Without this flag set, the streaming change data source would stream the changes from the transaction that was already included in the snapshot. This is is the issue that #2176 attempted to address.

The following line sets this flag unconditionally for the stream split: https://github.com/apache/flink-cdc/blob/c5396fbf29ae3a48bb13e38d113b8be674861a22/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerStreamFetchTask.java#L59

It makes Debezium jump one transaction ahead not only after completing the initial state snapshot but always during the start of streaming. This way, it may potentially skip changes from a transaction that wasn't fully captured prior to the restart.

The proposed solution is to set it only during the transition from the initial state snapshot to streaming.

### Testing considerations
1. In order to implement a test for the scenario in question, I would need a way to restart the connector in the middle of processing a transaction (something like `start(..., Predicate<SourceRecord> isStopRecord)` in the Debezium testing framework). How could I implement a similar case in Flink CDC?
2. The test implemented in https://github.com/apache/flink-cdc/pull/2176 doesn't fail even if the fix for the issue it covers is reverted, so at this point it's not clear how to reproduce the original issue.