### PR TITLE
[FLINK-36517][cdc-connect][paimon] use filterAndCommit API for Avoid commit the same datafile duplicate

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonCommitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonCommitter.java
@@ -27,6 +27,7 @@ import org.apache.paimon.options.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +50,8 @@ public class PaimonCommitter implements Committer<MultiTableCommittable> {
     }
 
     @Override
-    public void commit(Collection<CommitRequest<MultiTableCommittable>> commitRequests) {
+    public void commit(Collection<CommitRequest<MultiTableCommittable>> commitRequests)
+            throws IOException {
         if (commitRequests.isEmpty()) {
             return;
         }
@@ -60,27 +62,23 @@ public class PaimonCommitter implements Committer<MultiTableCommittable> {
                         .collect(Collectors.toList());
         // All CommitRequest shared the same checkpointId.
         long checkpointId = committables.get(0).checkpointId();
-        int retriedNumber = commitRequests.stream().findFirst().get().getNumberOfRetries();
         WrappedManifestCommittable wrappedManifestCommittable =
                 storeMultiCommitter.combine(checkpointId, 1L, committables);
         try {
-            if (retriedNumber > 0) {
-                storeMultiCommitter.filterAndCommit(
-                        Collections.singletonList(wrappedManifestCommittable));
-            } else {
-                storeMultiCommitter.commit(Collections.singletonList(wrappedManifestCommittable));
-            }
+            storeMultiCommitter.filterAndCommit(
+                    Collections.singletonList(wrappedManifestCommittable));
             commitRequests.forEach(CommitRequest::signalAlreadyCommitted);
             LOGGER.info(
-                    String.format(
-                            "Commit succeeded for %s with %s committable",
-                            checkpointId, committables.size()));
+                    "Commit succeeded for {} with {} committable",
+                    checkpointId,
+                    committables.size());
         } catch (Exception e) {
             commitRequests.forEach(CommitRequest::retryLater);
             LOGGER.warn(
-                    String.format(
-                            "Commit failed for %s with %s committable",
-                            checkpointId, committables.size()));
+                    "Commit failed for {} with {} committable",
+                    checkpointId,
+                    committables.size(),
+                    e);
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -84,6 +84,8 @@ public class PaimonSinkITCase {
 
     private BinaryRecordDataGenerator generator;
 
+    private static int checkpointId = 0;
+
     public static final String TEST_DATABASE = "test";
     private static final String HADOOP_CONF_DIR =
             Objects.requireNonNull(
@@ -188,6 +190,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         Collection<Committer.CommitRequest<MultiTableCommittable>> commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -214,6 +217,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -243,6 +247,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -274,6 +279,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         Collection<Committer.CommitRequest<MultiTableCommittable>> commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -324,6 +330,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -371,6 +378,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -433,6 +441,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         Collection<Committer.CommitRequest<MultiTableCommittable>> commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -473,6 +482,7 @@ public class PaimonSinkITCase {
         writer.flush(false);
         Collection<Committer.CommitRequest<MultiTableCommittable>> commitRequests =
                 writer.prepareCommit().stream()
+                        .map(this::correctCheckpointId)
                         .map(MockCommitRequestImpl::new)
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
@@ -503,19 +513,9 @@ public class PaimonSinkITCase {
                     });
             writer.flush(false);
             // Checkpoint id start from 1
-            long checkpointId = i;
             committer.commit(
                     writer.prepareCommit().stream()
-                            .map(
-                                    committable -> {
-                                        // update the right checkpointId for MultiTableCommittable
-                                        return new MultiTableCommittable(
-                                                committable.getDatabase(),
-                                                committable.getTable(),
-                                                checkpointId,
-                                                committable.kind(),
-                                                committable.wrappedCommittable());
-                                    })
+                            .map(this::correctCheckpointId)
                             .map(MockCommitRequestImpl::new)
                             .collect(Collectors.toList()));
         }
@@ -544,6 +544,16 @@ public class PaimonSinkITCase {
                         Row.ofKind(RowKind.INSERT, "7", "7"),
                         Row.ofKind(RowKind.INSERT, "8", "8")),
                 result);
+    }
+
+    private MultiTableCommittable correctCheckpointId(MultiTableCommittable committable) {
+        // update the right checkpointId for MultiTableCommittable
+        return new MultiTableCommittable(
+                committable.getDatabase(),
+                committable.getTable(),
+                checkpointId++,
+                committable.kind(),
+                committable.wrappedCommittable());
     }
 
     private static class MockCommitRequestImpl<CommT> extends CommitRequestImpl<CommT> {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -492,8 +492,7 @@ public class PaimonSinkITCase {
                                     table1,
                                     generator.generate(
                                             new Object[] {
-                                                BinaryStringData.fromString(
-                                                        Integer.toString(i)),
+                                                BinaryStringData.fromString(Integer.toString(i)),
                                                 BinaryStringData.fromString(Integer.toString(i))
                                             })));
             Assertions.assertDoesNotThrow(
@@ -503,7 +502,7 @@ public class PaimonSinkITCase {
                         }
                     });
             writer.flush(false);
