### PR TITLE
[FLINK-36375][cdc-runtime] Fix missed default value in AddColumnEvent/RenameColumnEvent

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceHelper.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceHelper.java
@@ -50,6 +50,7 @@ public class ValuesDataSourceHelper {
      */
     public enum EventSetId {
         SINGLE_SPLIT_SINGLE_TABLE,
+        SINGLE_SPLIT_SINGLE_TABLE_WITH_DEFAULT_VALUE,
         SINGLE_SPLIT_MULTI_TABLES,
         MULTI_SPLITS_SINGLE_TABLE,
         CUSTOM_SOURCE_EVENTS,
@@ -93,6 +94,11 @@ public class ValuesDataSourceHelper {
             case SINGLE_SPLIT_SINGLE_TABLE:
                 {
                     sourceEvents = singleSplitSingleTable();
+                    break;
+                }
+            case SINGLE_SPLIT_SINGLE_TABLE_WITH_DEFAULT_VALUE:
+                {
+                    sourceEvents = singleSplitSingleTableWithDefaultValue();
                     break;
                 }
             case SINGLE_SPLIT_MULTI_TABLES:
@@ -211,6 +217,30 @@ public class ValuesDataSourceHelper {
 
         eventOfSplits.add(split1);
         return eventOfSplits;
+    }
+
+    public static List<List<Event>> singleSplitSingleTableWithDefaultValue() {
+        List<List<Event>> eventOfSplits = singleSplitSingleTable();
+        // add column with default value
+        eventOfSplits.get(0).add(addColumnWithDefaultValue(TABLE_1));
+        // rename column with default value
+        eventOfSplits.get(0).add(renameColumnWithDefaultValue(TABLE_1));
+
+        return eventOfSplits;
+    }
+
+    private static AddColumnEvent addColumnWithDefaultValue(TableId tableId) {
+        AddColumnEvent.ColumnWithPosition columnWithPositionWithDefault =
+                new AddColumnEvent.ColumnWithPosition(
+                        Column.physicalColumn("colWithDefault", DataTypes.STRING(), null, "flink"));
+        return new AddColumnEvent(
+                tableId, Collections.singletonList(columnWithPositionWithDefault));
+    }
+
+    private static RenameColumnEvent renameColumnWithDefaultValue(TableId tableId) {
+        Map<String, String> nameMapping = new HashMap<>();
+        nameMapping.put("colWithDefault", "newColWithDefault");
+        return new RenameColumnEvent(tableId, nameMapping);
     }
 
     public static List<List<Event>> singleSplitMultiTables() {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/source/ValuesDataSourceOptions.java
@@ -41,6 +41,8 @@ public class ValuesDataSourceOptions {
                                                     text(
                                                             "SINGLE_SPLIT_SINGLE_TABLE: Default and predetermined case. Creating schema changes of single table and put them into one split."),
                                                     text(
+                                                            "SINGLE_SPLIT_SINGLE_TABLE_WITH_DEFAULT_VALUE: A predetermined case. Creating schema changes of single table (some columns have default value) and put them into one split."),
+                                                    text(
                                                             "SINGLE_SPLIT_MULTI_TABLES: A predetermined case. Creating schema changes of multiple tables and put them into one split."),
                                                     text(
                                                             "MULTI_SPLITS_SINGLE_TABLE: A predetermined case. Creating schema changes of single table and put them into multiple splits."),

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
@@ -376,7 +376,9 @@ public class SchemaRegistryRequestHandler implements Closeable {
                                                                                     .getType()
                                                                                     .nullable(),
                                                                             col.getAddColumn()
-                                                                                    .getComment())))
+                                                                                    .getComment(),
+                                                                            col.getAddColumn()
+                                                                                    .getDefaultValueExpression())))
                                             .collect(Collectors.toList())));
                 }
             case DROP_COLUMN:
@@ -428,7 +430,9 @@ public class SchemaRegistryRequestHandler implements Closeable {
                                                         Column.physicalColumn(
                                                                 value,
                                                                 column.getType().nullable(),
-                                                                column.getComment())));
+                                                                column.getComment(),
+                                                                column
+                                                                        .getDefaultValueExpression())));
                                     });
 
                     List<SchemaChangeEvent> events = new ArrayList<>();

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivationTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaDerivationTest.java
@@ -105,14 +105,18 @@ class SchemaDerivationTest {
         AddColumnEvent.ColumnWithPosition newCol2 =
                 new AddColumnEvent.ColumnWithPosition(
                         new PhysicalColumn("new_col2", DataTypes.STRING(), null));
-        List<AddColumnEvent.ColumnWithPosition> newColumns = Arrays.asList(newCol1, newCol2);
+        AddColumnEvent.ColumnWithPosition newCol3 =
+                new AddColumnEvent.ColumnWithPosition(
+                        new PhysicalColumn("new_col3", DataTypes.STRING(), null, "abc"));
+        List<AddColumnEvent.ColumnWithPosition> newColumns =
+                Arrays.asList(newCol1, newCol2, newCol3);
         List<SchemaChangeEvent> derivedChangesAfterAddColumn =
                 schemaDerivation.applySchemaChange(new AddColumnEvent(TABLE_1, newColumns));
         assertThat(derivedChangesAfterAddColumn).hasSize(1);
         assertThat(derivedChangesAfterAddColumn.get(0))
                 .asAddColumnEvent()
                 .hasTableId(MERGED_TABLE)
-                .containsAddedColumns(newCol1, newCol2);
+                .containsAddedColumns(newCol1, newCol2, newCol3);
 
         // Alter column type
         ImmutableMap<String, DataType> typeMapping = ImmutableMap.of("age", DataTypes.BIGINT());

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaManagerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaManagerTest.java
@@ -94,7 +94,10 @@ class SchemaManagerTest {
                         new AddColumnEvent.ColumnWithPosition(
                                 Column.physicalColumn("append_before_phone", DataTypes.BIGINT()),
                                 AddColumnEvent.ColumnPosition.BEFORE,
-                                "phone"));
+                                "phone"),
+                        new AddColumnEvent.ColumnWithPosition(
+                                Column.physicalColumn(
+                                        "col_with_default", DataTypes.BIGINT(), null, "10")));
 
         schemaManager.applyEvolvedSchemaChange(new CreateTableEvent(CUSTOMERS, CUSTOMERS_SCHEMA));
         schemaManager.applyEvolvedSchemaChange(new AddColumnEvent(CUSTOMERS, newColumns));
@@ -108,6 +111,7 @@ class SchemaManagerTest {
                                 .physicalColumn("append_before_phone", DataTypes.BIGINT())
                                 .physicalColumn("phone", DataTypes.BIGINT())
                                 .physicalColumn("append_last", DataTypes.BIGINT())
+                                .physicalColumn("col_with_default", DataTypes.BIGINT(), null, "10")
                                 .primaryKey("id")
                                 .build());
     }


### PR DESCRIPTION
SchemaOperator receives an AddColumnEvent/RenameColumnEvent inLenient mode , the default value will be lost when sent downstream.
JIRA: [https://issues.apache.org/jira/browse/FLINK-36375](https://github.com/apache/flink-cdc/pull/url)