### PR TITLE
[FLINK-36397][cdc-connector][mysql] Obtain the high watermark offset and table data in the same transaction during the Snapshot phase

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -55,7 +55,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
-import java.sql.*;
+import java.sql.Blob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.time.Duration;
 import java.util.Calendar;
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -257,9 +257,11 @@ public class MySqlSnapshotSplitReadTask
                         snapshotSplit.getSplitEnd() == null);
 
         String showMasterStmt = "show master status;";
-        final String multiQueriesConf = sourceConfig.getJdbcProperties().getProperty(PropertyKey.allowMultiQueries.getKeyName(),"false");
+        final String multiQueriesConf = sourceConfig.getJdbcProperties()
+                .getProperty(PropertyKey.allowMultiQueries.getKeyName(),"false");
         Boolean getOffsetDurSelect = false;
-        if(snapshotSplit.getSplitStart() == null && snapshotSplit.getSplitEnd() == null && multiQueriesConf.equals("true")){
+        if(snapshotSplit.getSplitStart() == null && snapshotSplit.getSplitEnd() == null
+                && multiQueriesConf.equals("true")){
             getOffsetDurSelect = true;
             selectSql = showMasterStmt + selectSql;
         }
@@ -286,7 +288,7 @@ public class MySqlSnapshotSplitReadTask
             //process the rs of offset first
             BinlogOffset offset = null;
             if(getOffsetDurSelect){
-                offset = DebeziumUtils.getOffsetFromRs(rs,showMasterStmt);
+                offset = DebeziumUtils.getOffsetFromRs(rs, showMasterStmt);
                 selectStatement.getMoreResults();
                 rs = selectStatement.getResultSet();
             }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -150,9 +150,6 @@ public class MySqlSnapshotSplitReadTask
         if (hooks.getPreLowWatermarkAction() != null) {
             hooks.getPreLowWatermarkAction().accept(jdbcConnection, snapshotSplit);
         }
-        LOG.info(jdbcConnection.connection().getAutoCommit()+"getAutoCommit");
-        jdbcConnection.setAutoCommit(false);
-        jdbcConnection.execute("start transaction");
         final BinlogOffset lowWatermark = DebeziumUtils.currentBinlogOffset(jdbcConnection);
         LOG.info(
                 "Snapshot step 1 - Determining low watermark {} for split {}",
@@ -169,8 +166,6 @@ public class MySqlSnapshotSplitReadTask
 
         LOG.info("Snapshot step 2 - Snapshotting data");
         BinlogOffset selectOffset = createDataEvents(ctx, snapshotSplit.getTableId());
-        jdbcConnection.execute("start transaction");
-        jdbcConnection.setAutoCommit(true);
 
         if (hooks.getPreHighWatermarkAction() != null) {
             hooks.getPreHighWatermarkAction().accept(jdbcConnection, snapshotSplit);


### PR DESCRIPTION
This closes [[FLINK-36397](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-36397)]
Obtain the high watermark offset and table data in the same transaction during the Snapshot phase,This ensures that the data retrieved is consistent and avoids any potential data loss.