### PR TITLE
[hotfix] Allow pinning issues & PRs that never decay

### DIFF
--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -54,3 +54,6 @@ jobs:
           # and will result in Stale label missing.
           remove-pr-stale-when-updated: false
           remove-issue-stale-when-updated: false
+          # Allow pinning issues and PRs that is not meant to be closed automatically
+          exempt-issue-labels: "pinned"
+          exempt-pr-labels: "pinned"


### PR DESCRIPTION
Some issues and PRs are not meant to be closed automatically, like roadmap / umbrella tickets. By specifying an exempt label, repo members could override stale checking by appending a **"pinned"** label.