### PR TITLE
[FLINK-36842] FlinkPipelineComposer allows injecting StreamExecutionEnvironment

### DIFF
--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/PipelineExecution.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/PipelineExecution.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.cdc.composer;
 
+import org.apache.flink.core.execution.JobClient;
+
 /** A pipeline execution that can be executed by a computing engine. */
 public interface PipelineExecution {
 
@@ -27,10 +29,18 @@ public interface PipelineExecution {
     class ExecutionInfo {
         private final String id;
         private final String description;
+        private final JobClient jobClient;
 
         public ExecutionInfo(String id, String description) {
             this.id = id;
             this.description = description;
+            this.jobClient = null;
+        }
+
+        public ExecutionInfo(String id, String description, JobClient jobClient) {
+            this.id = id;
+            this.description = description;
+            this.jobClient = jobClient;
         }
 
         public String getId() {
@@ -39,6 +49,10 @@ public interface PipelineExecution {
 
         public String getDescription() {
             return description;
+        }
+
+        public JobClient getJobClient() {
+            return jobClient;
         }
     }
 }

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
@@ -54,6 +54,11 @@ public class FlinkPipelineComposer implements PipelineComposer {
     private final StreamExecutionEnvironment env;
     private final boolean isBlocking;
 
+    public static FlinkPipelineComposer ofStreamExecutionEnvironment(
+            StreamExecutionEnvironment env) {
+        return new FlinkPipelineComposer(env, false);
+    }
+
     public static FlinkPipelineComposer ofRemoteCluster(
             org.apache.flink.configuration.Configuration flinkConfig, List<Path> additionalJars) {
         org.apache.flink.configuration.Configuration effectiveConfiguration =

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineExecution.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineExecution.java
@@ -44,6 +44,6 @@ public class FlinkPipelineExecution implements PipelineExecution {
         if (isBlocking) {
             jobClient.getJobExecutionResult().get();
         }
-        return new ExecutionInfo(jobClient.getJobID().toString(), jobName);
+        return new ExecutionInfo(jobClient.getJobID().toString(), jobName, jobClient);
     }
 }


### PR DESCRIPTION
As a user of the FlinkPipelineComposer API, I would like to run jobs with a pre-configured StreamExecutionEnvironment of my choosing, for commonality with executing non-Flink-CDC jobs. However, the API only allows me to pass a Configuration object, which FlinkPipelineComposer uses to build its own StreamExecutionEnvironment.

In addition, I would like to retrieve a JobClient from submitted jobs, again for commonality with non-Flink-CDC jobs.
