### PR TITLE
[FLINK-36541][pipeline-connector][paimon] pass checkpointId to StoreSinkWrite#prepareCommit correctly.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSink.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Committer;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.checkpoint.CheckpointIDCounter;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableMessageTypeInfo;
 import org.apache.flink.streaming.api.connector.sink2.WithPreCommitTopology;
@@ -61,7 +62,11 @@ public class PaimonSink<InputT> implements WithPreCommitTopology<InputT, MultiTa
 
     @Override
     public PaimonWriter<InputT> createWriter(InitContext context) {
-        return new PaimonWriter<>(catalogOptions, context.metricGroup(), commitUser, serializer);
+        long lastCheckpointId =
+                context.getRestoredCheckpointId()
+                        .orElse(CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1);
+        return new PaimonWriter<>(
+                catalogOptions, context.metricGroup(), commitUser, serializer, lastCheckpointId);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -253,6 +253,19 @@ public class PaimonSinkITCase {
                 .forEachRemaining(result::add);
         Assertions.assertEquals(
                 Collections.singletonList(Row.ofKind(RowKind.INSERT, "2", "x")), result);
+
+        result = new ArrayList<>();
+        tEnv.sqlQuery("select max_sequence_number from paimon_catalog.test.`table1$files`")
+                .execute()
+                .collect()
+                .forEachRemaining(result::add);
+        // Each commit will generate one sequence number(equal to checkpointId).
+        Assertions.assertEquals(
+                Arrays.asList(
+                        Row.ofKind(RowKind.INSERT, 1L),
+                        Row.ofKind(RowKind.INSERT, 2L),
+                        Row.ofKind(RowKind.INSERT, 3L)),
+                result);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
PaimonSink now implements StatefulSink to store checkpointId in state, It has been verified through local testing that it is compatible with the state of 3.2.0. I will try to add a state compatibility test.