### PR TITLE
[FLINK-35257][cdc-runtime]when schema.change.behavior is `exception`,…

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/SchemaOperator.java
@@ -31,7 +31,6 @@ import org.apache.flink.cdc.common.event.DropTableEvent;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.FlushEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
-import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
 import org.apache.flink.cdc.common.route.RouteRule;
@@ -432,15 +431,6 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
 
     private void handleSchemaChangeEvent(TableId tableId, SchemaChangeEvent schemaChangeEvent)
             throws InterruptedException, TimeoutException {
-
-        if (schemaChangeBehavior == SchemaChangeBehavior.EXCEPTION
-                && schemaChangeEvent.getType() != SchemaChangeEventType.CREATE_TABLE) {
-            // CreateTableEvent should be applied even in EXCEPTION mode
-            throw new RuntimeException(
-                    String.format(
-                            "Refused to apply schema change event %s in EXCEPTION mode.",
-                            schemaChangeEvent));
-        }
 
         // The request will block if another schema change event is being handled
         SchemaChangeResponse response = requestSchemaChange(tableId, schemaChangeEvent);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/coordinator/SchemaRegistryRequestHandler.java
@@ -240,6 +240,13 @@ public class SchemaRegistryRequestHandler implements Closeable {
             TableId tableId, List<SchemaChangeEvent> derivedSchemaChangeEvents) {
         for (SchemaChangeEvent changeEvent : derivedSchemaChangeEvents) {
             if (changeEvent.getType() != SchemaChangeEventType.CREATE_TABLE) {
+                if (schemaChangeBehavior == SchemaChangeBehavior.EXCEPTION) {
+                    // throw exception after all sink flush success
+                    throw new RuntimeException(
+                            String.format(
+                                    "Refused to apply schema change event %s in EXCEPTION mode.",
+                                    changeEvent));
+                }
                 if (schemaChangeBehavior == SchemaChangeBehavior.IGNORE) {
                     currentIgnoredSchemaChanges.add(changeEvent);
                     continue;


### PR DESCRIPTION
When schema.change.behavior is exception, the task should throw an exception failure after all downstream data is flushed.

After ddl data is received, the task fails quickly. The data between checkPoint and ddl is lost