### PR TITLE
[FLINK-34737][cdc][docs-zh] "Deployment - kubernetes" Page for Flink CDC Chinese Documentation

### DIFF
--- a/docs/content.zh/docs/deployment/kubernetes.md
+++ b/docs/content.zh/docs/deployment/kubernetes.md
@@ -24,92 +24,94 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Introduction
+# 介绍
 
-Kubernetes is a popular container-orchestration system for automating computer application deployment, scaling, and management.
-Flink's native Kubernetes integration allows you to directly deploy Flink on a running Kubernetes cluster.
-Moreover, Flink is able to dynamically allocate and de-allocate TaskManagers depending on the required resources because it can directly talk to Kubernetes.
+Kubernetes 是一个流行的容器编排系统，用于自动化计算机应用程序的部署、扩展和管理。  
+Flink 的原生 Kubernetes 集成允许你直接在运行中的 Kubernetes 集群上部署 Flink。  
+此外，Flink 能够根据所需资源动态分配和释放 TaskManagers，因为它可以直接与 Kubernetes 进行通信。
 
-Apache Flink also provides a Kubernetes operator for managing Flink clusters on Kubernetes. It supports both standalone and native deployment mode and greatly simplifies deployment, configuration and the life cycle management of Flink resources on Kubernetes.
+Apache Flink 还提供了一个 Kubernetes 操作器，用于在 Kubernetes 上管理 Flink 集群。它支持独立和原生部署模式，大大简化了在 Kubernetes 上部署、配置和管理 Flink 资源的生命周期。
 
-For more information, please refer to the [Flink Kubernetes Operator documentation](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/concepts/overview/).
+有关更多信息，请参考 [Flink Kubernetes Operator 文档](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/zh/docs/concepts/overview/)。
 
-## Preparation
+## 准备工作
 
-The doc assumes a running Kubernetes cluster fulfilling the following requirements:
+本文档假设你有一个运行中的 Kubernetes 集群，满足以下要求：
 
