### PR TITLE
[FLINK-36970][runtime] Merge result of data type BIGINT and DOUBLE should be DOUBLE instead of STRING

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
@@ -810,7 +810,9 @@ public class SchemaMergingUtils {
         mergingTree.put(DoubleType.class, ImmutableList.of(doubleType, stringType));
         mergingTree.put(FloatType.class, ImmutableList.of(floatType, doubleType, stringType));
         mergingTree.put(DecimalType.class, ImmutableList.of(stringType));
-        mergingTree.put(BigIntType.class, ImmutableList.of(bigIntType, decimalType, stringType));
+        mergingTree.put(
+                BigIntType.class,
+                ImmutableList.of(bigIntType, decimalType, doubleType, stringType));
         mergingTree.put(
                 IntType.class,
                 ImmutableList.of(intType, bigIntType, decimalType, doubleType, stringType));

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
@@ -994,7 +994,7 @@ class SchemaMergingUtilsTest {
                 BIGINT,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, BIGINT, BIGINT, BIGINT, BIGINT,
-                        DECIMAL, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
+                        DECIMAL, DOUBLE, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING));
 
         assertTypeMergingVector(
@@ -1007,14 +1007,14 @@ class SchemaMergingUtilsTest {
         assertTypeMergingVector(
                 FLOAT,
                 Arrays.asList(
-                        STRING, STRING, STRING, STRING, STRING, FLOAT, FLOAT, DOUBLE, STRING,
+                        STRING, STRING, STRING, STRING, STRING, FLOAT, FLOAT, DOUBLE, DOUBLE,
                         STRING, FLOAT, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING));
 
         assertTypeMergingVector(
                 DOUBLE,
                 Arrays.asList(
-                        STRING, STRING, STRING, STRING, STRING, DOUBLE, DOUBLE, DOUBLE, STRING,
+                        STRING, STRING, STRING, STRING, STRING, DOUBLE, DOUBLE, DOUBLE, DOUBLE,
                         STRING, DOUBLE, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING));
 

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
@@ -975,7 +975,7 @@ class SchemaMergingUtilsTest {
                         DECIMAL, FLOAT, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING));
 
-        // 16-bit TINYINT could fit into FLOAT (24 sig bits) or DOUBLE (53 sig bits)
+        // 16-bit SMALLINT could fit into FLOAT (24 sig bits) or DOUBLE (53 sig bits)
         assertTypeMergingVector(
                 SMALLINT,
                 Arrays.asList(
@@ -983,7 +983,7 @@ class SchemaMergingUtilsTest {
                         DECIMAL, FLOAT, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING));
 
-        // 32-bit TINYINT could fit into DOUBLE (53 sig bits)
+        // 32-bit INT could fit into DOUBLE (53 sig bits)
         assertTypeMergingVector(
                 INT,
                 Arrays.asList(


### PR DESCRIPTION
In SchemaMergingUtils#getLeastCommonType, the merge result of BIGINT and DOUBLE is STRING now.

However, considering JSON format, JSON numbers can be integers or floating point, which can be inferred as BIGINT and  DOUBLE respectively. In this case, a JSON number field will be inferred as STRING, which is confusing.

The updated data type merge tree is:

```mermaid
graph TD;
    BOOLEAN --> STRING;
    
    CHAR --> STRING;
    VARCHAR --> STRING;
    BINARY --> STRING;
    VARBINARY --> STRING;

    TINYINT --> FLOAT;
    SMALLINT --> FLOAT;
    FLOAT --> DOUBLE;
    INT --> DOUBLE;
    
    TINYINT --> SMALLINT --> INT --> BIGINT --> DOUBLE --> STRING;
    BIGINT --> DECIMAL;
    DECIMAL --> STRING;

    TIMESTAMP --> TIMESTAMP_LTZ --> TIMESTAMP_TZ --> STRING;

    TIME --> STRING;

    ROW -->  STRING;
    ARRAY --> STRING;
    MAP --> STRING;
```