### PR TITLE
[FLINK-36864] Fix unable to use numeric literals that goes beyond Int32 range

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -31,6 +31,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.codehaus.commons.compiler.CompileException;
@@ -138,6 +139,13 @@ public class JaninoCompiler {
         if (sqlLiteral instanceof SqlCharStringLiteral) {
             // Double quotation marks represent strings in Janino.
             value = "\"" + value.substring(1, value.length() - 1) + "\"";
+        } else if (sqlLiteral instanceof SqlNumericLiteral) {
+            if (((SqlNumericLiteral) sqlLiteral).isInteger()) {
+                long longValue = sqlLiteral.longValue(true);
+                if (longValue > Integer.MAX_VALUE || longValue < Integer.MIN_VALUE) {
+                    value += "L";
+                }
+            }
         }
         if (SQL_TYPE_NAME_IGNORE.contains(sqlLiteral.getTypeName())) {
             value = "\"" + value + "\"";


### PR DESCRIPTION
This closes FLINK-36864.

Flink SQL (and its underlying Calcite framework) allows integer literals within `Int64` range (`-9223372036854775808` ~ `9223372036854775807`), which is enough for most cases.

However, CDC YAML parser supports Int32 range (`-2147483648` ~ `2147483647`) only, because Java code only allows `Int32` literals without any suffix. This could be overridden by appending an extra "L" at the end of the literal.