### PR TITLE
[FLINK-36214] Downgrade scala-maven-plugin version to 4.8.0 to keep compatibility with Java 8

### DIFF
--- a/flink-cdc-pipeline-udf-examples/pom.xml
+++ b/flink-cdc-pipeline-udf-examples/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <scala.plugin.version>4.9.2</scala.plugin.version>
+        <scala.plugin.version>4.8.0</scala.plugin.version>
         <compiler.encoding>UTF-8</compiler.encoding>
     </properties>
     <dependencies>


### PR DESCRIPTION
This closes FLINK-36214.

As discussed in https://github.com/apache/spark/pull/41261, compiling scala codes with scala-maven-plugin 4.8.1+ with Java 8 target (See https://github.com/davidB/scala-maven-plugin/issues/686), causing the following benign error message:

```
[ERROR] -release is only supported on Java 9 and higher
```

As it has not been resolved in latest version (`4.9.2`), downgrading it would be a workaround for now.