### PR TITLE
[FLINK-36636][cdc] Timestamp data supports comparison in cdc pipeline transform

### DIFF
--- a/docs/content.zh/docs/core-concept/transform.md
+++ b/docs/content.zh/docs/core-concept/transform.md
@@ -92,10 +92,10 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 |----------------------|-----------------------------|-----------------------------------------------------------------|
 | value1 = value2      | valueEquals(value1, value2) | Returns TRUE if value1 is equal to value2; returns FALSE if value1 or value2 is NULL. |
 | value1 <> value2     | !valueEquals(value1, value2) | Returns TRUE if value1 is not equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 > value2      | value1 > value2             | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 >= value2     | value1 >= value2            | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 < value2      | value1 < value2             | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 <= value2     | value1 <= value2            | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 > value2      | greater(value1, value2)     | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 >= value2     | greaterOrEqual(value1, value2) | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 < value2      | less(value1, value2)        | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 <= value2     | lessOrEqual(value1, value2) | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
 | value IS NULL        | null == value               | Returns TRUE if value is NULL.                                  |
 | value IS NOT NULL    | null != value               | Returns TRUE if value is not NULL.                              |
 | value1 BETWEEN value2 AND value3 | betweenAsymmetric(value1, value2, value3) | Returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. |

--- a/docs/content.zh/docs/core-concept/transform.md
+++ b/docs/content.zh/docs/core-concept/transform.md
@@ -92,10 +92,10 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 |----------------------|-----------------------------|-----------------------------------------------------------------|
 | value1 = value2      | valueEquals(value1, value2) | Returns TRUE if value1 is equal to value2; returns FALSE if value1 or value2 is NULL. |
 | value1 <> value2     | !valueEquals(value1, value2) | Returns TRUE if value1 is not equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 > value2      | greater(value1, value2)     | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 >= value2     | greaterOrEqual(value1, value2) | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 < value2      | less(value1, value2)        | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 <= value2     | lessOrEqual(value1, value2) | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 > value2      | greaterThan(value1, value2)     | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 >= value2     | greaterThanOrEqual(value1, value2) | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 < value2      | lessThan(value1, value2)        | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 <= value2     | lessThanOrEqual(value1, value2) | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
 | value IS NULL        | null == value               | Returns TRUE if value is NULL.                                  |
 | value IS NOT NULL    | null != value               | Returns TRUE if value is not NULL.                              |
 | value1 BETWEEN value2 AND value3 | betweenAsymmetric(value1, value2, value3) | Returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. |

--- a/docs/content/docs/core-concept/transform.md
+++ b/docs/content/docs/core-concept/transform.md
@@ -88,22 +88,22 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 
 ## Comparison Functions
 
-| Function             | Janino Code                 | Description                                                     |
-|----------------------|-----------------------------|-----------------------------------------------------------------|
-| value1 = value2      | valueEquals(value1, value2) | Returns TRUE if value1 is equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 <> value2     | !valueEquals(value1, value2) | Returns TRUE if value1 is not equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 > value2      | value1 > value2             | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 >= value2     | value1 >= value2            | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 < value2      | value1 < value2             | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 <= value2     | value1 <= value2            | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value IS NULL        | null == value               | Returns TRUE if value is NULL.                                  |
-| value IS NOT NULL    | null != value               | Returns TRUE if value is not NULL.                              |
-| value1 BETWEEN value2 AND value3 | betweenAsymmetric(value1, value2, value3) | Returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. |
+| Function             | Janino Code                                  | Description                                                     |
+|----------------------|----------------------------------------------|-----------------------------------------------------------------|
+| value1 = value2      | valueEquals(value1, value2)                  | Returns TRUE if value1 is equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 <> value2     | !valueEquals(value1, value2)                 | Returns TRUE if value1 is not equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 > value2      | greater(value1, value2)                      | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 >= value2     | greaterOrEqual(value1, value2)               | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 < value2      | less(value1, value2)                         | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 <= value2     | lessOrEqual(value1, value2)                  | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value IS NULL        | null == value                                | Returns TRUE if value is NULL.                                  |
+| value IS NOT NULL    | null != value                                | Returns TRUE if value is not NULL.                              |
+| value1 BETWEEN value2 AND value3 | betweenAsymmetric(value1, value2, value3)    | Returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. |
 | value1 NOT BETWEEN value2 AND value3 | notBetweenAsymmetric(value1, value2, value3) | Returns TRUE if value1 is less than value2 or greater than value3. |
