### PR TITLE
[FLINK-36669][pipeline-connector][ES] The flink version of ES should use parent's pom

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-elasticsearch/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-elasticsearch/pom.xml
@@ -36,7 +36,6 @@ limitations under the License.
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <elasticsearch.version>8.12.1</elasticsearch.version>
-        <flink.version>1.18.0</flink.version>
         <scala.binary.version>4.0</scala.binary.version>
         <jackson.version>2.13.2</jackson.version>
         <surefire.module.config>--add-opens=java.base/java.util=ALL-UNNAMED</surefire.module.config>


### PR DESCRIPTION
[FLINK-36669](https://issues.apache.org/jira/browse/FLINK-36669)

When I was looking at the interaction between cdc-pipeline and flink, I found that there were multiple versions of flink implementations in the source code. The pom file of ES pipeline did not use the parent flink version like other connector pipelines. I think this is a small mistake because there is no special statement here.