### PR TITLE
[bp release-3.2][FLINK-36211][pipeline-connector/kafka] shade org.apache.flink.streaming.connectors.kafka to avoid conflict with flink-connector-kafka jar. (#3595)

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
@@ -106,6 +106,10 @@ limitations under the License.
                                     <pattern>org.apache.flink.connector.kafka</pattern>
                                     <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.flink.connector.kafka</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org.apache.flink.streaming.connectors.kafka</pattern>
+                                    <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.flink.streaming.connectors.kafka</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
cherry picked from commit f24399cf5a32f4c79bbb6a86e3a3399f17bfbbe0 to release-3.2