### PR TITLE
[FLINK-36461] Fix schema evolution failure with un-transformed tables

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
@@ -29,7 +29,6 @@ import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.event.TruncateTableEvent;
-import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.utils.SchemaUtils;
@@ -52,7 +51,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -73,7 +71,6 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
     private List<UserDefinedFunctionDescriptor> udfDescriptors;
     private Map<TableId, PreTransformProcessor> preTransformProcessorMap;
     private Map<TableId, Boolean> hasAsteriskMap;
-    private Map<TableId, List<String>> referencedColumnsMap;
 
     public static PreTransformOperator.Builder newBuilder() {
         return new PreTransformOperator.Builder();
@@ -165,7 +162,6 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
         }
         this.preTransformProcessorMap = new ConcurrentHashMap<>();
         this.hasAsteriskMap = new ConcurrentHashMap<>();
-        this.referencedColumnsMap = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -188,8 +184,7 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
                         new CreateTableEvent(
                                 stateTableChangeInfo.getTableId(),
                                 stateTableChangeInfo.getPreTransformedSchema());
-                // hasAsteriskMap and referencedColumnsMap needs to be recalculated after restoring
-                // from a checkpoint.
+                // hasAsteriskMap needs to be recalculated after restoring from a checkpoint.
                 cacheTransformRuleInfo(restoredCreateTableEvent);
 
                 // Since PostTransformOperator doesn't preserve state, pre-transformed schema
