### PR TITLE
[FLINK-36620][cdc-dist] Add support for specifying the --flink-home command line parameter with an '=' character

### DIFF
--- a/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
+++ b/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
@@ -27,14 +27,14 @@ for ((i=0; i < ${#args[@]}; i++)); do
             # Check if the value is not empty
             if [[ -n "$FLINK_HOME_VALUE" ]]; then
                 FLINK_HOME="$FLINK_HOME_VALUE"
-                echo "set FLINK_HOME to ${FLINK_HOME_VALUE}"
+                echo "[INFO] Set FLINK_HOME to ${FLINK_HOME_VALUE}."
                 break
             fi
             ;;
         --flink-home)
             if [[ -n "${args[i+1]}" ]]; then
                 FLINK_HOME="${args[i+1]}"
-                echo "set FLINK_HOME to ${FLINK_HOME}"
+                echo "[INFO] Set FLINK_HOME to ${FLINK_HOME}."
                 break
             fi
             ;;

--- a/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
+++ b/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
@@ -21,9 +21,20 @@ args=("$@")
 # Check if FLINK_HOME is set in command-line arguments by "--flink-home"
 for ((i=0; i < ${#args[@]}; i++)); do
     case "${args[i]}" in
+        --flink-home=*)
+            # Extract the value after "="
+            FLINK_HOME_VALUE="${args[i]#*=}"
+            # Check if the value is not empty
+            if [[ -n "$FLINK_HOME_VALUE" ]]; then
+                FLINK_HOME="$FLINK_HOME_VALUE"
+                echo "set FLINK_HOME to ${FLINK_HOME_VALUE}"
+                break
+            fi
+            ;;
         --flink-home)
             if [[ -n "${args[i+1]}" ]]; then
                 FLINK_HOME="${args[i+1]}"
+                echo "set FLINK_HOME to ${FLINK_HOME}"
                 break
             fi
             ;;


### PR DESCRIPTION
Currently, most of FlinkCDC's command line arguments are supported in the format `--$KEY $VALUE`  or `--$KEY=$VALUE`, e.g. --jar, but, except for flink home, which only supports space spacing. Users who use the `--flink-home=$FLINK_HOME` format on the command line (trying to be consistent with the other = spacing arguments) will not be able to set flink home correctly.

In particular, when there is an environment variable $FLINK_HOME and you want to override it by setting --flink-home=/path/to/new/flink/home, you will find that it does not work.

Here, we make the flink-home parameter available in both --flink-home $FLINK_HOME and --flink-home=$FLINK_HOME formats in the `flink-cdc.sh` script, so that users can avoid formatting differences and runtime exceptions when using command line arguments.