### PR TITLE
[Docs] Update mysql-to-doris.md, add scan.startup.mode config to make demo run more smoothly

### DIFF
--- a/docs/content.zh/docs/get-started/quickstart/mysql-to-doris.md
+++ b/docs/content.zh/docs/get-started/quickstart/mysql-to-doris.md
@@ -208,6 +208,7 @@ MacOS 由于内部实现容器的方式不同，在部署时宿主机直接修�
      tables: app_db.\.*
      server-id: 5400-5404
      server-time-zone: UTC
+     scan.startup.mode: earliest-offset
    
    sink:
      type: doris


### PR DESCRIPTION
When not set scan.startup.mode to earliest-offset, will use intial mode，the next part about incrementing data will not work. That's not very friendly to new starters.