### PR TITLE
[hotfix] Fix schema registry flush state switch logic with multiple parallelism

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
@@ -48,11 +48,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
@@ -103,8 +103,8 @@ public class SchemaRegistryRequestHandler implements Closeable {
         this.schemaDerivation = schemaDerivation;
         this.schemaChangeBehavior = schemaChangeBehavior;
 
-        this.activeSinkWriters = new HashSet<>();
-        this.flushedSinkWriters = new HashSet<>();
+        this.activeSinkWriters = ConcurrentHashMap.newKeySet();
+        this.flushedSinkWriters = ConcurrentHashMap.newKeySet();
         this.schemaChangeThreadPool = Executors.newSingleThreadExecutor();
 
         this.currentDerivedSchemaChangeEvents = new ArrayList<>();
@@ -122,7 +122,7 @@ public class SchemaRegistryRequestHandler implements Closeable {
             SchemaChangeRequest request) {
         if (schemaChangeStatus.compareAndSet(RequestStatus.IDLE, RequestStatus.WAITING_FOR_FLUSH)) {
             LOG.info(
-                    "Received schema change event request {} from table {}. Start to buffer requests for others.",
+                    "Received schema change event request {} from table {}. SchemaChangeStatus switched from IDLE to WAITING_FOR_FLUSH, other requests will be blocked.",
                     request.getSchemaChangeEvent(),
                     request.getTableId().toString());
             SchemaChangeEvent event = request.getSchemaChangeEvent();
@@ -134,7 +134,11 @@ public class SchemaRegistryRequestHandler implements Closeable {
                 Preconditions.checkState(
                         schemaChangeStatus.compareAndSet(
                                 RequestStatus.WAITING_FOR_FLUSH, RequestStatus.IDLE),
-                        "Illegal schemaChangeStatus state: should still in WAITING_FOR_FLUSH state if event was duplicated.");
+                        "Illegal schemaChangeStatus state: should still in WAITING_FOR_FLUSH state if event was duplicated, not "
+                                + schemaChangeStatus.get());
+                LOG.info(
+                        "SchemaChangeStatus switched from WAITING_FOR_FLUSH to IDLE for request {} due to duplicated request.",
+                        request);
                 return CompletableFuture.completedFuture(wrap(SchemaChangeResponse.duplicate()));
             }
             schemaManager.applyOriginalSchemaChange(event);
@@ -149,7 +153,11 @@ public class SchemaRegistryRequestHandler implements Closeable {
                 Preconditions.checkState(
                         schemaChangeStatus.compareAndSet(
                                 RequestStatus.WAITING_FOR_FLUSH, RequestStatus.IDLE),
-                        "Illegal schemaChangeStatus state: should still in WAITING_FOR_FLUSH state if event was ignored.");
+                        "Illegal schemaChangeStatus state: should still in WAITING_FOR_FLUSH state if event was ignored, not "
+                                + schemaChangeStatus.get());
+                LOG.info(
+                        "SchemaChangeStatus switched from WAITING_FOR_FLUSH to IDLE for request {} due to ignored request.",
+                        request);
                 return CompletableFuture.completedFuture(wrap(SchemaChangeResponse.ignored()));
             }
 
@@ -220,7 +228,11 @@ public class SchemaRegistryRequestHandler implements Closeable {
         }
         Preconditions.checkState(
                 schemaChangeStatus.compareAndSet(RequestStatus.APPLYING, RequestStatus.FINISHED),
-                "Illegal schemaChangeStatus state: should be APPLYING before applySchemaChange finishes");
+                "Illegal schemaChangeStatus state: should be APPLYING before applySchemaChange finishes, not "
+                        + schemaChangeStatus.get());
+        LOG.info(
+                "SchemaChangeStatus switched from APPLYING to FINISHED for request {}.",
+                currentDerivedSchemaChangeEvents);
     }
 
     /**
@@ -239,13 +251,21 @@ public class SchemaRegistryRequestHandler implements Closeable {
      * @param tableId the subtask in SchemaOperator and table that the FlushEvent is about
      * @param sinkSubtask the sink subtask succeed flushing
      */
