### PR TITLE
[FLINK-36895]The JdbcSourceChunkSplitter#queryMin method passed a parameter with tableName/coiumnName reversed.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/splitter/JdbcSourceChunkSplitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/splitter/JdbcSourceChunkSplitter.java
@@ -256,8 +256,8 @@ public abstract class JdbcSourceChunkSplitter implements ChunkSplitter {
             throws SQLException {
         return JdbcChunkUtils.queryMin(
                 jdbc,
-                jdbc.quotedColumnIdString(splitColumn.name()),
                 jdbc.quotedTableIdString(tableId),
+                jdbc.quotedColumnIdString(splitColumn.name()),
                 excludedLowerBound);
     }
 


### PR DESCRIPTION
JdbcChunkUtils#queryMin()
final String minQuery =
String.format(
"SELECT MIN(%s) FROM %s WHERE %s > ?",
quotedColumnName, quotedTableName, quotedColumnName);
 
but JdbcSourceChunkSplitter #queryMin
 
protected Object queryMin(
JdbcConnection jdbc, TableId tableId, Column splitColumn, Object excludedLowerBound)
throws SQLException

{ return JdbcChunkUtils.queryMin( jdbc, jdbc.quotedColumnIdString(splitColumn.name()), jdbc.quotedTableIdString(tableId), excludedLowerBound); }
 
Error passing column/tableId parameter. Resulting in the generated sql "select tableId from columnID".