### PR TITLE
[FLINK-36105] Fix unable to restore from checkpoint with Flink 1.20

### DIFF
--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -315,16 +315,16 @@ jobs:
       - name: Prepare CDC versions
         run: CDC_SOURCE_HOME=$PWD ruby tools/mig-test/prepare_libs.rb
       - name: Prepare Flink distro
-        run: wget https://dlcdn.apache.org/flink/flink-{{ matrix.flink-version }}/flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz && tar -xzvf flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz
+        run: wget https://dlcdn.apache.org/flink/flink-${{ matrix.flink-version }}/flink-${{ matrix.flink-version }}-bin-scala_2.12.tgz && tar -xzvf flink-${{ matrix.flink-version }}-bin-scala_2.12.tgz
         working-directory: ./tools/mig-test
       - name: Patch Flink configs
-        run: FLINK_HOME=./flink-{{ matrix.flink-version }}/ ruby misc/patch_flink_conf.rb
+        run: FLINK_HOME=./flink-${{ matrix.flink-version }}/ ruby misc/patch_flink_conf.rb
         working-directory: ./tools/mig-test
       - name: Start containers
         run: cd conf && docker compose up -d
         working-directory: ./tools/mig-test
       - name: Run migration tests
-        run: FLINK_HOME=./flink-{{ matrix.flink-version }}/ ruby run_migration_test.rb
+        run: FLINK_HOME=./flink-${{ matrix.flink-version }}/ ruby run_migration_test.rb ${{ matrix.flink-version }}
         working-directory: ./tools/mig-test
       - name: Stop containers
         if: always()
@@ -355,10 +355,10 @@ jobs:
       - name: Prepare CDC versions
         run: CDC_SOURCE_HOME=$PWD ruby tools/mig-test/prepare_libs.rb
       - name: Prepare Flink distro
-        run: wget https://dlcdn.apache.org/flink/flink-{{ matrix.flink-version }}/flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz && tar -xzvf flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz
+        run: wget https://dlcdn.apache.org/flink/flink-${{ matrix.flink-version }}/flink-${{ matrix.flink-version }}-bin-scala_2.12.tgz && tar -xzvf flink-${{ matrix.flink-version }}-bin-scala_2.12.tgz
         working-directory: ./tools/mig-test
       - name: Patch Flink configs
-        run: FLINK_HOME=./flink-{{ matrix.flink-version }}/ ruby misc/patch_flink_conf.rb
+        run: FLINK_HOME=./flink-${{ matrix.flink-version }}/ ruby misc/patch_flink_conf.rb
         working-directory: ./tools/mig-test
       - name: Compile Dummy DataStream Jobs
         run: cd datastream && ruby compile_jobs.rb
@@ -367,7 +367,7 @@ jobs:
         run: cd conf && docker compose up -d
         working-directory: ./tools/mig-test
       - name: Run migration tests
-        run: cd datastream && FLINK_HOME=../flink-{{ matrix.flink-version }}/ ruby run_migration_test.rb
+        run: cd datastream && FLINK_HOME=../flink-${{ matrix.flink-version }}/ ruby run_migration_test.rb
         working-directory: ./tools/mig-test
       - name: Stop containers
         if: always()

--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '8', '11' ]
+        flink-version: [ '1.18.1', '1.19.1', '1.20.0' ]
 
     steps:
       - uses: actions/checkout@v4
@@ -307,7 +307,7 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: 8
           distribution: temurin
           cache: maven
       - name: Install dependencies
@@ -315,16 +315,16 @@ jobs:
       - name: Prepare CDC versions
         run: CDC_SOURCE_HOME=$PWD ruby tools/mig-test/prepare_libs.rb
       - name: Prepare Flink distro
-        run: wget https://dlcdn.apache.org/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz && tar -xzvf flink-1.18.1-bin-scala_2.12.tgz
+        run: wget https://dlcdn.apache.org/flink/flink-{{ matrix.flink-version }}/flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz && tar -xzvf flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz
         working-directory: ./tools/mig-test
       - name: Patch Flink configs
