### PR TITLE
[FLINK-36579][cdc] Fix mysql cdc charset collation sort not equals ja…

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlChunkSplitter.java
@@ -170,7 +170,7 @@ public class MySqlChunkSplitter implements ChunkSplitter {
                         ? "null"
                         : chunkStartVal.toString());
         // we start from [null, min + chunk_size) and avoid [null, min)
-        Object chunkEnd =
+        Object[] nextComparableChunk =
                 nextChunkEnd(
                         jdbcConnection,
                         nextChunkStart == ChunkSplitterState.ChunkBound.START_BOUND
@@ -182,7 +182,10 @@ public class MySqlChunkSplitter implements ChunkSplitter {
                         chunkSize);
         // may sleep a while to avoid DDOS on MySQL server
         maySleep(nextChunkId, tableId);
-        if (chunkEnd != null && ObjectUtils.compare(chunkEnd, minMaxOfSplitColumn[1]) <= 0) {
+        Object chunkEnd = nextComparableChunk[0];
+        int compare = (int) nextComparableChunk[1];
+        if (chunkEnd != null
+                && (ObjectUtils.compare(chunkEnd, minMaxOfSplitColumn[1]) == 0 || compare == 0)) {
             nextChunkStart = ChunkSplitterState.ChunkBound.middleOf(chunkEnd);
             return createSnapshotSplit(
                     jdbcConnection,
@@ -319,7 +322,7 @@ public class MySqlChunkSplitter implements ChunkSplitter {
         return splits;
     }
 
-    private Object nextChunkEnd(
+    private Object[] nextChunkEnd(
             JdbcConnection jdbc,
             Object previousChunkEnd,
             TableId tableId,
@@ -328,14 +331,14 @@ public class MySqlChunkSplitter implements ChunkSplitter {
             int chunkSize)
             throws SQLException {
         // chunk end might be null when max values are removed
-        Object chunkEnd =
+        Object[] nextComparableChunk =
                 StatementUtils.queryNextChunkMax(
-                        jdbc, tableId, splitColumnName, chunkSize, previousChunkEnd);
+                        jdbc, tableId, splitColumnName, chunkSize, previousChunkEnd, max);
+        Object chunkEnd = nextComparableChunk[0];
         if (Objects.equals(previousChunkEnd, chunkEnd)) {
             // we don't allow equal chunk start and end,
             // should query the next one larger than chunkEnd
-            chunkEnd = StatementUtils.queryMin(jdbc, tableId, splitColumnName, chunkEnd);
-
+            //
             // queryMin will return null when the chunkEnd is the max value,
             // this will happen when the mysql table ignores the capitalization.
             // see more detail at the test MySqlConnectorITCase#testReadingWithMultiMaxValue.
@@ -344,15 +347,17 @@ public class MySqlChunkSplitter implements ChunkSplitter {
             // this method will return 'E' and will not return null.
             // When this method is invoked next time, queryMin will return null here.
             // So we need return null when we reach the max value here.
-            if (chunkEnd == null) {
-                return null;
-            }
+            nextComparableChunk =
+                    StatementUtils.queryMin(jdbc, tableId, splitColumnName, chunkEnd, max);
         }
-        if (ObjectUtils.compare(chunkEnd, max) >= 0) {
-            return null;
-        } else {
-            return chunkEnd;
+        if (nextComparableChunk[1] == null) {
+            nextComparableChunk[1] = 2;
         }
+        nextComparableChunk[1] = Integer.valueOf(nextComparableChunk[1].toString());
+        if (((int) nextComparableChunk[1]) == 1) {
+            nextComparableChunk[0] = null;
+        }
+        return nextComparableChunk;
     }
 
     private MySqlSnapshotSplit createSnapshotSplit(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
@@ -370,6 +370,27 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     }
 
     @Test
+    public void testAssignSnapshotSplitsWithUnevenlySplitKey() {
+        List<String> expected =
+                Arrays.asList(
+                        "varchar_value_test null [GbGGGGG]",
+                        "varchar_value_test [GbGGGGG] [GGcGGGG]",
+                        "varchar_value_test [GGcGGGG] [GGGdGGG]",
+                        "varchar_value_test [GGGdGGG] [GGGGeGG]",
+                        "varchar_value_test [GGGGeGG] [GGGGGfG]",
+                        "varchar_value_test [GGGGGfG] null");
+        List<String> splits =
+                getTestAssignSnapshotSplits(
+                        customerDatabase,
+                        2,
+                        CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.defaultValue(),
+                        CHUNK_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.defaultValue(),
+                        new String[] {"varchar_value_test"},
+                        "id");
+        assertEquals(expected, splits);
+    }
+
+    @Test
     public void testAssignMaxSplitSize() {
         List<String> expected = Collections.singletonList("customers_even_dist null null");
         List<String> splits =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/resources/ddl/customer.sql
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/resources/ddl/customer.sql
@@ -326,3 +326,19 @@ CREATE TABLE default_value_test (
 INSERT INTO default_value_test
 VALUES (1,'user1','Shanghai',123567),
        (2,'user2','Shanghai',123567);
+
+-- create table whose primary key are varchar collate utf8mb3_general_ci.
+CREATE TABLE varchar_value_test (
+  id VARCHAR(255) NOT NULL PRIMARY KEY COLLATE utf8mb3_general_ci ,
+  name VARCHAR(255) NOT NULL,
+  address VARCHAR(1024),
+  phone_number INTEGER
+);
+INSERT INTO varchar_value_test
+VALUES ('aGGGGGG','u1','Beijing',1),
+       ('GbGGGGG','u2','Beijing',2),
+       ('GGcGGGG','u3','Beijing',3),
+       ('GGGdGGG','u4','New York',4),
+       ('GGGGeGG','u5','New York',5),
+       ('GGGGGfG','u6','Berlin',6),
+       ('GGGGGGg','u7','Berlin',7);


### PR DESCRIPTION
Use id VARCHAR(255) NOT NULL PRIMARY KEY COLLATE utf8mb3_general_ci as ChunkSplitKey.
Once data for id is:
`aGGGGGG
GbGGGGG
GGcGGGG
GGGdGGG
GGGGeGG
GGGGGfG
GGGGGGg`

mysql sort order is unchanged.
but java string compare sort becomes reverse order.
`
    if (ObjectUtils.compare(chunkEnd, max) >= 0) {
        return null;
    } else {
        return chunkEnd;
    }

public static int compare(Object obj1, Object obj2) {
    if (obj1 instanceof Comparable && obj1.getClass().equals(obj2.getClass())) {
        return ((Comparable) obj1).compareTo(obj2);
    } else {
        return obj1.toString().compareTo(obj2.toString());
    }
}`
 
mysql-cdc queryNextChunkMax will return null. so current snapshotSplit is [null, null].
It will cause the read task to read all data in the table. and make current read task hang out for a long time.

jira issue:  https://issues.apache.org/jira/browse/FLINK-36579

use mysql compare when splitNextChunk instead of java compare.