### PR TITLE
[FLINK-36687][cdc-pipeline-connector/doris] Improve Doris Pipeline Connector Version to 24.0.1

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
     <name>flink-cdc-pipeline-connector-doris</name>
 
     <properties>
-        <doris.connector.version>1.6.2</doris.connector.version>
+        <doris.connector.version>24.0.1</doris.connector.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Improve Doris Pipeline Connector Version to 24.0.1, Related release note https://github.com/apache/doris-flink-connector/issues/477
https://github.com/apache/doris-flink-connector/issues/499