@@ -265,7 +260,6 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
     private Optional<SchemaChangeEvent> cacheChangeSchema(SchemaChangeEvent event) {
         TableId tableId = event.tableId();
         PreTransformChangeInfo tableChangeInfo = preTransformChangeInfoMap.get(tableId);
-        List<String> columnNamesBeforeChange = tableChangeInfo.getSourceSchema().getColumnNames();
 
         Schema originalSchema =
                 SchemaUtils.applySchemaChangeEvent(tableChangeInfo.getSourceSchema(), event);
@@ -279,11 +273,17 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
             // this TableId has not been captured by any transform rules, and should be regarded as
             // asterisk-ful by default.
             schemaChangeEvent =
-                    SchemaUtils.transformSchemaChangeEvent(true, columnNamesBeforeChange, event);
+                    SchemaUtils.transformSchemaChangeEvent(
+                            true, tableChangeInfo.getSourceSchema().getColumnNames(), event);
         } else {
+            // Otherwise, we will use the pre-transformed columns to determine if the given schema
+            // change event should be passed to downstream, only when it is presented in the
+            // pre-transformed schema.
             schemaChangeEvent =
                     SchemaUtils.transformSchemaChangeEvent(
-                            false, referencedColumnsMap.get(tableId), event);
+                            false,
+                            tableChangeInfo.getPreTransformedSchema().getColumnNames(),
+                            event);
         }
         if (schemaChangeEvent.isPresent()) {
             preTransformedSchema =
@@ -297,26 +297,8 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
 
     private void cacheTransformRuleInfo(CreateTableEvent createTableEvent) {
         TableId tableId = createTableEvent.tableId();
-        Set<String> referencedColumnsSet =
-                transforms.stream()
-                        .filter(t -> t.getSelectors().isMatch(tableId))
-                        .flatMap(
-                                rule ->
-                                        TransformParser.generateReferencedColumns(
-                                                rule.getProjection()
-                                                        .map(TransformProjection::getProjection)
-                                                        .orElse(null),
-                                                rule.getFilter()
-                                                        .map(TransformFilter::getExpression)
-                                                        .orElse(null),
-                                                createTableEvent.getSchema().getColumns())
-                                                .stream())
-                        .map(Column::getName)
-                        .collect(Collectors.toSet());
-
         boolean notTransformed =
                 transforms.stream().noneMatch(t -> t.getSelectors().isMatch(tableId));
-
         if (notTransformed) {
             // If this TableId isn't presented in any transform block, it should behave like a "*"
             // projection and should be regarded as asterisk-ful.
@@ -334,11 +316,6 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
 
             hasAsteriskMap.put(createTableEvent.tableId(), hasAsterisk);
         }
-        referencedColumnsMap.put(
-                createTableEvent.tableId(),
-                createTableEvent.getSchema().getColumnNames().stream()
-                        .filter(referencedColumnsSet::contains)
-                        .collect(Collectors.toList()));
     }
 
     private CreateTableEvent transformCreateTableEvent(CreateTableEvent createTableEvent) {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
@@ -260,7 +260,6 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
     private Optional<SchemaChangeEvent> cacheChangeSchema(SchemaChangeEvent event) {
         TableId tableId = event.tableId();
         PreTransformChangeInfo tableChangeInfo = preTransformChangeInfoMap.get(tableId);
-
         Schema originalSchema =
                 SchemaUtils.applySchemaChangeEvent(tableChangeInfo.getSourceSchema(), event);
         Schema preTransformedSchema = tableChangeInfo.getPreTransformedSchema();
@@ -270,8 +269,8 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
             // If this TableId is asterisk-ful, we should use the latest upstream schema as
             // referenced columns to perform schema evolution, not of the original ones generated
             // when creating tables. If hasAsteriskMap has no entry for this TableId, it means that
-            // this TableId has not been captured by any transform rules, and should be regarded as
-            // asterisk-ful by default.
+            // this TableId has not been referenced by any transform rules, and should be regarded
+            // as asterisk-ful by default.
             schemaChangeEvent =
                     SchemaUtils.transformSchemaChangeEvent(
                             true, tableChangeInfo.getSourceSchema().getColumnNames(), event);


### PR DESCRIPTION
This closes FLINK-36461.

Currently, such transform configuration will fail for any schema change events from tables except `foo.bar.baz`:

```yaml
transform:
  - source-table: foo.bar.baz
    projection: \*
```

The exception message is as follows:

```
java.lang.ArrayIndexOutOfBoundsException: -1
at java.util.ArrayList.elementData(ArrayList.java:424)
at java.util.ArrayList.get(ArrayList.java:437)
at org.apache.flink.cdc.common.utils.SchemaUtils.lambda$transformSchemaChangeEvent$11(SchemaUtils.java:371)
at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1384)
at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
at org.apache.flink.cdc.common.utils.SchemaUtils.transformSchemaChangeEvent(SchemaUtils.java:386)
at org.apache.flink.cdc.runtime.operators.transform.PreTransformOperator.cacheChangeSchema(PreTransformOperator.java:272)
at org.apache.flink.cdc.runtime.operators.transform.PreTransformOperator.processElement(PreTransformOperator.java:248)
at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:75)
at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:50)
at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:29)
at org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask$AsyncDataOutputToOutput.emitRecord(SourceOperatorStreamTask.java:310)
at org.apache.flink.streaming.api.operators.source.SourceOutputWithWatermarks.collect(SourceOutputWithWatermarks.java:110)
at org.apache.flink.streaming.api.operators.source.SourceOutputWithWatermarks.collect(SourceOutputWithWatermarks.java:101)
at org.apache.flink.api.connector.source.lib.util.IteratorSourceReaderBase.pollNext(IteratorSourceReaderBase.java:103)
at org.apache.flink.cdc.connectors.values.source.ValuesDataSource$EventIteratorReader.pollNext(ValuesDataSource.java:294)
at org.apache.flink.streaming.api.operators.SourceOperator.pollNext(SourceOperator.java:779)
at org.apache.flink.streaming.api.operators.SourceOperator.emitNext(SourceOperator.java:457)
at org.apache.flink.streaming.runtime.io.StreamTaskSourceInput.emitNext(StreamTaskSourceInput.java:70)
at org.apache.flink.streaming.runtime.io.StreamOneInputProcessor.processInput(StreamOneInputProcessor.java:68)
at org.apache.flink.streaming.runtime.tasks.StreamTask.processInput(StreamTask.java:616)
at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:231)
at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:1071)
at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:1020)
at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:959)
at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:938)
at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:751)
at org.apache.flink.runtime.taskmanager.Task.run(Task.java:567)
at java.lang.Thread.run(Thread.java:879)}}
```

This could be fixed by always passing latest schema as the "referenced column names" if an asterisk was used in projection expressions.