### PR TITLE
[hotfix][docs] Change docs in master to 3.4-SNAPSHOT

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -34,11 +34,11 @@ pygmentsUseClasses = true
   # where we change the version for the complete docs when forking of a release
   # branch etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "3.3-SNAPSHOT"
+  Version = "3.4-SNAPSHOT"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "3.3-SNAPSHOT"
+  VersionTitle = "3.4-SNAPSHOT"
 
   # The branch for this version of Apache Flink CDC
   Branch = "master"


### PR DESCRIPTION
This PR changes docs in master to 3.4-SNAPSHOT