### PR TITLE
[FLINK-36682][mysql][mongodb] Add scan.chunk.assign.strategy to avoid OOM exception.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/MongoDBSourceBuilder.java
@@ -21,6 +21,7 @@ import org.apache.flink.cdc.common.annotation.Experimental;
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 import org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceConfigFactory;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 
@@ -265,6 +266,12 @@ public class MongoDBSourceBuilder<T> {
      */
     public MongoDBSourceBuilder<T> scanNewlyAddedTableEnabled(boolean scanNewlyAddedTableEnabled) {
         this.configFactory.scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled);
+        return this;
+    }
+
+    /** Decide the strategy of how to assign split to reader. */
+    public MongoDBSourceBuilder<T> scanChunkAssignStrategy(AssignStrategy scanChunkAssignStrategy) {
+        this.configFactory.scanChunkAssignStrategy(scanChunkAssignStrategy);
         return this;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/AssignStrategy.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/AssignStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters;
+
+import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
+
+/** Strategy for {@link MongoDBChunkSplitter} to assign {@link SnapshotSplit}. */
+public enum AssignStrategy {
+    ASCENDING_ORDER("ascending_order"),
+    DESCENDING_ORDER("descending_order");
+    private final String value;
+
+    AssignStrategy(String value) {
+        this.value = value;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/MongoDBChunkSplitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/MongoDBChunkSplitter.java
@@ -24,7 +24,9 @@ import org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceConfig
 
 import io.debezium.relational.TableId;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 /** The splitter used to split collection into a set of chunks for MongoDB data source. */
 @Experimental
@@ -38,10 +40,15 @@ public class MongoDBChunkSplitter implements ChunkSplitter {
 
     @Override
     public Collection<SnapshotSplit> generateSplits(TableId collectionId) {
+        ArrayList<SnapshotSplit> snapshotSplits = new ArrayList<>();
         SplitContext splitContext = SplitContext.of(sourceConfig, collectionId);
         if (splitContext.isShardedCollection()) {
-            return ShardedSplitStrategy.INSTANCE.split(splitContext);
+            snapshotSplits.addAll(ShardedSplitStrategy.INSTANCE.split(splitContext));
         }
-        return SplitVectorSplitStrategy.INSTANCE.split(splitContext);
+        snapshotSplits.addAll(SplitVectorSplitStrategy.INSTANCE.split(splitContext));
+        if (AssignStrategy.DESCENDING_ORDER.equals(sourceConfig.getScanChunkAssignStrategy())) {
+            Collections.reverse(snapshotSplits);
+        }
+        return snapshotSplits;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceConfig.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.connectors.mongodb.source.config;
 import org.apache.flink.cdc.connectors.base.config.SourceConfig;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSource;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 
 import javax.annotation.Nullable;
 
@@ -54,6 +55,7 @@ public class MongoDBSourceConfig implements SourceConfig {
     private final boolean enableFullDocPrePostImage;
     private final boolean disableCursorTimeout;
     private final boolean skipSnapshotBackfill;
+    private final AssignStrategy scanChunkAssignStrategy;
 
     private final boolean isScanNewlyAddedTableEnabled;
 
@@ -78,7 +80,8 @@ public class MongoDBSourceConfig implements SourceConfig {
             boolean enableFullDocPrePostImage,
             boolean disableCursorTimeout,
             boolean skipSnapshotBackfill,
-            boolean isScanNewlyAddedTableEnabled) {
+            boolean isScanNewlyAddedTableEnabled,
+            AssignStrategy scanChunkAssignStrategy) {
         this.scheme = checkNotNull(scheme);
         this.hosts = checkNotNull(hosts);
         this.username = username;
@@ -101,6 +104,7 @@ public class MongoDBSourceConfig implements SourceConfig {
         this.disableCursorTimeout = disableCursorTimeout;
         this.skipSnapshotBackfill = skipSnapshotBackfill;
         this.isScanNewlyAddedTableEnabled = isScanNewlyAddedTableEnabled;
+        this.scanChunkAssignStrategy = scanChunkAssignStrategy;
     }
 
     public String getScheme() {
@@ -201,6 +205,10 @@ public class MongoDBSourceConfig implements SourceConfig {
         return isScanNewlyAddedTableEnabled;
     }
 
+    public AssignStrategy getScanChunkAssignStrategy() {
+        return scanChunkAssignStrategy;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -228,7 +236,8 @@ public class MongoDBSourceConfig implements SourceConfig {
                 && Objects.equals(collectionList, that.collectionList)
                 && Objects.equals(connectionString, that.connectionString)
                 && Objects.equals(skipSnapshotBackfill, that.skipSnapshotBackfill)
-                && Objects.equals(isScanNewlyAddedTableEnabled, that.isScanNewlyAddedTableEnabled);
+                && Objects.equals(isScanNewlyAddedTableEnabled, that.isScanNewlyAddedTableEnabled)
+                && Objects.equals(scanChunkAssignStrategy, that.scanChunkAssignStrategy);
     }
 
     @Override
@@ -252,6 +261,7 @@ public class MongoDBSourceConfig implements SourceConfig {
                 samplesPerChunk,
                 closeIdleReaders,
                 skipSnapshotBackfill,
-                isScanNewlyAddedTableEnabled);
+                isScanNewlyAddedTableEnabled,
+                scanChunkAssignStrategy);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceConfigFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.connectors.mongodb.source.config;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.connectors.base.config.SourceConfig.Factory;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,7 @@ import static org.apache.flink.cdc.connectors.base.options.SourceOptions.CHUNK_M
 import static org.apache.flink.cdc.connectors.base.utils.EnvironmentUtils.checkSupportCheckpointsAfterTasksFinished;
 import static org.apache.flink.cdc.connectors.mongodb.internal.MongoDBEnvelope.MONGODB_SCHEME;
 import static org.apache.flink.cdc.connectors.mongodb.internal.MongoDBEnvelope.MONGODB_SRV_SCHEME;
+import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_CHUNK_ASSIGN_STRATEGY;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -63,6 +65,8 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
     protected boolean skipSnapshotBackfill = false;
 
     protected boolean scanNewlyAddedTableEnabled = false;
+
+    protected AssignStrategy scanChunkAssignStrategy = SCAN_CHUNK_ASSIGN_STRATEGY.defaultValue();
 
     /** The protocol connected to MongoDB. For example mongodb or mongodb+srv. */
     public MongoDBSourceConfigFactory scheme(String scheme) {
@@ -271,6 +275,13 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
         return this;
     }
 
+    /** Decide the strategy of how to assign split to reader. */
+    public MongoDBSourceConfigFactory scanChunkAssignStrategy(
+            AssignStrategy scanChunkAssignStrategy) {
+        this.scanChunkAssignStrategy = scanChunkAssignStrategy;
+        return this;
+    }
+
     /** Creates a new {@link MongoDBSourceConfig} for the given subtask {@code subtaskId}. */
     @Override
     public MongoDBSourceConfig create(int subtaskId) {
@@ -296,6 +307,7 @@ public class MongoDBSourceConfigFactory implements Factory<MongoDBSourceConfig> 
                 enableFullDocPrePostImage,
                 disableCursorTimeout,
                 skipSnapshotBackfill,
-                scanNewlyAddedTableEnabled);
+                scanNewlyAddedTableEnabled,
+                scanChunkAssignStrategy);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.mongodb.source.config;
 
 import org.apache.flink.cdc.common.annotation.Experimental;
 import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSource;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
@@ -157,4 +158,27 @@ public class MongoDBSourceOptions {
                     .defaultValue(true)
                     .withDescription(
                             "MongoDB server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to true to prevent that.");
+
+    public static final ConfigOption<Boolean> SCAN_FLATTEN_NESTED_COLUMNS_ENABLED =
+            ConfigOptions.key("scan.flatten-nested-columns.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Optional flag to recursively flatten the Bson field into columns."
+                                    + "For a better understanding, the name of the flattened column will be composed of the path to get the column. "
+                                    + "For example, the field `col` in the Bson document {\"nested\": {\"col\": true}} is `nested.col` in the flattened schema. ");
+
+    public static final ConfigOption<Boolean> SCAN_PRIMITIVE_AS_STRING =
+            ConfigOptions.key("scan.primitive-as-string")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Optional flag to infer primitive types as string type.");
+
+    public static final ConfigOption<AssignStrategy> SCAN_CHUNK_ASSIGN_STRATEGY =
+            ConfigOptions.key("scan.chunk.assign.strategy")
+                    .enumType(AssignStrategy.class)
+                    .defaultValue(AssignStrategy.DESCENDING_ORDER)
+                    .withDescription(
+                            "Optional assign strategy for MySqlSnapshotSplitAssigner, valid enumerations are "
+                                    + "\"ascending_order\", \"descending_order\"");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/config/MongoDBSourceOptions.java
@@ -159,21 +159,6 @@ public class MongoDBSourceOptions {
                     .withDescription(
                             "MongoDB server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to true to prevent that.");
 
-    public static final ConfigOption<Boolean> SCAN_FLATTEN_NESTED_COLUMNS_ENABLED =
-            ConfigOptions.key("scan.flatten-nested-columns.enabled")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription(
-                            "Optional flag to recursively flatten the Bson field into columns."
-                                    + "For a better understanding, the name of the flattened column will be composed of the path to get the column. "
-                                    + "For example, the field `col` in the Bson document {\"nested\": {\"col\": true}} is `nested.col` in the flattened schema. ");
-
-    public static final ConfigOption<Boolean> SCAN_PRIMITIVE_AS_STRING =
-            ConfigOptions.key("scan.primitive-as-string")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription("Optional flag to infer primitive types as string type.");
-
     public static final ConfigOption<AssignStrategy> SCAN_CHUNK_ASSIGN_STRATEGY =
             ConfigOptions.key("scan.chunk.assign.strategy")
                     .enumType(AssignStrategy.class)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableSource.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSource;
 import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSourceBuilder;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.cdc.debezium.table.MetadataConverter;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -87,6 +88,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private final boolean skipSnapshotBackfill;
     private final boolean scanNewlyAddedTableEnabled;
 
+    private final AssignStrategy scanChunkAssignStrategy;
+
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
     // --------------------------------------------------------------------------------------------
@@ -121,7 +124,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             boolean enableFullDocPrePostImage,
             boolean noCursorTimeout,
             boolean skipSnapshotBackfill,
-            boolean scanNewlyAddedTableEnabled) {
+            boolean scanNewlyAddedTableEnabled,
+            AssignStrategy scanChunkAssignStrategy) {
         this.physicalSchema = physicalSchema;
         this.scheme = checkNotNull(scheme);
         this.hosts = checkNotNull(hosts);
@@ -148,6 +152,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.noCursorTimeout = noCursorTimeout;
         this.skipSnapshotBackfill = skipSnapshotBackfill;
         this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
+        this.scanChunkAssignStrategy = scanChunkAssignStrategy;
     }
 
     @Override
@@ -206,6 +211,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                             .startupOptions(startupOptions)
                             .skipSnapshotBackfill(skipSnapshotBackfill)
                             .scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled)
+                            .scanChunkAssignStrategy(scanChunkAssignStrategy)
                             .deserializer(deserializer)
                             .disableCursorTimeout(noCursorTimeout);
 
@@ -307,7 +313,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         enableFullDocPrePostImage,
                         noCursorTimeout,
                         skipSnapshotBackfill,
-                        scanNewlyAddedTableEnabled);
+                        scanNewlyAddedTableEnabled,
+                        scanChunkAssignStrategy);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -347,7 +354,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 && Objects.equals(enableFullDocPrePostImage, that.enableFullDocPrePostImage)
                 && Objects.equals(noCursorTimeout, that.noCursorTimeout)
                 && Objects.equals(skipSnapshotBackfill, that.skipSnapshotBackfill)
-                && Objects.equals(scanNewlyAddedTableEnabled, that.scanNewlyAddedTableEnabled);
+                && Objects.equals(scanNewlyAddedTableEnabled, that.scanNewlyAddedTableEnabled)
+                && Objects.equals(scanChunkAssignStrategy, that.scanChunkAssignStrategy);
     }
 
     @Override
@@ -378,7 +386,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                 enableFullDocPrePostImage,
                 noCursorTimeout,
                 skipSnapshotBackfill,
-                scanNewlyAddedTableEnabled);
+                scanNewlyAddedTableEnabled,
+                scanChunkAssignStrategy);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableSourceFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.mongodb.table;
 
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.base.utils.OptionUtils;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
@@ -51,6 +52,7 @@ import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourc
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.PASSWORD;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
+import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_CHUNK_ASSIGN_STRATEGY;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
@@ -110,6 +112,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         int splitSizeMB = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
         int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
         int samplesPerChunk = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES);
+        AssignStrategy assignStrategy = config.get(SCAN_CHUNK_ASSIGN_STRATEGY);
 
         boolean enableFullDocumentPrePostImage =
                 config.getOptional(FULL_DOCUMENT_PRE_POST_IMAGE).orElse(false);
@@ -146,7 +149,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 enableFullDocumentPrePostImage,
                 noCursorTimeout,
                 skipSnapshotBackfill,
-                scanNewlyAddedTableEnabled);
+                scanNewlyAddedTableEnabled,
+                assignStrategy);
     }
 
     private void checkPrimaryKey(UniqueConstraint pk, String message) {
@@ -228,6 +232,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_NO_CURSOR_TIMEOUT);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
+        options.add(SCAN_CHUNK_ASSIGN_STRATEGY);
         return options;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.connectors.mongodb.table;
 
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters.AssignStrategy;
 import org.apache.flink.cdc.debezium.DebeziumSourceFunction;
 import org.apache.flink.cdc.debezium.utils.ResolvedSchemaUtils;
 import org.apache.flink.configuration.Configuration;
