### PR TITLE
[FLINK-36978]Fix the bug where the command-line option `from-savepoint` is invalid in K8s deployment mode.

### DIFF
--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliExecutor.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliExecutor.java
@@ -74,10 +74,10 @@ public class CliExecutor {
             ComposeDeploymentFactory composeDeploymentFactory = new ComposeDeploymentFactory();
             PipelineDeploymentExecutor composeExecutor =
                     composeDeploymentFactory.getFlinkComposeExecutor(commandLine);
-            return composeExecutor.deploy(
-                    commandLine,
-                    org.apache.flink.configuration.Configuration.fromMap(flinkConfig.toMap()),
-                    additionalJars);
+            org.apache.flink.configuration.Configuration configuration =
+                    org.apache.flink.configuration.Configuration.fromMap(flinkConfig.toMap());
+            SavepointRestoreSettings.toConfiguration(savepointSettings, configuration);
+            return composeExecutor.deploy(commandLine, configuration, additionalJars);
         } else {
             // Run CDC Job And Parse pipeline definition file
             PipelineDefinitionParser pipelineDefinitionParser = new YamlPipelineDefinitionParser();


### PR DESCRIPTION
Fix the bug where the command-line option `from-savepoint` is invalid in K8s deployment mode.