### PR TITLE
[FLINK-36407] Shut down coordinatorExecutor upon closing SchemaRegistry

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistry.java
@@ -168,6 +168,7 @@ public class SchemaRegistry implements OperatorCoordinator, CoordinationRequestH
     @Override
     public void close() throws Exception {
         LOG.info("SchemaRegistry for {} closed.", operatorName);
+        coordinatorExecutor.shutdown();
         requestHandler.close();
     }
 


### PR DESCRIPTION
See the details in [FLINK-36407](https://issues.apache.org/jira/browse/FLINK-36407). Not sure how this can be unit-tested given that the issue is not reproducible with JUnit.