### PR TITLE
[hotfix] Miscellaneous fixes on GHA workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -39,10 +39,13 @@ e2e-tests:
   - flink-cdc-e2e-tests/**/*
 migration-tests:
   - flink-cdc-migration-tests/**/*
+add-ons:
+  - flink-cdc-pipeline-model/**/*
+  - flink-cdc-pipeline-udf-examples/**/*
 base:
   - flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/**/*
 debezium:
-  - flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-debezium/**/*
+  - flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/**/*
 connector-test-util:
   - flink-cdc-connect/flink-cdc-source-connectors/flink-connector-test-util/**/*
 db2-cdc-connector:
@@ -86,3 +89,7 @@ starrocks-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/**/*
 elasticsearch-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-elasticsearch/**/*
+oceanbase-pipeline-connector:
+  - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oceanbase/**/*
+maxcompute-pipeline-connector:
+  - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/**/*

--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -41,11 +41,11 @@ jobs:
           close-issue-message: >
             This issue has been closed because Flink CDC doesn't use GitHub issue trackers.
           # Stale PRs
-          days-before-pr-stale: 60
-          days-before-pr-close: 30
+          days-before-pr-stale: 120
+          days-before-pr-close: 60
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had recent
-            activity for 60 days. It will be closed in 30 days if no further activity occurs.
+            activity for 120 days. It will be closed in 60 days if no further activity occurs.
           close-pr-message: >
             This pull request has been closed because it has not had recent activity. You could reopen it
             if you try to continue your work, and anyone who are interested in it are encouraged to continue

--- a/.github/workflows/flink_cdc_ci_nightly.yml
+++ b/.github/workflows/flink_cdc_ci_nightly.yml
@@ -16,7 +16,7 @@
 name: Flink CDC CI Nightly
 on:
   schedule:
-    - cron: '0 0 * * *' # Deploy every day
+    - cron: '43 0 * * *' # Run daily, but not at 00:00 UTC to avoid job failure due to network throttle
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This PR contains some pretty trivial fixes on our GHA workflows:

* Changes PR stale cycle to 120d / 60d

Now, our `actions/stale` workflow closes inactive PRs with a 60 / 30 days cycle, that is to say, 60 days' inactive to label it "Stale" and 30 more days to close it. But it turns out to be too eager and has accidentally closed many useful PRs.

This change has been discussed with other maintainers.

* Update outdated "Labeler"

Labeler can automatically detect what files have been touched, and categorize PRs with suitable labels, based on a predefined ruleset. It's just a routine update on the rule definition.

* Run nightly CI on a more "random" time instead of 00:00 UTC

There are really too much CI workflows scheduled to run on UTC midnight that Apache's download server could not handle ([like this](https://github.com/apache/flink-cdc/actions/runs/12497630902/job/34870461577)). Changing it to another "arbitrary" time to reduce such failure.