### PR TITLE
[FLINK-36226][cdc][docs] Build 3.2 docs and mark it as stable

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -54,7 +54,7 @@ jobs:
       matrix:
         branch:
           - master
-          - release-3.0
+          - release-3.2
           - release-3.1
 
     steps:
@@ -69,8 +69,8 @@ jobs:
           echo "flink_branch=${currentBranch}" >> ${GITHUB_ENV}
           
           if [ "${currentBranch}" = "master" ]; then
-          echo "flink_alias=release-3.2" >> ${GITHUB_ENV}
-          elif [ "${currentBranch}" = "release-3.1" ]; then
+          echo "flink_alias=release-3.3" >> ${GITHUB_ENV}
+          elif [ "${currentBranch}" = "release-3.2" ]; then
           echo "flink_alias=stable" >> ${GITHUB_ENV}
           fi
 


### PR DESCRIPTION
This pull request update GitHub workflow for building documentation, to build 3.2 docs and mark it as stable.