### PR TITLE
[FLINK-36309][pipeline-connector/paimon] Paimon Sink commit failed should log stackTrace 

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonCommitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonCommitter.java
@@ -72,15 +72,16 @@ public class PaimonCommitter implements Committer<MultiTableCommittable> {
             }
             commitRequests.forEach(CommitRequest::signalAlreadyCommitted);
             LOGGER.info(
-                    String.format(
-                            "Commit succeeded for %s with %s committable",
-                            checkpointId, committables.size()));
+                    "Commit succeeded for {} with {} committable",
+                    checkpointId,
+                    committables.size());
         } catch (Exception e) {
             commitRequests.forEach(CommitRequest::retryLater);
             LOGGER.warn(
-                    String.format(
-                            "Commit failed for %s with %s committable",
-                            checkpointId, committables.size()));
+                    "Commit failed for {} with {} committable",
+                    checkpointId,
+                    committables.size(),
+                    e);
         }
     }
 


### PR DESCRIPTION
Flink CDC Paimon Sink Commit failed should log StackTrace, not just a warning log.
```
2024-09-18 11:15:07,984 WARN  org.apache.flink.cdc.connectors.paimon.sink.v2.PaimonCommitter [] - Commit failed for 4 with 2 committable
2024-09-18 11:15:08,093 WARN  org.apache.flink.cdc.connectors.paimon.sink.v2.PaimonCommitter [] - Commit failed for 5 with 2 committable
2024-09-18 11:15:08,410 WARN  org.apache.flink.cdc.connectors.paimon.sink.v2.PaimonCommitter [] - Commit failed for 1 with 2 committable
```