-- Kubernetes >= 1.9.
-- KubeConfig, which has access to list, create, delete pods and services, configurable via `~/.kube/config`. You can verify permissions by running `kubectl auth can-i <list|create|edit|delete> pods`.
-- Enabled Kubernetes DNS.
-- `default` service account with [RBAC](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#rbac) permissions to create, delete pods.
+- Kubernetes >= 1.9。
+- KubeConfig，能够列出、创建和删除 pods 和 services，配置在 `~/.kube/config` 中。你可以通过运行 `kubectl auth can-i <list|create|edit|delete> pods` 来验证权限。
+- 启用 Kubernetes DNS。
+- `default` 服务账户具有 [RBAC](https://nightlies.apache.org/flink/flink-docs-master/zh/docs/deployment/resource-providers/native_kubernetes/) 权限以创建和删除 pods。
 
-If you have problems setting up a Kubernetes cluster, please take a look at [how to setup a Kubernetes cluster](https://kubernetes.io/docs/setup/).
+如果你在设置 Kubernetes 集群时遇到问题，请查看 [如何设置 Kubernetes 集群](https://kubernetes.io/zh-cn/docs/setup/)。
 
-## Session Mode
+## 会话模式
 
-Flink runs on all UNIX-like environments, i.e. Linux, Mac OS X, and Cygwin (for Windows).  
-You can refer [overview]({{< ref "docs/connectors/pipeline-connectors/overview" >}}) to check supported versions and download [the binary release](https://flink.apache.org/downloads/) of Flink,
-then extract the archive:
+Flink 可以在所有类 UNIX 环境中运行，即 Linux、Mac OS X 和 Cygwin（适用于 Windows）。  
+你可以参考 [概述]({{< ref "docs/connectors/pipeline-connectors/overview" >}}) 查看支持的版本并下载 [Flink 的二进制发行版](https://flink.apache.org/downloads/)，然后解压归档文件：
 
 ```bash
 tar -xzf flink-*.tgz
 ```
 
-You should set `FLINK_HOME` environment variables like:
+你应该设置 `FLINK_HOME` 环境变量，如下所示：
 
 ```bash
 export FLINK_HOME=/path/flink-*
 ```
 
-### Start a session cluster
+### 启动会话集群
 
-To start a session cluster on k8s, run the bash script that comes with Flink:
+要在 Kubernetes 上启动会话集群，请运行附带 Flink 的 bash 脚本：
 
 ```bash
 cd /path/flink-*
-./bin/kubernetes-session.sh -Dkubernetes.cluster-id=my-first-flink-cluster
+./bin/kubernetes-session.sh -Dkubernetes.cluster.id=my-first-flink-cluster
 ```
 
-After successful startup, the return information is as follows：
+成功启动后，返回信息如下：
 
 ```
-org.apache.flink.kubernetes.utils.KubernetesUtils            [] - Kubernetes deployment requires a fixed port. Configuration blob.server.port will be set to 6124
-org.apache.flink.kubernetes.utils.KubernetesUtils            [] - Kubernetes deployment requires a fixed port. Configuration taskmanager.rpc.port will be set to 6122
-org.apache.flink.kubernetes.KubernetesClusterDescriptor      [] - Please note that Flink client operations(e.g. cancel, list, stop, savepoint, etc.) won't work from outside the Kubernetes cluster since 'kubernetes.rest-service.exposed.type' has been set to ClusterIP.
-org.apache.flink.kubernetes.KubernetesClusterDescriptor      [] - Create flink session cluster my-first-flink-cluster successfully, JobManager Web Interface: http://my-first-flink-cluster-rest.default:8081
+org.apache.flink.kubernetes.utils.KubernetesUtils            [] - Kubernetes 部署需要固定端口。配置 blob.server.port 将设置为 6124
+org.apache.flink.kubernetes.utils.KubernetesUtils            [] - Kubernetes 部署需要固定端口。配置 taskmanager.rpc.port 将设置为 6122
+org.apache.flink.kubernetes.KubernetesClusterDescriptor      [] - 请注意，Flink 客户端操作（例如取消、列出、停止、保存点等）将无法在 Kubernetes 集群外部工作，因为 'kubernetes.rest-service.exposed.type' 已设置为 ClusterIP。
+org.apache.flink.kubernetes.KubernetesClusterDescriptor      [] - 成功创建 Flink 会话集群 my-first-flink-cluster，JobManager Web 界面： http://my-first-flink-cluster-rest.default:8081
 ```
 
 {{< hint info >}}
-please refer to [Flink documentation](https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/resource-providers/native_kubernetes/#accessing-flinks-web-ui) to expose Flink’s Web UI and REST endpoint.   
-You should ensure that REST endpoint can be accessed by the node of your submission.
+请参考 [Flink 文档](https://nightlies.apache.org/flink/flink-docs-master/zh/docs/deployment/resource-providers/native_kubernetes/#accessing-flinks-web-ui) 来暴露 Flink 的 Web UI 和 REST 端点。  
+你应该确保 REST 端点可以被提交节点访问。
 {{< /hint >}}
-Then, you need to add these two config to your flink-conf.yaml:
+
+接下来，你需要将以下两个配置添加到你的 flink-conf.yaml 中：
 
 ```yaml
 rest.bind-port: {{REST_PORT}}
 rest.address: {{NODE_IP}}
 ```
 
-{{REST_PORT}} and {{NODE_IP}} should be replaced by the actual values of your JobManager Web Interface.
+{{REST_PORT}} 和 {{NODE_IP}} 应替换为你的 JobManager Web 界面的实际值。
 
-### Set up Flink CDC
-Download the tar file of Flink CDC from [release page](https://github.com/apache/flink-cdc/releases), then extract the archive:
+### 设置 Flink CDC
+
+从 [发布页面](https://github.com/apache/flink-cdc/releases) 下载 Flink CDC 的 tar 文件，然后解压归档文件：
 
 ```bash
 tar -xzf flink-cdc-*.tar.gz
 ```
 
-Extracted `flink-cdc` contains four directories: `bin`,`lib`,`log` and `conf`.
+解压后的 `flink-cdc` 包含四个目录：`bin`、`lib`、`log` 和 `conf`。
 
-Download the connector jars from [release page](https://github.com/apache/flink-cdc/releases), and move it to the `lib` directory.    
-Download links are available only for stable releases, SNAPSHOT dependencies need to be built based on specific branch by yourself.
+从 [发布页面](https://github.com/apache/flink-cdc/releases) 下载连接器 jar 文件，并将其移动到 `lib` 目录。  
+下载链接仅适用于稳定版本，SNAPSHOT 依赖项需要根据特定分支自行构建。
 
-### Submit a Flink CDC Job
-Here is an example file for synchronizing the entire database `mysql-to-doris.yaml`：
+### 提交 Flink CDC 作业
+
+以下是一个示例文件，用于同步整个数据库 `mysql-to-doris.yaml`：
 
 ```yaml
 ################################################################################
-# Description: Sync MySQL all tables to Doris
+# 描述：将 MySQL 所有表同步到 Doris
 ################################################################################
 source:
  type: mysql
@@ -128,32 +130,31 @@ sink:
  password: ""
 
 pipeline:
- name: Sync MySQL Database to Doris
+ name: 将 MySQL 数据库同步到 Doris
  parallelism: 2
-
 ```
 
-You need to modify the configuration file according to your needs, refer to connectors more information.   
-- [MySQL pipeline connector]({{< ref "docs/connectors/pipeline-connectors/mysql.md" >}})
-- [Apache Doris pipeline connector]({{< ref "docs/connectors/pipeline-connectors/doris.md" >}})       
+你需要根据自己的需求修改配置文件，更多信息请参考连接器。
+- [MySQL 管道连接器]({{< ref "docs/connectors/pipeline-connectors/mysql.md" >}})
+- [Apache Doris 管道连接器]({{< ref "docs/connectors/pipeline-connectors/doris.md" >}})
 
-Finally, submit job to Flink Standalone cluster using Cli.
+最后，使用 CLI 向 Flink 独立集群提交作业。
 
 ```bash
 cd /path/flink-cdc-*
 ./bin/flink-cdc.sh mysql-to-doris.yaml
 ```
 
-After successful submission, the return information is as follows：
+成功提交后，返回信息如下：
 
 ```bash
-Pipeline has been submitted to cluster.
-Job ID: ae30f4580f1918bebf16752d4963dc54
-Job Description: Sync MySQL Database to Doris
+管道已提交到集群。
+作业 ID: ae30f4580f1918bebf16752d4963dc54
+作业描述: 将 MySQL 数据库同步到 Doris
 ```
 
-Then you can find a job named `Sync MySQL Database to Doris` running through Flink Web UI.  
+然后你可以通过 Flink Web UI 找到名为 `将 MySQL 数据库同步到 Doris` 的作业正在运行。
 
 {{< hint info >}}
-Please note that submitting with **native application mode** and **Flink Kubernetes operator** are not supported for now.
+请注意，当前不支持使用 **原生应用模式** 和 **Flink Kubernetes 操作器** 提交作业。
 {{< /hint >}}


### PR DESCRIPTION
What is the purpose of the change
---
Translate "Deployment - kubernetes" page into Chinese.

The page url is https://nightlies.apache.org/flink/flink-cdc-docs-release-3.0/zh/docs/deployment/kubernetes/

The markdown file is located in `flink-cdc/docs/content.zh/docs/deployment/kubernetes.md`

Brief change log
---
- Translate `flink-cdc/docs/content.zh/docs/deployment/kubernetes.md`, that mainly introduces submitting a Flink CDC job on kubernetes.

Verifying this change
---
This change is a trivial rework / code cleanup without any test coverage.

Documentation
---
- Does this pull request introduce a new feature? **no**
- If yes, how is the feature documented? **not applicable**