-        run: FLINK_HOME=./flink-1.18.1/ ruby misc/patch_flink_conf.rb
+        run: FLINK_HOME=./flink-{{ matrix.flink-version }}/ ruby misc/patch_flink_conf.rb
         working-directory: ./tools/mig-test
       - name: Start containers
         run: cd conf && docker compose up -d
         working-directory: ./tools/mig-test
       - name: Run migration tests
-        run: FLINK_HOME=./flink-1.18.1/ ruby run_migration_test.rb
+        run: FLINK_HOME=./flink-{{ matrix.flink-version }}/ ruby run_migration_test.rb
         working-directory: ./tools/mig-test
       - name: Stop containers
         if: always()
@@ -336,7 +336,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ '8', '11' ]
+        flink-version: [ '1.18.1', '1.19.1', '1.20.0' ]
 
     steps:
       - uses: actions/checkout@v4
@@ -347,7 +347,7 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: 8
           distribution: temurin
           cache: maven
       - name: Install dependencies
@@ -355,10 +355,10 @@ jobs:
       - name: Prepare CDC versions
         run: CDC_SOURCE_HOME=$PWD ruby tools/mig-test/prepare_libs.rb
       - name: Prepare Flink distro
-        run: wget https://dlcdn.apache.org/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz && tar -xzvf flink-1.18.1-bin-scala_2.12.tgz
+        run: wget https://dlcdn.apache.org/flink/flink-{{ matrix.flink-version }}/flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz && tar -xzvf flink-{{ matrix.flink-version }}-bin-scala_2.12.tgz
         working-directory: ./tools/mig-test
       - name: Patch Flink configs
-        run: FLINK_HOME=./flink-1.18.1/ ruby misc/patch_flink_conf.rb
+        run: FLINK_HOME=./flink-{{ matrix.flink-version }}/ ruby misc/patch_flink_conf.rb
         working-directory: ./tools/mig-test
       - name: Compile Dummy DataStream Jobs
         run: cd datastream && ruby compile_jobs.rb
@@ -367,7 +367,7 @@ jobs:
         run: cd conf && docker compose up -d
         working-directory: ./tools/mig-test
       - name: Run migration tests
-        run: cd datastream && FLINK_HOME=../flink-1.18.1/ ruby run_migration_test.rb
+        run: cd datastream && FLINK_HOME=../flink-{{ matrix.flink-version }}/ ruby run_migration_test.rb
         working-directory: ./tools/mig-test
       - name: Stop containers
         if: always()

--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontend.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontend.java
@@ -22,7 +22,6 @@ import org.apache.flink.cdc.cli.utils.FlinkEnvironmentUtils;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.composer.PipelineExecution;
-import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
@@ -34,6 +33,7 @@ import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -120,18 +120,43 @@ public class CliFrontend {
             String savepointPath = commandLine.getOptionValue(SAVEPOINT_PATH_OPTION.getOpt());
             boolean allowNonRestoredState =
                     commandLine.hasOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION.getOpt());
-            final RestoreMode restoreMode;
+            final Object restoreMode;
             if (commandLine.hasOption(SAVEPOINT_CLAIM_MODE)) {
                 restoreMode =
                         org.apache.flink.configuration.ConfigurationUtils.convertValue(
                                 commandLine.getOptionValue(SAVEPOINT_CLAIM_MODE),
-                                RestoreMode.class);
+                                ConfigurationUtils.getClaimModeClass());
             } else {
                 restoreMode = SavepointConfigOptions.RESTORE_MODE.defaultValue();
             }
             // allowNonRestoredState is always false because all operators are predefined.
