### PR TITLE
[FLINK-36088][pipeline-connector][paimon] Fix NullPointerException in BucketAssignOperator.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketAssignOperator.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/bucket/BucketAssignOperator.java
@@ -130,7 +130,7 @@ public class BucketAssignOperator extends AbstractStreamOperator<Event>
 
         if (event instanceof DataChangeEvent) {
             DataChangeEvent dataChangeEvent = (DataChangeEvent) event;
-            if (schemaMaps.containsKey(dataChangeEvent.tableId())) {
+            if (!schemaMaps.containsKey(dataChangeEvent.tableId())) {
                 Optional<Schema> schema =
                         schemaEvolutionClient.getLatestEvolvedSchema(dataChangeEvent.tableId());
                 if (schema.isPresent()) {


### PR DESCRIPTION
Try to get latestSchema from SchemaRegistry when job restarted.
 this pr is aimed to correct the judgement to request the latest Schema from SchemaRegistry for the DataChangeEvent that haven't met before.