-    public void flushSuccess(TableId tableId, int sinkSubtask) {
+    public void flushSuccess(TableId tableId, int sinkSubtask, int parallelism) {
         flushedSinkWriters.add(sinkSubtask);
+        if (activeSinkWriters.size() < parallelism) {
+            LOG.info(
+                    "Not all active sink writers have been registered. Current {}, expected {}.",
+                    activeSinkWriters.size(),
+                    parallelism);
+            return;
+        }
         if (flushedSinkWriters.equals(activeSinkWriters)) {
             Preconditions.checkState(
                     schemaChangeStatus.compareAndSet(
                             RequestStatus.WAITING_FOR_FLUSH, RequestStatus.APPLYING),
-                    "Illegal schemaChangeStatus state: should be WAITING_FOR_FLUSH before collecting enough FlushEvents");
+                    "Illegal schemaChangeStatus state: should be WAITING_FOR_FLUSH before collecting enough FlushEvents, not "
+                            + schemaChangeStatus);
             LOG.info(
                     "All sink subtask have flushed for table {}. Start to apply schema change.",
                     tableId.toString());
@@ -259,6 +279,10 @@ public class SchemaRegistryRequestHandler implements Closeable {
                 !schemaChangeStatus.get().equals(RequestStatus.IDLE),
                 "Illegal schemaChangeStatus: should not be IDLE before getting schema change request results.");
         if (schemaChangeStatus.compareAndSet(RequestStatus.FINISHED, RequestStatus.IDLE)) {
+            LOG.info(
+                    "SchemaChangeStatus switched from FINISHED to IDLE for request {}",
+                    currentDerivedSchemaChangeEvents);
+
             // This request has been finished, return it and prepare for the next request
             List<SchemaChangeEvent> finishedEvents = clearCurrentSchemaChangeRequest();
             return CompletableFuture.supplyAsync(


### PR DESCRIPTION
Currently, SchemaRegistryRequestHandler regards Flush success when it has collected all FlushSuccessEvent from all registered subTasks.

```java
if (flushedSinkWriters.equals(activeSinkWriters)) {
    // ...
}
```

However, some subTasks might not be registered early enough, which means flush success condition might be falsely triggered:

```c
// 6 early came sink tasks have registered & flushed successfully
SchemaRegistry - Sink subtask 5 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistry - Sink subtask 0 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistry - Sink subtask 1 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistry - Sink subtask 2 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistry - Sink subtask 4 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistry - Sink subtask 7 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0

// Mistake here: Schema registry thought it has collected enough flush events
schemaChangeStatus WAITING_FOR_FLUSH -> APPLYING for request [CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING}, primaryKeys=col1, options=()}]. Collected enough flush writers [0, 1, 2, 4, 5, 7] of [0, 1, 2, 4, 5, 7]

// This is not correct: some subtasks have not been registered yet
SchemaRegistryRequestHandler - All sink subtask have flushed for table default_namespace.default_schema.table1. Start to apply schema change.

// Late-coming flush events will wrongly trigger transition again
SchemaRegistryRequestHandler - Register sink subtask 3.
SchemaRegistryRequestHandler - Register sink subtask 6.
SchemaRegistry - Sink subtask 3 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistry - Sink subtask 6 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0

// Causing schema registry crash
java.lang.IllegalStateException: Illegal schemaChangeStatus state: should be WAITING_FOR_FLUSH before collecting enough FlushEvents, not FINISHED. When receiving sink success from 6 with table default_namespace.default_schema.table1. Current flushedSinkWriters: [0, 1, 2, 3, 4, 5, 6, 7]; activeSinkWriters: [0, 1, 2, 3, 4, 5, 6, 7]
```

After this change, the `WAITING_FOR_FLUSH -> APPLYING` transition also verifies if all subTasks has been registered (should be >= parallelism).

```c
SchemaRegistry - Sink subtask 4 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.
SchemaRegistry - Sink subtask 2 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.
SchemaRegistry - Sink subtask 6 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.
SchemaRegistry - Sink subtask 3 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.
SchemaRegistry - Sink subtask 0 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.
SchemaRegistry - Sink subtask 1 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.
SchemaRegistry - Sink subtask 5 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0
SchemaRegistryRequestHandler - Not all active sink writers have been registered.

// Will not start schema change until all sinks registered and flushed
SchemaRegistryRequestHandler - Register sink subtask 7.
SchemaRegistry - Sink subtask 7 succeed flushing for table default_namespace.default_schema.table1. Attempt number: 0

// OK now
SchemaRegistryRequestHandler - SchemaChangeStatus WAITING_FOR_FLUSH -> APPLYING
SchemaRegistryRequestHandler - All sink subtask have flushed for table default_namespace.default_schema.table1. Start to apply schema change.
```