-| string1 LIKE string2 | like(string1, string2)      | Returns TRUE if string1 matches pattern string2.                |
-| string1 NOT LIKE string2 | notLike(string1, string2) | Returns TRUE if string1 does not match pattern string2.       |
-| value1 IN (value2 [, value3]* ) | in(value1, value2 [, value3]*) | Returns TRUE if value1 exists in the given list (value2, value3, …). |
-| value1 NOT IN (value2 [, value3]* ) | notIn(value1, value2 [, value3]*) | Returns TRUE if value1 does not exist in the given list (value2, value3, …).  |
+| string1 LIKE string2 | like(string1, string2)                       | Returns TRUE if string1 matches pattern string2.                |
+| string1 NOT LIKE string2 | notLike(string1, string2)                    | Returns TRUE if string1 does not match pattern string2.       |
+| value1 IN (value2 [, value3]* ) | in(value1, value2 [, value3]*)               | Returns TRUE if value1 exists in the given list (value2, value3, …). |
+| value1 NOT IN (value2 [, value3]* ) | notIn(value1, value2 [, value3]*)            | Returns TRUE if value1 does not exist in the given list (value2, value3, …).  |
 
 ## Logical Functions
 

--- a/docs/content/docs/core-concept/transform.md
+++ b/docs/content/docs/core-concept/transform.md
@@ -92,10 +92,10 @@ Flink CDC uses [Calcite](https://calcite.apache.org/) to parse expressions and [
 |----------------------|----------------------------------------------|-----------------------------------------------------------------|
 | value1 = value2      | valueEquals(value1, value2)                  | Returns TRUE if value1 is equal to value2; returns FALSE if value1 or value2 is NULL. |
 | value1 <> value2     | !valueEquals(value1, value2)                 | Returns TRUE if value1 is not equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 > value2      | greater(value1, value2)                      | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 >= value2     | greaterOrEqual(value1, value2)               | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
-| value1 < value2      | less(value1, value2)                         | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
-| value1 <= value2     | lessOrEqual(value1, value2)                  | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 > value2      | greaterThan(value1, value2)                  | Returns TRUE if value1 is greater than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 >= value2     | greaterThanOrEqual(value1, value2)               | Returns TRUE if value1 is greater than or equal to value2; returns FALSE if value1 or value2 is NULL. |
+| value1 < value2      | lessThan(value1, value2)                         | Returns TRUE if value1 is less than value2; returns FALSE if value1 or value2 is NULL. |
+| value1 <= value2     | lessThanOrEqual(value1, value2)                  | Returns TRUE if value1 is less than or equal to value2; returns FALSE if value1 or value2 is NULL. |
 | value IS NULL        | null == value                                | Returns TRUE if value is NULL.                                  |
 | value IS NOT NULL    | null != value                                | Returns TRUE if value is not NULL.                              |
 | value1 BETWEEN value2 AND value3 | betweenAsymmetric(value1, value2, value3)    | Returns TRUE if value1 is greater than or equal to value2 and less than or equal to value3. |

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
@@ -867,4 +867,32 @@ public class SystemFunctionUtils {
         }
         return String.valueOf(object);
     }
+
+    public static boolean greater(Comparable comparable1, Comparable comparable2) {
+        if (comparable1 == null || comparable2 == null) {
+            return false;
+        }
+        return comparable1.compareTo(comparable2) > 0;
+    }
+
+    public static boolean greaterOrEqual(Comparable comparable1, Comparable comparable2) {
+        if (comparable1 == null || comparable2 == null) {
+            return false;
+        }
+        return comparable1.compareTo(comparable2) >= 0;
+    }
+
+    public static boolean less(Comparable comparable1, Comparable comparable2) {
+        if (comparable1 == null || comparable2 == null) {
+            return false;
+        }
+        return comparable1.compareTo(comparable2) < 0;
+    }
+
+    public static boolean lessOrEqual(Comparable comparable1, Comparable comparable2) {
+        if (comparable1 == null || comparable2 == null) {
+            return false;
+        }
+        return comparable1.compareTo(comparable2) <= 0;
+    }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
@@ -868,31 +868,48 @@ public class SystemFunctionUtils {
         return String.valueOf(object);
     }
 
