### PR TITLE
[FLINK-36618][cdc-connector][postgres] Improve PostgresDialect.discoverDataCollections to reduce the start time of Postgres CDC.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialect.java
@@ -50,7 +50,6 @@ import io.debezium.schema.TopicSelector;
 import javax.annotation.Nullable;
 
 import java.sql.SQLException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -171,11 +170,7 @@ public class PostgresDialect implements JdbcDataSourceDialect {
 
         try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
             // fetch table schemas
-            Map<TableId, TableChange> tableSchemas = new HashMap<>();
-            for (TableId tableId : capturedTableIds) {
-                TableChange tableSchema = queryTableSchema(jdbc, tableId);
-                tableSchemas.put(tableId, tableSchema);
-            }
+            Map<TableId, TableChange> tableSchemas = queryTableSchema(jdbc, capturedTableIds);
             return tableSchemas;
         } catch (Exception e) {
             throw new FlinkRuntimeException(
@@ -194,6 +189,14 @@ public class PostgresDialect implements JdbcDataSourceDialect {
             schema = new CustomPostgresSchema((PostgresConnection) jdbc, sourceConfig);
         }
         return schema.getTableSchema(tableId);
+    }
+
+    private Map<TableId, TableChange> queryTableSchema(
+            JdbcConnection jdbc, List<TableId> tableIds) {
+        if (schema == null) {
+            schema = new CustomPostgresSchema((PostgresConnection) jdbc, sourceConfig);
+        }
+        return schema.getTableSchema(tableIds);
     }
 
     @Override


### PR DESCRIPTION
As shown in https://issues.apache.org/jira/browse/FLINK-36618, this PR will significantly improve startup time several times or even dozens of times( maybe more) depending on number of table