### PR TITLE
[hotfix] Fix Stale label automatically removed with no update

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -50,7 +50,7 @@ jobs:
             This pull request has been closed because it has not had recent activity. You could reopen it
             if you try to continue your work, and anyone who are interested in it are encouraged to continue
             work on this pull request.
-          close-pr-label: stale
-          remove-pr-stale-when-updated: true
-          remove-issue-stale-when-updated: true
-          labels-to-add-when-unstale: 'waiting for review'
+          # Auto-remove stale has conflicts with existing approve label workflows
+          # and will result in Stale label missing.
+          remove-pr-stale-when-updated: false
+          remove-issue-stale-when-updated: false


### PR DESCRIPTION
This fixes `Stale` bot not working as expected due to workflow interactions.

Currently, `approve_label` workflow will trigger update for all PRs' update time, causing Stale label automatically removed though this PR has no updates at all.

Removing auto-remove feature should fix this.