### PR TITLE
[FLINK-36597] Optimize SnapshotSplitAssigner error log output

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -428,7 +428,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     @Override
     public void startAssignNewlyAddedTables() {
         Preconditions.checkState(
-                isAssigningFinished(assignerStatus), "Invalid assigner status {}", assignerStatus);
+                isAssigningFinished(assignerStatus), "Invalid assigner status %s", assignerStatus);
         assignerStatus = assignerStatus.startAssignNewlyTables();
     }
 
@@ -436,7 +436,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     public void onStreamSplitUpdated() {
         Preconditions.checkState(
                 isNewlyAddedAssigningSnapshotFinished(assignerStatus),
-                "Invalid assigner status {}",
+                "Invalid assigner status %s",
                 assignerStatus);
         assignerStatus = assignerStatus.onStreamSplitUpdated();
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -471,7 +471,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
     public void startAssignNewlyAddedTables() {
         Preconditions.checkState(
                 AssignerStatus.isAssigningFinished(assignerStatus),
-                "Invalid assigner status {}",
+                "Invalid assigner status %s",
                 assignerStatus);
         assignerStatus = assignerStatus.startAssignNewlyTables();
     }
@@ -480,7 +480,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
     public void onBinlogSplitUpdated() {
         Preconditions.checkState(
                 AssignerStatus.isNewlyAddedAssigningSnapshotFinished(assignerStatus),
-                "Invalid assigner status {}",
+                "Invalid assigner status %s",
                 assignerStatus);
         assignerStatus = assignerStatus.onBinlogSplitUpdated();
     }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/0e010724-e702-4864-a8e1-c6eb112f610b)

Caused by: java.lang.IllegalStateException: Invalid assigner status {} [NEWLY_ADDED_ASSIGNING_FINISHED]
-->
Caused by: java.lang.IllegalStateException: Invalid assigner status NEWLY_ADDED_ASSIGNING_FINISHED
