### PR TITLE
[docs] Fix ToC to include H1

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -65,6 +65,8 @@ pygmentsUseClasses = true
 [markup]
 [markup.goldmark.renderer]
   unsafe = true
+[markup.tableOfContents]
+  startLevel = 1
 
 [languages]
 [languages.en]


### PR DESCRIPTION
The existing Table of Contents on the right-hand side of the page does not display H1 elements. 
H1 are used throughout the docs as part of the logical presentation of content.
Therefore it makes sense to include them, as is already done in the main Flink docs.

![CleanShot 2024-12-02 at 15 38 23](https://github.com/user-attachments/assets/ff54e0ea-abd1-4cfa-8f0e-cf3beb5502a7)

