### PR TITLE
[FLINK-36741][cdc][transform] Fix the precision of and length of data type has been lost when use transform and support DecimalData

### DIFF
--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -1979,7 +1979,7 @@ class FlinkPipelineTransformITCase {
                                                 + "2147483648 AS greater_than_int_max, "
                                                 + "-2147483648 AS int_min, "
                                                 + "-2147483649 AS less_than_int_min, "
-                                                + "CAST(1234567890123456789 AS DECIMAL(20, 0)) AS really_big_decimal",
+                                                + "CAST(1234567890123456789 AS DECIMAL(19, 0)) AS really_big_decimal",
                                         "CAST(id AS BIGINT) + 2147483648 > 2147483649", // equivalent to id > 1
                                         null,
                                         null,

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineUdfITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineUdfITCase.java
@@ -841,7 +841,7 @@ public class FlinkPipelineUdfITCase {
     @ParameterizedTest
     @MethodSource("testParams")
     @Disabled("For manual test as there is a limit for quota.")
-    void testTransformWithModel(ValuesDataSink.SinkApi sinkApi) throws Exception {
+    void testTransformWithModel(ValuesDataSink.SinkApi sinkApi, String language) throws Exception {
         FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
 
         // Setup value source
@@ -907,6 +907,112 @@ public class FlinkPipelineUdfITCase {
                         "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING NOT NULL,`col2` STRING,`emb` STRING}, primaryKeys=col1, options=({key1=value1})}")
                 // The result of transform by model is not fixed.
                 .hasSize(9);
+    }
+
+    @ParameterizedTest
+    @MethodSource("testParams")
+    void testComplicatedUdfReturnTypes(ValuesDataSink.SinkApi sinkApi, String language)
+            throws Exception {
+        FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
+
+        // Setup value source
+        Configuration sourceConfig = new Configuration();
+        sourceConfig.set(
+                ValuesDataSourceOptions.EVENT_SET_ID,
+                ValuesDataSourceHelper.EventSetId.SINGLE_SPLIT_SINGLE_TABLE);
+        SourceDef sourceDef =
+                new SourceDef(ValuesDataFactory.IDENTIFIER, "Value Source", sourceConfig);
+
+        // Setup value sink
+        Configuration sinkConfig = new Configuration();
+        sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
+        SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
+
+        // Setup transform
+        TransformDef transformDef =
+                new TransformDef(
+                        "default_namespace.default_schema.table1",
+                        "*, get_char() AS char_col, get_varchar() AS varchar_col, get_binary() AS binary_col, get_varbinary() AS varbinary_col, get_ts() AS ts_col, get_ts_ltz() AS ts_ltz_col, get_decimal() AS decimal_col, get_non_null() AS non_null_col",
+                        null,
+                        "col1",
+                        null,
+                        "key1=value1",
+                        "",
+                        null);
+
+        // Setup pipeline
+        Configuration pipelineConfig = new Configuration();
+        pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, 1);
+        pipelineConfig.set(PipelineOptions.PIPELINE_LOCAL_TIME_ZONE, "America/Los_Angeles");
+        pipelineConfig.set(
+                PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR, SchemaChangeBehavior.EVOLVE);
+        PipelineDef pipelineDef =
+                new PipelineDef(
+                        sourceDef,
+                        sinkDef,
+                        Collections.emptyList(),
+                        Collections.singletonList(transformDef),
+                        Arrays.asList(
+                                new UdfDef(
+                                        "get_char",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.CharTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_varchar",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.VarCharTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_binary",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.BinaryTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_varbinary",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.VarBinaryTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_ts",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.TimestampTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_ts_ltz",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.LocalZonedTimestampTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_decimal",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.DecimalTypeReturningClass",
+                                                language)),
+                                new UdfDef(
+                                        "get_non_null",
+                                        String.format(
+                                                "org.apache.flink.cdc.udf.examples.%s.precision.DecimalTypeNonNullReturningClass",
+                                                language))),
+                        pipelineConfig);
+
+        // Execute the pipeline
+        PipelineExecution execution = composer.compose(pipelineDef);
+        execution.execute();
+
+        // Check the order and content of all received events
+        String[] outputEvents = outCaptor.toString().trim().split("\n");
+        assertThat(outputEvents)
+                .contains(
+                        "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING,`char_col` STRING,`varchar_col` STRING,`binary_col` BINARY(17),`varbinary_col` VARBINARY(17),`ts_col` TIMESTAMP(2),`ts_ltz_col` TIMESTAMP_LTZ(2),`decimal_col` DECIMAL(10, 3),`non_null_col` DECIMAL(10, 3)}, primaryKeys=col1, options=({key1=value1})}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[1, 1, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[2, 2, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[3, 3, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=INSERT, meta=()}",
+                        "AddColumnEvent{tableId=default_namespace.default_schema.table1, addedColumns=[ColumnWithPosition{column=`col3` STRING, position=AFTER, existedColumnName=col2}]}",
+                        "RenameColumnEvent{tableId=default_namespace.default_schema.table1, nameMapping={col2=newCol2, col3=newCol3}}",
+                        "DropColumnEvent{tableId=default_namespace.default_schema.table1, droppedColumnNames=[newCol2]}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[1, 1, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], after=[], op=DELETE, meta=()}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[2, , This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], after=[2, x, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=UPDATE, meta=()}");
     }
 
     private static Stream<Arguments> testParams() {

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineUdfITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineUdfITCase.java
@@ -1004,7 +1004,7 @@ public class FlinkPipelineUdfITCase {
         String[] outputEvents = outCaptor.toString().trim().split("\n");
         assertThat(outputEvents)
                 .contains(
-                        "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING,`col2` STRING,`char_col` STRING,`varchar_col` STRING,`binary_col` BINARY(17),`varbinary_col` VARBINARY(17),`ts_col` TIMESTAMP(2),`ts_ltz_col` TIMESTAMP_LTZ(2),`decimal_col` DECIMAL(10, 3),`non_null_col` DECIMAL(10, 3)}, primaryKeys=col1, options=({key1=value1})}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.table1, schema=columns={`col1` STRING NOT NULL,`col2` STRING,`char_col` STRING,`varchar_col` STRING,`binary_col` BINARY(17),`varbinary_col` VARBINARY(17),`ts_col` TIMESTAMP(2),`ts_ltz_col` TIMESTAMP_LTZ(2),`decimal_col` DECIMAL(10, 3),`non_null_col` DECIMAL(10, 3)}, primaryKeys=col1, options=({key1=value1})}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[1, 1, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[2, 2, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.table1, before=[], after=[3, 3, This is a string., This is a string., eHl6enk=, eHl6enk=, 1970-01-02T00:00, 1970-01-02T00:00, 12.315, 12.315], op=INSERT, meta=()}",

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkHelper.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkHelper.java
@@ -67,10 +67,13 @@ public class ValuesDataSinkHelper {
         return fields.stream()
                 .map(
                         o -> {
+                            if (o == null) {
+                                return "null";
+                            }
                             if (o instanceof byte[]) {
                                 return BaseEncoding.base64().encode((byte[]) o);
                             } else {
-                                return o;
+                                return o.toString();
                             }
                         })
                 .collect(Collectors.toList());

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/BinaryTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/BinaryTypeReturningClass.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+/** This is an example UDF class for testing purposes only. */
+public class BinaryTypeReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.BINARY(17);
+    }
+
+    public byte[] eval() {
+        return "xyzzy".getBytes();
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/CharTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/CharTypeReturningClass.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+/** This is an example UDF class for testing purposes only. */
+public class CharTypeReturningClass implements UserDefinedFunction {
+
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.CHAR(17);
+    }
+
+    public String eval() {
+        return "This is a string.";
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/DecimalTypeNonNullReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/DecimalTypeNonNullReturningClass.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+import java.math.BigDecimal;
+
+/** This is an example UDF class for testing purposes only. */
+public class DecimalTypeNonNullReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.DECIMAL(10, 3).notNull();
+    }
+
+    public DecimalData eval() {
+        return DecimalData.fromBigDecimal(new BigDecimal("12.315"), 10, 3);
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/DecimalTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/DecimalTypeReturningClass.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+import java.math.BigDecimal;
+
+/** This is an example UDF class for testing purposes only. */
+public class DecimalTypeReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.DECIMAL(10, 3);
+    }
+
+    public DecimalData eval() {
+        return DecimalData.fromBigDecimal(new BigDecimal("12.315"), 10, 3);
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/LocalZonedTimestampTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/LocalZonedTimestampTypeReturningClass.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+/** This is an example UDF class for testing purposes only. */
+public class LocalZonedTimestampTypeReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.TIMESTAMP_LTZ(2);
+    }
+
+    public LocalZonedTimestampData eval() {
+        return LocalZonedTimestampData.fromEpochMillis(24 * 60 * 60 * 1000);
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/TimestampTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/TimestampTypeReturningClass.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.data.TimestampData;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+/** This is an example UDF class for testing purposes only. */
+public class TimestampTypeReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.TIMESTAMP(2);
+    }
+
+    public TimestampData eval() {
+        return TimestampData.fromMillis(24 * 60 * 60 * 1000);
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarBinaryTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarBinaryTypeReturningClass.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+/** This is an example UDF class for testing purposes only. */
+public class VarBinaryTypeReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.VARBINARY(17);
+    }
+
+    public byte[] eval() {
+        return "xyzzy".getBytes();
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarCharTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarCharTypeReturningClass.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.java.precision;
+
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+
+/** This is an example UDF class for testing purposes only. */
+public class VarCharTypeReturningClass implements UserDefinedFunction {
+    @Override
+    public DataType getReturnType() {
+        return DataTypes.VARCHAR(17);
+    }
+
+    public String eval() {
+        return "This is a string.";
+    }
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/BinaryTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/BinaryTypeReturningClass.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+/** This is an example UDF class for testing purposes only. */
+class BinaryTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.BINARY(17)
+  def eval: Array[Byte] = "xyzzy".getBytes
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/CharTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/CharTypeReturningClass.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+/** This is an example UDF class for testing purposes only. */
+class CharTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.CHAR(17)
+  def eval = "This is a string."
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/DecimalTypeNonNullReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/DecimalTypeNonNullReturningClass.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.data.DecimalData
+import org.apache.flink.cdc.common.types.{DataType, DataTypes}
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+import java.math.BigDecimal
+
+/** This is an example UDF class for testing purposes only. */
+class DecimalTypeNonNullReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.DECIMAL(10, 3).notNull()
+  def eval: DecimalData = DecimalData.fromBigDecimal(new BigDecimal("12.315"), 10, 3)
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/DecimalTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/DecimalTypeReturningClass.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.data.DecimalData
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+import java.math.BigDecimal
+
+/** This is an example UDF class for testing purposes only. */
+class DecimalTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.DECIMAL(10, 3)
+  def eval: DecimalData = DecimalData.fromBigDecimal(new BigDecimal("12.315"), 10, 3)
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/LocalZonedTimestampTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/LocalZonedTimestampTypeReturningClass.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.data.LocalZonedTimestampData
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+/** This is an example UDF class for testing purposes only. */
+class LocalZonedTimestampTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.TIMESTAMP_LTZ(2)
+  def eval: LocalZonedTimestampData = LocalZonedTimestampData.fromEpochMillis(24 * 60 * 60 * 1000)
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/TimestampTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/TimestampTypeReturningClass.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.data.TimestampData
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+/** This is an example UDF class for testing purposes only. */
+class TimestampTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.TIMESTAMP(2)
+  def eval: TimestampData = TimestampData.fromMillis(24 * 60 * 60 * 1000)
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/VarBinaryTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/VarBinaryTypeReturningClass.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+/** This is an example UDF class for testing purposes only. */
+class VarBinaryTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.VARBINARY(17)
+  def eval: Array[Byte] = "xyzzy".getBytes
+}

--- a/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/VarCharTypeReturningClass.scala
+++ b/flink-cdc-pipeline-udf-examples/src/main/scala/org/apache/flink/cdc/udf/examples/scala/precision/VarCharTypeReturningClass.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.udf.examples.scala.precision
+
+import org.apache.flink.cdc.common.types.DataType
+import org.apache.flink.cdc.common.types.DataTypes
+import org.apache.flink.cdc.common.udf.UserDefinedFunction
+
+/** This is an example UDF class for testing purposes only. */
+class VarCharTypeReturningClass extends UserDefinedFunction {
+  override def getReturnType: DataType = DataTypes.VARCHAR(17)
+  def eval = "This is a string."
+}

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -470,7 +470,7 @@ public class JaninoCompiler {
                 return new Java.MethodInvocation(
                         Location.NOWHERE,
                         null,
-                        "castToBigDecimal",
+                        "castToDecimalData",
                         newAtoms.toArray(new Java.Rvalue[0]));
             case "CHAR":
             case "VARCHAR":
@@ -496,7 +496,7 @@ public class JaninoCompiler {
             return String.format(
                     "(%s) __instanceOf%s.eval",
                     DataTypeConverter.convertOriginalClass(udfFunction.getReturnTypeHint())
-                            .getName(),
+                            .getCanonicalName(),
                     udfFunction.getClassName());
         } else {
             return String.format("__instanceOf%s.eval", udfFunction.getClassName());

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/TransformParser.java
@@ -176,8 +176,8 @@ public class TransformParser {
                                 new HepPlanner(new HepProgramBuilder().build()),
                                 new RexBuilder(factory)),
                         StandardConvertletTable.INSTANCE,
-                        SqlToRelConverter.config().withTrimUnusedFields(false));
-        RelRoot relRoot = sqlToRelConverter.convertQuery(validateSqlNode, false, true);
+                        SqlToRelConverter.config().withTrimUnusedFields(true));
+        RelRoot relRoot = sqlToRelConverter.convertQuery(validateSqlNode, false, false);
         return relRoot.rel;
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/metadata/TransformTable.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/metadata/TransformTable.java
@@ -23,9 +23,7 @@ import org.apache.flink.cdc.runtime.typeutils.DataTypeConverter;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.impl.AbstractTable;
-import org.apache.calcite.util.Pair;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /** TransformTable to generate the metadata of calcite. */
@@ -46,14 +44,6 @@ public class TransformTable extends AbstractTable {
 
     @Override
     public RelDataType getRowType(RelDataTypeFactory relDataTypeFactory) {
-        List<String> names = new ArrayList<>();
-        List<RelDataType> types = new ArrayList<>();
-        for (Column column : columns) {
-            names.add(column.getName());
-            RelDataType sqlType =
-                    DataTypeConverter.convertCalciteType(relDataTypeFactory, column.getType());
-            types.add(sqlType);
-        }
-        return relDataTypeFactory.createStructType(Pair.zip(names, types));
+        return DataTypeConverter.convertCalciteRelDataType(relDataTypeFactory, columns);
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/typeutils/DataTypeConverter.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/typeutils/DataTypeConverter.java
@@ -27,14 +27,27 @@ import org.apache.flink.cdc.common.data.TimestampData;
 import org.apache.flink.cdc.common.data.binary.BinaryStringData;
 import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.types.ArrayType;
+import org.apache.flink.cdc.common.types.BigIntType;
 import org.apache.flink.cdc.common.types.BinaryType;
+import org.apache.flink.cdc.common.types.BooleanType;
+import org.apache.flink.cdc.common.types.CharType;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.types.DateType;
 import org.apache.flink.cdc.common.types.DecimalType;
+import org.apache.flink.cdc.common.types.DoubleType;
+import org.apache.flink.cdc.common.types.FloatType;
+import org.apache.flink.cdc.common.types.IntType;
+import org.apache.flink.cdc.common.types.LocalZonedTimestampType;
 import org.apache.flink.cdc.common.types.MapType;
 import org.apache.flink.cdc.common.types.RowType;
+import org.apache.flink.cdc.common.types.SmallIntType;
+import org.apache.flink.cdc.common.types.TimeType;
 import org.apache.flink.cdc.common.types.TimestampType;
+import org.apache.flink.cdc.common.types.TinyIntType;
 import org.apache.flink.cdc.common.types.VarBinaryType;
+import org.apache.flink.cdc.common.types.VarCharType;
+import org.apache.flink.cdc.common.types.ZonedTimestampType;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -98,7 +111,7 @@ public class DataTypeConverter {
             case VARBINARY:
                 return byte[].class;
             case DECIMAL:
-                return BigDecimal.class;
+                return DecimalData.class;
             case ROW:
                 return Object.class;
             case ARRAY:
@@ -108,6 +121,172 @@ public class DataTypeConverter {
             default:
                 throw new UnsupportedOperationException("Unsupported type: " + dataType);
         }
+    }
+
+    public static RelDataType convertCalciteRelDataType(
+            RelDataTypeFactory typeFactory, List<Column> columns) {
+        RelDataTypeFactory.Builder fieldInfoBuilder = typeFactory.builder();
+        for (Column column : columns) {
+            switch (column.getType().getTypeRoot()) {
+                case BOOLEAN:
+                    BooleanType booleanType = (BooleanType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.BOOLEAN)
+                            .nullable(booleanType.isNullable());
+                    break;
+                case TINYINT:
+                    TinyIntType tinyIntType = (TinyIntType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.TINYINT)
+                            .nullable(tinyIntType.isNullable());
+                    break;
+                case SMALLINT:
+                    SmallIntType smallIntType = (SmallIntType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.SMALLINT)
+                            .nullable(smallIntType.isNullable());
+                    break;
+                case INTEGER:
+                    IntType intType = (IntType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.INTEGER)
+                            .nullable(intType.isNullable());
+                    break;
+                case BIGINT:
+                    BigIntType bigIntType = (BigIntType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.BIGINT)
+                            .nullable(bigIntType.isNullable());
+                    break;
+                case DATE:
+                    DateType dataType = (DateType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.DATE)
+                            .nullable(dataType.isNullable());
+                    break;
+                case TIME_WITHOUT_TIME_ZONE:
+                    TimeType timeType = (TimeType) column.getType();
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE,
+                                    timeType.getPrecision())
+                            .nullable(timeType.isNullable());
+                    break;
+                case TIMESTAMP_WITHOUT_TIME_ZONE:
+                    TimestampType timestampType = (TimestampType) column.getType();
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    SqlTypeName.TIMESTAMP,
+                                    timestampType.getPrecision())
+                            .nullable(timestampType.isNullable());
+                    break;
+                case TIMESTAMP_WITH_TIME_ZONE:
+                    ZonedTimestampType zonedTimestampType = (ZonedTimestampType) column.getType();
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    SqlTypeName.TIMESTAMP,
+                                    zonedTimestampType.getPrecision())
+                            .nullable(zonedTimestampType.isNullable());
+                    break;
+                case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                    LocalZonedTimestampType localZonedTimestampType =
+                            (LocalZonedTimestampType) column.getType();
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                                    localZonedTimestampType.getPrecision())
+                            .nullable(localZonedTimestampType.isNullable());
+                    break;
+                case FLOAT:
+                    FloatType floatType = (FloatType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.FLOAT)
+                            .nullable(floatType.isNullable());
+                    break;
+                case DOUBLE:
+                    DoubleType doubleType = (DoubleType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.DOUBLE)
+                            .nullable(doubleType.isNullable());
+                    break;
+                case CHAR:
+                    CharType charType = (CharType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.CHAR, charType.getLength())
+                            .nullable(charType.isNullable());
+                    break;
+                case VARCHAR:
+                    VarCharType varCharType = (VarCharType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.VARCHAR, varCharType.getLength())
+                            .nullable(varCharType.isNullable());
+                    break;
+                case BINARY:
+                    BinaryType binaryType = (BinaryType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.BINARY, binaryType.getLength())
+                            .nullable(binaryType.isNullable());
+                    break;
+                case VARBINARY:
+                    VarBinaryType varBinaryType = (VarBinaryType) column.getType();
+                    fieldInfoBuilder
+                            .add(column.getName(), SqlTypeName.VARBINARY, varBinaryType.getLength())
+                            .nullable(varBinaryType.isNullable());
+                    break;
+                case DECIMAL:
+                    DecimalType decimalType = (DecimalType) column.getType();
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    SqlTypeName.DECIMAL,
+                                    decimalType.getPrecision(),
+                                    decimalType.getScale())
+                            .nullable(decimalType.isNullable());
+                    break;
+                case ROW:
+                    List<RelDataType> dataTypes =
+                            ((RowType) column.getType())
+                                    .getFieldTypes().stream()
+                                            .map((type) -> convertCalciteType(typeFactory, type))
+                                            .collect(Collectors.toList());
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    typeFactory.createStructType(
+                                            dataTypes,
+                                            ((RowType) column.getType()).getFieldNames()))
+                            .nullable(true);
+                    break;
+                case ARRAY:
+                    DataType elementType = ((ArrayType) column.getType()).getElementType();
+                    fieldInfoBuilder
+                            .add(
+                                    column.getName(),
+                                    typeFactory.createArrayType(
+                                            convertCalciteType(typeFactory, elementType), -1))
+                            .nullable(true);
+                    break;
+                case MAP:
+                    RelDataType keyType =
+                            convertCalciteType(
+                                    typeFactory, ((MapType) column.getType()).getKeyType());
+                    RelDataType valueType =
+                            convertCalciteType(
+                                    typeFactory, ((MapType) column.getType()).getValueType());
+                    fieldInfoBuilder
+                            .add(column.getName(), typeFactory.createMapType(keyType, valueType))
+                            .nullable(true);
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            "Unsupported type: " + column.getType());
+            }
+        }
+        return fieldInfoBuilder.build();
     }
 
     public static RelDataType convertCalciteType(
@@ -126,25 +305,43 @@ public class DataTypeConverter {
             case DATE:
                 return typeFactory.createSqlType(SqlTypeName.DATE);
             case TIME_WITHOUT_TIME_ZONE:
-                return typeFactory.createSqlType(SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE);
+                TimeType timeType = (TimeType) dataType;
+                return typeFactory.createSqlType(
+                        SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE, timeType.getPrecision());
             case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return typeFactory.createSqlType(SqlTypeName.TIMESTAMP);
+                TimestampType timestampType = (TimestampType) dataType;
+                return typeFactory.createSqlType(
+                        SqlTypeName.TIMESTAMP, timestampType.getPrecision());
+            case TIMESTAMP_WITH_TIME_ZONE:
+                ZonedTimestampType zonedTimestampType = (ZonedTimestampType) dataType;
+                return typeFactory.createSqlType(
+                        SqlTypeName.TIMESTAMP, zonedTimestampType.getPrecision());
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-                return typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+                LocalZonedTimestampType localZonedTimestampType =
+                        (LocalZonedTimestampType) dataType;
+                return typeFactory.createSqlType(
+                        SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        localZonedTimestampType.getPrecision());
             case FLOAT:
                 return typeFactory.createSqlType(SqlTypeName.FLOAT);
             case DOUBLE:
                 return typeFactory.createSqlType(SqlTypeName.DOUBLE);
             case CHAR:
-                return typeFactory.createSqlType(SqlTypeName.CHAR);
+                CharType charType = (CharType) dataType;
+                return typeFactory.createSqlType(SqlTypeName.CHAR, charType.getLength());
             case VARCHAR:
-                return typeFactory.createSqlType(SqlTypeName.VARCHAR);
+                VarCharType varCharType = (VarCharType) dataType;
+                return typeFactory.createSqlType(SqlTypeName.VARCHAR, varCharType.getLength());
             case BINARY:
-                return typeFactory.createSqlType(SqlTypeName.BINARY);
+                BinaryType binaryType = (BinaryType) dataType;
+                return typeFactory.createSqlType(SqlTypeName.BINARY, binaryType.getLength());
             case VARBINARY:
-                return typeFactory.createSqlType(SqlTypeName.VARBINARY);
+                VarBinaryType varBinaryType = (VarBinaryType) dataType;
+                return typeFactory.createSqlType(SqlTypeName.VARBINARY, varBinaryType.getLength());
             case DECIMAL:
-                return typeFactory.createSqlType(SqlTypeName.DECIMAL);
+                DecimalType decimalType = (DecimalType) dataType;
+                return typeFactory.createSqlType(
+                        SqlTypeName.DECIMAL, decimalType.getPrecision(), decimalType.getScale());
             case ROW:
                 List<RelDataType> dataTypes =
                         ((RowType) dataType)
@@ -197,9 +394,9 @@ public class DataTypeConverter {
             case VARCHAR:
                 return DataTypes.STRING();
             case BINARY:
-                return DataTypes.BINARY(BinaryType.MAX_LENGTH);
+                return DataTypes.BINARY(relDataType.getPrecision());
             case VARBINARY:
-                return DataTypes.VARBINARY(VarBinaryType.MAX_LENGTH);
+                return DataTypes.VARBINARY(relDataType.getPrecision());
             case DECIMAL:
                 return DataTypes.DECIMAL(relDataType.getPrecision(), relDataType.getScale());
             case ARRAY:
@@ -298,7 +495,7 @@ public class DataTypeConverter {
             case VARBINARY:
                 return convertToBinary(value);
             case DECIMAL:
-                return convertToDecimalOriginal(value);
+                return convertToDecimal(value);
             case ROW:
                 return value;
             case ARRAY:
@@ -620,6 +817,7 @@ public class DataTypeConverter {
         }
     }
 
+    // convert to DecimalData
     private static Object convertToDecimal(Object obj) {
         if (obj instanceof BigDecimal) {
             BigDecimal bigDecimalValue = (BigDecimal) obj;
@@ -627,18 +825,6 @@ public class DataTypeConverter {
                     bigDecimalValue, bigDecimalValue.precision(), bigDecimalValue.scale());
         } else if (obj instanceof DecimalData) {
             return obj;
-        } else {
-            throw new UnsupportedOperationException(
-                    "Unsupported Decimal value type: " + obj.getClass().getSimpleName());
-        }
-    }
-
-    private static Object convertToDecimalOriginal(Object obj) {
-        if (obj instanceof BigDecimal) {
-            return obj;
-        } else if (obj instanceof DecimalData) {
-            DecimalData decimalData = (DecimalData) obj;
-            return decimalData.toBigDecimal();
         } else {
             throw new UnsupportedOperationException(
                     "Unsupported Decimal value type: " + obj.getClass().getSimpleName());


### PR DESCRIPTION
The precision and scale of Decimal has been lost when use FlinkCDC transform to project express or alias.

The fields of this table are as follows:

| Column Name | Data Type |
| :---- | :----: |
| id | int |
| name | varchar(50) |
| sex | char(1) |
| address | binary(50) |
| phone | varbinary(50) |
| deposit | decimal(10, 2) |
| birthday | timestamp(3) |
| birthday_ltz | timestamp_ltz(3) |
| update_time | time(3) |

The projection rule of this pipeline are as follows:

```
projection: id, UPPER(name) as name2, UPPER(sex) as sex2, COALESCE(address,address) as address2, COALESCE(phone,phone) as phone2, COALESCE(deposit,deposit) as deposit2, COALESCE(birthday,birthday) as birthday2, COALESCE(birthday_ltz,birthday_ltz) as birthday_ltz2, COALESCE(update_time,update_time) as update_time2
```

The parsed data types are as follows:

| Column Name | Data Type |
| :---- | :----: |
| id | int |
| name2 | string |
| sex2 | string |
| address2 | binary(2147483647) |
| phone2 | bytes |
| deposit2 | decimal(19, 0) |
| birthday2 | timestamp(0) |
| birthday_ltz2 | timestamp_ltz(0) |
| update_time2 | time(0) |

The expected data types are as follows:

| Column Name | Data Type |
| :---- | :----: |
| id | int |
| name2 | string |
| sex2 | string |
| address2 | binary(50) |
| phone2 | varbinary(50) |
| deposit2 | decimal(10, 2) |
| birthday2 | timestamp(3) |
| birthday_ltz2 | timestamp_ltz(3) |
| update_time2 | time(3) |

I have fixed it.

This code submission includes the following modifications:

1.Add convertCalciteRelDataType in DataTypeConverter.
2.Add the convert of precision in DataTypeConverter.convertCalciteType.
3.Use DecimalData instead of BigDecimal in YAML task.
4.Optimize the strategy of SqlToRelConverter.
5.Fix the precision and length of data type has been lost in TransformTable.getRowType.
6.Modify testGenerateProjectionColumns in TransformParserTest to verify the repair.
7.Add testComplicatedUdfReturnTypes to verify the repair when using udf.
8.ValuesDataSinkHelper supports get null field.