### PR TITLE
[FLINK-36221] Add `CAST ... AS ...` documentations

### DIFF
--- a/docs/content.zh/docs/core-concept/transform.md
+++ b/docs/content.zh/docs/core-concept/transform.md
@@ -155,7 +155,7 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 
 ## Casting Functions
 
-You can use `CAST( <EXPR> AS <TYPE> )` syntax to convert the type of expressions. Possible conversion paths are:
+You can use `CAST( <EXPR> AS <T> )` syntax to convert any valid expression `<EXPR>` to a specific type `<T>`. Possible conversion paths are:
 
 | Source Type                         | Target Type | Notes                                                                                      |
 |-------------------------------------|-------------|--------------------------------------------------------------------------------------------|

--- a/docs/content.zh/docs/core-concept/transform.md
+++ b/docs/content.zh/docs/core-concept/transform.md
@@ -153,6 +153,23 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 | COALESCE(value1 [, value2]*) | coalesce(Object... objects) | Returns the first argument that is not NULL.If all arguments are NULL, it returns NULL as well. The return type is the least restrictive, common type of all of its arguments. The return type is nullable if all arguments are nullable as well. |
 | IF(condition, true_value, false_value)   | condition ? true_value : false_value | Returns the true_value if condition is met, otherwise false_value. E.g., IF(5 > 3, 5, 3) returns 5. |
 
+## Casting Functions
+
+You can use `CAST( <EXPR> AS <TYPE> )` syntax to convert the type of expressions. Possible conversion paths are:
+
+| Source Type                         | Target Type | Notes                                                                                      |
+|-------------------------------------|-------------|--------------------------------------------------------------------------------------------|
+| ANY                                 | STRING      | All types can be cast to STRING.                                                           |
+| NUMERIC, STRING                     | BOOLEAN     | Any non-zero numerics will be evaluated to `TRUE`.                                         |
+| NUMERIC                             | BYTE        | Value must be in the range of Byte (-128 ~ 127).                                           |
+| NUMERIC                             | SHORT       | Value must be in the range of Short (-32768 ~ 32767).                                      |
+| NUMERIC                             | INTEGER     | Value must be in the range of Integer (-2147483648 ~ 2147483647).                          |
+| NUMERIC                             | LONG        | Value must be in the range of Long (-9223372036854775808 ~ 9223372036854775807).           |
+| NUMERIC                             | FLOAT       | Value must be in the range of Float (1.40239846e-45f ~ 3.40282347e+38f).                   |
+| NUMERIC                             | DOUBLE      | Value must be in the range of Double (4.94065645841246544e-324 ~ 1.79769313486231570e+308) |
+| NUMERIC                             | DECIMAL     | Value must be in the range of BigDecimal(10, 0).                                           |
+| STRING, TIMESTAMP_TZ, TIMESTAMP_LTZ | TIMESTAMP   | String type value must be a valid `ISO_LOCAL_DATE_TIME` string.                            |
+
 # Example
 ## Add computed columns
 Evaluation expressions can be used to generate new columns. For example, if we want to append two computed columns based on the table `web_order` in the database `mydb`, we may define a transform rule as follows:

--- a/docs/content/docs/core-concept/transform.md
+++ b/docs/content/docs/core-concept/transform.md
@@ -155,7 +155,7 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 
 ## Casting Functions
 
-You can use `CAST( <EXPR> AS <TYPE> )` syntax to convert the type of expressions. Possible conversion paths are:
+You can use `CAST( <EXPR> AS <T> )` syntax to convert any valid expression `<EXPR>` to a specific type `<T>`. Possible conversion paths are:
 
 | Source Type                         | Target Type | Notes                                                                                      |
 |-------------------------------------|-------------|--------------------------------------------------------------------------------------------|

--- a/docs/content/docs/core-concept/transform.md
+++ b/docs/content/docs/core-concept/transform.md
@@ -153,6 +153,23 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 | COALESCE(value1 [, value2]*) | coalesce(Object... objects) | Returns the first argument that is not NULL.If all arguments are NULL, it returns NULL as well. The return type is the least restrictive, common type of all of its arguments. The return type is nullable if all arguments are nullable as well. |
 | IF(condition, true_value, false_value)   | condition ? true_value : false_value | Returns the true_value if condition is met, otherwise false_value. E.g., IF(5 > 3, 5, 3) returns 5. |
 
+## Casting Functions
+
+You can use `CAST( <EXPR> AS <TYPE> )` syntax to convert the type of expressions. Possible conversion paths are:
+
+| Source Type                         | Target Type | Notes                                                                                      |
+|-------------------------------------|-------------|--------------------------------------------------------------------------------------------|
+| ANY                                 | STRING      | All types can be cast to STRING.                                                           |
+| NUMERIC, STRING                     | BOOLEAN     | Any non-zero numerics will be evaluated to `TRUE`.                                         |
+| NUMERIC                             | BYTE        | Value must be in the range of Byte (-128 ~ 127).                                           |
+| NUMERIC                             | SHORT       | Value must be in the range of Short (-32768 ~ 32767).                                      |
+| NUMERIC                             | INTEGER     | Value must be in the range of Integer (-2147483648 ~ 2147483647).                          |
+| NUMERIC                             | LONG        | Value must be in the range of Long (-9223372036854775808 ~ 9223372036854775807).           |
+| NUMERIC                             | FLOAT       | Value must be in the range of Float (1.40239846e-45f ~ 3.40282347e+38f).                   |
+| NUMERIC                             | DOUBLE      | Value must be in the range of Double (4.94065645841246544e-324 ~ 1.79769313486231570e+308) |
+| NUMERIC                             | DECIMAL     | Value must be in the range of BigDecimal(10, 0).                                           |
+| STRING, TIMESTAMP_TZ, TIMESTAMP_LTZ | TIMESTAMP   | String type value must be a valid `ISO_LOCAL_DATE_TIME` string.                            |
+
 # Example
 ## Add computed columns
 Evaluation expressions can be used to generate new columns. For example, if we want to append two computed columns based on the table `web_order` in the database `mydb`, we may define a transform rule as follows:


### PR DESCRIPTION
This closes FLINK-36221.

[FLINK-34877](https://issues.apache.org/jira/browse/FLINK-34877) adds `CAST ... AS ...` syntax in transform expressions, but there's no corresponding documentations yet. Adding it would make it easier for users to write expressions.