### PR TITLE
[hotfix] Add missing `sink.version` option for StarRocks connector

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkFactory.java
@@ -122,6 +122,11 @@ public class StarRocksDataSinkFactory implements DataSinkFactory {
                                 sinkConfig.set(
                                         StarRocksSinkOptions.SINK_METRIC_HISTOGRAM_WINDOW_SIZE,
                                         config));
+
+        cdcConfig
+                .getOptional(StarRocksDataSinkOptions.SINK_VERSION)
+                .ifPresent(config -> sinkConfig.set(StarRocksSinkOptions.SINK_VERSION, config));
+
         // specified sink configurations for cdc scenario
         sinkConfig.set(StarRocksSinkOptions.DATABASE_NAME, "*");
         sinkConfig.set(StarRocksSinkOptions.TABLE_NAME, "*");
@@ -176,6 +181,7 @@ public class StarRocksDataSinkFactory implements DataSinkFactory {
         optionalOptions.add(StarRocksDataSinkOptions.SINK_METRIC_HISTOGRAM_WINDOW_SIZE);
         optionalOptions.add(StarRocksDataSinkOptions.TABLE_CREATE_NUM_BUCKETS);
         optionalOptions.add(StarRocksDataSinkOptions.TABLE_SCHEMA_CHANGE_TIMEOUT);
+        optionalOptions.add(StarRocksDataSinkOptions.SINK_VERSION);
         return optionalOptions;
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkOptions.java
@@ -119,6 +119,16 @@ public class StarRocksDataSinkOptions {
                     .defaultValue(100)
                     .withDescription("Window size of histogram metrics.");
 
+    public static final ConfigOption<String> SINK_VERSION =
+            ConfigOptions.key("sink.version")
+                    .stringType()
+                    .defaultValue(StarRocksSinkOptions.SINK_VERSION.defaultValue())
+                    .withDescription(
+                            "The interface used to load data. This parameter is supported from Flink connector version 1.2.4 onwards.\n"
+                                    + "V1: Use Stream Load interface to load data. Connectors before 1.2.4 only support this mode.\n"
+                                    + "V2: Use Transaction Stream Load interface to load data. It requires StarRocks to be at least version 2.4. Recommends V2 because it optimizes the memory usage and provides a more stable exactly-once implementation.\n"
+                                    + "AUTO: If the version of StarRocks supports transaction Stream Load, will choose V2 automatically, otherwise choose V1.");
+
     /** The prefix for stream load properties, such as sink.properties.timeout. */
     public static final String SINK_PROPERTIES_PREFIX = StarRocksSinkOptions.SINK_PROPERTIES_PREFIX;
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksDataSinkFactoryTest.java
@@ -150,4 +150,26 @@ public class StarRocksDataSinkFactoryTest {
                                 conf, conf, Thread.currentThread().getContextClassLoader()));
         Assertions.assertThat(dataSink).isInstanceOf(StarRocksDataSink.class);
     }
+
+    @Test
+    void testSpecifiedSinkVersion() {
+        DataSinkFactory sinkFactory =
+                FactoryDiscoveryUtils.getFactoryByIdentifier("starrocks", DataSinkFactory.class);
+        Assertions.assertThat(sinkFactory).isInstanceOf(StarRocksDataSinkFactory.class);
+
+        Configuration conf =
+                Configuration.fromMap(
+                        ImmutableMap.<String, String>builder()
+                                .put("jdbc-url", "jdbc:mysql://127.0.0.1:9030")
+                                .put("load-url", "127.0.0.1:8030")
+                                .put("username", "root")
+                                .put("password", "")
+                                .put("sink.version", "V1")
+                                .build());
+        DataSink dataSink =
+                sinkFactory.createDataSink(
+                        new FactoryHelper.DefaultContext(
+                                conf, conf, Thread.currentThread().getContextClassLoader()));
+        Assertions.assertThat(dataSink).isInstanceOf(StarRocksDataSink.class);
+    }
 }


### PR DESCRIPTION
`starrocks-connector-for-apache-flink` supports [an option called `sink.version`](https://github.com/StarRocks/starrocks-connector-for-apache-flink/blob/main/docs/content/connector-sink.md), and user may choose which interface to use (V1, V2, or Auto) when stream loading data. This option could be easily ported to pipeline connector.