### PR TITLE
[FLINK-37191][mysql] Avoid back filling if the lowWatermark of BinlogSplit is equal to highWatermark.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffset.java
@@ -255,6 +255,11 @@ public class BinlogOffset implements Comparable<BinlogOffset>, Serializable {
             return Long.compare(this.getRestartSkipRows(), that.getRestartSkipRows());
         }
 
+        // serverId of BinlogOffset in snapshot phase is 0.
+        if (serverId == 0) {
+            return 0;
+        }
+
         // The skip rows are the same, so compare the timestamp ...
         return Long.compare(this.getTimestampSec(), that.getTimestampSec());
     }


### PR DESCRIPTION
To fix timeout in test case of PolardbxSourceITCase. 

Avoid extra backfill when there is no binlog event between lowWatermark and highWatermark.

 