### PR TITLE
[FLINK-36211][pipeline-connector/kafka] shade org.apache.flink.streaming.connectors.kafka

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
@@ -106,6 +106,10 @@ limitations under the License.
                                     <pattern>org.apache.flink.connector.kafka</pattern>
                                     <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.flink.connector.kafka</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.connectors.kafka</pattern>
+                                    <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.flink.streaming.connectors.kafka</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
To avoid conflict with flink-connector-kafka jar.