### PR TITLE
[FLINK-36754][transform] when projection is empty or null, it is treated as an asterisk

### DIFF
--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/TransformDef.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/TransformDef.java
@@ -75,16 +75,16 @@ public class TransformDef {
         return sourceTable;
     }
 
-    public Optional<String> getProjection() {
-        return Optional.ofNullable(projection);
+    public String getProjection() {
+        return projection;
     }
 
     public boolean isValidProjection() {
         return !StringUtils.isNullOrWhitespaceOnly(projection);
     }
 
-    public Optional<String> getFilter() {
-        return Optional.ofNullable(filter);
+    public String getFilter() {
+        return filter;
     }
 
     public boolean isValidFilter() {

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/TransformDef.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/TransformDef.java
@@ -20,7 +20,6 @@ package org.apache.flink.cdc.composer.definition;
 import org.apache.flink.cdc.common.utils.StringUtils;
 
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Definition of a transformation.
@@ -91,8 +90,8 @@ public class TransformDef {
         return !StringUtils.isNullOrWhitespaceOnly(filter);
     }
 
-    public Optional<String> getDescription() {
-        return Optional.ofNullable(description);
+    public String getDescription() {
+        return description;
     }
 
     public String getPrimaryKeys() {

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/TransformTranslator.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/TransformTranslator.java
@@ -59,8 +59,8 @@ public class TransformTranslator {
         for (TransformDef transform : transforms) {
             preTransformFunctionBuilder.addTransform(
                     transform.getSourceTable(),
-                    transform.getProjection().orElse(null),
-                    transform.getFilter().orElse(null),
+                    transform.getProjection(),
+                    transform.getFilter(),
                     transform.getPrimaryKeys(),
                     transform.getPartitionKeys(),
                     transform.getTableOptions(),
@@ -98,8 +98,8 @@ public class TransformTranslator {
             if (transform.isValidProjection() || transform.isValidFilter()) {
                 postTransformFunctionBuilder.addTransform(
                         transform.getSourceTable(),
-                        transform.isValidProjection() ? transform.getProjection().get() : null,
-                        transform.isValidFilter() ? transform.getFilter().get() : null,
+                        transform.getProjection(),
+                        transform.getFilter(),
                         transform.getPrimaryKeys(),
                         transform.getPartitionKeys(),
                         transform.getTableOptions(),

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -382,6 +382,7 @@ class FlinkPipelineTransformITCase {
                         null,
                         null,
                         null,
+                        null,
                         null);
 
         TransformDef emptyProjection =
@@ -392,6 +393,7 @@ class FlinkPipelineTransformITCase {
                         null,
                         null,
                         null,
+                        null,
                         null);
 
         TransformDef asteriskProjection =
@@ -399,6 +401,7 @@ class FlinkPipelineTransformITCase {
                         "default_namespace.default_schema.mytable2",
                         "*",
                         "age < 18",
+                        null,
                         null,
                         null,
                         null,
@@ -422,9 +425,11 @@ class FlinkPipelineTransformITCase {
                                                             null,
                                                             null,
                                                             null,
+                                                            null,
                                                             null)),
                                             Collections.emptyList()))
                     .rootCause()
+                    .isExactlyInstanceOf(IllegalStateException.class)
                     .hasMessage(
                             "Unable to merge schema columns={`id` BIGINT,`name` VARCHAR(255),`age` TINYINT,`description` STRING}, primaryKeys=id, options=() "
                                     + "and columns={`id` BIGINT,`name` STRING}, primaryKeys=id, options=() with different column counts.");
@@ -442,6 +447,7 @@ class FlinkPipelineTransformITCase {
                                                     // reference all column
                                                     "id,UPPER(name) AS name,age,description",
                                                     "age >= 18",
+                                                    null,
                                                     null,
                                                     null,
                                                     null,

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -197,8 +197,8 @@ class FlinkPipelineTransformITCase {
                                 null,
                                 null)),
                 Arrays.asList(
-                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
-                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT,`name` VARCHAR(255),`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT NOT NULL,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT NOT NULL,`name` VARCHAR(255),`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[3, Carol, 15, student], op=INSERT, meta=()}"));
     }
 
@@ -219,9 +219,9 @@ class FlinkPipelineTransformITCase {
                                 null,
                                 null)),
                 Arrays.asList(
-                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT NOT NULL,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[1, Alice, 18], op=INSERT, meta=()}",
-                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT,`name` VARCHAR(255),`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT NOT NULL,`name` VARCHAR(255),`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[3, Carol, 15, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[4, Derrida, 25, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[4, Derrida, 25, student], after=[], op=DELETE, meta=()}"));
@@ -373,6 +373,7 @@ class FlinkPipelineTransformITCase {
 
     @ParameterizedTest
     @EnumSource
+    @Disabled("to be fixed in FLINK-37132")
     void testMultiTransformSchemaColumnsCompatibilityWithNullProjection(
             ValuesDataSink.SinkApi sinkApi) {
         TransformDef nullProjection =
@@ -412,6 +413,7 @@ class FlinkPipelineTransformITCase {
 
     @ParameterizedTest
     @EnumSource
+    @Disabled("to be fixed in FLINK-37132")
     void testMultiTransformSchemaColumnsCompatibilityWithEmptyProjection(
             ValuesDataSink.SinkApi sinkApi) {
         TransformDef emptyProjection =
@@ -508,7 +510,7 @@ class FlinkPipelineTransformITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[1, Alice, 18], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[2, Bob, 20], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[2, Bob, 20], after=[2, Bob, 30], op=UPDATE, meta=()}",
-                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT,`name` STRING,`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT NOT NULL,`name` STRING,`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[3, Carol, 15, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[4, DERRIDA, 25, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[4, DERRIDA, 25, student], after=[], op=DELETE, meta=()}"));
@@ -1591,7 +1593,7 @@ class FlinkPipelineTransformITCase {
         assertThat(outputEvents)
                 .containsExactly(
                         // Initial stage
-                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
+                        "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT NOT NULL,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[2, Barcarolle, 22], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[3, Cecily, 23], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[3, Cecily, 23], after=[3, Colin, 24], op=UPDATE, meta=()}",

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -489,7 +489,7 @@ class FlinkPipelineTransformITCase {
         runGenericTransformTest(
                 sinkApi,
                 Arrays.asList(
-                        // nullProjection、emptyProjection、asteriskProjection has the same meaning
+                        // Setting projection as null, '', or * should be equivalent
                         nullProjection,
                         emptyProjection,
                         asteriskProjection,

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -77,6 +77,7 @@ import java.util.stream.Stream;
 
 import static org.apache.flink.configuration.CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Integration test for {@link FlinkPipelineComposer}. */
 class FlinkPipelineTransformITCase {
@@ -368,6 +369,93 @@ class FlinkPipelineTransformITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[3, Carol, 15, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[4, DERRIDA, 25, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[4, DERRIDA, 25, student], after=[], op=DELETE, meta=()}"));
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void testMultiTransformSchemaColumnsCompatibility(ValuesDataSink.SinkApi sinkApi) {
+        TransformDef nullProjection =
+                new TransformDef(
+                        "default_namespace.default_schema.mytable2",
+                        null,
+                        "age < 18",
+                        null,
+                        null,
+                        null,
+                        null);
+
+        TransformDef emptyProjection =
+                new TransformDef(
+                        "default_namespace.default_schema.mytable2",
+                        "",
+                        "age < 18",
+                        null,
+                        null,
+                        null,
+                        null);
+
+        TransformDef asteriskProjection =
+                new TransformDef(
+                        "default_namespace.default_schema.mytable2",
+                        "*",
+                        "age < 18",
+                        null,
+                        null,
+                        null,
+                        null);
+
+        List<TransformDef> transformDefList =
+                Arrays.asList(nullProjection, emptyProjection, asteriskProjection);
+
+        for (TransformDef transformDef : transformDefList) {
+            assertThatThrownBy(
+                            () ->
+                                    runGenericTransformTest(
+                                            sinkApi,
+                                            Arrays.asList(
+                                                    transformDef,
+                                                    new TransformDef(
+                                                            "default_namespace.default_schema.mytable2",
+                                                            // reference part column
+                                                            "id,UPPER(name) AS name",
+                                                            "age >= 18",
+                                                            null,
+                                                            null,
+                                                            null,
+                                                            null)),
+                                            Collections.emptyList()))
+                    .rootCause()
+                    .hasMessage(
+                            "Unable to merge schema columns={`id` BIGINT,`name` VARCHAR(255),`age` TINYINT,`description` STRING}, primaryKeys=id, options=() "
+                                    + "and columns={`id` BIGINT,`name` STRING}, primaryKeys=id, options=() with different column counts.");
+        }
+
+        for (TransformDef transformDef : transformDefList) {
+            assertThatThrownBy(
+                    () ->
+                            runGenericTransformTest(
+                                    sinkApi,
+                                    Arrays.asList(
+                                            transformDef,
+                                            new TransformDef(
+                                                    "default_namespace.default_schema.mytable2",
+                                                    // reference all column
+                                                    "id,UPPER(name) AS name,age,description",
+                                                    "age >= 18",
+                                                    null,
+                                                    null,
+                                                    null,
+                                                    null)),
+                                    Arrays.asList(
+                                            "CreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT,`name` STRING,`age` INT}, primaryKeys=id, options=()}",
+                                            "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[1, Alice, 18], op=INSERT, meta=()}",
+                                            "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[2, Bob, 20], op=INSERT, meta=()}",
+                                            "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[2, Bob, 20], after=[2, Bob, 30], op=UPDATE, meta=()}",
+                                            "CreateTableEvent{tableId=default_namespace.default_schema.mytable2, schema=columns={`id` BIGINT,`name` STRING,`age` TINYINT,`description` STRING}, primaryKeys=id, options=()}",
+                                            "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[3, Carol, 15, student], op=INSERT, meta=()}",
+                                            "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[], after=[4, DERRIDA, 25, student], op=INSERT, meta=()}",
+                                            "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[4, DERRIDA, 25, student], after=[], op=DELETE, meta=()}")));
+        }
     }
 
     /** This tests if transform generates metadata info correctly. */

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
@@ -389,17 +389,8 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
             if (!transform.getSelectors().isMatch(tableId)) {
                 continue;
             }
-            if (!transform.getProjection().isPresent()) {
-                processProjectionTransform(tableId, tableSchema, referencedColumnsSet, null);
-                hasMatchTransform = true;
-            } else {
-                TransformProjection transformProjection = transform.getProjection().get();
-                if (transformProjection.isValid()) {
-                    processProjectionTransform(
-                            tableId, tableSchema, referencedColumnsSet, transform);
-                    hasMatchTransform = true;
-                }
-            }
+            processProjectionTransform(tableId, tableSchema, referencedColumnsSet, transform);
+            hasMatchTransform = true;
         }
         if (!hasMatchTransform) {
             processProjectionTransform(tableId, tableSchema, referencedColumnsSet, null);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformRule.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformRule.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.runtime.operators.transform;
 
 import org.apache.flink.cdc.common.source.SupportedMetadataColumn;
+import org.apache.flink.cdc.common.utils.StringUtils;
 
 import javax.annotation.Nullable;
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformRule.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformRule.java
@@ -48,7 +48,7 @@ public class TransformRule implements Serializable {
             @Nullable String postTransformConverter,
             SupportedMetadataColumn[] supportedMetadataColumns) {
         this.tableInclusions = tableInclusions;
-        this.projection = projection;
+        this.projection = StringUtils.isNullOrWhitespaceOnly(projection) ? "*" : projection;
         this.filter = normalizeFilter(projection, filter);
         this.primaryKey = primaryKey;
         this.partitionKey = partitionKey;


### PR DESCRIPTION
When projection is empty or NULL, the projection should be treated as an asterisk. The following transform rule should throw an exception [different column counts], but the actual schema columns are id and name, which is not expected.
```
transform:
  - source-table: testdb.test_table1
    filter: age> 8 and age < 18
  - source-table: testdb.test_table1
    projection: id,UPPER(name) AS name
    filter: age >= 18 
```
 
The following transform rule will throw exception [different column counts]
```
transform:
  - source-table: testdb.test_table1
    projection: *
    filter: age> 8 and age < 18
  - source-table: testdb.test_table1
    projection: id,UPPER(name) AS name
    filter: age >= 18 
```
We should treat projection as asterisk when it is empty or NULL, to be consistent