### PR TITLE
[CI][hotfix] Fix CI failure in new GitHub runner images

### DIFF
--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -47,6 +47,12 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
+      - name: Set JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Compiling jar packages
         run: mvn --no-snapshot-updates -B package -DskipTests
       - name: Run license check

--- a/.github/workflows/flink_cdc_migration_test.yml
+++ b/.github/workflows/flink_cdc_migration_test.yml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 8
+          distribution: temurin
       - name: Compile snapshot CDC version
         run: mvn --no-snapshot-updates -B install -DskipTests
       - name: Run migration tests


### PR DESCRIPTION
This fixes CI running failure after GitHub runners updated default Java version to 17 recently.