### PR TITLE
upgrade-tikv-client

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/tikv/cdc/CDCConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/tikv/cdc/CDCConfig.java
@@ -1,0 +1,42 @@
+package org.tikv.cdc;
+
+import org.tikv.kvproto.Kvrpcpb;
+
+public class CDCConfig {
+    private static final int EVENT_BUFFER_SIZE = 50000;
+    private static final int MAX_ROW_KEY_SIZE = 10240;
+    private static final boolean READ_OLD_VALUE = true;
+    private int eventBufferSize = 50000;
+    private int maxRowKeySize = 10240;
+    private boolean readOldValue = true;
+
+    public CDCConfig() {}
+
+    public void setEventBufferSize(int bufferSize) {
+        this.eventBufferSize = bufferSize;
+    }
+
+    public void setMaxRowKeySize(int rowKeySize) {
+        this.maxRowKeySize = rowKeySize;
+    }
+
+    public void setReadOldValue(boolean value) {
+        this.readOldValue = value;
+    }
+
+    public int getEventBufferSize() {
+        return this.eventBufferSize;
+    }
+
+    public int getMaxRowKeySize() {
+        return this.maxRowKeySize;
+    }
+
+    public boolean getReadOldValue() {
+        return this.readOldValue;
+    }
+
+    Kvrpcpb.ExtraOp getExtraOp() {
+        return this.readOldValue ? Kvrpcpb.ExtraOp.ReadOldValue : Kvrpcpb.ExtraOp.Noop;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ limitations under the License.
         <flink.major.version>1.18</flink.major.version>
         <flink.shaded.version>17.0</flink.shaded.version>
         <debezium.version>1.9.8.Final</debezium.version>
-        <tikv.version>3.2.0</tikv.version>
+        <tikv.version>3.3.0</tikv.version>
         <geometry.version>2.2.0</geometry.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
upgrade ticdc's tikv.version from 3.2.0 to 3.3.0, so that It won't be a conflict with Flink's own Rocksdb ,  because tikv-client 3.3.0 without rocksdb。