### PR TITLE
[FLINK-36565] Route module allows merging Decimals with various precisions

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
@@ -33,6 +33,9 @@ import org.apache.flink.cdc.common.types.DataTypeFamily;
 import org.apache.flink.cdc.common.types.DataTypeRoot;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.types.DecimalType;
+import org.apache.flink.cdc.common.types.LocalZonedTimestampType;
+import org.apache.flink.cdc.common.types.TimestampType;
+import org.apache.flink.cdc.common.types.ZonedTimestampType;
 
 import javax.annotation.Nullable;
 
@@ -176,6 +179,24 @@ public class SchemaUtils {
         if (lType.equals(rType)) {
             // identical type
             mergedType = rType;
+        } else if (lType instanceof TimestampType && rType instanceof TimestampType) {
+            return DataTypes.TIMESTAMP(
+                    Math.max(
+                            ((TimestampType) lType).getPrecision(),
+                            ((TimestampType) rType).getPrecision()));
+        } else if (lType instanceof ZonedTimestampType && rType instanceof ZonedTimestampType) {
+            return DataTypes.TIMESTAMP_TZ(
+                    Math.max(
+                            ((ZonedTimestampType) lType).getPrecision(),
+                            ((ZonedTimestampType) rType).getPrecision()));
+        } else if (lType instanceof LocalZonedTimestampType
+                && rType instanceof LocalZonedTimestampType) {
+            return DataTypes.TIMESTAMP_LTZ(
+                    Math.max(
+                            ((LocalZonedTimestampType) lType).getPrecision(),
+                            ((LocalZonedTimestampType) rType).getPrecision()));
+        } else if (lType.is(DataTypeFamily.TIMESTAMP) && rType.is(DataTypeFamily.TIMESTAMP)) {
+            return DataTypes.TIMESTAMP(TimestampType.MAX_PRECISION);
         } else if (lType.is(DataTypeFamily.INTEGER_NUMERIC)
                 && rType.is(DataTypeFamily.INTEGER_NUMERIC)) {
             mergedType = DataTypes.BIGINT();
@@ -185,7 +206,7 @@ public class SchemaUtils {
         } else if (lType.is(DataTypeFamily.APPROXIMATE_NUMERIC)
                 && rType.is(DataTypeFamily.APPROXIMATE_NUMERIC)) {
             mergedType = DataTypes.DOUBLE();
-        } else if (lType.is(DataTypeRoot.DECIMAL) && rType.is(DataTypeRoot.DECIMAL)) {
+        } else if (lType instanceof DecimalType && rType instanceof DecimalType) {
             // Merge two decimal types
             DecimalType lhsDecimal = (DecimalType) lType;
             DecimalType rhsDecimal = (DecimalType) rType;
@@ -195,7 +216,7 @@ public class SchemaUtils {
                             rhsDecimal.getPrecision() - rhsDecimal.getScale());
             int resultScale = Math.max(lhsDecimal.getScale(), rhsDecimal.getScale());
             mergedType = DataTypes.DECIMAL(resultIntDigits + resultScale, resultScale);
-        } else if (lType.is(DataTypeRoot.DECIMAL) && rType.is(DataTypeFamily.EXACT_NUMERIC)) {
+        } else if (lType instanceof DecimalType && rType.is(DataTypeFamily.EXACT_NUMERIC)) {
             // Merge decimal and int
             DecimalType lhsDecimal = (DecimalType) lType;
             mergedType =
@@ -204,7 +225,7 @@ public class SchemaUtils {
                                     lhsDecimal.getPrecision(),
                                     lhsDecimal.getScale() + getNumericPrecision(rType)),
                             lhsDecimal.getScale());
-        } else if (rType.is(DataTypeRoot.DECIMAL) && lType.is(DataTypeFamily.EXACT_NUMERIC)) {
+        } else if (rType instanceof DecimalType && lType.is(DataTypeFamily.EXACT_NUMERIC)) {
             // Merge decimal and int
             DecimalType rhsDecimal = (DecimalType) rType;
             mergedType =

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
@@ -215,25 +215,41 @@ public class SchemaUtils {
                             lhsDecimal.getPrecision() - lhsDecimal.getScale(),
                             rhsDecimal.getPrecision() - rhsDecimal.getScale());
             int resultScale = Math.max(lhsDecimal.getScale(), rhsDecimal.getScale());
+            Preconditions.checkArgument(
+                    resultIntDigits + resultScale <= DecimalType.MAX_PRECISION,
+                    String.format(
+                            "Failed to merge %s and %s type into DECIMAL. %d precision digits required, %d available",
+                            lType,
+                            rType,
+                            resultIntDigits + resultScale,
+                            DecimalType.MAX_PRECISION));
             mergedType = DataTypes.DECIMAL(resultIntDigits + resultScale, resultScale);
         } else if (lType instanceof DecimalType && rType.is(DataTypeFamily.EXACT_NUMERIC)) {
             // Merge decimal and int
             DecimalType lhsDecimal = (DecimalType) lType;
-            mergedType =
-                    DataTypes.DECIMAL(
-                            Math.max(
-                                    lhsDecimal.getPrecision(),
-                                    lhsDecimal.getScale() + getNumericPrecision(rType)),
-                            lhsDecimal.getScale());
+            int resultPrecision =
+                    Math.max(
+                            lhsDecimal.getPrecision(),
+                            lhsDecimal.getScale() + getNumericPrecision(rType));
+            Preconditions.checkArgument(
+                    resultPrecision <= DecimalType.MAX_PRECISION,
+                    String.format(
+                            "Failed to merge %s and %s type into DECIMAL. %d precision digits required, %d available",
+                            lType, rType, resultPrecision, DecimalType.MAX_PRECISION));
+            mergedType = DataTypes.DECIMAL(resultPrecision, lhsDecimal.getScale());
         } else if (rType instanceof DecimalType && lType.is(DataTypeFamily.EXACT_NUMERIC)) {
             // Merge decimal and int
             DecimalType rhsDecimal = (DecimalType) rType;
-            mergedType =
-                    DataTypes.DECIMAL(
-                            Math.max(
-                                    rhsDecimal.getPrecision(),
-                                    rhsDecimal.getScale() + getNumericPrecision(lType)),
-                            rhsDecimal.getScale());
+            int resultPrecision =
+                    Math.max(
+                            rhsDecimal.getPrecision(),
+                            rhsDecimal.getScale() + getNumericPrecision(lType));
+            Preconditions.checkArgument(
+                    resultPrecision <= DecimalType.MAX_PRECISION,
+                    String.format(
+                            "Failed to merge %s and %s type into DECIMAL. %d precision digits required, %d available",
+                            lType, rType, resultPrecision, DecimalType.MAX_PRECISION));
+            mergedType = DataTypes.DECIMAL(resultPrecision, rhsDecimal.getScale());
         } else {
             throw new IllegalStateException(
                     String.format("Incompatible types: \"%s\" and \"%s\"", lType, rType));

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -291,6 +291,35 @@ public class SchemaUtilsTest {
                                 DataTypes.INT().nullable(), DataTypes.INT().nullable()))
                 .isEqualTo(DataTypes.INT().nullable());
 
+        // Test merging temporal types
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(DataTypes.TIMESTAMP(9), DataTypes.TIMESTAMP(6)))
+                .isEqualTo(DataTypes.TIMESTAMP(9));
+
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(
+                                DataTypes.TIMESTAMP_TZ(3), DataTypes.TIMESTAMP_TZ(7)))
+                .isEqualTo(DataTypes.TIMESTAMP_TZ(7));
+
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(
+                                DataTypes.TIMESTAMP_LTZ(2), DataTypes.TIMESTAMP_LTZ(1)))
+                .isEqualTo(DataTypes.TIMESTAMP_LTZ(2));
+
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(
+                                DataTypes.TIMESTAMP_LTZ(), DataTypes.TIMESTAMP()))
+                .isEqualTo(DataTypes.TIMESTAMP(9));
+
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(DataTypes.TIMESTAMP_TZ(), DataTypes.TIMESTAMP()))
+                .isEqualTo(DataTypes.TIMESTAMP(9));
+
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(
+                                DataTypes.TIMESTAMP_LTZ(), DataTypes.TIMESTAMP_TZ()))
+                .isEqualTo(DataTypes.TIMESTAMP(9));
+
         // incompatible type merges test
         Assertions.assertThatThrownBy(
                         () -> SchemaUtils.inferWiderType(DataTypes.INT(), DataTypes.DOUBLE()))

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -273,6 +273,23 @@ public class SchemaUtilsTest {
                                 DataTypes.DECIMAL(5, 4), DataTypes.DECIMAL(10, 2)))
                 .isEqualTo(DataTypes.DECIMAL(12, 4));
 
