### PR TITLE
[hotfix][ci] Shorten CI workflow tag prefixes to improve CI workflow readability

### DIFF
--- a/.github/workflows/flink_cdc.yml
+++ b/.github/workflows/flink_cdc.yml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Flink CDC CI
+name: CI
 on:
   push:
     branches:

--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -95,7 +95,7 @@ env:
   flink-cdc-e2e-tests/flink-cdc-source-e2e-tests"
 
 jobs:
-  compile_and_test:
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:

--- a/.github/workflows/flink_cdc_migration_test.yml
+++ b/.github/workflows/flink_cdc_migration_test.yml
@@ -19,7 +19,7 @@ on:
   workflow_call:
 
 jobs:
-  migration_test_ut:
+  unit_test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -35,7 +35,7 @@ jobs:
       - name: Run migration tests
         run: cd flink-cdc-migration-tests && mvn clean verify
 
-  pipeline_migration_test:
+  pipeline:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -74,7 +74,7 @@ jobs:
         run: cd conf && docker compose down
         working-directory: ./tools/mig-test
 
-  data_stream_migration_test:
+  datastream:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/flink_cdc_migration_test.yml
+++ b/.github/workflows/flink_cdc_migration_test.yml
@@ -19,7 +19,7 @@ on:
   workflow_call:
 
 jobs:
-  unit_test:
+  misc_test:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Currently, our CI workflow architecture is deep and hard to recognize, and layers have long and duplicate prefixes.

<img width="503" alt="截圖 2024-11-12 20 21 36" src="https://github.com/user-attachments/assets/6eaa024c-694f-480e-b34a-f2f1d87cebb3">

This PR simplifies layer names to make CI job summary clearer.