-            return SavepointRestoreSettings.forPath(
-                    savepointPath, allowNonRestoredState, restoreMode);
+
+            return (SavepointRestoreSettings)
+                    Arrays.stream(SavepointRestoreSettings.class.getMethods())
+                            .filter(
+                                    method ->
+                                            method.getName().equals("forPath")
+                                                    && method.getParameterCount() == 3)
+                            .findFirst()
+                            .map(
+                                    method -> {
+                                        try {
+                                            return method.invoke(
+                                                    null,
+                                                    savepointPath,
+                                                    allowNonRestoredState,
+                                                    restoreMode);
+                                        } catch (IllegalAccessException
+                                                | InvocationTargetException e) {
+                                            throw new RuntimeException(
+                                                    "Failed to invoke SavepointRestoreSettings#forPath nethod.",
+                                                    e);
+                                        }
+                                    })
+                            .orElseThrow(
+                                    () ->
+                                            new RuntimeException(
+                                                    "Failed to resolve SavepointRestoreSettings#forPath method."));
         } else {
             return SavepointRestoreSettings.none();
         }

--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/utils/ConfigurationUtils.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/utils/ConfigurationUtils.java
@@ -75,4 +75,16 @@ public class ConfigurationUtils {
                 && !target.equalsIgnoreCase(LocalExecutor.NAME)
                 && !target.equalsIgnoreCase(RemoteExecutor.NAME);
     }
+
+    public static Class<?> getClaimModeClass() {
+        try {
+            return Class.forName("org.apache.flink.core.execution.RestoreMode");
+        } catch (ClassNotFoundException ignored) {
+            try {
+                return Class.forName("org.apache.flink.runtime.jobgraph.RestoreMode");
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 }

--- a/tools/mig-test/misc/patch_flink_conf.rb
+++ b/tools/mig-test/misc/patch_flink_conf.rb
@@ -26,7 +26,11 @@ parallelism.default: 4
 execution.checkpointing.interval: 300
 EXTRACONF
 
-File.write("#{FLINK_HOME}/conf/flink-conf.yaml", EXTRA_CONF, mode: 'a+')
+if File.file?("#{FLINK_HOME}/conf/flink-conf.yaml")
+  File.write("#{FLINK_HOME}/conf/flink-conf.yaml", EXTRA_CONF, mode: 'a+')
+else
+  File.write("#{FLINK_HOME}/conf/config.yaml", EXTRA_CONF, mode: 'a+')
+end
 
 # MySQL connector is not provided
 `wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar -O #{FLINK_HOME}/lib/mysql-connector-java-8.0.27.jar`

--- a/tools/mig-test/run_migration_test.rb
+++ b/tools/mig-test/run_migration_test.rb
@@ -114,7 +114,13 @@ def test_migration(from_version, to_version)
   end
 end
 
-version_list = %w[3.0.0 3.0.1 3.1.0 3.1.1 3.3-SNAPSHOT]
+version_list = case ARGV[0]
+               when '1.18.1' then %w[3.0.0 3.0.1 3.1.1 3.3-SNAPSHOT]
+               when '1.19.1' then %w[3.1.1 3.3-SNAPSHOT]
+               when '1.20.0' then %w[3.3-SNAPSHOT]
+               else []
+               end
+
 no_savepoint_versions = %w[3.0.0 3.0.1]
 version_result = Hash.new('❓')
 @failures = []
@@ -157,6 +163,6 @@ rescue LoadError
 end
 puts "✅ - Compatible, ❌ - Not compatible, ❓ - Target version doesn't support `--from-savepoint`"
 
-if @failures.filter { |old_version, new_version| new_version == version_list.last && old_version != '3.1.0' }.any?
+if @failures.any?
   abort 'Some migration to snapshot version tests failed.'
 end


### PR DESCRIPTION
This closes FLINK-36105.

Some manual testing reveals that Flink CDC job could not restore from savepoint when using Flink 1.20.0. Turns out FLINK-34455 (https://github.com/apache/flink/pull/24320) has moved `RestoreMode` enum class from `flink-runtime` to `flink-core`, causing incompatiblity since CDC is still developed upon Flink 1.18.

Using some reflection hackaround to circumvent this for now.