### PR TITLE
[hotfix] `testSourceMetrics` fails due to missing serverTimeZone option

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceITCase.java
@@ -709,6 +709,7 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
                         .port(MYSQL_CONTAINER.getDatabasePort())
                         .databaseList(customDatabase.getDatabaseName())
                         .tableList(customDatabase.getDatabaseName() + ".customers")
+                        .serverTimeZone("UTC")
                         .username(customDatabase.getUsername())
                         .password(customDatabase.getPassword())
                         .deserializer(new StringDebeziumDeserializationSchema())


### PR DESCRIPTION
When debugging & testing locally (with non-UTC timezone), `testSourceMetrics` case will fail due to the following exception:

```
Caused by: org.apache.flink.table.api.ValidationException: The MySQL server has a timezone offset (0 seconds ahead of UTC) which does not match the configured timezone Asia/Shanghai. Specify the right server-time-zone to avoid inconsistencies for time-related fields.
	at org.apache.flink.cdc.connectors.mysql.MySqlValidator.checkTimeZone(MySqlValidator.java:215)
	at org.apache.flink.cdc.connectors.mysql.MySqlValidator.validate(MySqlValidator.java:76)
	at org.apache.flink.cdc.connectors.mysql.source.MySqlSource.createEnumerator(MySqlSource.java:200)
	at org.apache.flink.runtime.source.coordinator.SourceCoordinator.start(SourceCoordinator.java:221)
	... 33 more
```

Turns out it was caused by a missing timezone configuration option.