### PR TITLE
[FLINK-37012][transform] Fix exception caused by metadataColumns causing argument type mismatch

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumnProcessor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumnProcessor.java
@@ -186,9 +186,7 @@ public class ProjectionColumnProcessor {
                     break;
                 }
             }
-        }
 
-        for (String originalColumnName : originalColumnNames) {
             METADATA_COLUMNS.stream()
                     .filter(col -> col.f0.equals(originalColumnName))
                     .findFirst()


### PR DESCRIPTION
pipelin.yml
```
...

transform:
  - source-table: testdb.cdc_test
    projection: id, concat(__table_name__,'_',id) as tbname_id
    primary-keys: id
....
```
When the id is not string type, the following exception is thrown
```
Caused by: java.lang.IllegalArgumentException: argument type mismatch
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:497)
        at org.codehaus.janino.ExpressionEvaluator.evaluate(ExpressionEvaluator.java:541)
        at org.codehaus.janino.ExpressionEvaluator.evaluate(ExpressionEvaluator.java:533)
        at org.apache.flink.cdc.runtime.operators.transform.ProjectionColumnProcessor.evaluate(ProjectionColumnProcessor.java:99)
        at org.apache.flink.cdc.runtime.operators.transform.TransformProjectionProcessor.processData(TransformProjectionProcessor.java:154) 
```