+        // Test overflow decimal conversions
+        Assertions.assertThatThrownBy(
+                        () ->
+                                SchemaUtils.inferWiderType(
+                                        DataTypes.DECIMAL(5, 5), DataTypes.DECIMAL(38, 0)))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Failed to merge DECIMAL(5, 5) NOT NULL and DECIMAL(38, 0) NOT NULL type into DECIMAL. 43 precision digits required, 38 available");
+
+        Assertions.assertThatThrownBy(
+                        () ->
+                                SchemaUtils.inferWiderType(
+                                        DataTypes.DECIMAL(38, 0), DataTypes.DECIMAL(5, 5)))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "Failed to merge DECIMAL(38, 0) NOT NULL and DECIMAL(5, 5) NOT NULL type into DECIMAL. 43 precision digits required, 38 available");
+
         // Test merging with nullability
         Assertions.assertThat(
                         SchemaUtils.inferWiderType(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
@@ -417,7 +417,8 @@ public class DorisMetadataApplierITCase extends DorisSinkTestBase {
                 new SchemaOperatorTranslator(
                         SchemaChangeBehavior.EVOLVE,
                         "$$_schema_operator_$$",
-                        DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT);
+                        DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT,
+                        "UTC");
 
         OperatorIDGenerator schemaOperatorIDGenerator =
                 new OperatorIDGenerator(schemaOperatorTranslator.getSchemaOperatorUid());

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
@@ -366,7 +366,8 @@ public class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
                 new SchemaOperatorTranslator(
                         SchemaChangeBehavior.EVOLVE,
                         "$$_schema_operator_$$",
-                        DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT);
+                        DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT,
+                        "UTC");
 
         OperatorIDGenerator schemaOperatorIDGenerator =
                 new OperatorIDGenerator(schemaOperatorTranslator.getSchemaOperatorUid());

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolveE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolveE2eITCase.java
@@ -115,7 +115,7 @@ public class SchemaEvolveE2eITCase extends PipelineTestEnvironment {
                 false,
                 Collections.emptyList(),
                 Arrays.asList(
-                        "java.lang.IllegalStateException: Incompatible types: \"INT\" and \"DOUBLE\"",
+                        "java.lang.IllegalStateException: Incompatible types found for column `age`: \"INT\" and \"DOUBLE\"",
                         "org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy"));
     }
 

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolvingTransformE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolvingTransformE2eITCase.java
@@ -115,7 +115,7 @@ public class SchemaEvolvingTransformE2eITCase extends PipelineTestEnvironment {
                 false,
                 Collections.emptyList(),
                 Arrays.asList(
-                        "java.lang.IllegalStateException: Incompatible types: \"INT\" and \"DOUBLE\"",
+                        "java.lang.IllegalStateException: Incompatible types found for column `age`: \"INT\" and \"DOUBLE\"",
                         "org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy"));
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -20,8 +20,11 @@ package org.apache.flink.cdc.runtime.operators.schema;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
 import org.apache.flink.cdc.common.data.RecordData;
 import org.apache.flink.cdc.common.data.StringData;
