### PR TITLE
[FLINK-36981][cdc] Fix the bug of transform merging with route in YAML task

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperator.java
@@ -81,7 +81,7 @@ public class PostTransformOperator extends AbstractStreamOperator<Event>
     private List<UserDefinedFunctionDescriptor> udfDescriptors;
     private transient Map<String, Object> udfFunctionInstances;
 
-    private transient Map<Tuple2<TableId, TransformProjection>, TransformProjectionProcessor>
+    private transient Map<Tuple2<TableId, String>, TransformProjectionProcessor>
             transformProjectionProcessorMap;
     private transient Map<Tuple2<TableId, TransformFilter>, TransformFilterProcessor>
             transformFilterProcessorMap;
@@ -355,12 +355,14 @@ public class PostTransformOperator extends AbstractStreamOperator<Event>
         for (PostTransformer transform : transforms) {
             Selectors selectors = transform.getSelectors();
             if (selectors.isMatch(tableId) && transform.getProjection().isPresent()) {
-                TransformProjection transformProjection = transform.getProjection().get();
+                TransformProjection transformProjection =
+                        TransformProjection.of(transform.getProjection().get().getProjection())
+                                .get();
                 if (transformProjection.isValid()) {
                     if (!transformProjectionProcessorMap.containsKey(
-                            Tuple2.of(tableId, transformProjection))) {
+                            Tuple2.of(tableId, transformProjection.getProjection()))) {
                         transformProjectionProcessorMap.put(
-                                Tuple2.of(tableId, transformProjection),
+                                Tuple2.of(tableId, transformProjection.getProjection()),
                                 TransformProjectionProcessor.of(
                                         transformProjection,
                                         timezone,
@@ -370,7 +372,7 @@ public class PostTransformOperator extends AbstractStreamOperator<Event>
                     }
                     TransformProjectionProcessor postTransformProcessor =
                             transformProjectionProcessorMap.get(
-                                    Tuple2.of(tableId, transformProjection));
+                                    Tuple2.of(tableId, transformProjection.getProjection()));
                     // update the columns of projection and add the column of projection into Schema
                     newSchemas.add(
                             postTransformProcessor.processSchemaChangeEvent(
@@ -434,12 +436,9 @@ public class PostTransformOperator extends AbstractStreamOperator<Event>
                         && transformProjectionOptional.get().isValid()) {
                     TransformProjection transformProjection = transformProjectionOptional.get();
                     if (!transformProjectionProcessorMap.containsKey(
-                                    Tuple2.of(tableId, transformProjection))
-                            || !transformProjectionProcessorMap
-                                    .get(Tuple2.of(tableId, transformProjection))
-                                    .hasTableInfo()) {
+                            Tuple2.of(tableId, transformProjection.getProjection()))) {
                         transformProjectionProcessorMap.put(
-                                Tuple2.of(tableId, transformProjection),
+                                Tuple2.of(tableId, transformProjection.getProjection()),
                                 TransformProjectionProcessor.of(
                                         tableInfo,
                                         transformProjection,
@@ -447,10 +446,26 @@ public class PostTransformOperator extends AbstractStreamOperator<Event>
                                         udfDescriptors,
                                         getUdfFunctionInstances(),
                                         transform.getSupportedMetadataColumns()));
+                    } else if (!transformProjectionProcessorMap
+                            .get(Tuple2.of(tableId, transformProjection.getProjection()))
+                            .hasTableInfo()) {
+                        TransformProjectionProcessor transformProjectionProcessorWithoutTableInfo =
+                                transformProjectionProcessorMap.get(
+                                        Tuple2.of(tableId, transformProjection.getProjection()));
+                        transformProjectionProcessorMap.put(
+                                Tuple2.of(tableId, transformProjection.getProjection()),
+                                TransformProjectionProcessor.of(
+                                        tableInfo,
+                                        transformProjectionProcessorWithoutTableInfo
+                                                .getTransformProjection(),
+                                        timezone,
+                                        udfDescriptors,
+                                        getUdfFunctionInstances(),
+                                        transform.getSupportedMetadataColumns()));
                     }
                     TransformProjectionProcessor postTransformProcessor =
                             transformProjectionProcessorMap.get(
-                                    Tuple2.of(tableId, transformProjection));
+                                    Tuple2.of(tableId, transformProjection.getProjection()));
                     dataChangeEventOptional =
                             processProjection(
                                     postTransformProcessor,

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformProjection.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformProjection.java
@@ -17,14 +17,12 @@
 
 package org.apache.flink.cdc.runtime.operators.transform;
 
-import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.utils.StringUtils;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * The projection of transform applies to describe a projection of filtering tables. Projection
@@ -41,6 +39,11 @@ public class TransformProjection implements Serializable {
     private static final long serialVersionUID = 1L;
     private String projection;
     private List<ProjectionColumn> projectionColumns;
+
+    public TransformProjection(String projection) {
+        this.projection = projection;
+        this.projectionColumns = new ArrayList<>();
+    }
 
     public TransformProjection(String projection, List<ProjectionColumn> projectionColumns) {
         this.projection = projection;
@@ -68,11 +71,5 @@ public class TransformProjection implements Serializable {
             return Optional.empty();
         }
         return Optional.of(new TransformProjection(projection, new ArrayList<>()));
-    }
-
-    public List<Column> getAllColumnList() {
-        return projectionColumns.stream()
-                .map(ProjectionColumn::getColumn)
-                .collect(Collectors.toList());
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformProjectionProcessor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformProjectionProcessor.java
@@ -79,6 +79,10 @@ public class TransformProjectionProcessor {
         return this.postTransformChangeInfo != null;
     }
 
+    public TransformProjection getTransformProjection() {
+        return transformProjection;
+    }
+
     public static TransformProjectionProcessor of(
             PostTransformChangeInfo tableInfo,
             TransformProjection transformProjection,


### PR DESCRIPTION
# Situation
In FlinkPipelineComposerITCase.testTransformMergingWithRoute:
```
// Create test dataset:
// Create table 1 [id, name, age]
// Table 1: +I[1, Alice, 18]
// Table 1: +I[2, Bob, 20]
// Table 1: -U[2, Bob, 20] +U[2, Bob, 30]
// Create table 2 [id, name, age, description]
// Table 2: +I[3, Charlie, 15, student]
// Table 2: +I[4, Donald, 25, student]
// Table 2: -D[4, Donald, 25, student]
// Rename column for table 1: name -> last_name
// Add column for table 2: gender
// Table 1: +I[5, Eliza, 24]
// Table 2: +I[6, Frank, 30, student, male] 
```
This is executed correctly.

```
// Create test dataset:
// Create table 1 [id, name, age]
// Create table 2 [id, name, age, description]
// Table 1: +I[1, Alice, 18]
// Table 1: +I[2, Bob, 20]
// Table 1: -U[2, Bob, 20] +U[2, Bob, 30]
// Table 2: +I[3, Charlie, 15, student]
// Table 2: +I[4, Donald, 25, student]
// Table 2: -D[4, Donald, 25, student]
// Rename column for table 1: name -> last_name
// Add column for table 2: gender
// Table 1: +I[5, Eliza, 24]
// Table 2: +I[6, Frank, 30, student, male] 
```
This will cause an exception.
```
Caused by: org.codehaus.commons.compiler.CompileException: Line 1, Column 76: Assignment conversion not possible from type "java.lang.Integer" to type "java.lang.Long" 
```

# Cause
When a conversion rule of transform matches multiple tables, only tables with the same structure are supported. However, in the scenario of sharding databases and tables, it is possible to match multiple tables with different structures.  
In the `Map<Tuple2<TableId, TransformProjection>, TransformProjectionProcessor>
            transformProjectionProcessorMap` ,`TransformProjection` is wrongly shared, resulting in `Schema` always having the schema of the latest matched table.

# Fix
1.Change `Map<Tuple2<TableId, TransformProjection>, TransformProjectionProcessor>
            transformProjectionProcessorMap` into `Map<Tuple2<TableId, String>, TransformProjectionProcessor>
            transformProjectionProcessorMap`.
2.When transformProjectionProcessor has none TableInfo, set TransformProjection into new transformProjectionProcessor from existed transformProjectionProcessor.