-    public static boolean greater(Comparable comparable1, Comparable comparable2) {
-        if (comparable1 == null || comparable2 == null) {
-            return false;
+    private static int universalCompares(Object lhs, Object rhs) {
+        Class<?> leftClass = lhs.getClass();
+        Class<?> rightClass = rhs.getClass();
+        if (leftClass.equals(rightClass) && Comparable.class.isAssignableFrom(leftClass)) {
+            return ((Comparable) lhs).compareTo(rhs);
+        } else if (Number.class.isAssignableFrom(leftClass)
+                && Number.class.isAssignableFrom(rightClass)) {
+            return Double.compare(((Number) lhs).doubleValue(), ((Number) rhs).doubleValue());
+        } else {
+            throw new RuntimeException(
+                    "Comparison of unsupported data types: "
+                            + leftClass.getName()
+                            + " and "
+                            + rightClass.getName());
         }
-        return comparable1.compareTo(comparable2) > 0;
     }
 
-    public static boolean greaterOrEqual(Comparable comparable1, Comparable comparable2) {
-        if (comparable1 == null || comparable2 == null) {
+    public static boolean greaterThan(Object lhs, Object rhs) {
+        if (lhs == null || rhs == null) {
             return false;
         }
-        return comparable1.compareTo(comparable2) >= 0;
+        return universalCompares(lhs, rhs) > 0;
     }
 
-    public static boolean less(Comparable comparable1, Comparable comparable2) {
-        if (comparable1 == null || comparable2 == null) {
+    public static boolean greaterThanOrEqual(Object lhs, Object rhs) {
+        if (lhs == null || rhs == null) {
             return false;
         }
-        return comparable1.compareTo(comparable2) < 0;
+        return universalCompares(lhs, rhs) >= 0;
     }
 
-    public static boolean lessOrEqual(Comparable comparable1, Comparable comparable2) {
-        if (comparable1 == null || comparable2 == null) {
+    public static boolean lessThan(Object lhs, Object rhs) {
+        if (lhs == null || rhs == null) {
             return false;
         }
-        return comparable1.compareTo(comparable2) <= 0;
+        return universalCompares(lhs, rhs) < 0;
+    }
+
+    public static boolean lessThanOrEqual(Object lhs, Object rhs) {
+        if (lhs == null || rhs == null) {
+            return false;
+        }
+        return universalCompares(lhs, rhs) <= 0;
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
@@ -871,10 +871,9 @@ public class SystemFunctionUtils {
     private static int universalCompares(Object lhs, Object rhs) {
         Class<?> leftClass = lhs.getClass();
         Class<?> rightClass = rhs.getClass();
-        if (leftClass.equals(rightClass) && Comparable.class.isAssignableFrom(leftClass)) {
+        if (leftClass.equals(rightClass) && lhs instanceof Comparable) {
             return ((Comparable) lhs).compareTo(rhs);
-        } else if (Number.class.isAssignableFrom(leftClass)
-                && Number.class.isAssignableFrom(rightClass)) {
+        } else if (lhs instanceof Number && rhs instanceof Number) {
             return Double.compare(((Number) lhs).doubleValue(), ((Number) rhs).doubleValue());
         } else {
             throw new RuntimeException(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -321,16 +321,16 @@ public class JaninoCompiler {
         String compareMethodName;
         switch (sqlBasicCall.getKind()) {
             case LESS_THAN:
-                compareMethodName = "LESS";
+                compareMethodName = "LESS_THAN";
                 break;
             case GREATER_THAN:
-                compareMethodName = "GREATER";
+                compareMethodName = "GREATER_THAN";
                 break;
             case LESS_THAN_OR_EQUAL:
-                compareMethodName = "LESS_OR_EQUAL";
+                compareMethodName = "LESS_THAN_OR_EQUAL";
                 break;
             case GREATER_THAN_OR_EQUAL:
-                compareMethodName = "GREATER_OR_EQUAL";
+                compareMethodName = "GREATER_THAN_OR_EQUAL";
                 break;
             default:
                 throw new ParseException(

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
@@ -282,7 +282,7 @@ public class PostTransformOperatorTest {
             TableId.tableId("my_company", "my_branch", "compare_table");
     private static final Schema COMPARE_SCHEMA =
             Schema.newBuilder()
-                    .physicalColumn("col1", DataTypes.STRING())
+                    .physicalColumn("col1", DataTypes.STRING().notNull())
                     .physicalColumn("numerical_equal", DataTypes.BOOLEAN())
                     .physicalColumn("string_equal", DataTypes.BOOLEAN())
                     .physicalColumn("time_equal", DataTypes.BOOLEAN())
@@ -295,7 +295,7 @@ public class PostTransformOperatorTest {
             TableId.tableId("my_company", "my_branch", "compare_data_table");
     private static final Schema COMPARE_DATA_SCHEMA =
             Schema.newBuilder()
-                    .physicalColumn("id", DataTypes.INT())
+                    .physicalColumn("id", DataTypes.INT().notNull())
                     .physicalColumn("c1", DataTypes.FLOAT().nullable())
                     .physicalColumn("c2", DataTypes.DOUBLE().nullable())
                     .physicalColumn("c3", DataTypes.TIMESTAMP().nullable())
@@ -303,7 +303,7 @@ public class PostTransformOperatorTest {
                     .build();
     private static final Schema EXPECTD_COMPARE_DATA_SCHEMA =
             Schema.newBuilder()
-                    .physicalColumn("id", DataTypes.INT())
+                    .physicalColumn("id", DataTypes.INT().notNull())
                     .physicalColumn("float_equal", DataTypes.BOOLEAN())
                     .physicalColumn("double_equal", DataTypes.BOOLEAN())
                     .physicalColumn("timestamp_equal", DataTypes.BOOLEAN())

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
@@ -2009,9 +2009,10 @@ public class PostTransformOperatorTest {
                                 "2 > 1")
                         .addTimezone("UTC")
                         .build();
-        EventOperatorTestHarness<PostTransformOperator, Event>
+        RegularEventOperatorTestHarness<PostTransformOperator, Event>
                 transformFunctionEventEventOperatorTestHarness =
-                        new EventOperatorTestHarness<>(transform, 1);
+                        RegularEventOperatorTestHarness.with(transform, 1);
+
         // Initialization
         transformFunctionEventEventOperatorTestHarness.open();
         // Create table
@@ -2058,9 +2059,9 @@ public class PostTransformOperatorTest {
                                 "2 > 1")
                         .addTimezone("UTC")
                         .build();
-        EventOperatorTestHarness<PostTransformOperator, Event>
+        RegularEventOperatorTestHarness<PostTransformOperator, Event>
                 transformFunctionEventEventOperatorTestHarness =
-                        new EventOperatorTestHarness<>(transform, 1);
+                        RegularEventOperatorTestHarness.with(transform, 1);
         // Initialization
         transformFunctionEventEventOperatorTestHarness.open();
         // Create table
@@ -2102,9 +2103,9 @@ public class PostTransformOperatorTest {
                                 null)
                         .addTimezone("UTC")
                         .build();
-        EventOperatorTestHarness<PostTransformOperator, Event>
+        RegularEventOperatorTestHarness<PostTransformOperator, Event>
                 transformFunctionEventEventOperatorTestHarness =
-                        new EventOperatorTestHarness<>(transform, 1);
+                        RegularEventOperatorTestHarness.with(transform, 1);
         // Initialization
         transformFunctionEventEventOperatorTestHarness.open();
         // Create table

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -263,7 +263,7 @@ public class TransformParserTest {
                 "TO_DATE(dt, 'yyyy-MM-dd')", "toDate(dt, \"yyyy-MM-dd\", __time_zone__)");
         testFilterExpression("TO_TIMESTAMP(dt)", "toTimestamp(dt, __time_zone__)");
         testFilterExpression("TIMESTAMP_DIFF('DAY', dt1, dt2)", "timestampDiff(\"DAY\", dt1, dt2)");
-        testFilterExpression("IF(a>b,a,b)", "greater(a, b) ? a : b");
+        testFilterExpression("IF(a>b,a,b)", "greaterThan(a, b) ? a : b");
         testFilterExpression("NULLIF(a,b)", "nullif(a, b)");
         testFilterExpression("COALESCE(a,b,c)", "coalesce(a, b, c)");
         testFilterExpression("id + 2", "id + 2");
@@ -271,17 +271,18 @@ public class TransformParserTest {
         testFilterExpression("id * 2", "id * 2");
         testFilterExpression("id / 2", "id / 2");
         testFilterExpression("id % 2", "id % 2");
-        testFilterExpression("a < b", "less(a, b)");
-        testFilterExpression("a <= b", "lessOrEqual(a, b)");
-        testFilterExpression("a > b", "greater(a, b)");
-        testFilterExpression("a >= b", "greaterOrEqual(a, b)");
+        testFilterExpression("a < b", "lessThan(a, b)");
+        testFilterExpression("a <= b", "lessThanOrEqual(a, b)");
+        testFilterExpression("a > b", "greaterThan(a, b)");
+        testFilterExpression("a >= b", "greaterThanOrEqual(a, b)");
         testFilterExpression("__table_name__ = 'tb'", "valueEquals(__table_name__, \"tb\")");
         testFilterExpression("__schema_name__ = 'tb'", "valueEquals(__schema_name__, \"tb\")");
         testFilterExpression(
                 "__namespace_name__ = 'tb'", "valueEquals(__namespace_name__, \"tb\")");
         testFilterExpression("upper(lower(id))", "upper(lower(id))");
         testFilterExpression(
-                "abs(uniq_id) > 10 and id is not null", "greater(abs(uniq_id), 10) && null != id");
+                "abs(uniq_id) > 10 and id is not null",
+                "greaterThan(abs(uniq_id), 10) && null != id");
         testFilterExpression(
                 "case id when 1 then 'a' when 2 then 'b' else 'c' end",
                 "(valueEquals(id, 1) ? \"a\" : valueEquals(id, 2) ? \"b\" : \"c\")");
@@ -474,10 +475,10 @@ public class TransformParserTest {
                 "typeof(id % 2)", "__instanceOfTypeOfFunctionClass.eval(id % 2)");
         testFilterExpressionWithUdf(
                 "addone(addone(id)) > 4 OR typeof(id) <> 'bool' AND format('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "greater(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
+                "greaterThan(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
         testFilterExpressionWithUdf(
                 "ADDONE(ADDONE(id)) > 4 OR TYPEOF(id) <> 'bool' AND FORMAT('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "greater(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
+                "greaterThan(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
     }
 
     @Test

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -263,7 +263,7 @@ public class TransformParserTest {
                 "TO_DATE(dt, 'yyyy-MM-dd')", "toDate(dt, \"yyyy-MM-dd\", __time_zone__)");
         testFilterExpression("TO_TIMESTAMP(dt)", "toTimestamp(dt, __time_zone__)");
         testFilterExpression("TIMESTAMP_DIFF('DAY', dt1, dt2)", "timestampDiff(\"DAY\", dt1, dt2)");
-        testFilterExpression("IF(a>b,a,b)", "a > b ? a : b");
+        testFilterExpression("IF(a>b,a,b)", "greater(a, b) ? a : b");
         testFilterExpression("NULLIF(a,b)", "nullif(a, b)");
         testFilterExpression("COALESCE(a,b,c)", "coalesce(a, b, c)");
         testFilterExpression("id + 2", "id + 2");
@@ -271,17 +271,17 @@ public class TransformParserTest {
         testFilterExpression("id * 2", "id * 2");
         testFilterExpression("id / 2", "id / 2");
         testFilterExpression("id % 2", "id % 2");
-        testFilterExpression("a < b", "a < b");
-        testFilterExpression("a <= b", "a <= b");
-        testFilterExpression("a > b", "a > b");
-        testFilterExpression("a >= b", "a >= b");
+        testFilterExpression("a < b", "less(a, b)");
+        testFilterExpression("a <= b", "lessOrEqual(a, b)");
+        testFilterExpression("a > b", "greater(a, b)");
+        testFilterExpression("a >= b", "greaterOrEqual(a, b)");
         testFilterExpression("__table_name__ = 'tb'", "valueEquals(__table_name__, \"tb\")");
         testFilterExpression("__schema_name__ = 'tb'", "valueEquals(__schema_name__, \"tb\")");
         testFilterExpression(
                 "__namespace_name__ = 'tb'", "valueEquals(__namespace_name__, \"tb\")");
         testFilterExpression("upper(lower(id))", "upper(lower(id))");
         testFilterExpression(
-                "abs(uniq_id) > 10 and id is not null", "abs(uniq_id) > 10 && null != id");
+                "abs(uniq_id) > 10 and id is not null", "greater(abs(uniq_id), 10) && null != id");
         testFilterExpression(
                 "case id when 1 then 'a' when 2 then 'b' else 'c' end",
                 "(valueEquals(id, 1) ? \"a\" : valueEquals(id, 2) ? \"b\" : \"c\")");

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -474,10 +474,10 @@ public class TransformParserTest {
                 "typeof(id % 2)", "__instanceOfTypeOfFunctionClass.eval(id % 2)");
         testFilterExpressionWithUdf(
                 "addone(addone(id)) > 4 OR typeof(id) <> 'bool' AND format('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)) > 4 || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
+                "greater(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
         testFilterExpressionWithUdf(
                 "ADDONE(ADDONE(id)) > 4 OR TYPEOF(id) <> 'bool' AND FORMAT('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)) > 4 || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
+                "greater(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
     }
 
     @Test

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -484,14 +484,14 @@ public class TransformParserTest {
     @Test
     void testLargeNumericalLiterals() {
         // For literals within [-2147483648, 2147483647] range, plain Integers are OK
-        testFilterExpression("id > 2147483647", "id > 2147483647");
-        testFilterExpression("id < -2147483648", "id < -2147483648");
+        testFilterExpression("id > 2147483647", "greaterThan(id, 2147483647)");
+        testFilterExpression("id < -2147483648", "lessThan(id, -2147483648)");
 
         // For out-of-range literals, an extra `L` suffix is required
-        testFilterExpression("id > 2147483648", "id > 2147483648L");
-        testFilterExpression("id > -2147483649", "id > -2147483649L");
-        testFilterExpression("id < 9223372036854775807", "id < 9223372036854775807L");
-        testFilterExpression("id > -9223372036854775808", "id > -9223372036854775808L");
+        testFilterExpression("id > 2147483648", "greaterThan(id, 2147483648L)");
+        testFilterExpression("id > -2147483649", "greaterThan(id, -2147483649L)");
+        testFilterExpression("id < 9223372036854775807", "lessThan(id, 9223372036854775807L)");
+        testFilterExpression("id > -9223372036854775808", "greaterThan(id, -9223372036854775808L)");
 
         // But there's still a limit
         Assertions.assertThatThrownBy(


### PR DESCRIPTION
Timestamp data can not be compared in cdc pipeline transform.

When projecting or filtering code containing timestamp comparisons, the program will encounter errors.

```
TO_TIMESTAMP('2024-01-01 00:00:00') < TO_TIMESTAMP('2024-08-01 00:00:00')
```

Error:

```
org.apache.flink.api.common.InvalidProgramException: Expression cannot be compiled. This is a bug. Please file an issue.
Expression: import static org.apache.flink.cdc.runtime.functions.SystemFunctionUtils.*;toTimestamp("2024-01-01 00:00:00", __time_zone__) < toTimestamp("2024-08-01 00:00:00", __time_zone__) ? 1 : 0
...
...
Caused by: org.codehaus.commons.compiler.CompileException: Line 1, Column 176: Operator "<" not allowed on reference operands 
```

This PR has already solved the problem, and its modifications mainly include the following:

1. Support comparing two identical types which implements Comparable.
2. Support comparing two different numerical types which extends Number.
3. Fix incorrect descriptions in the document: TIMESTAMP_DIFF.
4. Fix existing unit tests and add type comparison unit tests.