+import org.apache.flink.cdc.common.data.TimestampData;
+import org.apache.flink.cdc.common.data.ZonedTimestampData;
 import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.DropTableEvent;
 import org.apache.flink.cdc.common.event.Event;
@@ -72,6 +75,8 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -96,6 +101,8 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
     private static final Duration CACHE_EXPIRE_DURATION = Duration.ofDays(1);
 
     private final List<RouteRule> routingRules;
+
+    private final String timezone;
 
     /**
      * Storing route source table selector, sink table name (before symbol replacement), and replace
@@ -127,6 +134,7 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
         this.chainingStrategy = ChainingStrategy.ALWAYS;
         this.rpcTimeOutInMillis = DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT.toMillis();
         this.schemaChangeBehavior = SchemaChangeBehavior.EVOLVE;
+        this.timezone = "UTC";
     }
 
     @VisibleForTesting
@@ -135,8 +143,10 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
         this.chainingStrategy = ChainingStrategy.ALWAYS;
         this.rpcTimeOutInMillis = rpcTimeOut.toMillis();
         this.schemaChangeBehavior = SchemaChangeBehavior.EVOLVE;
+        this.timezone = "UTC";
     }
 
+    @VisibleForTesting
     public SchemaOperator(
             List<RouteRule> routingRules,
             Duration rpcTimeOut,
@@ -145,6 +155,19 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
         this.chainingStrategy = ChainingStrategy.ALWAYS;
         this.rpcTimeOutInMillis = rpcTimeOut.toMillis();
         this.schemaChangeBehavior = schemaChangeBehavior;
+        this.timezone = "UTC";
+    }
+
+    public SchemaOperator(
+            List<RouteRule> routingRules,
+            Duration rpcTimeOut,
+            SchemaChangeBehavior schemaChangeBehavior,
+            String timezone) {
+        this.routingRules = routingRules;
+        this.chainingStrategy = ChainingStrategy.ALWAYS;
+        this.rpcTimeOutInMillis = rpcTimeOut.toMillis();
+        this.schemaChangeBehavior = schemaChangeBehavior;
+        this.timezone = timezone;
     }
 
     @Override
@@ -372,7 +395,11 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
                 } else {
                     fieldGetters.add(
                             new TypeCoercionFieldGetter(
-                                    column.getType(), fieldGetter, tolerantMode));
+                                    originalSchema.getColumn(columnName).get().getType(),
+                                    column.getType(),
+                                    fieldGetter,
+                                    tolerantMode,
+                                    timezone));
                 }
             }
         }
@@ -541,17 +568,23 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
     }
 
     private static class TypeCoercionFieldGetter implements RecordData.FieldGetter {
+        private final DataType originalType;
         private final DataType destinationType;
         private final RecordData.FieldGetter originalFieldGetter;
         private final boolean tolerantMode;
+        private final String timezone;
 
         public TypeCoercionFieldGetter(
+                DataType originalType,
                 DataType destinationType,
                 RecordData.FieldGetter originalFieldGetter,
-                boolean tolerantMode) {
+                boolean tolerantMode,
+                String timezone) {
+            this.originalType = originalType;
             this.destinationType = destinationType;
             this.originalFieldGetter = originalFieldGetter;
             this.tolerantMode = tolerantMode;
+            this.timezone = timezone;
         }
 
         private Object fail(IllegalArgumentException e) throws IllegalArgumentException {
@@ -609,6 +642,21 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
                                                     + "Currently only CHAR / VARCHAR can be accepted by a STRING column",
                                             originalField.getClass())));
                 }
+            } else if (destinationType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)
+                    && originalType.is(DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE)) {
+                // For now, TimestampData / ZonedTimestampData / LocalZonedTimestampData has no
+                // difference in its internal representation, so there's no need to do any precision
+                // conversion.
+                return originalField;
+            } else if (destinationType.is(DataTypeRoot.TIMESTAMP_WITH_TIME_ZONE)
+                    && originalType.is(DataTypeRoot.TIMESTAMP_WITH_TIME_ZONE)) {
+                return originalField;
+            } else if (destinationType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
+                    && originalType.is(DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE)) {
+                return originalField;
+            } else if (destinationType.is(DataTypeFamily.TIMESTAMP)
+                    && originalType.is(DataTypeFamily.TIMESTAMP)) {
+                return castToTimestamp(originalField, timezone);
             } else {
                 return fail(
                         new IllegalArgumentException(
@@ -623,5 +671,24 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
     public void snapshotState(StateSnapshotContext context) throws Exception {
         // Needless to do anything, since AbstractStreamOperator#snapshotState and #processElement
         // is guaranteed not to be mixed together.
+    }
+
+    private static TimestampData castToTimestamp(Object object, String timezone) {
+        if (object == null) {
+            return null;
+        }
+        if (object instanceof LocalZonedTimestampData) {
+            return TimestampData.fromLocalDateTime(
+                    LocalDateTime.ofInstant(
+                            ((LocalZonedTimestampData) object).toInstant(), ZoneId.of(timezone)));
+        } else if (object instanceof ZonedTimestampData) {
+            return TimestampData.fromLocalDateTime(
+                    LocalDateTime.ofInstant(
+                            ((ZonedTimestampData) object).toInstant(), ZoneId.of(timezone)));
+        } else {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Unable to implicitly coerce object `%s` as a TIMESTAMP.", object));
+        }
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.runtime.operators.schema;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.common.data.DecimalData;
 import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
 import org.apache.flink.cdc.common.data.RecordData;
 import org.apache.flink.cdc.common.data.StringData;
@@ -40,6 +41,7 @@ import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypeFamily;
 import org.apache.flink.cdc.common.types.DataTypeRoot;
+import org.apache.flink.cdc.common.types.DecimalType;
 import org.apache.flink.cdc.common.utils.ChangeEventUtils;
 import org.apache.flink.cdc.runtime.operators.schema.coordinator.SchemaRegistry;
 import org.apache.flink.cdc.runtime.operators.schema.event.CoordinationResponseUtils;
@@ -74,6 +76,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -611,14 +614,40 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
                 } else if (originalField instanceof Integer) {
                     // INT
                     return ((Integer) originalField).longValue();
+                } else if (originalField instanceof Long) {
+                    // BIGINT
+                    return originalField;
                 } else {
                     return fail(
                             new IllegalArgumentException(
                                     String.format(
                                             "Cannot fit type \"%s\" into a BIGINT column. "
-                                                    + "Currently only TINYINT / SMALLINT / INT can be accepted by a BIGINT column",
+                                                    + "Currently only TINYINT / SMALLINT / INT / LONG can be accepted by a BIGINT column",
                                             originalField.getClass())));
                 }
+            } else if (destinationType instanceof DecimalType) {
+                DecimalType decimalType = (DecimalType) destinationType;
+                BigDecimal decimalValue;
+                if (originalField instanceof Byte) {
+                    decimalValue = BigDecimal.valueOf(((Byte) originalField).longValue(), 0);
+                } else if (originalField instanceof Short) {
+                    decimalValue = BigDecimal.valueOf(((Short) originalField).longValue(), 0);
+                } else if (originalField instanceof Integer) {
+                    decimalValue = BigDecimal.valueOf(((Integer) originalField).longValue(), 0);
+                } else if (originalField instanceof Long) {
+                    decimalValue = BigDecimal.valueOf((Long) originalField, 0);
+                } else if (originalField instanceof DecimalData) {
+                    decimalValue = ((DecimalData) originalField).toBigDecimal();
+                } else {
+                    return fail(
+                            new IllegalArgumentException(
+                                    String.format(
+                                            "Cannot fit type \"%s\" into a DECIMAL column. "
+                                                    + "Currently only BYTE / SHORT / INT / LONG / DECIMAL can be accepted by a DECIMAL column",
+                                            originalField.getClass())));
+                }
+                return decimalValue != null ? DecimalData.fromBigDecimal(
+                        decimalValue, decimalType.getPrecision(), decimalType.getScale()) : null;
             } else if (destinationType.is(DataTypeFamily.APPROXIMATE_NUMERIC)) {
                 if (originalField instanceof Float) {
                     // FLOAT

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorFactory.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperatorFactory.java
@@ -47,8 +47,9 @@ public class SchemaOperatorFactory extends SimpleOperatorFactory<Event>
             MetadataApplier metadataApplier,
             List<RouteRule> routingRules,
             Duration rpcTimeOut,
-            SchemaChangeBehavior schemaChangeBehavior) {
-        super(new SchemaOperator(routingRules, rpcTimeOut, schemaChangeBehavior));
+            SchemaChangeBehavior schemaChangeBehavior,
+            String timezone) {
+        super(new SchemaOperator(routingRules, rpcTimeOut, schemaChangeBehavior, timezone));
         this.metadataApplier = metadataApplier;
         this.routingRules = routingRules;
         this.schemaChangeBehavior = schemaChangeBehavior;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivation.java
@@ -31,9 +31,8 @@ import org.apache.flink.cdc.common.schema.PhysicalColumn;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.types.DataType;
-import org.apache.flink.cdc.common.types.DataTypeFamily;
-import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.utils.ChangeEventUtils;
+import org.apache.flink.cdc.common.utils.SchemaUtils;
 import org.apache.flink.cdc.runtime.serializer.TableIdSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -254,7 +253,9 @@ public class SchemaDerivation {
                                 // Check type compatibility
                                 DataType widerType =
                                         getWiderType(
-                                                existedColumnInDerivedTable.getType(), dataType);
+                                                columnName,
+                                                existedColumnInDerivedTable.getType(),
+                                                dataType);
                                 if (!widerType.equals(existedColumnInDerivedTable.getType())) {
                                     typeDifference.put(
                                             existedColumnInDerivedTable.getName(), widerType);
@@ -289,6 +290,7 @@ public class SchemaDerivation {
                         .equals(addedColumn.getAddColumn().getType())) {
                     DataType widerType =
                             getWiderType(
+                                    existedColumnInDerivedTable.getName(),
                                     existedColumnInDerivedTable.getType(),
                                     addedColumn.getAddColumn().getType());
                     if (!widerType.equals(existedColumnInDerivedTable.getType())) {
@@ -325,7 +327,10 @@ public class SchemaDerivation {
                 Column existedColumnInDerivedTable = optionalColumnInDerivedTable.get();
                 if (!existedColumnInDerivedTable.getType().equals(column.getType())) {
                     DataType widerType =
-                            getWiderType(existedColumnInDerivedTable.getType(), column.getType());
+                            getWiderType(
+                                    existedColumnInDerivedTable.getName(),
+                                    existedColumnInDerivedTable.getType(),
+                                    column.getType());
                     if (!widerType.equals(existedColumnInDerivedTable.getType())) {
                         newTypeMapping.put(existedColumnInDerivedTable.getName(), widerType);
                     }
@@ -343,23 +348,14 @@ public class SchemaDerivation {
         return schemaChangeEvents;
     }
 
-    private DataType getWiderType(DataType thisType, DataType thatType) {
-        if (thisType.equals(thatType)) {
-            return thisType;
+    private DataType getWiderType(String columnName, DataType thisType, DataType thatType) {
+        try {
+            return SchemaUtils.inferWiderType(thisType, thatType);
+        } catch (IllegalStateException e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Incompatible types found for column `%s`: \"%s\" and \"%s\"",
+                            columnName, thisType, thatType));
         }
-        if (thisType.is(DataTypeFamily.INTEGER_NUMERIC)
-                && thatType.is(DataTypeFamily.INTEGER_NUMERIC)) {
-            return DataTypes.BIGINT();
-        }
-        if (thisType.is(DataTypeFamily.CHARACTER_STRING)
-                && thatType.is(DataTypeFamily.CHARACTER_STRING)) {
-            return DataTypes.STRING();
-        }
-        if (thisType.is(DataTypeFamily.APPROXIMATE_NUMERIC)
-                && thatType.is(DataTypeFamily.APPROXIMATE_NUMERIC)) {
-            return DataTypes.DOUBLE();
-        }
-        throw new IllegalStateException(
-                String.format("Incompatible types: \"%s\" and \"%s\"", thisType, thatType));
     }
 }

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivationTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivationTest.java
@@ -381,7 +381,7 @@ class SchemaDerivationTest {
                                 schemaDerivation.applySchemaChange(
                                         new CreateTableEvent(TABLE_2, INCOMPATIBLE_SCHEMA)))
                 .isInstanceOf(IllegalStateException.class)
-                .hasMessage("Incompatible types: \"INT\" and \"STRING\"");
+                .hasMessage("Incompatible types found for column `age`: \"INT\" and \"STRING\"");
     }
 
     @Test


### PR DESCRIPTION
This closes FLINK-36565.

Currently, table-merging router does not allow coercing `Decimal` fields with different precisions from upstream, which means some lossless conversions are actually not possible, including:

* `TINYINT`, `SMALLINT`, `INT`, `BIGINT` to `DECIMAL(p > 17, s >= 0)`
* low precision `DECIMAL` to high precision ones

---

I've baked the changes in #3636 (FLINK-36474) into this PR since there are some common changes between them.