### PR TITLE
[FLINK-36285][doris] Fix unable to alter column type without default value specified

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
     <name>flink-cdc-pipeline-connector-doris</name>
 
     <properties>
-        <doris.connector.version>1.6.2</doris.connector.version>
+        <doris.connector.version>24.0.1</doris.connector.version>
     </properties>
 
     <dependencies>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
@@ -193,6 +193,21 @@ public class DorisMetadataApplierITCase extends DorisSinkTestBase {
                         tableId, Collections.singletonMap("name", DataTypes.VARCHAR(19))));
     }
 
+    private List<Event> generateAlterColumnTypeWithDefaultValueEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null, "2.71828"))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null, "Alice"))
+                        .primaryKey("id")
+                        .build();
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                new AlterColumnTypeEvent(
+                        tableId, Collections.singletonMap("name", DataTypes.VARCHAR(19))));
+    }
+
     private List<Event> generateNarrowingAlterColumnTypeEvents(TableId tableId) {
         Schema schema =
                 Schema.newBuilder()
@@ -382,6 +397,25 @@ public class DorisMetadataApplierITCase extends DorisSinkTestBase {
                         "id | INT | Yes | true | null",
                         "number | DOUBLE | Yes | false | null",
                         "name | VARCHAR(57) | Yes | false | null");
+
+        assertEqualsInOrder(expected, actual);
+    }
+
+    @Test
+    public void testDorisAlterColumnTypeWithDefaultValue() throws Exception {
+        TableId tableId =
+                TableId.tableId(
+                        DorisContainer.DORIS_DATABASE_NAME, DorisContainer.DORIS_TABLE_NAME);
+
+        runJobWithEvents(generateAlterColumnTypeWithDefaultValueEvents(tableId));
+
+        List<String> actual = inspectTableSchema(tableId);
+
+        List<String> expected =
+                Arrays.asList(
+                        "id | INT | Yes | true | null",
+                        "number | DOUBLE | Yes | false | 2.71828",
+                        "name | VARCHAR(57) | Yes | false | Alice");
 
         assertEqualsInOrder(expected, actual);
     }

--- a/tools/ci/license_check.rb
+++ b/tools/ci/license_check.rb
@@ -113,7 +113,7 @@ def check_jar_license(jar_file)
   Zip::File.open(jar_file) do |jar|
     jar.filter { |e| e.ftype == :file }
        .filter { |e| !File.basename(e.name).downcase.end_with?(*BINARY_FILE_EXTENSIONS) }
-       .filter { |e| !File.basename(e.name).downcase.start_with? 'license', 'dependencies', 'notice' }
+       .filter { |e| !File.basename(e.name).downcase.start_with? 'license', 'dependencies', 'notice', 'third-party' }
        .filter { |e| EXCEPTION_PACKAGES.none? { |ex| e.name.include? ex } }
        .map do |e|
          content = e.get_input_stream.read.force_encoding('UTF-8')


### PR DESCRIPTION
This closes FLINK-36285.

Thanks to @qg-lin's great work in https://github.com/apache/doris-flink-connector/pull/490, doris-flink-connector now supports altering column type without passing default value explicitly. Bumping dependency version should close this issue.