### PR TITLE
[FLINK-35387][cdc-connector][postgres] PG CDC source support heart beat.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/WatermarkDispatcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/WatermarkDispatcher.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.base;
 
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
@@ -24,6 +25,7 @@ import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind
 import java.util.Map;
 
 /** CDC event dispatcher which provides ability to dispatch watermark. */
+@PublicEvolving
 public interface WatermarkDispatcher {
 
     void dispatchWatermarkEvent(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/WatermarkDispatcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/WatermarkDispatcher.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base;
+
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
+
+import java.util.Map;
+
+/** CDC event dispatcher which provides ability to dispatch watermark. */
+public interface WatermarkDispatcher {
+
+    void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            SourceSplitBase sourceSplit,
+            Offset watermark,
+            WatermarkKind watermarkKind)
+            throws InterruptedException;
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/relational/JdbcSourceEventDispatcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/relational/JdbcSourceEventDispatcher.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.base.relational;
 
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
 import org.apache.flink.cdc.connectors.base.relational.handler.SchemaChangeEventHandler;
 import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
@@ -61,7 +62,8 @@ import java.util.Map;
  *     this is useful for downstream to deserialize the {@link HistoryRecord} back.
  * </pre>
  */
-public class JdbcSourceEventDispatcher<P extends Partition> extends EventDispatcher<P, TableId> {
+public class JdbcSourceEventDispatcher<P extends Partition> extends EventDispatcher<P, TableId>
+        implements WatermarkDispatcher {
     private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceEventDispatcher.class);
 
     public static final String HISTORY_RECORD_FIELD = "historyRecord";
@@ -238,6 +240,7 @@ public class JdbcSourceEventDispatcher<P extends Partition> extends EventDispatc
         }
     }
 
+    @Override
     public void dispatchWatermarkEvent(
             Map<String, ?> sourcePartition,
             SourceSplitBase sourceSplit,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/AbstractScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/AbstractScanFetchTask.java
@@ -135,7 +135,7 @@ public abstract class AbstractScanFetchTask implements FetchTask {
             Context context, SourceSplitBase split, Offset lowWatermark) throws Exception {
         if (context instanceof JdbcSourceFetchTaskContext) {
             ((JdbcSourceFetchTaskContext) context)
-                    .getDispatcher()
+                    .getWaterMarkDispatcher()
                     .dispatchWatermarkEvent(
                             ((JdbcSourceFetchTaskContext) context)
                                     .getPartition()
@@ -157,7 +157,7 @@ public abstract class AbstractScanFetchTask implements FetchTask {
             Context context, SourceSplitBase split, Offset highWatermark) throws Exception {
         if (context instanceof JdbcSourceFetchTaskContext) {
             ((JdbcSourceFetchTaskContext) context)
-                    .getDispatcher()
+                    .getWaterMarkDispatcher()
                     .dispatchWatermarkEvent(
                             ((JdbcSourceFetchTaskContext) context)
                                     .getPartition()
@@ -180,7 +180,7 @@ public abstract class AbstractScanFetchTask implements FetchTask {
             Context context, SourceSplitBase split, Offset endWatermark) throws Exception {
         if (context instanceof JdbcSourceFetchTaskContext) {
             ((JdbcSourceFetchTaskContext) context)
-                    .getDispatcher()
+                    .getWaterMarkDispatcher()
                     .dispatchWatermarkEvent(
                             ((JdbcSourceFetchTaskContext) context)
                                     .getPartition()

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
@@ -17,16 +17,18 @@
 
 package org.apache.flink.cdc.connectors.base.source.reader.external;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
 import org.apache.flink.cdc.connectors.base.config.SourceConfig;
 import org.apache.flink.cdc.connectors.base.dialect.JdbcDataSourceDialect;
-import org.apache.flink.cdc.connectors.base.relational.JdbcSourceEventDispatcher;
 import org.apache.flink.cdc.connectors.base.utils.SourceRecordUtils;
 import org.apache.flink.table.types.logical.RowType;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.spi.OffsetContext;
 import io.debezium.pipeline.spi.Partition;
 import io.debezium.relational.RelationalDatabaseSchema;
@@ -43,6 +45,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /** The context for fetch task that fetching data of snapshot split from JDBC data source. */
+@Internal
 public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
 
     protected final JdbcSourceConfig sourceConfig;
@@ -171,7 +174,9 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
 
     public abstract ErrorHandler getErrorHandler();
 
-    public abstract JdbcSourceEventDispatcher getDispatcher();
+    public abstract EventDispatcher getEventDispatcher();
+
+    public abstract WatermarkDispatcher getWaterMarkDispatcher();
 
     public abstract OffsetContext getOffsetContext();
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/fetch/Db2ScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/fetch/Db2ScanFetchTask.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.cdc.connectors.db2.source.fetch;
 
-import org.apache.flink.cdc.connectors.base.relational.JdbcSourceEventDispatcher;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
@@ -74,7 +73,7 @@ public class Db2ScanFetchTask extends AbstractScanFetchTask {
                         sourceFetchContext.getSnapshotChangeEventSourceMetrics(),
                         sourceFetchContext.getDatabaseSchema(),
                         sourceFetchContext.getConnection(),
-                        sourceFetchContext.getDispatcher(),
+                        sourceFetchContext.getEventDispatcher(),
                         sourceFetchContext.getSnapshotReceiver(),
                         snapshotSplit);
         Db2SnapshotSplitChangeEventSourceContext changeEventSourceContext =
@@ -132,7 +131,8 @@ public class Db2ScanFetchTask extends AbstractScanFetchTask {
                 new Db2ConnectorConfig(dezConf),
                 context.getConnection(),
                 context.getMetaDataConnection(),
-                context.getDispatcher(),
+                context.getEventDispatcher(),
+                context.getWaterMarkDispatcher(),
                 context.getErrorHandler(),
                 context.getDatabaseSchema(),
                 backfillBinlogSplit);
@@ -150,7 +150,7 @@ public class Db2ScanFetchTask extends AbstractScanFetchTask {
         private final Db2ConnectorConfig connectorConfig;
         private final Db2DatabaseSchema databaseSchema;
         private final Db2Connection jdbcConnection;
-        private final JdbcSourceEventDispatcher<Db2Partition> dispatcher;
+        private final EventDispatcher<Db2Partition, TableId> dispatcher;
         private final Clock clock;
         private final SnapshotSplit snapshotSplit;
         private final Db2OffsetContext offsetContext;
@@ -163,7 +163,7 @@ public class Db2ScanFetchTask extends AbstractScanFetchTask {
                 SnapshotProgressListener<Db2Partition> snapshotProgressListener,
                 Db2DatabaseSchema databaseSchema,
                 Db2Connection jdbcConnection,
-                JdbcSourceEventDispatcher<Db2Partition> dispatcher,
+                EventDispatcher<Db2Partition, TableId> dispatcher,
                 EventDispatcher.SnapshotReceiver<Db2Partition> snapshotReceiver,
                 SnapshotSplit snapshotSplit) {
             super(connectorConfig, snapshotProgressListener);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/fetch/Db2SourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/fetch/Db2SourceFetchTaskContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.db2.source.fetch;
 
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
 import org.apache.flink.cdc.connectors.base.relational.JdbcSourceEventDispatcher;
 import org.apache.flink.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
@@ -216,7 +217,12 @@ public class Db2SourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     }
 
     @Override
-    public JdbcSourceEventDispatcher<Db2Partition> getDispatcher() {
+    public JdbcSourceEventDispatcher getEventDispatcher() {
+        return dispatcher;
+    }
+
+    @Override
+    public WatermarkDispatcher getWaterMarkDispatcher() {
         return dispatcher;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/EventProcessorFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/EventProcessorFactory.java
@@ -18,7 +18,7 @@
 package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
 
 import org.apache.flink.cdc.common.annotation.Internal;
-import org.apache.flink.cdc.connectors.base.relational.JdbcSourceEventDispatcher;
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
 import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
@@ -36,7 +36,9 @@ import io.debezium.connector.oracle.logminer.processor.infinispan.EmbeddedInfini
 import io.debezium.connector.oracle.logminer.processor.infinispan.RemoteInfinispanLogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.memory.MemoryLogMinerEventProcessor;
 import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.relational.TableId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +58,8 @@ public class EventProcessorFactory {
             ChangeEventSource.ChangeEventSourceContext context,
             OracleConnectorConfig connectorConfig,
             OracleConnection jdbcConnection,
-            JdbcSourceEventDispatcher<OraclePartition> dispatcher,
+            EventDispatcher<OraclePartition, TableId> eventDispatcher,
+            WatermarkDispatcher watermarkDispatcher,
             OraclePartition partition,
             OracleOffsetContext offsetContext,
             OracleDatabaseSchema schema,
@@ -70,7 +73,8 @@ public class EventProcessorFactory {
                     context,
                     connectorConfig,
                     jdbcConnection,
-                    dispatcher,
+                    eventDispatcher,
+                    watermarkDispatcher,
                     partition,
                     offsetContext,
                     schema,
@@ -83,7 +87,8 @@ public class EventProcessorFactory {
                     context,
                     connectorConfig,
                     jdbcConnection,
-                    dispatcher,
+                    eventDispatcher,
+                    watermarkDispatcher,
                     partition,
                     offsetContext,
                     schema,
@@ -95,7 +100,8 @@ public class EventProcessorFactory {
                     context,
                     connectorConfig,
                     jdbcConnection,
-                    dispatcher,
+                    eventDispatcher,
+                    watermarkDispatcher,
                     partition,
                     offsetContext,
                     schema,
@@ -117,13 +123,14 @@ public class EventProcessorFactory {
         private final ErrorHandler errorHandler;
 
         private ChangeEventSource.ChangeEventSourceContext context;
-        private final JdbcSourceEventDispatcher<OraclePartition> dispatcher;
+        private final WatermarkDispatcher watermarkDispatcher;
 
         public CDCMemoryLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
                 OracleConnectorConfig connectorConfig,
                 OracleConnection jdbcConnection,
-                JdbcSourceEventDispatcher<OraclePartition> dispatcher,
+                EventDispatcher<OraclePartition, TableId> eventDispatcher,
+                WatermarkDispatcher watermarkDispatcher,
                 OraclePartition partition,
                 OracleOffsetContext offsetContext,
                 OracleDatabaseSchema schema,
@@ -134,7 +141,7 @@ public class EventProcessorFactory {
                     context,
                     connectorConfig,
                     jdbcConnection,
-                    dispatcher,
+                    eventDispatcher,
                     partition,
                     offsetContext,
                     schema,
@@ -142,14 +149,14 @@ public class EventProcessorFactory {
             this.redoLogSplit = redoLogSplit;
             this.errorHandler = errorHandler;
             this.context = context;
-            this.dispatcher = dispatcher;
+            this.watermarkDispatcher = watermarkDispatcher;
         }
 
         @Override
         protected void processRow(OraclePartition partition, LogMinerEventRow row)
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
-                    partition, row, redoLogSplit, errorHandler, dispatcher, context)) {
+                    partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
                 return;
             }
             super.processRow(partition, row);
@@ -166,13 +173,14 @@ public class EventProcessorFactory {
         private final ErrorHandler errorHandler;
 
         private ChangeEventSource.ChangeEventSourceContext context;
-        private final JdbcSourceEventDispatcher<OraclePartition> dispatcher;
+        private final WatermarkDispatcher watermarkDispatcher;
 
         public CDCEmbeddedInfinispanLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
                 OracleConnectorConfig connectorConfig,
                 OracleConnection jdbcConnection,
-                JdbcSourceEventDispatcher<OraclePartition> dispatcher,
+                EventDispatcher<OraclePartition, TableId> eventDispatcher,
+                WatermarkDispatcher watermarkDispatcher,
                 OraclePartition partition,
                 OracleOffsetContext offsetContext,
                 OracleDatabaseSchema schema,
@@ -183,7 +191,7 @@ public class EventProcessorFactory {
                     context,
                     connectorConfig,
                     jdbcConnection,
-                    dispatcher,
+                    eventDispatcher,
                     partition,
                     offsetContext,
                     schema,
@@ -191,14 +199,14 @@ public class EventProcessorFactory {
             this.redoLogSplit = redoLogSplit;
             this.errorHandler = errorHandler;
             this.context = context;
-            this.dispatcher = dispatcher;
+            this.watermarkDispatcher = watermarkDispatcher;
         }
 
         @Override
         protected void processRow(OraclePartition partition, LogMinerEventRow row)
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
-                    partition, row, redoLogSplit, errorHandler, dispatcher, context)) {
+                    partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
                 return;
             }
             super.processRow(partition, row);
@@ -215,13 +223,14 @@ public class EventProcessorFactory {
         private final ErrorHandler errorHandler;
 
         private ChangeEventSource.ChangeEventSourceContext context;
-        private final JdbcSourceEventDispatcher<OraclePartition> dispatcher;
+        private final WatermarkDispatcher watermarkDispatcher;
 
         public CDCRemoteInfinispanLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
                 OracleConnectorConfig connectorConfig,
                 OracleConnection jdbcConnection,
-                JdbcSourceEventDispatcher<OraclePartition> dispatcher,
+                EventDispatcher<OraclePartition, TableId> eventDispatcher,
+                WatermarkDispatcher watermarkDispatcher,
                 OraclePartition partition,
                 OracleOffsetContext offsetContext,
                 OracleDatabaseSchema schema,
@@ -232,7 +241,7 @@ public class EventProcessorFactory {
                     context,
                     connectorConfig,
                     jdbcConnection,
-                    dispatcher,
+                    eventDispatcher,
                     partition,
                     offsetContext,
                     schema,
@@ -240,14 +249,14 @@ public class EventProcessorFactory {
             this.redoLogSplit = redoLogSplit;
             this.errorHandler = errorHandler;
             this.context = context;
-            this.dispatcher = dispatcher;
+            this.watermarkDispatcher = watermarkDispatcher;
         }
 
         @Override
         protected void processRow(OraclePartition partition, LogMinerEventRow row)
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
-                    partition, row, redoLogSplit, errorHandler, dispatcher, context)) {
+                    partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
                 return;
             }
             super.processRow(partition, row);
@@ -259,7 +268,7 @@ public class EventProcessorFactory {
             LogMinerEventRow row,
             StreamSplit redoLogSplit,
             ErrorHandler errorHandler,
-            JdbcSourceEventDispatcher dispatcher,
+            WatermarkDispatcher dispatcher,
             ChangeEventSource.ChangeEventSourceContext context) {
         // check do we need to stop for fetch redo log for snapshot split.
         if (isBoundedRead(redoLogSplit)) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
 
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
 import org.apache.flink.cdc.connectors.base.dialect.JdbcDataSourceDialect;
 import org.apache.flink.cdc.connectors.base.relational.JdbcSourceEventDispatcher;
@@ -230,7 +231,12 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     }
 
     @Override
-    public JdbcSourceEventDispatcher<OraclePartition> getDispatcher() {
+    public JdbcSourceEventDispatcher<OraclePartition> getEventDispatcher() {
+        return dispatcher;
+    }
+
+    @Override
+    public WatermarkDispatcher getWaterMarkDispatcher() {
         return dispatcher;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/CDCPostgresDispatcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/CDCPostgresDispatcher.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.fetch;
+
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkEvent;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresEventDispatcher;
+import io.debezium.heartbeat.HeartbeatFactory;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.ChangeEventCreator;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionFilters;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.Map;
+
+/** Postgres Dispatcher for cdc source with watermark. */
+public class CDCPostgresDispatcher extends PostgresEventDispatcher<TableId>
+        implements WatermarkDispatcher {
+    private final String topic;
+    private final ChangeEventQueue<DataChangeEvent> queue;
+
+    public CDCPostgresDispatcher(
+            PostgresConnectorConfig connectorConfig,
+            TopicSelector topicSelector,
+            DatabaseSchema schema,
+            ChangeEventQueue queue,
+            DataCollectionFilters.DataCollectionFilter filter,
+            ChangeEventCreator changeEventCreator,
+            EventMetadataProvider metadataProvider,
+            HeartbeatFactory heartbeatFactory,
+            SchemaNameAdjuster schemaNameAdjuster) {
+        super(
+                connectorConfig,
+                topicSelector,
+                schema,
+                queue,
+                filter,
+                changeEventCreator,
+                metadataProvider,
+                heartbeatFactory,
+                schemaNameAdjuster);
+        this.topic = topicSelector.getPrimaryTopic();
+        this.queue = queue;
+    }
+
+    @Override
+    public void dispatchWatermarkEvent(
+            Map<String, ?> sourcePartition,
+            SourceSplitBase sourceSplit,
+            Offset watermark,
+            WatermarkKind watermarkKind)
+            throws InterruptedException {
+        SourceRecord sourceRecord =
+                WatermarkEvent.create(
+                        sourcePartition, topic, sourceSplit.splitId(), watermarkKind, watermark);
+        queue.enqueue(new DataChangeEvent(sourceRecord));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
@@ -44,6 +44,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -74,6 +75,7 @@ import static org.apache.flink.table.api.DataTypes.BIGINT;
 import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.flink.table.catalog.Column.physical;
 import static org.apache.flink.util.Preconditions.checkState;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /** IT tests for {@link PostgresSourceBuilder.PostgresIncrementalSource}. */
@@ -253,9 +255,7 @@ public class PostgresSourceITCase extends PostgresTestBase {
                         PostgresTestUtils.FailoverType.NONE,
                         PostgresTestUtils.FailoverPhase.NEVER,
                         new String[] {"customers_no_pk"},
-                        RestartStrategies.noRestart(),
-                        false,
-                        null);
+                        RestartStrategies.noRestart());
             } catch (Exception e) {
                 assertTrue(
                         ExceptionUtils.findThrowableWithMessage(
@@ -272,9 +272,7 @@ public class PostgresSourceITCase extends PostgresTestBase {
                     PostgresTestUtils.FailoverType.NONE,
                     PostgresTestUtils.FailoverPhase.NEVER,
                     new String[] {"customers_no_pk"},
-                    RestartStrategies.noRestart(),
-                    false,
-                    null);
+                    RestartStrategies.noRestart());
         }
     }
 
@@ -287,8 +285,7 @@ public class PostgresSourceITCase extends PostgresTestBase {
                 PostgresTestUtils.FailoverPhase.SNAPSHOT,
                 new String[] {"customers"},
                 RestartStrategies.fixedDelayRestart(1, 0),
-                true,
-                null);
+                Collections.singletonMap("scan.incremental.snapshot.backfill.skip", "true"));
     }
 
     @Test
@@ -660,8 +657,8 @@ public class PostgresSourceITCase extends PostgresTestBase {
                     PostgresTestUtils.FailoverPhase.NEVER,
                     new String[] {"customers"},
                     RestartStrategies.noRestart(),
-                    false,
-                    chunkColumn);
+                    Collections.singletonMap(
+                            "scan.incremental.snapshot.chunk.key-column", chunkColumn));
         } catch (Exception e) {
             assertTrue(
                     ExceptionUtils.findThrowableWithMessage(
@@ -670,6 +667,34 @@ public class PostgresSourceITCase extends PostgresTestBase {
                                             "Chunk key column '%s' doesn't exist in the primary key [%s] of the table %s.",
                                             chunkColumn, "id", "customer.customers"))
                             .isPresent());
+        }
+    }
+
+    @Test
+    public void testHeartBeat() throws Exception {
+        try (PostgresConnection connection = getConnection()) {
+            connection.execute("CREATE TABLE IF NOT EXISTS heart_beat_table(a int)");
+            connection.commit();
+        }
+
+        TableId tableId = new TableId(null, "public", "heart_beat_table");
+        try (PostgresConnection connection = getConnection()) {
+            assertEquals(0, getCountOfTable(connection, tableId));
+        }
+
+        Map<String, String> options = new HashMap<>();
+        options.put("heartbeat.interval.ms", "100");
+        options.put("debezium.heartbeat.action.query", "INSERT INTO heart_beat_table VALUES(1)");
+        testPostgresParallelSource(
+                1,
+                scanStartupMode,
+                PostgresTestUtils.FailoverType.NONE,
+                PostgresTestUtils.FailoverPhase.NEVER,
+                new String[] {"customers"},
+                RestartStrategies.noRestart(),
+                options);
+        try (PostgresConnection connection = getConnection()) {
+            assertTrue(getCountOfTable(connection, tableId) > 0);
         }
     }
 
@@ -776,8 +801,25 @@ public class PostgresSourceITCase extends PostgresTestBase {
                 failoverPhase,
                 captureCustomerTables,
                 RestartStrategies.fixedDelayRestart(1, 0),
-                false,
-                null);
+                new HashMap<>());
+    }
+
+    private void testPostgresParallelSource(
+            int parallelism,
+            String scanStartupMode,
+            PostgresTestUtils.FailoverType failoverType,
+            PostgresTestUtils.FailoverPhase failoverPhase,
+            String[] captureCustomerTables,
+            RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration)
+            throws Exception {
+        testPostgresParallelSource(
+                parallelism,
+                scanStartupMode,
+                failoverType,
+                failoverPhase,
+                captureCustomerTables,
+                restartStrategyConfiguration,
+                new HashMap<>());
     }
 
     private void testPostgresParallelSource(
@@ -787,8 +829,7 @@ public class PostgresSourceITCase extends PostgresTestBase {
             PostgresTestUtils.FailoverPhase failoverPhase,
             String[] captureCustomerTables,
             RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration,
-            boolean skipSnapshotBackfill,
-            String chunkColumn)
+            Map<String, String> otherOptions)
             throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
@@ -817,9 +858,8 @@ public class PostgresSourceITCase extends PostgresTestBase {
                                 + " 'scan.startup.mode' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '100',"
                                 + " 'slot.name' = '%s',"
-                                + " 'scan.incremental.snapshot.backfill.skip' = '%s',"
                                 + " 'scan.lsn-commit.checkpoints-num-delay' = '1'"
-                                + ""
+                                + "%s"
                                 + ")",
                         customDatabase.getHost(),
                         customDatabase.getDatabasePort(),
@@ -830,12 +870,16 @@ public class PostgresSourceITCase extends PostgresTestBase {
                         getTableNameRegex(captureCustomerTables),
                         scanStartupMode,
                         slotName,
-                        skipSnapshotBackfill,
-                        chunkColumn == null
+                        otherOptions.isEmpty()
                                 ? ""
-                                : ",'scan.incremental.snapshot.chunk.key-column'='"
-                                        + chunkColumn
-                                        + "'");
+                                : ","
+                                        + otherOptions.entrySet().stream()
+                                                .map(
+                                                        e ->
+                                                                String.format(
+                                                                        "'%s'='%s'",
+                                                                        e.getKey(), e.getValue()))
+                                                .collect(Collectors.joining(",")));
         tEnv.executeSql(sourceDDL);
         TableResult tableResult = tEnv.executeSql("select * from customers");
 
@@ -1162,5 +1206,24 @@ public class PostgresSourceITCase extends PostgresTestBase {
         properties.put("password", customDatabase.getPassword());
         properties.put("dbname", customDatabase.getDatabaseName());
         return createConnection(properties);
+    }
+
+    private static long getCountOfTable(JdbcConnection jdbc, TableId tableId) throws SQLException {
+        // The statement used to get approximate row count which is less
+        // accurate than COUNT(*), but is more efficient for large table.
+        // https://stackoverflow.com/questions/7943233/fast-way-to-discover-the-row-count-of-a-table-in-postgresql
+        // NOTE: it requires ANALYZE or VACUUM to be run first in PostgreSQL.
+        final String query = String.format("SELECT COUNT(1) FROM %s", tableId.toString());
+
+        return jdbc.queryAndMap(
+                query,
+                rs -> {
+                    if (!rs.next()) {
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", query));
+                    }
+                    return rs.getLong(1);
+                });
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerSourceFetchTaskContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.sqlserver.source.reader.fetch;
 
+import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
 import org.apache.flink.cdc.connectors.base.relational.JdbcSourceEventDispatcher;
 import org.apache.flink.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
@@ -229,7 +230,12 @@ public class SqlServerSourceFetchTaskContext extends JdbcSourceFetchTaskContext 
     }
 
     @Override
-    public JdbcSourceEventDispatcher<SqlServerPartition> getDispatcher() {
+    public JdbcSourceEventDispatcher<SqlServerPartition> getEventDispatcher() {
+        return dispatcher;
+    }
+
+    @Override
+    public WatermarkDispatcher getWaterMarkDispatcher() {
         return dispatcher;
     }
 


### PR DESCRIPTION
As shown in FLINK-35387, postgres cdc support: debezium.heartbeat.action.query