### PR TITLE
[CliFrontend]support overwrite flink config by command line

### DIFF
--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontendOptions.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontendOptions.java
@@ -94,6 +94,15 @@ public class CliFrontendOptions {
                                     + "program that was part of the program when the savepoint was triggered.")
                     .build();
 
+    public static final Option FLINK_CONFIG =
+            Option.builder("fc")
+                    .longOpt("flink-config")
+                    .hasArg()
+                    .desc(
+                            "<property=value>. Allows specifying multiple flink generic configuration options. The available"
+                                    + "options can be found at https://nightlies.apache.org/flink/flink-docs-stable/ops/config.html")
+                    .build();
+
     public static Options initializeOptions() {
         return new Options()
                 .addOption(HELP)
@@ -105,6 +114,7 @@ public class CliFrontendOptions {
                 .addOption(USE_MINI_CLUSTER)
                 .addOption(SAVEPOINT_PATH_OPTION)
                 .addOption(SAVEPOINT_CLAIM_MODE)
-                .addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION);
+                .addOption(SAVEPOINT_ALLOW_NON_RESTORED_OPTION)
+                .addOption(FLINK_CONFIG);
     }
 }

--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/CliFrontendTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/CliFrontendTest.java
@@ -34,6 +34,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -143,6 +144,31 @@ class CliFrontendTest {
         PipelineExecution.ExecutionInfo executionInfo = executor.run();
         assertThat(executionInfo.getId()).isEqualTo("fake-id");
         assertThat(executionInfo.getDescription()).isEqualTo("fake-description");
+    }
+
+    @Test
+    void testPipelineExecutingWithFlinkConfig() throws Exception {
+        CliExecutor executor =
+                createExecutor(
+                        pipelineDef(),
+                        "--flink-home",
+                        flinkHome(),
+                        "--global-config",
+                        globalPipelineConfig(),
+                        "--flink-conf",
+                        "execution.target=yarn-session",
+                        "--flink-conf",
+                        "rest.bind-port=42689",
+                        "-fc",
+                        "yarn.application.id=application_1714009558476_3563",
+                        "-fc",
+                        "rest.bind-address=10.1.140.140");
+        Map<String, String> configMap = executor.getFlinkConfig().toMap();
+        assertThat(configMap.get("execution.target")).isEqualTo("yarn-session");
+        assertThat(configMap.get("rest.bind-port")).isEqualTo("42689");
+        assertThat(configMap.get("yarn.application.id"))
+                .isEqualTo("application_1714009558476_3563");
+        assertThat(configMap.get("rest.bind-address")).isEqualTo("10.1.140.140");
     }
 
     private CliExecutor createExecutor(String... args) throws Exception {


### PR DESCRIPTION
Support overwrite flink config in the command line, for example:

`bin/flink-cdc.sh1732864461789.yaml --flink-conf execution.checkpointing.interval=10min --flink-conf rest.bind-port=42689 --flink-conf yarn.application.id=application_1714009558476_3563 --flink-conf execution.target=yarn-session --flink-conf rest.bind-address=10.5.140.140`

The example provided is used to submit a job to a specified host's YARN session cluster with specific Flink configurations. 