-            //Checkpoint id start from 1
+            // Checkpoint id start from 1
             long checkpointId = i;
             committer.commit(
                     writer.prepareCommit().stream()

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -84,7 +84,7 @@ public class PaimonSinkITCase {
 
     private BinaryRecordDataGenerator generator;
 
-    private static int checkpointId = 0;
+    private static int checkpointId = 1;
 
     public static final String TEST_DATABASE = "test";
     private static final String HADOOP_CONF_DIR =

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -477,8 +477,8 @@ public class PaimonSinkITCase {
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
 
-        // We add a loop for restore 3 times
-        for (int i = 0; i < 3; i++) {
+        // We add a loop for restore 6 times
+        for (int i = 2; i < 9; i++) {
             // We've two steps in checkpoint: 1. snapshotState(ckp); 2.
             // notifyCheckpointComplete(ckp).
             // It's possible that flink job will restore from a checkpoint with only step#1 finished
@@ -493,8 +493,8 @@ public class PaimonSinkITCase {
                                     generator.generate(
                                             new Object[] {
                                                 BinaryStringData.fromString(
-                                                        Integer.toString(i + 2)),
-                                                BinaryStringData.fromString(Integer.toString(i + 2))
+                                                        Integer.toString(i)),
+                                                BinaryStringData.fromString(Integer.toString(i))
                                             })));
             Assertions.assertDoesNotThrow(
                     () -> {
@@ -504,7 +504,7 @@ public class PaimonSinkITCase {
                     });
             writer.flush(false);
             //Checkpoint id start from 1
-            long checkpointId = i + 2;
+            long checkpointId = i;
             committer.commit(
                     writer.prepareCommit().stream()
                             .map(
@@ -526,7 +526,8 @@ public class PaimonSinkITCase {
                 .execute()
                 .collect()
                 .forEachRemaining(result::add);
-        Assertions.assertEquals(result.size(), 4);
+        // 8 APPEND and 1 COMPACT
+        Assertions.assertEquals(result.size(), 9);
         result.clear();
 
         tEnv.sqlQuery("select * from paimon_catalog.test.`table1`")
@@ -538,7 +539,11 @@ public class PaimonSinkITCase {
                         Row.ofKind(RowKind.INSERT, "1", "1"),
                         Row.ofKind(RowKind.INSERT, "2", "2"),
                         Row.ofKind(RowKind.INSERT, "3", "3"),
-                        Row.ofKind(RowKind.INSERT, "4", "4")),
+                        Row.ofKind(RowKind.INSERT, "4", "4"),
+                        Row.ofKind(RowKind.INSERT, "5", "5"),
+                        Row.ofKind(RowKind.INSERT, "6", "6"),
+                        Row.ofKind(RowKind.INSERT, "7", "7"),
+                        Row.ofKind(RowKind.INSERT, "8", "8")),
                 result);
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -477,7 +477,7 @@ public class PaimonSinkITCase {
                         .collect(Collectors.toList());
         committer.commit(commitRequests);
 
-        // We add a loop for restore 6 times
+        // We add a loop for restore 7 times
         for (int i = 2; i < 9; i++) {
             // We've two steps in checkpoint: 1. snapshotState(ckp); 2.
             // notifyCheckpointComplete(ckp).


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-35938 problem still persists.

`storeMultiCommitter.commit` API may cause the same datafile commit twice when job restart from failure.
