### PR TITLE
[FLINK-36247][cdc-connector] Fix potential transaction leak during MySQL snapshot phase

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/StatementUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/StatementUtils.java
@@ -235,7 +235,6 @@ public class StatementUtils {
     private static PreparedStatement initStatement(JdbcConnection jdbc, String sql, int fetchSize)
             throws SQLException {
         final Connection connection = jdbc.connection();
-        connection.setAutoCommit(false);
         final PreparedStatement statement = connection.prepareStatement(sql);
         statement.setFetchSize(fetchSize);
         return statement;


### PR DESCRIPTION
[FLINK-36247](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-36247)

remove `connection.setAutoCommit(false)`