### PR TITLE
[FLINK-36442][postgres-cdc] Add insert-only change stream option

### DIFF
--- a/docs/content/docs/connectors/flink-sources/postgres-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/postgres-cdc.md
@@ -166,7 +166,7 @@ SELECT * FROM shipments;
       <td>optional</td>
       <td style="word-wrap: break-word;">all</td>
       <td>String</td>
-      <td>The changelog mode used for encoding streaming changes. Supported values are <code>all</code> (which encodes changes as retract stream using all RowKinds) and <code>upsert</code> (which encodes changes as upsert stream that describes idempotent updates on a key).
+      <td>The changelog mode used for encoding streaming changes. Supported values are <code>all</code> (which encodes changes as retract stream using all RowKinds) <code>upsert</code> (which encodes changes as upsert stream that describes idempotent updates on a key), and <code>insert-only</code> (which encodes changes as an insert-only stream).
           <br/> <code>upsert</code> mode can be used for tables with primary keys when replica identity <code>FULL</code> is not an option. Primary keys must be set to use <code>upsert</code> mode.</td>
     </tr>
     <tr>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/DebeziumChangelogMode.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/DebeziumChangelogMode.java
@@ -25,7 +25,11 @@ public enum DebeziumChangelogMode {
      * Encodes changes as upsert stream that describes idempotent updates on a key. Primary keys
      * must be set in tables to use this changelog mode.
      */
-    UPSERT("upsert");
+    UPSERT("upsert"),
+    /**
+     * Encodes changes as an insert-only stream.
+     */
+    INSERT_ONLY("insert-only");
 
     private final String value;
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/DebeziumChangelogMode.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/DebeziumChangelogMode.java
@@ -26,9 +26,7 @@ public enum DebeziumChangelogMode {
      * must be set in tables to use this changelog mode.
      */
     UPSERT("upsert"),
-    /**
-     * Encodes changes as an insert-only stream.
-     */
+    /** Encodes changes as an insert-only stream. */
     INSERT_ONLY("insert-only");
 
     private final String value;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -128,12 +128,17 @@ public final class RowDataDebeziumDeserializeSchema
             insert.setRowKind(RowKind.INSERT);
             emit(record, insert, out);
         } else if (op == Envelope.Operation.DELETE) {
+            if (changelogMode == DebeziumChangelogMode.INSERT_ONLY) {
+                return;
+            }
             GenericRowData delete = extractBeforeRow(value, valueSchema);
             validator.validate(delete, RowKind.DELETE);
             delete.setRowKind(RowKind.DELETE);
             emit(record, delete, out);
         } else {
-            if (changelogMode == DebeziumChangelogMode.ALL) {
+            if (changelogMode == DebeziumChangelogMode.INSERT_ONLY) {
+                return;
+            } else if (changelogMode == DebeziumChangelogMode.ALL) {
                 GenericRowData before = extractBeforeRow(value, valueSchema);
                 validator.validate(before, RowKind.UPDATE_BEFORE);
                 before.setRowKind(RowKind.UPDATE_BEFORE);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceOptions.java
@@ -59,7 +59,8 @@ public class PostgresSourceOptions extends JdbcSourceOptions {
                     .withDescription(
                             "The changelog mode used for encoding streaming changes.\n"
                                     + "\"all\": Encodes changes as retract stream using all RowKinds. This is the default mode.\n"
-                                    + "\"upsert\": Encodes changes as upsert stream that describes idempotent updates on a key. It can be used for tables with primary keys when replica identity FULL is not an option.");
+                                    + "\"upsert\": Encodes changes as upsert stream that describes idempotent updates on a key. It can be used for tables with primary keys when replica identity FULL is not an option.\n"
+                                    + "\"insert-only\": Encodes changes as an insert-only stream.\n");
 
     public static final ConfigOption<Boolean> SCAN_INCREMENTAL_SNAPSHOT_ENABLED =
             ConfigOptions.key("scan.incremental.snapshot.enabled")

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableSource.java
@@ -161,10 +161,12 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
     @Override
     public ChangelogMode getChangelogMode() {
         switch (changelogMode) {
-            case UPSERT:
-                return org.apache.flink.table.connector.ChangelogMode.upsert();
             case ALL:
                 return org.apache.flink.table.connector.ChangelogMode.all();
+            case UPSERT:
+                return org.apache.flink.table.connector.ChangelogMode.upsert();
+            case INSERT_ONLY:
+                return org.apache.flink.table.connector.ChangelogMode.insertOnly();
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported changelog mode: " + changelogMode);


### PR DESCRIPTION
[FLINK-36442](https://issues.apache.org/jira/browse/FLINK-36442)

Adds the option to do an insert-only stream for connectors that support specifying a changelog mode. This allows debezium connectors to be imported into flink as stream tables to take advantage of flink's strong stream processing capabilities. There is currently no way to convert a all/upsert changelog stream to an insert-only stream with just the flink table api so this appears to be the only workaround.

This PR duplicates #3562 but follows community rules.
cc @henneberger