### PR TITLE
[FLINK-36878][pipeline-connector][kafka] Shade org.apache.kafka with …

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/pom.xml
@@ -100,7 +100,7 @@ limitations under the License.
                             <relocations>
                                 <relocation>
                                     <pattern>org.apache.kafka</pattern>
-                                    <shadedPattern>org.apache.flink.cdc.connectors.kafka.shaded.org.apache.kafka</shadedPattern>
+                                    <shadedPattern>org.apache.flink.kafka.shaded.org.apache.kafka</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>org.apache.flink.connector.kafka</pattern>


### PR DESCRIPTION
…org.apache.flink.kafka.shaded.org.apache.kafka instead of cdc path