### PR TITLE
[FLINK-36866] Fix unable to narrow casting on numeric values

### DIFF
--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.composer.flink;
 
 import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.data.DecimalData;
 import org.apache.flink.cdc.common.data.binary.BinaryRecordData;
 import org.apache.flink.cdc.common.data.binary.BinaryStringData;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
@@ -62,6 +63,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -70,6 +72,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.configuration.CoreOptions.ALWAYS_PARENT_FIRST_LOADER_PATTERNS_ADDITIONAL;
@@ -1603,6 +1606,170 @@ class FlinkPipelineTransformITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable2, before=[4, Derrida, 25, student, Derrida, 26, extras], after=[], op=DELETE, meta=()}");
     }
 
+    String[] runNumericCastingWith(String expression) throws Exception {
+        try {
+            FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
+
+            // Setup value source
+            Configuration sourceConfig = new Configuration();
+
+            sourceConfig.set(
+                    ValuesDataSourceOptions.EVENT_SET_ID,
+                    ValuesDataSourceHelper.EventSetId.CUSTOM_SOURCE_EVENTS);
+
+            TableId tableId = TableId.tableId("ns", "scm", "tbl");
+            List<Event> events = generateNumericCastingEvents(tableId);
+
+            ValuesDataSourceHelper.setSourceEvents(Collections.singletonList(events));
+
+            SourceDef sourceDef =
+                    new SourceDef(ValuesDataFactory.IDENTIFIER, "Value Source", sourceConfig);
+
+            // Setup value sink
+            Configuration sinkConfig = new Configuration();
+            SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
+
+            // Setup pipeline
+            Configuration pipelineConfig = new Configuration();
+            pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, 1);
+            pipelineConfig.set(
+                    PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR, SchemaChangeBehavior.EVOLVE);
+            PipelineDef pipelineDef =
+                    new PipelineDef(
+                            sourceDef,
+                            sinkDef,
+                            Collections.emptyList(),
+                            Collections.singletonList(
+                                    new TransformDef(
+                                            "ns.scm.tbl",
+                                            expression,
+                                            null,
+                                            null,
+                                            null,
+                                            null,
+                                            null)),
+                            Collections.emptyList(),
+                            pipelineConfig);
+
+            // Execute the pipeline
+            PipelineExecution execution = composer.compose(pipelineDef);
+            execution.execute();
+
+            // Check the order and content of all received events
+            String[] outputEvents = outCaptor.toString().trim().split("\n");
+            return outputEvents;
+        } finally {
+            outCaptor.reset();
+        }
+    }
+
+    // Generate a projection expression like CAST(tiny AS <T>) AS tiny, ...
+    private static String generateCastTo(String type) {
+        return "id, "
+                + Stream.of("tiny", "small", "int", "bigint", "float", "double", "decimal")
+                        .map(col -> String.format("CAST(%s_c AS %s) AS %s_c", col, type, col))
+                        .collect(Collectors.joining(", "));
+    }
+
+    @Test
+    void testNumericCastingsWithTruncation() throws Exception {
+        assertThat(runNumericCastingWith("*"))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` TINYINT,`small_c` SMALLINT,`int_c` INT,`bigint_c` BIGINT,`float_c` FLOAT,`double_c` DOUBLE,`decimal_c` DECIMAL(10, 2)}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -6.7, -8.9, -10.11], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0.0, 0.0, 0.00], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 6.7, 8.9, 10.11], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("BOOLEAN")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` BOOLEAN,`small_c` BOOLEAN,`int_c` BOOLEAN,`bigint_c` BOOLEAN,`float_c` BOOLEAN,`double_c` BOOLEAN,`decimal_c` BOOLEAN}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, true, true, true, true, true, true, true], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, false, false, false, false, false, false, false], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, true, true, true, true, true, true, true], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("TINYINT")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` TINYINT,`small_c` TINYINT,`int_c` TINYINT,`bigint_c` TINYINT,`float_c` TINYINT,`double_c` TINYINT,`decimal_c` TINYINT}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -6, -8, -10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0, 0, 0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 6, 8, 10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("SMALLINT")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` SMALLINT,`small_c` SMALLINT,`int_c` SMALLINT,`bigint_c` SMALLINT,`float_c` SMALLINT,`double_c` SMALLINT,`decimal_c` SMALLINT}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -6, -8, -10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0, 0, 0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 6, 8, 10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("INT")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` INT,`small_c` INT,`int_c` INT,`bigint_c` INT,`float_c` INT,`double_c` INT,`decimal_c` INT}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -6, -8, -10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0, 0, 0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 6, 8, 10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("BIGINT")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` BIGINT,`small_c` BIGINT,`int_c` BIGINT,`bigint_c` BIGINT,`float_c` BIGINT,`double_c` BIGINT,`decimal_c` BIGINT}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -6, -8, -10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0, 0, 0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 6, 8, 10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("FLOAT")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` FLOAT,`small_c` FLOAT,`int_c` FLOAT,`bigint_c` FLOAT,`float_c` FLOAT,`double_c` FLOAT,`decimal_c` FLOAT}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2.0, -3.0, -4.0, -5.0, -6.7, -8.9, -10.11], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2.0, 3.0, 4.0, 5.0, 6.7, 8.9, 10.11], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("DOUBLE")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` DOUBLE,`small_c` DOUBLE,`int_c` DOUBLE,`bigint_c` DOUBLE,`float_c` DOUBLE,`double_c` DOUBLE,`decimal_c` DOUBLE}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2.0, -3.0, -4.0, -5.0, -6.699999809265137, -8.9, -10.11], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2.0, 3.0, 4.0, 5.0, 6.699999809265137, 8.9, 10.11], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("DECIMAL(1, 0)")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` DECIMAL(1, 0),`small_c` DECIMAL(1, 0),`int_c` DECIMAL(1, 0),`bigint_c` DECIMAL(1, 0),`float_c` DECIMAL(1, 0),`double_c` DECIMAL(1, 0),`decimal_c` DECIMAL(1, 0)}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -7, -9, null], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0, 0, 0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 7, 9, null], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("DECIMAL(2, 0)")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` DECIMAL(2, 0),`small_c` DECIMAL(2, 0),`int_c` DECIMAL(2, 0),`bigint_c` DECIMAL(2, 0),`float_c` DECIMAL(2, 0),`double_c` DECIMAL(2, 0),`decimal_c` DECIMAL(2, 0)}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2, -3, -4, -5, -7, -9, -10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0, 0, 0, 0, 0, 0, 0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2, 3, 4, 5, 7, 9, 10], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("DECIMAL(3, 1)")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` DECIMAL(3, 1),`small_c` DECIMAL(3, 1),`int_c` DECIMAL(3, 1),`bigint_c` DECIMAL(3, 1),`float_c` DECIMAL(3, 1),`double_c` DECIMAL(3, 1),`decimal_c` DECIMAL(3, 1)}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2.0, -3.0, -4.0, -5.0, -6.7, -8.9, -10.1], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2.0, 3.0, 4.0, 5.0, 6.7, 8.9, 10.1], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+
+        assertThat(runNumericCastingWith(generateCastTo("DECIMAL(19, 10)")))
+                .containsExactly(
+                        "CreateTableEvent{tableId=ns.scm.tbl, schema=columns={`id` BIGINT,`tiny_c` DECIMAL(19, 10),`small_c` DECIMAL(19, 10),`int_c` DECIMAL(19, 10),`bigint_c` DECIMAL(19, 10),`float_c` DECIMAL(19, 10),`double_c` DECIMAL(19, 10),`decimal_c` DECIMAL(19, 10)}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[-1, -2.0000000000, -3.0000000000, -4.0000000000, -5.0000000000, -6.7000000000, -8.9000000000, -10.1100000000], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[0, 0.0000000000, 0.0000000000, 0.0000000000, 0.0000000000, 0.0000000000, 0.0000000000, 0.0000000000], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[1, 2.0000000000, 3.0000000000, 4.0000000000, 5.0000000000, 6.7000000000, 8.9000000000, 10.1100000000], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=ns.scm.tbl, before=[], after=[2, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+    }
+
     private List<Event> generateSchemaEvolutionEvents(TableId tableId) {
         List<Event> events = new ArrayList<>();
 
@@ -1768,6 +1935,73 @@ class FlinkPipelineTransformITCase {
             events.add(
                     DataChangeEvent.deleteEvent(tableId, generate(schemaV5, "12th", 15, "Oops")));
         }
+        return events;
+    }
+
+    private List<Event> generateNumericCastingEvents(TableId tableId) {
+        List<Event> events = new ArrayList<>();
+
+        // Initial schema
+        {
+            Schema schema =
+                    Schema.newBuilder()
+                            .physicalColumn("id", DataTypes.BIGINT())
+                            .physicalColumn("tiny_c", DataTypes.TINYINT())
+                            .physicalColumn("small_c", DataTypes.SMALLINT())
+                            .physicalColumn("int_c", DataTypes.INT())
+                            .physicalColumn("bigint_c", DataTypes.BIGINT())
+                            .physicalColumn("float_c", DataTypes.FLOAT())
+                            .physicalColumn("double_c", DataTypes.DOUBLE())
+                            .physicalColumn("decimal_c", DataTypes.DECIMAL(10, 2))
+                            .primaryKey("id")
+                            .build();
+
+            events.add(new CreateTableEvent(tableId, schema));
+            events.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generate(
+                                    schema,
+                                    -1L,
+                                    (byte) -2,
+                                    (short) -3,
+                                    -4,
+                                    (long) -5,
+                                    -6.7f,
+                                    -8.9d,
+                                    DecimalData.fromBigDecimal(new BigDecimal("-10.11"), 10, 2))));
+            events.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generate(
+                                    schema,
+                                    0L,
+                                    (byte) 0,
+                                    (short) 0,
+                                    0,
+                                    (long) 0,
+                                    0f,
+                                    0d,
+                                    DecimalData.fromBigDecimal(BigDecimal.ZERO, 10, 2))));
+            events.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generate(
+                                    schema,
+                                    1L,
+                                    (byte) 2,
+                                    (short) 3,
+                                    4,
+                                    (long) 5,
+                                    6.7f,
+                                    8.9d,
+                                    DecimalData.fromBigDecimal(new BigDecimal("10.11"), 10, 2))));
+            events.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generate(schema, 2L, null, null, null, null, null, null, null)));
+        }
+
         return events;
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
@@ -606,53 +606,140 @@ public class SystemFunctionUtils {
         return object.toString();
     }
 
+    public static Boolean castToBoolean(Object object) {
+        if (object == null) {
+            return null;
+        } else if (object instanceof Boolean) {
+            return (Boolean) object;
+        } else if (object instanceof Byte) {
+            return !object.equals((byte) 0);
+        } else if (object instanceof Short) {
+            return !object.equals((short) 0);
+        } else if (object instanceof Integer) {
+            return !object.equals(0);
+        } else if (object instanceof Long) {
+            return !object.equals(0L);
+        } else if (object instanceof Float) {
+            return !object.equals(0f);
+        } else if (object instanceof Double) {
+            return !object.equals(0d);
+        } else if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).compareTo(BigDecimal.ZERO) != 0;
+        }
+        return Boolean.valueOf(castToString(object));
+    }
+
     public static Byte castToByte(Object object) {
         if (object == null) {
             return null;
         }
-        return Byte.valueOf(castObjectIntoString(object));
-    }
-
-    public static Boolean castToBoolean(Object object) {
-        if (object == null) {
-            return null;
+        if (object instanceof Boolean) {
+            return (byte) ((Boolean) object ? 1 : 0);
         }
-        if (object instanceof Byte
-                || object instanceof Short
-                || object instanceof Integer
-                || object instanceof Long
-                || object instanceof Float
-                || object instanceof Double
-                || object instanceof BigDecimal) {
-            return !object.equals(0);
+        if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).byteValue();
         }
-        return Boolean.valueOf(castToString(object));
+        if (object instanceof Double) {
+            return ((Double) object).byteValue();
+        }
+        if (object instanceof Float) {
+            return ((Float) object).byteValue();
+        }
+        String stringRep = castToString(object);
+        try {
+            return Byte.valueOf(stringRep);
+        } catch (NumberFormatException e) {
+            return Double.valueOf(stringRep).byteValue();
+        }
     }
 
     public static Short castToShort(Object object) {
         if (object == null) {
             return null;
         }
-        return Short.valueOf(castObjectIntoString(object));
+        if (object instanceof Boolean) {
+            return (short) ((Boolean) object ? 1 : 0);
+        }
+        if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).shortValue();
+        }
+        if (object instanceof Double) {
+            return ((Double) object).shortValue();
+        }
+        if (object instanceof Float) {
+            return ((Float) object).shortValue();
+        }
+        String stringRep = castToString(object);
+        try {
+            return Short.valueOf(stringRep);
+        } catch (NumberFormatException e) {
+            return Double.valueOf(stringRep).shortValue();
+        }
     }
 
     public static Integer castToInteger(Object object) {
         if (object == null) {
             return null;
         }
-        return Integer.valueOf(castObjectIntoString(object));
+        if (object instanceof Boolean) {
+            return (Boolean) object ? 1 : 0;
+        }
+        if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).intValue();
+        }
+        if (object instanceof Double) {
+            return ((Double) object).intValue();
+        }
+        if (object instanceof Float) {
+            return ((Float) object).intValue();
+        }
+        String stringRep = castToString(object);
+        try {
+            return Integer.valueOf(stringRep);
+        } catch (NumberFormatException e) {
+            return Double.valueOf(stringRep).intValue();
+        }
     }
 
     public static Long castToLong(Object object) {
         if (object == null) {
             return null;
         }
-        return Long.valueOf(castObjectIntoString(object));
+        if (object instanceof Boolean) {
+            return (Boolean) object ? 1L : 0L;
+        }
+        if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).longValue();
+        }
+        if (object instanceof Double) {
+            return ((Double) object).longValue();
+        }
+        if (object instanceof Float) {
+            return ((Float) object).longValue();
+        }
+        String stringRep = castToString(object);
+        try {
+            return Long.valueOf(stringRep);
+        } catch (NumberFormatException e) {
+            return Double.valueOf(stringRep).longValue();
+        }
     }
 
     public static Float castToFloat(Object object) {
         if (object == null) {
             return null;
+        }
+        if (object instanceof Boolean) {
+            return (Boolean) object ? 1f : 0f;
+        }
+        if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).floatValue();
+        }
+        if (object instanceof Double) {
+            return ((Double) object).floatValue();
+        }
+        if (object instanceof Float) {
+            return (Float) object;
         }
         return Float.valueOf(castObjectIntoString(object));
     }
@@ -661,6 +748,18 @@ public class SystemFunctionUtils {
         if (object == null) {
             return null;
         }
+        if (object instanceof Boolean) {
+            return (Boolean) object ? 1d : 0d;
+        }
+        if (object instanceof BigDecimal) {
+            return ((BigDecimal) object).doubleValue();
+        }
+        if (object instanceof Double) {
+            return (Double) object;
+        }
+        if (object instanceof Float) {
+            return ((Float) object).doubleValue();
+        }
         return Double.valueOf(castObjectIntoString(object));
     }
 
@@ -668,9 +767,15 @@ public class SystemFunctionUtils {
         if (object == null) {
             return null;
         }
+        if (object instanceof Boolean) {
+            object = (Boolean) object ? 1 : 0;
+        }
         BigDecimal bigDecimal =
                 new BigDecimal(castObjectIntoString(object), new MathContext(precision));
-        bigDecimal = bigDecimal.setScale(scale, BigDecimal.ROUND_HALF_UP);
+        bigDecimal = bigDecimal.setScale(scale, RoundingMode.HALF_UP);
+        if (bigDecimal.precision() > precision) {
+            return null;
+        }
         return bigDecimal;
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/SystemFunctionUtils.java
@@ -774,6 +774,8 @@ public class SystemFunctionUtils {
                 new BigDecimal(castObjectIntoString(object), new MathContext(precision));
         bigDecimal = bigDecimal.setScale(scale, RoundingMode.HALF_UP);
         if (bigDecimal.precision() > precision) {
+            // TODO: Handle malformed data properly after dirty data handling is implemented in
+            // Pipeline Framework.
             return null;
         }
         return bigDecimal;

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.math.BigDecimal;
+import java.time.format.DateTimeParseException;
 
 /** Unit tests for the {@link PostTransformOperator}. */
 public class PostTransformOperatorTest {
@@ -1479,8 +1480,8 @@ public class PostTransformOperatorTest {
                             transform.processElement(new StreamRecord<>(insertEvent1));
                         })
                 .isExactlyInstanceOf(RuntimeException.class)
-                .hasRootCauseInstanceOf(NumberFormatException.class)
-                .hasRootCauseMessage("For input string: \"1.0\"");
+                .hasRootCauseInstanceOf(DateTimeParseException.class)
+                .hasRootCauseMessage("Text '1.0' could not be parsed at index 0");
     }
 
     @Test


### PR DESCRIPTION
A follow up of #3357. It would be surprising if narrowing expressions like `CAST(3.14 AS INT)` are forbidden.