### PR TITLE
[hotfix][maxcompute] Fix MaxCompute Pipeline Connector unit tests by upgrading maxcompute-emulator

### DIFF
--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -58,7 +58,8 @@ env:
   flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka,\
   flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon,\
   flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-elasticsearch,\
-  flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oceanbase"
+  flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oceanbase,\
+  flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute"
 
   MODULES_MYSQL: "\
   flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc,\

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/EmulatorTestBase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/EmulatorTestBase.java
@@ -41,7 +41,7 @@ public class EmulatorTestBase {
     private static final Logger LOG = LoggerFactory.getLogger(EmulatorTestBase.class);
 
     public static final DockerImageName MAXCOMPUTE_IMAGE =
-            DockerImageName.parse("maxcompute/maxcompute-emulator:v0.0.4");
+            DockerImageName.parse("maxcompute/maxcompute-emulator:v0.0.7");
 
     @ClassRule
     public static GenericContainer<?> maxcompute =

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/utils/TypeConvertUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/utils/TypeConvertUtilsTest.java
@@ -167,7 +167,7 @@ public class TypeConvertUtilsTest {
                             123456.789d,
                             12345,
                             12345,
-                            TimestampData.fromTimestamp(Timestamp.from(Instant.ofEpochSecond(0))),
+                            TimestampData.fromTimestamp(Timestamp.valueOf("1970-01-01 00:00:00")),
                             LocalZonedTimestampData.fromInstant(Instant.ofEpochSecond(0)),
                             ZonedTimestampData.fromZonedDateTime(
                                     ZonedDateTime.ofInstant(
@@ -179,7 +179,7 @@ public class TypeConvertUtilsTest {
         TypeConvertUtils.toMaxComputeRecord(schemaWithoutComplexType, record1, arrayRecord);
 
         String expect =
-                "char,varchar,string,false,=01=02=03=04=05,=01=02=03=04=05=06=07=08=09=0A,0.00,1,2,12345,12345,123.456,123456.789,00:00:00.012345,2003-10-20,1970-01-01T08:00,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z";
+                "char,varchar,string,false,=01=02=03=04=05,=01=02=03=04=05=06=07=08=09=0A,0.00,1,2,12345,12345,123.456,123456.789,00:00:00.012345,2003-10-20,1970-01-01T00:00,1970-01-01T00:00:00Z,1970-01-01T00:00:00Z";
         Assert.assertEquals(expect, arrayRecord.toString());
     }
 }


### PR DESCRIPTION
This PR fixes failing unit tests in MaxCompute Pipeline Connector by upgrading the maxcompute-emulator dependency from 0.0.4 to 0.0.7.

## Changes
- Updated `maxcompute-emulator` version in org.apache.flink.cdc.connectors.maxcompute.EmulatorTestBase