### PR TITLE
[BP release-3.2][FLINK-36681][mysql-cdc][docs] Fix the wrong chunks splitting query in incremental snapshot reading section

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
@@ -581,7 +581,7 @@ MySQL CDC Source 使用主键列将表划分为多个分片（chunk）。 默认
  [100, +∞)
 ```
 
-对于其他主键列类型， MySQL CDC Source 将以下形式执行语句： `SELECT MAX(STR_ID) AS chunk_high FROM (SELECT * FROM TestTable WHERE STR_ID > 'uuid-001' limit 25)` 来获得每个区块的低值和高值，
+对于其他主键列类型， MySQL CDC Source 将以下形式执行语句： `SELECT MAX(STR_ID) AS chunk_high FROM (SELECT * FROM TestTable WHERE STR_ID > 'uuid-001' ORDER BY STR_ID ASC LIMIT 25)` 来获得每个区块的低值和高值，
 分割块集如下所示：
 
  ```

--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -612,7 +612,7 @@ and the table option `scan.incremental.snapshot.chunk.size` value is `25`, the t
  [100, +∞)
 ```
 
-For other primary key column type, MySQL CDC Source executes the statement in the form of `SELECT MAX(STR_ID) AS chunk_high FROM (SELECT * FROM TestTable WHERE STR_ID > 'uuid-001' limit 25)` to get the low and high value for each chunk, 
+For other primary key column type, MySQL CDC Source executes the statement in the form of `SELECT MAX(STR_ID) AS chunk_high FROM (SELECT * FROM TestTable WHERE STR_ID > 'uuid-001' ORDER BY STR_ID ASC LIMIT 25)` to get the low and high value for each chunk, 
 the splitting chunks set would be like:
 
  ```


### PR DESCRIPTION
backport [FLINK-36681](https://issues.apache.org/jira/browse/FLINK-36681) to release-3.2

(cherry picked from commit https://github.com/apache/flink-cdc/commit/ba74c7c45ff69ccb0052e9ae17972de4a4257ba0)