### PR TITLE
[BP release-3.2][FLINK-36509][pipeline-connector][paimon] Add partition columns to primary keys

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplier.java
@@ -153,14 +153,22 @@ public class PaimonMetadataApplier implements MetadataApplier {
                                         LogicalTypeConversion.toDataType(
                                                 DataTypeUtils.toFlinkDataType(column.getType())
                                                         .getLogicalType())));
-        builder.primaryKey(schema.primaryKeys().toArray(new String[0]));
+        List<String> partitionKeys = new ArrayList<>();
+        List<String> primaryKeys = schema.primaryKeys();
         if (partitionMaps.containsKey(event.tableId())) {
-            builder.partitionKeys(partitionMaps.get(event.tableId()));
+            partitionKeys.addAll(partitionMaps.get(event.tableId()));
         } else if (schema.partitionKeys() != null && !schema.partitionKeys().isEmpty()) {
-            builder.partitionKeys(schema.partitionKeys());
+            partitionKeys.addAll(schema.partitionKeys());
         }
-        builder.options(tableOptions);
-        builder.options(schema.options());
+        for (String partitionColumn : partitionKeys) {
+            if (!primaryKeys.contains(partitionColumn)) {
+                primaryKeys.add(partitionColumn);
+            }
+        }
+        builder.partitionKeys(partitionKeys)
+                .primaryKey(primaryKeys)
+                .options(tableOptions)
+                .options(schema.options());
         catalog.createTable(
                 new Identifier(event.tableId().getSchemaName(), event.tableId().getTableName()),
                 builder.build(),


### PR DESCRIPTION
backport FLINK-36509 to release-3.2

(cherry picked from commit ae986ab3f607d788b4b82e2aabceb3e807a54139)