### PR TITLE
[FLINK-36463][cdc][mysql] Forbid to override some debezium options

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -267,6 +267,9 @@ public class MySqlTableSourceFactoryTest {
         options.put("server-time-zone", "Asia/Shanghai");
         options.put("scan.newly-added-table.enabled", "true");
         options.put("debezium.snapshot.mode", "never");
+        options.put("debezium.offset.flush.interval.ms", "3000");
+        options.put("debezium.tombstones.on.delete", "true");
+        options.put("debezium.test", "test");
         options.put("jdbc.properties.useSSL", "false");
         options.put("heartbeat.interval", "15213ms");
         options.put("scan.incremental.snapshot.chunk.key-column", "testCol");
@@ -276,6 +279,9 @@ public class MySqlTableSourceFactoryTest {
         DynamicTableSource actualSource = createTableSource(options);
         Properties dbzProperties = new Properties();
         dbzProperties.put("snapshot.mode", "never");
+        dbzProperties.put("offset.flush.interval.ms", "3000");
+        dbzProperties.put("tombstones.on.delete", "true");
+        dbzProperties.put("test", "test");
         Properties jdbcProperties = new Properties();
         jdbcProperties.setProperty("useSSL", "false");
         MySqlTableSource expectedSource =
@@ -307,6 +313,14 @@ public class MySqlTableSourceFactoryTest {
                         "testCol",
                         true);
         assertEquals(expectedSource, actualSource);
+        assertTrue(actualSource instanceof MySqlTableSource);
+        MySqlTableSource actualMySqlTableSource = (MySqlTableSource) actualSource;
+        Properties parellelProperties = new Properties();
+        parellelProperties.put("test", "test");
+        assertEquals(
+                parellelProperties,
+                actualMySqlTableSource.getParallelDbzProperties(
+                        actualMySqlTableSource.getDbzProperties()));
     }
 
     @Test


### PR DESCRIPTION
FlinkCDC uses debezium for capturing and parsing incremental data, but during the snapshot phase, FlinkCDC uses its own designed read implementation, so for FlinkCDC, some debezium options do not take effect, such as 'debezium.snapshot.query.mode'.