### PR TITLE
[FLINK-36678][docs][deploy] Fixed the documentation error of Flink CDC YARN deployment mode

### DIFF
--- a/docs/content.zh/docs/deployment/yarn.md
+++ b/docs/content.zh/docs/deployment/yarn.md
@@ -133,7 +133,7 @@ pipeline:
 ```
 
 You need to modify the configuration file according to your needs.
-Finally, submit job to Flink Standalone cluster using Cli.
+Finally, submit job to Flink Yarn Session cluster using Cli.
 
 ```bash
 cd /path/flink-cdc-*

--- a/docs/content/docs/deployment/yarn.md
+++ b/docs/content/docs/deployment/yarn.md
@@ -133,7 +133,7 @@ pipeline:
 ```
 
 You need to modify the configuration file according to your needs.
-Finally, submit job to Flink Standalone cluster using Cli.
+Finally, submit job to Flink Yarn Session cluster using Cli.
 
 ```bash
 cd /path/flink-cdc-*


### PR DESCRIPTION
See the details in #3706 , backport PR for release-3.2 branch