### PR TITLE
[FLINK-36093][transform] fix preTransformoperator wrongly filters columns when multiple transform

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
@@ -49,6 +49,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -275,6 +276,7 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
             preTransformedSchema =
                     SchemaUtils.applySchemaChangeEvent(
                             tableChangeInfo.getPreTransformedSchema(), schemaChangeEvent.get());
+            cachePreTransformProcessor(tableId, preTransformedSchema);
         }
         preTransformChangeInfoMap.put(
                 tableId, PreTransformChangeInfo.of(tableId, originalSchema, preTransformedSchema));
@@ -320,8 +322,6 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
 
     private CreateTableEvent transformCreateTableEvent(CreateTableEvent createTableEvent) {
         TableId tableId = createTableEvent.tableId();
-        PreTransformChangeInfo tableChangeInfo = preTransformChangeInfoMap.get(tableId);
-        cacheTransformRuleInfo(createTableEvent);
         for (Tuple2<Selectors, SchemaMetadataTransform> transform : schemaMetadataTransformers) {
             Selectors selectors = transform.f0;
             if (selectors.isMatch(tableId)) {
@@ -333,27 +333,50 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
             }
         }
 
+        cachePreTransformProcessor(tableId, createTableEvent.getSchema());
+        if (preTransformProcessorMap.containsKey(tableId)) {
+            return preTransformProcessorMap
+                    .get(tableId)
+                    .preTransformCreateTableEvent(createTableEvent);
+        }
+        return createTableEvent;
+    }
+
+    private void cachePreTransformProcessor(TableId tableId, Schema tableSchema) {
+        LinkedHashSet<Column> referencedColumnsSet = new LinkedHashSet<>();
         for (PreTransformer transform : transforms) {
             Selectors selectors = transform.getSelectors();
             if (selectors.isMatch(tableId) && transform.getProjection().isPresent()) {
                 TransformProjection transformProjection = transform.getProjection().get();
                 TransformFilter transformFilter = transform.getFilter().orElse(null);
                 if (transformProjection.isValid()) {
-                    if (!preTransformProcessorMap.containsKey(tableId)) {
-                        preTransformProcessorMap.put(
-                                tableId,
-                                new PreTransformProcessor(
-                                        tableChangeInfo, transformProjection, transformFilter));
-                    }
-                    PreTransformProcessor preTransformProcessor =
-                            preTransformProcessorMap.get(tableId);
-                    // TODO: Currently this code wrongly filters out rows that weren't referenced in
-                    // the first matching transform rule but in the following transform rules.
-                    return preTransformProcessor.preTransformCreateTableEvent(createTableEvent);
+                    List<Column> referencedColumns =
+                            TransformParser.generateReferencedColumns(
+                                    transformProjection.getProjection(),
+                                    transformFilter != null
+                                            ? transformFilter.getExpression()
+                                            : null,
+                                    tableSchema.getColumns());
+                    boolean hasAsterisk =
+                            TransformParser.hasAsterisk(transformProjection.getProjection());
+                    hasAsteriskMap.put(tableId, hasAsterisk);
+                    // update referenced columns of other projections of the same tableId, if any
+                    referencedColumnsSet.addAll(referencedColumns);
+                    referencedColumnsMap.put(
+                            tableId,
+                            referencedColumnsSet.stream()
+                                    .map(Column::getName)
+                                    .collect(Collectors.toList()));
+                    PreTransformChangeInfo tableChangeInfo =
+                            PreTransformChangeInfo.of(
+                                    tableId,
+                                    tableSchema,
+                                    tableSchema.copy(new ArrayList<>(referencedColumnsSet)));
+                    preTransformProcessorMap.put(
+                            tableId, new PreTransformProcessor(tableChangeInfo));
                 }
             }
         }
-        return createTableEvent;
     }
 
     private Schema transformSchemaMetaData(
@@ -377,37 +400,16 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
         return schemaBuilder.build();
     }
 
-    private DataChangeEvent processDataChangeEvent(DataChangeEvent dataChangeEvent)
-            throws Exception {
-        TableId tableId = dataChangeEvent.tableId();
-        for (PreTransformer transform : transforms) {
-            Selectors selectors = transform.getSelectors();
-
-            if (selectors.isMatch(tableId) && transform.getProjection().isPresent()) {
-                TransformProjection transformProjection = transform.getProjection().get();
-                TransformFilter transformFilter = transform.getFilter().orElse(null);
-                if (transformProjection.isValid()) {
-                    return processProjection(transformProjection, transformFilter, dataChangeEvent);
-                }
-            }
+    private DataChangeEvent processDataChangeEvent(DataChangeEvent dataChangeEvent) {
+        if (!transforms.isEmpty()) {
+            return processProjection(dataChangeEvent);
         }
         return dataChangeEvent;
     }
 
-    private DataChangeEvent processProjection(
-            TransformProjection transformProjection,
-            @Nullable TransformFilter transformFilter,
-            DataChangeEvent dataChangeEvent) {
-        TableId tableId = dataChangeEvent.tableId();
-        PreTransformChangeInfo tableChangeInfo = preTransformChangeInfoMap.get(tableId);
-        if (!preTransformProcessorMap.containsKey(tableId)
-                || !preTransformProcessorMap.get(tableId).hasTableChangeInfo()) {
-            preTransformProcessorMap.put(
-                    tableId,
-                    new PreTransformProcessor(
-                            tableChangeInfo, transformProjection, transformFilter));
-        }
-        PreTransformProcessor preTransformProcessor = preTransformProcessorMap.get(tableId);
+    private DataChangeEvent processProjection(DataChangeEvent dataChangeEvent) {
+        PreTransformProcessor preTransformProcessor =
+                preTransformProcessorMap.get(dataChangeEvent.tableId());
         BinaryRecordData before = (BinaryRecordData) dataChangeEvent.before();
         BinaryRecordData after = (BinaryRecordData) dataChangeEvent.after();
         if (before != null) {


### PR DESCRIPTION
Currently, such transform rule could not work:

```yaml
transform:
projection: 'A' as result
filter: tag >= 0
projection: score as result
filter: tag < 0
```
Here, `score` column will be filtered out in PreTransform stage, since it wasn't referenced in the first transform rule. As a result, the following transform rule will fail since `score` does not exist in PostTransform operator.
