### PR TITLE
[legal] Add third-party OSS NOTICE

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,3 +12,136 @@ ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUT
 DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
 USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------------------------------------------------------
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+Apache Commons
+Copyright 2022 - 2024 The Apache Software Foundation
+
+Apache Doris
+Copyright 2022 - 2024 The Apache Software Foundation
+
+Apache Flink
+Copyright 2014 - 2024 The Apache Software Foundation
+
+Apache Kafka
+Copyright 2011 - 2024 The Apache Software Foundation
+
+Apache Logging Services
+Copyright 2001 - 2024 The Apache Software Foundation
+
+Apache Paimon
+Copyright 2023 - 2024 The Apache Software Foundation
+
+----------------------------------------------------------
+
+Debezium
+
+Copyright 2020 - 2024 Debezium Community. All rights reserved.
+
+Code released under Apache License, v2.0.
+
+----------------------------------------------------------
+
+Elasticsearch
+
+Copyright 2010 - 2024 Elasticsearch B.V. All Rights Reserved.
+
+Source code in this repository is covered by (i) a triple license under the "GNU
+Affero General Public License v3.0 only", "the Server Side Public License, v 1",
+and the "Elastic License 2.0", or (ii) an "Apache License 2.0" compatible
+license or (iii) solely under the "Elastic License 2.0", in each case, as noted
+in the applicable header. The default throughout the repository is a triple
+license under the "GNU Affero General Public License v3.0 only", "the Server
+Side Public License, v 1", and the "Elastic License 2.0", unless the header
+specifies another license. Code that is licensed solely under the "Elastic
+License 2.0" is found only in the x-pack folder.
+
+----------------------------------------------------------
+
+HikariCP
+
+Copyright 2013 - 2024 Brett Wooldridge, et al. All Rights Reserved.
+
+----------------------------------------------------------
+
+Jackson
+
+Copyright 2011 - 2024 FasterXML, LLC. All Rights Reserved.
+
+----------------------------------------------------------
+
+Mongo Java Driver
+
+Copyright 2013 - 2024 MongoDB, Inc. All Rights Reserved.
+
+Licensed under Apache License Version 2.0.
+
+----------------------------------------------------------
+
+mysql-binlog-connector-java
+
+Copyright 2013 - 2024 Stanley Shyiko, et al. All Rights Reserved.
+
+----------------------------------------------------------
+
+PostgreSQL Database Management System
+(formerly known as Postgres, then as Postgres95)
+
+Portions Copyright (c) 1996-2024, PostgreSQL Global Development Group
+
+Portions Copyright (c) 1994, The Regents of the University of California
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose, without fee, and without a written agreement
+is hereby granted, provided that the above copyright notice and this
+paragraph and the following two paragraphs appear in all copies.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+----------------------------------------------------------
+
+SnakeYAML
+
+Copyright 2018 - 2024 Andrey Somov, et al. All Rights Reserved.
+
+Licensed under Apache License Version 2.0.
+
+----------------------------------------------------------
+
+StarRocks
+
+Copyright 2021 - 2024 StarRocks, Inc. All rights reserved.
+
+Licensed under Apache License Version 2.0.
+
+----------------------------------------------------------
+
+TiDB
+
+Copyright 2016 - 2024 PingCAP Inc. All Rights Reserved.
+
+Licensed under Apache License Version 2.0.
+
+----------------------------------------------------------
+
+Vitess
+
+Copyright 1998 - 2024 The Linux Foundation. All Rights Reserved.
+
+Licensed under Apache License Version 2.0.
+
+----------------------------------------------------------

--- a/NOTICE
+++ b/NOTICE
@@ -18,6 +18,9 @@ USE OR PERFORMANCE OF THIS SOFTWARE.
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+Apache Calcite
+Copyright 2014 - 2024 The Apache Software Foundation
+
 Apache Commons
 Copyright 2022 - 2024 The Apache Software Foundation
 
@@ -60,17 +63,71 @@ Side Public License, v 1", and the "Elastic License 2.0", unless the header
 specifies another license. Code that is licensed solely under the "Elastic
 License 2.0" is found only in the x-pack folder.
 
+---------------------------------------------------------
+
+Guava - Google core libraries for Java
+
+Copyright 2009 - 2024 Google LLC. All Rights Reserved.
+
+Licensed under Apache License Version 2.0, January 2004
+
 ----------------------------------------------------------
 
 HikariCP
 
 Copyright 2013 - 2024 Brett Wooldridge, et al. All Rights Reserved.
 
+Licensed under Apache License Version 2.0, January 2004
+
 ----------------------------------------------------------
 
 Jackson
 
 Copyright 2011 - 2024 FasterXML, LLC. All Rights Reserved.
+
+Licensed under Apache License Version 2.0, January 2004
+
+----------------------------------------------------------
+
+Janino - An embedded Java[TM] compiler
+
+Copyright (c) 2001-2016, Arno Unkrig
+Copyright (c) 2015-2016  TIBCO Software Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials
+      provided with the distribution.
+   3. Neither the name of JANINO nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------
+
+Microsoft JDBC Driver for SQL Server
+
+Copyright(c) 2021 - 2024 Microsoft Corporation
+
+The Microsoft JDBC Driver for SQL Server is licensed under the MIT license.
 
 ----------------------------------------------------------
 
@@ -85,6 +142,8 @@ Licensed under Apache License Version 2.0.
 mysql-binlog-connector-java
 
 Copyright 2013 - 2024 Stanley Shyiko, et al. All Rights Reserved.
+
+Licensed under Apache License Version 2.0.
 
 ----------------------------------------------------------
 
@@ -122,7 +181,7 @@ Licensed under Apache License Version 2.0.
 
 ----------------------------------------------------------
 
-StarRocks
+StarRocks, and starrocks-connector-for-apache-flink
 
 Copyright 2021 - 2024 StarRocks, Inc. All rights reserved.
 

--- a/flink-cdc-dist/src/main/assembly/assembly.xml
+++ b/flink-cdc-dist/src/main/assembly/assembly.xml
@@ -39,6 +39,13 @@ limitations under the License.
             <outputDirectory/>
             <fileMode>0644</fileMode>
         </file>
+
+        <!-- copy oss notice -->
+        <file>
+            <source>../NOTICE</source>
+            <outputDirectory/>
+            <fileMode>0644</fileMode>
+        </file>
     </files>
 
     <fileSets>


### PR DESCRIPTION
Now, Flink CDC's NOTICE file contains no third-party software notice, which violates corresponding open-source license that requires explicit mentioning during redistribution.

I added corresponding third-party open-source software licenses by referencing a properly written [NOTICE file example](https://github.com/apache/paimon/blob/master/NOTICE) from Paimon project.