### PR TITLE
[FLINK-37156] [cdc-composer/cli] pipeline supports collecting data once and writing it to multiple sinks.

### DIFF
--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -144,14 +144,17 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
                                 SOURCE_KEY));
 
         // Sink is required
-        SinkDef sinkDef =
-                toSinkDef(
-                        checkNotNull(
-                                pipelineDefJsonNode.get(SINK_KEY),
-                                "Missing required field \"%s\" in pipeline definition",
-                                SINK_KEY),
-                        schemaChangeBehavior);
-
+        JsonNode sinkNodes = checkNotNull(
+                pipelineDefJsonNode.get(SINK_KEY),
+                "Missing required field \"%s\" in pipeline definition",
+                SINK_KEY);
+        List<SinkDef> sinkDefs = new ArrayList<>();
+        sinkNodes.forEach(
+            sink ->
+                    sinkDefs.add(
+                            toSinkDef(
+                                    sink,
+                                    schemaChangeBehavior)));
         // Transforms are optional
         List<TransformDef> transformDefs = new ArrayList<>();
         Optional.ofNullable(pipelineDefJsonNode.get(TRANSFORM_KEY))
@@ -171,7 +174,7 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
         pipelineConfig.addAll(userPipelineConfig);
 
         return new PipelineDef(
-                sourceDef, sinkDef, routeDefs, transformDefs, udfDefs, modelDefs, pipelineConfig);
+                sourceDef, sinkDefs, routeDefs, transformDefs, udfDefs, modelDefs, pipelineConfig);
     }
 
     private SourceDef toSourceDef(JsonNode sourceNode) {

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/PipelineDef.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/PipelineDef.java
@@ -52,7 +52,7 @@ import static org.apache.flink.cdc.common.pipeline.PipelineOptions.PIPELINE_LOCA
  */
 public class PipelineDef {
     private final SourceDef source;
-    private final SinkDef sink;
+    private final List<SinkDef> sinks;
     private final List<RouteDef> routes;
     private final List<TransformDef> transforms;
     private final List<UdfDef> udfs;
@@ -61,14 +61,14 @@ public class PipelineDef {
 
     public PipelineDef(
             SourceDef source,
-            SinkDef sink,
+            List<SinkDef> sinks,
             List<RouteDef> routes,
             List<TransformDef> transforms,
             List<UdfDef> udfs,
             List<ModelDef> models,
             Configuration config) {
         this.source = source;
-        this.sink = sink;
+        this.sinks = sinks;
         this.routes = routes;
         this.transforms = transforms;
         this.udfs = udfs;
@@ -78,20 +78,20 @@ public class PipelineDef {
 
     public PipelineDef(
             SourceDef source,
-            SinkDef sink,
+            List<SinkDef> sinks,
             List<RouteDef> routes,
             List<TransformDef> transforms,
             List<UdfDef> udfs,
             Configuration config) {
-        this(source, sink, routes, transforms, udfs, new ArrayList<>(), config);
+        this(source, sinks, routes, transforms, udfs, new ArrayList<>(), config);
     }
 
     public SourceDef getSource() {
         return source;
     }
 
-    public SinkDef getSink() {
-        return sink;
+    public List<SinkDef> getSinks() {
+        return sinks;
     }
 
     public List<RouteDef> getRoute() {
@@ -119,8 +119,8 @@ public class PipelineDef {
         return "PipelineDef{"
                 + "source="
                 + source
-                + ", sink="
-                + sink
+                + ", sinks="
+                + sinks
                 + ", routes="
                 + routes
                 + ", transforms="
@@ -144,7 +144,7 @@ public class PipelineDef {
         }
         PipelineDef that = (PipelineDef) o;
         return Objects.equals(source, that.source)
-                && Objects.equals(sink, that.sink)
+                && Objects.equals(sinks, that.sinks)
                 && Objects.equals(routes, that.routes)
                 && Objects.equals(transforms, that.transforms)
                 && Objects.equals(udfs, that.udfs)
@@ -154,7 +154,7 @@ public class PipelineDef {
 
     @Override
     public int hashCode() {
-        return Objects.hash(source, sink, routes, transforms, udfs, models, config);
+        return Objects.hash(source, sinks, routes, transforms, udfs, models, config);
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
I've implemented a solution where data is collected from MySQL once and then sent to multiple target data sources, such as Paimon, Kafka, and StarRocks, which reduces redundant data collection.
pipeline yaml :
```
source:
  type: mysql
  name: MySQL Source
  hostname: 127.0.0.1
  port: 3306
  username:root
  password: 123456
  tables: test.order
  server-id: 5401-5404
  jdbc.properties.useSSL: false

sink:
   - type: paimon
     name: Paimon Sink
     catalog.properties.metastore: filesystem
     catalog.properties.warehouse: /tmp/path/warehouse
   - type: kafka
     name: Kafka Sink
     properties.bootstrap.servers: PLAINTEXT://localhost:9092
   - type: starrocks
     jdbc-url: jdbc:mysql://127.0.0.1:9030
     load-url: 127.0.0.1:8030
     username: root
     password: ""
     table.create.properties.replication_num: 1

route:
  - source-table:  test.order
    sink-table:  test.order

pipeline:
  name: MySQL to Paimon Pipeline
  parallelism: 2
```


<img width="1611" alt="image" src="https://github.com/user-attachments/assets/00ff0811-d682-4cfe-b21e-18ca56bbf53f" />

