### PR TITLE
[FLINK-36150][pipeline-connector/mysql] tables.exclude is still valid if scan.binlog.newly-added-table.enabled is true.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -173,6 +173,12 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
                         .scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled);
 
         List<TableId> tableIds = MySqlSchemaUtils.listTables(configFactory.createConfig(0), null);
+
+        if (scanBinlogNewlyAddedTableEnabled && scanNewlyAddedTableEnabled) {
+            throw new IllegalArgumentException(
+                    "If both scan.binlog.newly-added-table.enabled and scan.newly-added-table.enabled are true, data maybe duplicate after restore");
+        }
+
         if (scanBinlogNewlyAddedTableEnabled) {
             String newTables = validateTableAndReturnDebeziumStyle(tables);
             configFactory.tableList(newTables);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -237,7 +237,9 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
     private List<CreateTableEvent> generateCreateTableEvent(MySqlSourceConfig sourceConfig) {
         try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
             List<CreateTableEvent> createTableEventCache = new ArrayList<>();
-            List<TableId> capturedTableIds = listTables(jdbc, sourceConfig.getTableFilters());
+            List<TableId> capturedTableIds =
+                    listTables(
+                            jdbc, sourceConfig.getDatabaseFilter(), sourceConfig.getTableFilter());
             for (TableId tableId : capturedTableIds) {
                 Schema schema = getSchema(jdbc, tableId);
                 createTableEventCache.add(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
@@ -39,10 +39,12 @@ import java.util.stream.Collectors;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.HOSTNAME;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.PASSWORD;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.PORT;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES_EXCLUDE;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.USERNAME;
+import static org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED;
 import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
 import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +71,26 @@ public class MySqlDataSourceFactoryTest extends MySqlSourceTestBase {
         MySqlDataSource dataSource = (MySqlDataSource) factory.createDataSource(context);
         assertThat(dataSource.getSourceConfig().getTableList())
                 .isEqualTo(Arrays.asList(inventoryDatabase.getDatabaseName() + ".products"));
+    }
+
+    @Test
+    public void testCreateSourceScanBinlogNewlyAddedTableEnabled() {
+        inventoryDatabase.createAndInitialize();
+        Map<String, String> options = new HashMap<>();
+        options.put(HOSTNAME.key(), MYSQL_CONTAINER.getHost());
+        options.put(PORT.key(), String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
+        options.put(USERNAME.key(), TEST_USER);
+        options.put(PASSWORD.key(), TEST_PASSWORD);
+        options.put(TABLES.key(), inventoryDatabase.getDatabaseName() + ".prod\\.*");
+        options.put(SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED.key(), "true");
+        options.put(SCAN_NEWLY_ADDED_TABLE_ENABLED.key(), "true");
+        Factory.Context context = new MockContext(Configuration.fromMap(options));
+
+        MySqlDataSourceFactory factory = new MySqlDataSourceFactory();
+        assertThatThrownBy(() -> factory.createDataSource(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "If both scan.binlog.newly-added-table.enabled and scan.newly-added-table.enabled are true, data maybe duplicate after restore");
     }
 
     @Test

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MysqlPipelineNewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MysqlPipelineNewlyAddedTableITCase.java
@@ -228,8 +228,13 @@ public class MysqlPipelineNewlyAddedTableITCase extends MySqlSourceTestBase {
         initialAddressTables(
                 getConnection(), Lists.newArrayList("address_beijing", "address_shanghai"));
         List<Event> actual = fetchResults(iterator, 4);
-        assertThat(((ChangeEvent) actual.get(0)).tableId())
-                .isEqualTo(TableId.tableId(customDatabase.getDatabaseName(), "address_shanghai"));
+        List<String> tableNames =
+                actual.stream()
+                        .filter((event) -> event instanceof CreateTableEvent)
+                        .map((event) -> ((SchemaChangeEvent) event).tableId().getTableName())
+                        .collect(Collectors.toList());
+        assertThat(tableNames.size()).isEqualTo(1);
+        assertThat(tableNames.get(0)).isEqualTo("address_shanghai");
     }
 
     @Test

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MysqlPipelineNewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MysqlPipelineNewlyAddedTableITCase.java
@@ -60,6 +60,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.testcontainers.shaded.com.google.common.collect.Lists;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -91,6 +92,7 @@ import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOption
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.SERVER_ID;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.SERVER_TIME_ZONE;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES_EXCLUDE;
 import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.USERNAME;
 import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
 import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
@@ -192,6 +194,42 @@ public class MysqlPipelineNewlyAddedTableITCase extends MySqlSourceTestBase {
         assertThat(tableNames.size()).isEqualTo(2);
         assertThat(tableNames.get(0)).isEqualTo("address_beijing");
         assertThat(tableNames.get(1)).isEqualTo("address_shanghai");
+    }
+
+    @Test
+    public void testScanBinlogNewlyAddedTableEnabledAndExcludeTables() throws Exception {
+        List<String> tables = Collections.singletonList("address_\\.*");
+        Map<String, String> options = new HashMap<>();
+        options.put(SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED.key(), "true");
+        options.put(TABLES_EXCLUDE.key(), customDatabase.getDatabaseName() + ".address_beijing");
+        options.put(SCAN_STARTUP_MODE.key(), "timestamp");
+        options.put(
+                SCAN_STARTUP_TIMESTAMP_MILLIS.key(), String.valueOf(System.currentTimeMillis()));
+
+        FlinkSourceProvider sourceProvider = getFlinkSourceProvider(tables, 4, options);
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(new Configuration());
+        env.enableCheckpointing(200);
+        DataStreamSource<Event> source =
+                env.fromSource(
+                        sourceProvider.getSource(),
+                        WatermarkStrategy.noWatermarks(),
+                        MySqlDataSourceFactory.IDENTIFIER,
+                        new EventTypeInfo());
+
+        TypeSerializer<Event> serializer =
+                source.getTransformation().getOutputType().createSerializer(env.getConfig());
+        CheckpointedCollectResultBuffer<Event> resultBuffer =
+                new CheckpointedCollectResultBuffer<>(serializer);
+        String accumulatorName = "dataStreamCollect_" + UUID.randomUUID();
+        CollectResultIterator<Event> iterator =
+                addCollector(env, source, resultBuffer, serializer, accumulatorName);
+        env.executeAsync("AddNewlyTablesWhenReadingBinlog");
+        initialAddressTables(
+                getConnection(), Lists.newArrayList("address_beijing", "address_shanghai"));
+        List<Event> actual = fetchResults(iterator, 4);
+        assertThat(((ChangeEvent) actual.get(0)).tableId())
+                .isEqualTo(TableId.tableId(customDatabase.getDatabaseName(), "address_shanghai"));
     }
 
     @Test

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/DebeziumUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/DebeziumUtils.java
@@ -193,7 +193,9 @@ public class DebeziumUtils {
 
         final List<TableId> capturedTableIds;
         try {
-            capturedTableIds = TableDiscoveryUtils.listTables(jdbc, sourceConfig.getTableFilters());
+            capturedTableIds =
+                    TableDiscoveryUtils.listTables(
+                            jdbc, sourceConfig.getDatabaseFilter(), sourceConfig.getTableFilter());
         } catch (SQLException e) {
             throw new FlinkRuntimeException("Failed to discover captured tables", e);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/schema/Selectors.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/schema/Selectors.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.schema;
+
+import org.apache.flink.cdc.common.utils.Predicates;
+
+import io.debezium.relational.TableId;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/** Selectors for filtering tables. */
+public class Selectors {
+
+    private List<Selector> selectors;
+
+    private Selectors() {}
+
+    /**
+     * A {@link Selector} that determines whether a table identified by a given {@link TableId} is
+     * to be included.
+     */
+    private static class Selector {
+        private final Predicate<String> namespacePred;
+        private final Predicate<String> tableNamePred;
+
+        public Selector(String namespace, String schemaName, String tableName) {
+            this.namespacePred =
+                    namespace == null ? (namespacePred) -> false : Predicates.includes(namespace);
+            this.tableNamePred =
+                    tableName == null ? (tableNamePred) -> false : Predicates.includes(tableName);
+        }
+
+        public boolean isMatch(TableId tableId) {
+
+            String namespace = tableId.catalog();
+
+            if (namespace == null || namespace.isEmpty()) {
+                return tableNamePred.test(tableId.table());
+            }
+            return namespacePred.test(tableId.catalog()) && tableNamePred.test(tableId.table());
+        }
+    }
+
+    /** Match the {@link TableId} against the {@link Selector}s. * */
+    public boolean isMatch(TableId tableId) {
+        for (Selector selector : selectors) {
+            if (selector.isMatch(tableId)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Builder for {@link Selectors}. */
+    public static class SelectorsBuilder {
+
+        private List<Selector> selectors;
+
+        /**
+         * Current {@link TableId} used in mysql cdc connector will map database name to catalog.
+         *
+         * @param tableInclusions
+         * @return
+         */
+        public SelectorsBuilder includeTables(String tableInclusions) {
+
+            if (tableInclusions == null || tableInclusions.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Invalid table inclusion pattern cannot be null or empty");
+            }
+
+            List<Selector> selectors = new ArrayList<>();
+            Set<String> tableSplitSet =
+                    Predicates.setOf(
+                            tableInclusions, Predicates.RegExSplitterByComma::split, (str) -> str);
+            for (String tableSplit : tableSplitSet) {
+                List<String> tableIdList =
+                        Predicates.listOf(
+                                tableSplit, Predicates.RegExSplitterByDot::split, (str) -> str);
+                Iterator<String> iterator = tableIdList.iterator();
+                if (tableIdList.size() == 1) {
+                    selectors.add(new Selector(null, null, iterator.next()));
+                } else if (tableIdList.size() == 2) {
+                    selectors.add(new Selector(iterator.next(), null, iterator.next()));
+                } else {
+                    throw new IllegalArgumentException(
+                            "Invalid table inclusion pattern: " + tableInclusions);
+                }
+            }
+            this.selectors = selectors;
+            return this;
+        }
+
+        public Selectors build() {
+            Selectors selectors = new Selectors();
+            selectors.selectors = this.selectors;
+            return selectors;
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/schema/Selectors.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/schema/Selectors.java
@@ -42,7 +42,7 @@ public class Selectors {
         private final Predicate<String> namespacePred;
         private final Predicate<String> tableNamePred;
 
-        public Selector(String namespace, String schemaName, String tableName) {
+        public Selector(String namespace, String tableName) {
             this.namespacePred =
                     namespace == null ? (namespacePred) -> false : Predicates.includes(namespace);
             this.tableNamePred =
@@ -98,9 +98,9 @@ public class Selectors {
                                 tableSplit, Predicates.RegExSplitterByDot::split, (str) -> str);
                 Iterator<String> iterator = tableIdList.iterator();
                 if (tableIdList.size() == 1) {
-                    selectors.add(new Selector(null, null, iterator.next()));
+                    selectors.add(new Selector(null, iterator.next()));
                 } else if (tableIdList.size() == 2) {
-                    selectors.add(new Selector(iterator.next(), null, iterator.next()));
+                    selectors.add(new Selector(iterator.next(), iterator.next()));
                 } else {
                     throw new IllegalArgumentException(
                             "Invalid table inclusion pattern: " + tableInclusions);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -601,11 +601,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
             return new MySqlChunkSplitter(
                     mySqlSchema,
                     sourceConfig,
-                    tableId != null
-                                    && sourceConfig
-                                            .getTableFilters()
-                                            .dataCollectionFilter()
-                                            .isIncluded(tableId)
+                    tableId != null && sourceConfig.getTableFilter().test(tableId)
                             ? chunkSplitterState
                             : ChunkSplitterState.NO_SPLITTING_TABLE_STATE);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -49,6 +49,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private ServerIdRange serverIdRange;
     private List<String> databaseList;
     private List<String> tableList;
+    private String excludeTableList;
     private String serverTimeZone = ZoneId.systemDefault().getId();
     private StartupOptions startupOptions = StartupOptions.initial();
     private int splitSize = MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue();
@@ -99,6 +100,11 @@ public class MySqlSourceConfigFactory implements Serializable {
      */
     public MySqlSourceConfigFactory tableList(String... tableList) {
         this.tableList = Arrays.asList(tableList);
+        return this;
+    }
+
+    public MySqlSourceConfigFactory excludeTableList(String tableInclusions) {
+        this.excludeTableList = tableInclusions;
         return this;
     }
 
@@ -360,6 +366,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 password,
                 databaseList,
                 tableList,
+                excludeTableList,
                 serverIdRange,
                 startupOptions,
                 splitSize,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReader.java
@@ -235,10 +235,7 @@ public class MySqlSourceReader<T>
             LOG.info("Source reader {} adds split {}", subtaskId, split);
             if (split.isSnapshotSplit()) {
                 MySqlSnapshotSplit snapshotSplit = split.asSnapshotSplit();
-                if (sourceConfig
-                        .getTableFilters()
-                        .dataCollectionFilter()
-                        .isIncluded(split.asSnapshotSplit().getTableId())) {
+                if (sourceConfig.getTableFilter().test(split.asSnapshotSplit().getTableId())) {
                     if (snapshotSplit.isSnapshotReadFinished()) {
                         finishedUnackedSplits.put(snapshotSplit.splitId(), snapshotSplit);
                     } else {


### PR DESCRIPTION
As described in https://issues.apache.org/jira/browse/FLINK-36150 , this PR aims to pass `tables.exclude` to MySqlSourceConfig and will use it when find tables from mysql database.