### PR TITLE
修改FlinkDeployment的jarURI地址错误的问题

### DIFF
--- a/docs/content.zh/docs/deployment/kubernetes.md
+++ b/docs/content.zh/docs/deployment/kubernetes.md
@@ -244,7 +244,7 @@ spec:
       - '--use-mini-cluster'
       - /opt/flink/flink-cdc-{{< param Version >}}/conf/mysql-to-doris.yaml
     entryClass: org.apache.flink.cdc.cli.CliFrontend
-    jarURI: 'local:///opt/flink/flink-cdc-{{< param Version >}}/lib/flink-cdc-dist-{{< param Version >}}.jar'
+    jarURI: 'local:///opt/flink/lib/flink-cdc-dist-{{< param Version >}}.jar'
     parallelism: 1
     state: running
     upgradeMode: savepoint


### PR DESCRIPTION
因为在Dockerfile的最后一句命令:

RUN mv $FLINK_HOME/flink-cdc-3.3-SNAPSHOT/lib/flink-cdc-dist-3.3-SNAPSHOT.jar $FLINK_HOME/lib/

已经把flink-cdc.xxx.jar移动到了$FLINK_HOME/lib下面了，所以，如果按照这个流程操作下去，就会出现如下的错误信息： Caused by: java.io.IOException: JAR file does not exist '/opt/flink/flink-cdc-3.2.1/lib/flink-cdc-dist-3.2.1.jar'
        at org.apache.flink.util.JarUtils.checkJarFile(JarUtils.java:46) ~[flink-dist-1.18.0.jar:1.18.0]
        at org.apache.flink.client.program.PackagedProgram.checkJarFile(PackagedProgram.java:615) ~[flink-dist-1.18.0.jar:1.18.0]
        at org.apache.flink.client.program.PackagedProgram.loadJarFile(PackagedProgram.java:465) ~[flink-dist-1.18.0.jar:1.18.0]
        at org.apache.flink.client.program.PackagedProgram.<init>(PackagedProgram.java:135) ~[flink-dist-1.18.0.jar:1.18.0]
        at org.apache.flink.client.program.PackagedProgram.<init>(PackagedProgram.java:65) ~[flink-dist-1.18.0.jar:1.18.0]
        at org.apache.flink.client.program.PackagedProgram$Builder.build(PackagedProgram.java:691) ~[flink-dist-1.18.0.jar:1.18.0]
        at org.apache.flink.client.program.DefaultPackagedProgramRetriever.getPackagedProgram(DefaultPackagedProgramRetriever.java:213) ~[flink-dist-1.18.0.jar:1.18.0]
        ... 2 more