### PR TITLE
[hotfix] Fix building status badge in README as workflow files have been refactored

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@
 <a href="https://github.com/apache/flink-cdc/releases" target="_blank">
     <img src="https://img.shields.io/github/v/release/apache/flink-cdc?color=yellow" alt="Release">
 </a>
-<a href="https://github.com/apache/flink-cdc/actions/workflows/flink_cdc.yml" target="_blank">
-    <img src="https://img.shields.io/github/actions/workflow/status/apache/flink-cdc/flink_cdc.yml?branch=master" alt="Build">
+<a href="https://github.com/apache/flink-cdc/actions/workflows/flink_cdc_java_8.yml" target="_blank">
+    <img src="https://img.shields.io/github/actions/workflow/status/apache/flink-cdc/flink_cdc_java_8.yml?branch=master" alt="Build">
+</a>
+<a href="https://github.com/apache/flink-cdc/actions/workflows/flink_cdc_java_11.yml" target="_blank">
+    <img src="https://img.shields.io/github/actions/workflow/status/apache/flink-cdc/flink_cdc_java_11.yml?branch=master&label=nightly" alt="Build">
 </a>
 <a href="https://github.com/apache/flink-cdc/tree/master/LICENSE" target="_blank">
     <img src="https://img.shields.io/static/v1?label=license&message=Apache License 2.0&color=white" alt="License">


### PR DESCRIPTION
Since #3633 has changed GitHub workflow file names, the building status badge in README has been broken:

<img width="208" alt="Badge broken screenshot" src="https://github.com/user-attachments/assets/cd490739-859d-42a4-a983-2754727c10c4" />

Updating workflow name could resolve this.