@@ -56,6 +57,7 @@ import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourc
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
+import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_CHUNK_ASSIGN_STRATEGY;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SAMPLES;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB;
 import static org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
@@ -98,6 +100,8 @@ public class MongoDBTableFactoryTest {
     private static final String PASSWORD = "flinkpw";
     private static final String MY_DATABASE = "myDB";
     private static final String MY_TABLE = "myTable";
+    private static final ObjectIdentifier SOURCE_TABLE_IDENTIFIER =
+            ObjectIdentifier.of("default", "default", "t1");
     private static final ZoneId LOCAL_TIME_ZONE = ZoneId.systemDefault();
     private static final int BATCH_SIZE_DEFAULT = BATCH_SIZE.defaultValue();
     private static final int POLL_MAX_BATCH_SIZE_DEFAULT = POLL_MAX_BATCH_SIZE.defaultValue();
@@ -124,6 +128,9 @@ public class MongoDBTableFactoryTest {
 
     private static final boolean SCAN_NEWLY_ADDED_TABLE_ENABLED_DEFAULT =
             SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue();
+
+    private static final AssignStrategy SCAN_CHUNK_ASSIGN_STRATEGY_DEFAULT =
+            SCAN_CHUNK_ASSIGN_STRATEGY.defaultValue();
 
     @Test
     public void testCommonProperties() {
@@ -156,7 +163,8 @@ public class MongoDBTableFactoryTest {
                         FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT,
                         SCAN_NO_CURSOR_TIMEOUT_DEFAULT,
                         SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP_DEFAULT,
-                        SCAN_NEWLY_ADDED_TABLE_ENABLED_DEFAULT);
+                        SCAN_NEWLY_ADDED_TABLE_ENABLED_DEFAULT,
+                        SCAN_CHUNK_ASSIGN_STRATEGY.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -208,7 +216,8 @@ public class MongoDBTableFactoryTest {
                         true,
                         false,
                         true,
-                        true);
+                        true,
+                        SCAN_CHUNK_ASSIGN_STRATEGY.defaultValue());
         assertEquals(expectedSource, actualSource);
     }
 
@@ -249,7 +258,8 @@ public class MongoDBTableFactoryTest {
                         FULL_DOCUMENT_PRE_POST_IMAGE_ENABLED_DEFAULT,
                         SCAN_NO_CURSOR_TIMEOUT_DEFAULT,
                         SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP_DEFAULT,
-                        SCAN_NEWLY_ADDED_TABLE_ENABLED_DEFAULT);
+                        SCAN_NEWLY_ADDED_TABLE_ENABLED_DEFAULT,
+                        SCAN_CHUNK_ASSIGN_STRATEGY_DEFAULT);
 
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.connectors.mysql.source;
 
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
@@ -265,6 +266,12 @@ public class MySqlSourceBuilder<T> {
      */
     public MySqlSourceBuilder<T> closeIdleReaders(boolean closeIdleReaders) {
         this.configFactory.closeIdleReaders(closeIdleReaders);
+        return this;
+    }
+
+    /** Set the strategy of how to assign splits to reader. */
+    public MySqlSourceBuilder<T> scanChunkAssignStrategy(AssignStrategy scanChunkAssignStrategy) {
+        this.configFactory.scanChunkAssignStrategy(scanChunkAssignStrategy);
         return this;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/AssignStrategy.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/AssignStrategy.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.assigners;
+
+import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSchemalessSnapshotSplit;
+
+/**
+ * Strategy for {@link MySqlSnapshotSplitAssigner} to assign {@link MySqlSchemalessSnapshotSplit}.
+ */
+public enum AssignStrategy {
+    ASCENDING_ORDER("ascending_order"),
+    DESCENDING_ORDER("descending_order");
+    private final String value;
+
+    AssignStrategy(String value) {
+        this.value = value;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -45,6 +45,7 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -319,6 +320,10 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                         splits.stream()
                                 .map(MySqlSnapshotSplit::toSchemalessSnapshotSplit)
                                 .collect(Collectors.toList());
+                if (AssignStrategy.DESCENDING_ORDER.equals(
+                        sourceConfig.getScanChunkAssignStrategy())) {
+                    Collections.reverse(schemaLessSnapshotSplits);
+                }
                 chunkNum += splits.size();
                 remainingSplits.addAll(schemaLessSnapshotSplits);
                 if (!chunkSplitter.hasNextChunk()) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.mysql.source.config;
 
 import org.apache.flink.cdc.connectors.mysql.schema.Selectors;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
 import org.apache.flink.table.catalog.ObjectPath;
 
@@ -67,6 +68,8 @@ public class MySqlSourceConfig implements Serializable {
     private final Map<ObjectPath, String> chunkKeyColumns;
     private final boolean skipSnapshotBackfill;
 
+    private final AssignStrategy scanChunkAssignStrategy;
+
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
     // --------------------------------------------------------------------------------------------
@@ -99,7 +102,8 @@ public class MySqlSourceConfig implements Serializable {
             Properties dbzProperties,
             Properties jdbcProperties,
             Map<ObjectPath, String> chunkKeyColumns,
-            boolean skipSnapshotBackfill) {
+            boolean skipSnapshotBackfill,
+            AssignStrategy scanChunkAssignStrategy) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
         this.username = checkNotNull(username);
@@ -127,6 +131,7 @@ public class MySqlSourceConfig implements Serializable {
         this.jdbcProperties = jdbcProperties;
         this.chunkKeyColumns = chunkKeyColumns;
         this.skipSnapshotBackfill = skipSnapshotBackfill;
+        this.scanChunkAssignStrategy = scanChunkAssignStrategy;
     }
 
     public String getHostname() {
@@ -253,5 +258,9 @@ public class MySqlSourceConfig implements Serializable {
 
     public boolean isSkipSnapshotBackfill() {
         return skipSnapshotBackfill;
+    }
+
+    public AssignStrategy getScanChunkAssignStrategy() {
+        return scanChunkAssignStrategy;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.connectors.mysql.source.config;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
 import org.apache.flink.table.catalog.ObjectPath;
 
@@ -70,6 +71,8 @@ public class MySqlSourceConfigFactory implements Serializable {
     private Properties dbzProperties;
     private Map<ObjectPath, String> chunkKeyColumns = new HashMap<>();
     private boolean skipSnapshotBackfill = false;
+
+    private AssignStrategy scanChunkAssignStrategy = AssignStrategy.DESCENDING_ORDER;
 
     public MySqlSourceConfigFactory hostname(String hostname) {
         this.hostname = hostname;
@@ -291,6 +294,11 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
+    /** How to assign splits to split reader. */
+    public void scanChunkAssignStrategy(AssignStrategy scanChunkAssignStrategy) {
+        this.scanChunkAssignStrategy = scanChunkAssignStrategy;
+    }
+
     /** Creates a new {@link MySqlSourceConfig} for the given subtask {@code subtaskId}. */
     public MySqlSourceConfig createConfig(int subtaskId) {
         // hard code server name, because we don't need to distinguish it, docs:
@@ -384,6 +392,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 props,
                 jdbcProperties,
                 chunkKeyColumns,
-                skipSnapshotBackfill);
+                skipSnapshotBackfill,
+                scanChunkAssignStrategy);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.mysql.source.config;
 
 import org.apache.flink.cdc.common.annotation.Experimental;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 
@@ -183,6 +184,14 @@ public class MySqlSourceOptions {
                     .noDefaultValue()
                     .withDescription(
                             "Optional timestamp used in case of \"timestamp\" startup mode");
+
+    public static final ConfigOption<AssignStrategy> SCAN_CHUNK_ASSIGN_STRATEGY =
+            ConfigOptions.key("scan.chunk.assign.strategy")
+                    .enumType(AssignStrategy.class)
+                    .defaultValue(AssignStrategy.DESCENDING_ORDER)
+                    .withDescription(
+                            "Optional assign strategy for MySqlSnapshotSplitAssigner, valid enumerations are "
+                                    + "\"ascending_order\", \"descending_order\"");
 
     public static final ConfigOption<Duration> HEARTBEAT_INTERVAL =
             ConfigOptions.key("heartbeat.interval")

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSource.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.connectors.mysql.table;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.cdc.debezium.DebeziumSourceFunction;
 import org.apache.flink.cdc.debezium.table.MetadataConverter;
@@ -99,6 +100,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     private final String chunkKeyColumn;
     final boolean skipSnapshotBackFill;
 
+    final AssignStrategy assignStrategy;
+
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
     // --------------------------------------------------------------------------------------------
@@ -135,7 +138,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             Properties jdbcProperties,
             Duration heartbeatInterval,
             @Nullable String chunkKeyColumn,
-            boolean skipSnapshotBackFill) {
+            boolean skipSnapshotBackFill,
+            AssignStrategy assignStrategy) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -165,6 +169,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.heartbeatInterval = heartbeatInterval;
         this.chunkKeyColumn = chunkKeyColumn;
         this.skipSnapshotBackFill = skipSnapshotBackFill;
+        this.assignStrategy = assignStrategy;
     }
 
     @Override
@@ -220,6 +225,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .heartbeatInterval(heartbeatInterval)
                             .chunkKeyColumn(new ObjectPath(database, tableName), chunkKeyColumn)
                             .skipSnapshotBackfill(skipSnapshotBackFill)
+                            .scanChunkAssignStrategy(assignStrategy)
                             .build();
             return SourceProvider.of(parallelSource);
         } else {
@@ -305,7 +311,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         jdbcProperties,
                         heartbeatInterval,
                         chunkKeyColumn,
-                        skipSnapshotBackFill);
+                        skipSnapshotBackFill,
+                        assignStrategy);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -347,7 +354,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 && Objects.equals(jdbcProperties, that.jdbcProperties)
                 && Objects.equals(heartbeatInterval, that.heartbeatInterval)
                 && Objects.equals(chunkKeyColumn, that.chunkKeyColumn)
-                && Objects.equals(skipSnapshotBackFill, that.skipSnapshotBackFill);
+                && Objects.equals(skipSnapshotBackFill, that.skipSnapshotBackFill)
+                && Objects.equals(assignStrategy, that.assignStrategy);
     }
 
     @Override
@@ -380,7 +388,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 jdbcProperties,
                 heartbeatInterval,
                 chunkKeyColumn,
-                skipSnapshotBackFill);
+                skipSnapshotBackFill,
+                assignStrategy);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.mysql.table;
 
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceOptions;
 import org.apache.flink.cdc.connectors.mysql.source.config.ServerIdRange;
 import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
@@ -102,6 +103,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 config.get(MySqlSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED);
         boolean skipSnapshotBackFill =
                 config.get(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
+        AssignStrategy assignStrategy = config.get(MySqlSourceOptions.SCAN_CHUNK_ASSIGN_STRATEGY);
 
         if (enableParallelRead) {
             validatePrimaryKeyIfEnableParallel(physicalSchema, chunkKeyColumn);
@@ -145,7 +147,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 JdbcUrlUtils.getJdbcProperties(context.getCatalogTable().getOptions()),
                 heartbeatInterval,
                 chunkKeyColumn,
-                skipSnapshotBackFill);
+                skipSnapshotBackFill,
+                assignStrategy);
     }
 
     @Override
@@ -191,6 +194,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         options.add(MySqlSourceOptions.HEARTBEAT_INTERVAL);
         options.add(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
         options.add(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
+        options.add(MySqlSourceOptions.SCAN_CHUNK_ASSIGN_STRATEGY);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -150,16 +150,14 @@ public class BinlogSplitReaderTest extends MySqlSourceTestBase {
                 getMySqlSplits(new String[] {"customers_even_dist"}, sourceConfig);
         String[] expected =
                 new String[] {
-                    "+I[101, user_1, Shanghai, 123567891234]",
-                    "+I[102, user_2, Shanghai, 123567891234]",
+                    "+I[109, user_9, Shanghai, 123567891234]",
+                    "+I[110, user_10, Shanghai, 123567891234]",
                     "-D[102, user_2, Shanghai, 123567891234]",
                     "+I[102, user_2, Shanghai, 123567891234]",
                     "-U[103, user_3, Shanghai, 123567891234]",
                     "+U[103, user_3, Hangzhou, 123567891234]",
                     "-U[103, user_3, Hangzhou, 123567891234]",
                     "+U[103, user_3, Shanghai, 123567891234]",
-                    "+I[104, user_4, Shanghai, 123567891234]",
-                    "+I[103, user_3, Shanghai, 123567891234]"
                 };
 
         List<String> actual =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -103,10 +103,8 @@ public class SnapshotSplitReaderTest extends MySqlSourceTestBase {
 
         String[] expected =
                 new String[] {
-                    "+I[101, user_1, Shanghai, 123567891234]",
-                    "+I[102, user_2, Shanghai, 123567891234]",
-                    "+I[103, user_3, Shanghai, 123567891234]",
-                    "+I[104, user_4, Shanghai, 123567891234]"
+                    "+I[110, user_10, Shanghai, 123567891234]",
+                    "+I[109, user_9, Shanghai, 123567891234]"
                 };
         List<String> actual =
                 readTableSnapshotSplits(mySqlSplits, statefulTaskContext, 1, dataType);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssignerTest.java
@@ -70,9 +70,9 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     public void testAssignSingleTableSplits() {
         List<String> expected =
                 Arrays.asList(
-                        "customers_even_dist null [105]",
+                        "customers_even_dist [109] null",
                         "customers_even_dist [105] [109]",
-                        "customers_even_dist [109] null");
+                        "customers_even_dist null [105]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         4,
@@ -98,12 +98,12 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     public void testAssignMultipleTableSplits() {
         List<String> expected =
                 Arrays.asList(
-                        "customers_even_dist null [105]",
-                        "customers_even_dist [105] [109]",
                         "customers_even_dist [109] null",
-                        "customers_sparse_dist null [10]",
+                        "customers_even_dist [105] [109]",
+                        "customers_even_dist null [105]",
+                        "customers_sparse_dist [18] null",
                         "customers_sparse_dist [10] [18]",
-                        "customers_sparse_dist [18] null");
+                        "customers_sparse_dist null [10]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         4,
@@ -137,9 +137,9 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     public void testAssignCompositePkTableSplitsEvenlyWithChunkKeyColumn() {
         List<String> expected =
                 Arrays.asList(
-                        "evenly_shopping_cart null [105]",
+                        "evenly_shopping_cart [109] null",
                         "evenly_shopping_cart [105] [109]",
-                        "evenly_shopping_cart [109] null");
+                        "evenly_shopping_cart null [105]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         customerDatabase,
@@ -174,7 +174,7 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     @Test
     public void testEnableAutoIncrementedKeyOptimization() {
         List<String> expected =
-                Arrays.asList("shopping_cart_big null [3]", "shopping_cart_big [3] null");
+                Arrays.asList("shopping_cart_big [3] null", "shopping_cart_big null [3]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         2,
@@ -204,8 +204,8 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     public void testAssignSnapshotSplitsWithDecimalKey() {
         List<String> expected =
                 Arrays.asList(
-                        "shopping_cart_dec null [123458.1230]",
-                        "shopping_cart_dec [123458.1230] null");
+                        "shopping_cart_dec [123458.1230] null",
+                        "shopping_cart_dec null [123458.1230]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         2,
@@ -240,9 +240,9 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
         // test sparse table with bigger distribution factor upper
         List<String> expected =
                 Arrays.asList(
-                        "customers_sparse_dist null [10]",
+                        "customers_sparse_dist [18] null",
                         "customers_sparse_dist [10] [18]",
-                        "customers_sparse_dist [18] null");
+                        "customers_sparse_dist null [10]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         4,
@@ -267,7 +267,7 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
 
         // test sparse table that the approximate row count is bigger than chunk size
         List<String> expected2 =
-                Arrays.asList("customers_sparse_dist null [18]", "customers_sparse_dist [18] null");
+                Arrays.asList("customers_sparse_dist [18] null", "customers_sparse_dist null [18]");
         List<String> splits2 =
                 getTestAssignSnapshotSplits(
                         8,
@@ -282,9 +282,9 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
         // test dense table with smaller dense distribution factor lower
         List<String> expected =
                 Arrays.asList(
-                        "customers_dense_dist null [2]",
+                        "customers_dense_dist [3] null",
                         "customers_dense_dist [2] [3]",
-                        "customers_dense_dist [3] null");
+                        "customers_dense_dist null [2]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         2,
@@ -355,11 +355,11 @@ public class MySqlSnapshotSplitAssignerTest extends MySqlSourceTestBase {
     public void testAssignMinSplitSize() {
         List<String> expected =
                 Arrays.asList(
-                        "customers_even_dist null [103]",
-                        "customers_even_dist [103] [105]",
-                        "customers_even_dist [105] [107]",
+                        "customers_even_dist [109] null",
                         "customers_even_dist [107] [109]",
-                        "customers_even_dist [109] null");
+                        "customers_even_dist [105] [107]",
+                        "customers_even_dist [103] [105]",
+                        "customers_even_dist null [103]");
         List<String> splits =
                 getTestAssignSnapshotSplits(
                         2,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.connectors.mysql.table;
 
+import org.apache.flink.cdc.connectors.mysql.source.assigners.AssignStrategy;
 import org.apache.flink.cdc.debezium.utils.ResolvedSchemaUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
@@ -127,7 +128,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -173,7 +175,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         "testCol",
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -215,7 +218,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -255,7 +259,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -311,7 +316,8 @@ public class MySqlTableSourceFactoryTest {
                         jdbcProperties,
                         Duration.ofMillis(15213),
                         "testCol",
-                        true);
+                        true,
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
         assertTrue(actualSource instanceof MySqlTableSource);
         MySqlTableSource actualMySqlTableSource = (MySqlTableSource) actualSource;
@@ -365,7 +371,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -403,7 +410,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -442,7 +450,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -482,7 +491,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -520,7 +530,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         assertEquals(expectedSource, actualSource);
     }
 
@@ -563,7 +574,8 @@ public class MySqlTableSourceFactoryTest {
                         new Properties(),
                         HEARTBEAT_INTERVAL.defaultValue(),
                         null,
-                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        AssignStrategy.DESCENDING_ORDER);
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");
 


### PR DESCRIPTION
Introduce a new config option scan.chunk.assign.strategy to control the order of split assignment.