### PR TITLE
[FLINK-35890][cdc] Select only the increment but still enter the SNAPSHOT lead to ckp failed

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/DebeziumSourceFunction.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/DebeziumSourceFunction.java
@@ -394,6 +394,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         // and https://debezium.io/blog/2018/03/16/note-on-database-history-topic-configuration/
         properties.setProperty("database.history", determineDatabase().getCanonicalName());
 
+        String snapshotMode = properties.getProperty("snapshot.mode");
+
         // we have to filter out the heartbeat events, otherwise the deserializer will fail
         String dbzHeartbeatPrefix =
                 properties.getProperty(
@@ -403,7 +405,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 new DebeziumChangeFetcher<>(
                         sourceContext,
                         deserializer,
-                        restoredOffsetState == null, // DB snapshot phase if restore state is null
+                        // DB snapshot phase if restore state is null
+                        !"never".equals(snapshotMode) && restoredOffsetState == null,
                         dbzHeartbeatPrefix,
                         handover);
 


### PR DESCRIPTION
# ISSUE
Hi, when I was using Flink CDC Postgre, I chose 'debezium.snapshot.mode' = 'never' to skip the snapshot phase, but the code still entered the snapshot branch, and this log was printed, 'Database snapshot phase can 't perform checkpoint, acquired Checkpoint lock.'
(Since our business creates the task first and then writes the data), the task cannot perform ckp, and the status is always stuck in in progress. After the timeout, the task restarts.
Normally, if you only choose incremental data synchronization, you should not enter this branch.
 
The failure of ckp does not mean that the first one fails. After multiple ckp are successfully performed, it will then get stuck, causing a timeout and restarting the task. This is a problem that must occur. After it appeared in production, it also recurred many times in local testing.
 
Then we test, if there is data flowing in, the task status will be normal.
 
sql and conf like this

![](https://issues.apache.org/jira/secure/attachment/13070439/13070439_image-2024-07-24-16-47-19-258.png)

# Why do this？

I think this miss one case，when I  set "snapshot = nerver",  I don't want to enter DB snapshot phase, and it can resolve my problem.
