### PR TITLE
[FLINK-37278] Optimize regular schema evolution topology's performance

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.cdc.runtime.operators.schema.regular;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
@@ -62,6 +63,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.cdc.runtime.operators.schema.common.CoordinationResponseUtils.wrap;
@@ -73,16 +75,13 @@ public class SchemaCoordinator extends SchemaRegistry {
     /** Executor service to execute schema change. */
     private final ExecutorService schemaChangeThreadPool;
 
-    /**
-     * Atomic flag indicating if current RequestHandler could accept more schema changes for now.
-     */
-    private transient RequestStatus schemaChangeStatus;
-
     /** Sink writers which have sent flush success events for the request. */
     private transient ConcurrentHashMap<Integer, Set<Integer>> flushedSinkWriters;
 
-    /** Currently handling request's completable future. */
-    private transient CompletableFuture<CoordinationResponse> pendingResponseFuture;
+    /** Currently handling requests' completable future. */
+    private transient Map<
+                    Integer, Tuple2<SchemaChangeRequest, CompletableFuture<CoordinationResponse>>>
+            pendingRequests;
 
     // Static fields
     public SchemaCoordinator(
@@ -108,7 +107,7 @@ public class SchemaCoordinator extends SchemaRegistry {
     public void start() throws Exception {
         super.start();
         this.flushedSinkWriters = new ConcurrentHashMap<>();
-        this.schemaChangeStatus = RequestStatus.IDLE;
+        this.pendingRequests = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -185,7 +184,7 @@ public class SchemaCoordinator extends SchemaRegistry {
     }
 
     @Override
-    protected void handleFlushSuccessEvent(FlushSuccessEvent event) {
+    protected void handleFlushSuccessEvent(FlushSuccessEvent event) throws TimeoutException {
         int sinkSubtask = event.getSinkSubTaskId();
         int sourceSubtask = event.getSourceSubTaskId();
         LOG.info(
@@ -200,16 +199,25 @@ public class SchemaCoordinator extends SchemaRegistry {
                 "Currently flushed sink writers for source task {} are: {}",
                 sourceSubtask,
                 flushedSinkWriters.get(sourceSubtask));
+
+        if (flushedSinkWriters.get(sourceSubtask).size() >= currentParallelism) {
+            LOG.info(
+                    "Source SubTask {} have collected enough flush success event. Will start evolving schema changes...",
+                    sourceSubtask);
+            flushedSinkWriters.remove(sourceSubtask);
+            startSchemaChangesEvolve(sourceSubtask);
+        }
     }
 
     @Override
     protected void handleUnrecoverableError(String taskDescription, Throwable t) {
         super.handleUnrecoverableError(taskDescription, t);
 
-        // There's a pending future, release it exceptionally before quitting
-        if (pendingResponseFuture != null) {
-            pendingResponseFuture.completeExceptionally(t);
-        }
+        // For each pending future, release it exceptionally before quitting
+        pendingRequests.forEach(
+                (index, tuple) -> {
+                    tuple.f1.completeExceptionally(t);
+                });
     }
 
     /**
@@ -219,73 +227,14 @@ public class SchemaCoordinator extends SchemaRegistry {
      */
     public void handleSchemaChangeRequest(
             SchemaChangeRequest request, CompletableFuture<CoordinationResponse> responseFuture) {
-
-        // We use subTaskId to identify each schema change request
-        int subTaskId = request.getSubTaskId();
-
-        if (schemaChangeStatus == RequestStatus.IDLE) {
-            if (activeSinkWriters.size() < currentParallelism) {
-                LOG.info(
-                        "Not all active sink writers have been registered. Current {}, expected {}.",
-                        activeSinkWriters.size(),
-                        currentParallelism);
-                responseFuture.complete(wrap(SchemaChangeResponse.waitingForFlush()));
-                return;
-            }
-
-            if (!activeSinkWriters.equals(flushedSinkWriters.get(subTaskId))) {
-                LOG.info(
-                        "Not all active sink writers have completed flush. Flushed writers: {}, expected: {}.",
-                        flushedSinkWriters.get(subTaskId),
-                        activeSinkWriters);
-                responseFuture.complete(wrap(SchemaChangeResponse.waitingForFlush()));
-                return;
-            }
-
-            LOG.info(
-                    "All sink writers have flushed for subTaskId {}. Switching to APPLYING state and starting schema evolution...",
-                    subTaskId);
-            flushedSinkWriters.remove(subTaskId);
-            schemaChangeStatus = RequestStatus.APPLYING;
-            pendingResponseFuture = responseFuture;
-            startSchemaChangesEvolve(request, responseFuture);
-        } else {
-            responseFuture.complete(wrap(SchemaChangeResponse.busy()));
-        }
+        pendingRequests.put(request.getSubTaskId(), Tuple2.of(request, responseFuture));
     }
 
-    private void startSchemaChangesEvolve(
-            SchemaChangeRequest request, CompletableFuture<CoordinationResponse> responseFuture) {
-        SchemaChangeEvent originalEvent = request.getSchemaChangeEvent();
-        TableId originalTableId = originalEvent.tableId();
-        Schema currentUpstreamSchema =
-                schemaManager.getLatestOriginalSchema(originalTableId).orElse(null);
-
-        List<SchemaChangeEvent> deducedSchemaChangeEvents = new ArrayList<>();
-
-        // For redundant schema change events (possibly coming from duplicate emitted
-        // CreateTableEvents in snapshot stage), we just skip them.
-        if (!SchemaUtils.isSchemaChangeEventRedundant(currentUpstreamSchema, originalEvent)) {
-            schemaManager.applyOriginalSchemaChange(originalEvent);
-            deducedSchemaChangeEvents.addAll(deduceEvolvedSchemaChanges(originalEvent));
-        } else {
-            LOG.info(
-                    "Schema change event {} is redundant for current schema {}, just skip it.",
-                    originalEvent,
-                    currentUpstreamSchema);
-        }
-
-        LOG.info(
-                "All sink subtask have flushed for table {}. Start to apply schema change request: \n\t{}\nthat extracts to:\n\t{}",
-                request.getTableId().toString(),
-                request,
-                deducedSchemaChangeEvents.stream()
-                        .map(SchemaChangeEvent::toString)
-                        .collect(Collectors.joining("\n\t")));
+    private void startSchemaChangesEvolve(int sourceSubTaskId) {
         schemaChangeThreadPool.submit(
                 () -> {
                     try {
-                        applySchemaChange(originalEvent, deducedSchemaChangeEvents);
+                        applySchemaChange(sourceSubTaskId);
                     } catch (Throwable t) {
                         failJob(
                                 "Schema change applying task",
@@ -379,8 +328,54 @@ public class SchemaCoordinator extends SchemaRegistry {
     }
 
     /** Applies the schema change to the external system. */
-    private void applySchemaChange(
-            SchemaChangeEvent originalEvent, List<SchemaChangeEvent> deducedSchemaChangeEvents) {
+    private void applySchemaChange(int sourceSubTaskId) {
+        try {
+            loopUntil(
+                    () -> pendingRequests.containsKey(sourceSubTaskId),
+                    () ->
+                            LOG.info(
+                                    "SchemaOperator {} has not submitted schema change request yet. Waiting...",
+                                    sourceSubTaskId),
+                    Duration.ofMillis(100),
+                    rpcTimeout);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(
+                    "Timeout waiting for schema change request from SchemaOperator.", e);
+        }
+
+        Tuple2<SchemaChangeRequest, CompletableFuture<CoordinationResponse>> requestBody =
+                pendingRequests.get(sourceSubTaskId);
+        SchemaChangeRequest request = requestBody.f0;
+        CompletableFuture<CoordinationResponse> responseFuture = requestBody.f1;
+
+        SchemaChangeEvent originalEvent = request.getSchemaChangeEvent();
+
+        TableId originalTableId = originalEvent.tableId();
+        Schema currentUpstreamSchema =
+                schemaManager.getLatestOriginalSchema(originalTableId).orElse(null);
+
+        List<SchemaChangeEvent> deducedSchemaChangeEvents = new ArrayList<>();
+
+        // For redundant schema change events (possibly coming from duplicate emitted
+        // CreateTableEvents in snapshot stage), we just skip them.
+        if (!SchemaUtils.isSchemaChangeEventRedundant(currentUpstreamSchema, originalEvent)) {
+            schemaManager.applyOriginalSchemaChange(originalEvent);
+            deducedSchemaChangeEvents.addAll(deduceEvolvedSchemaChanges(originalEvent));
+        } else {
+            LOG.info(
+                    "Schema change event {} is redundant for current schema {}, just skip it.",
+                    originalEvent,
+                    currentUpstreamSchema);
+        }
+
+        LOG.info(
+                "All sink subtask have flushed for table {}. Start to apply schema change request: \n\t{}\nthat extracts to:\n\t{}",
+                request.getTableId().toString(),
+                request,
+                deducedSchemaChangeEvents.stream()
+                        .map(SchemaChangeEvent::toString)
+                        .collect(Collectors.joining("\n\t")));
+
         if (SchemaChangeBehavior.EXCEPTION.equals(behavior)) {
             if (deducedSchemaChangeEvents.stream()
                     .anyMatch(evt -> !(evt instanceof CreateTableEvent))) {
@@ -415,18 +410,16 @@ public class SchemaCoordinator extends SchemaRegistry {
         }
 
         // And returns all successfully applied schema change events to SchemaOperator.
-        pendingResponseFuture.complete(
+        responseFuture.complete(
                 wrap(
                         SchemaChangeResponse.success(
                                 appliedSchemaChangeEvents, refreshedEvolvedSchemas)));
-        pendingResponseFuture = null;
 
-        Preconditions.checkState(
-                schemaChangeStatus == RequestStatus.APPLYING,
-                "Illegal schemaChangeStatus state: should be APPLYING before applySchemaChange finishes, not "
-                        + schemaChangeStatus);
-        schemaChangeStatus = RequestStatus.IDLE;
-        LOG.info("SchemaChangeStatus switched from APPLYING to IDLE.");
+        pendingRequests.remove(sourceSubTaskId);
+        LOG.info(
+                "Finished handling schema change request from {}. Pending requests: {}",
+                sourceSubTaskId,
+                pendingRequests);
     }
 
     private boolean applyAndUpdateEvolvedSchemaChange(SchemaChangeEvent schemaChangeEvent) {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -411,9 +411,7 @@ public class SchemaCoordinator extends SchemaRegistry {
 
         // And returns all successfully applied schema change events to SchemaOperator.
         responseFuture.complete(
-                wrap(
-                        SchemaChangeResponse.success(
-                                appliedSchemaChangeEvents, refreshedEvolvedSchemas)));
+                wrap(new SchemaChangeResponse(appliedSchemaChangeEvents, refreshedEvolvedSchemas)));
 
         pendingRequests.remove(sourceSubTaskId);
         LOG.info(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -336,8 +336,8 @@ public class SchemaCoordinator extends SchemaRegistry {
                             LOG.info(
                                     "SchemaOperator {} has not submitted schema change request yet. Waiting...",
                                     sourceSubTaskId),
-                    Duration.ofMillis(100),
-                    rpcTimeout);
+                    rpcTimeout,
+                    Duration.ofMillis(100));
         } catch (TimeoutException e) {
             throw new RuntimeException(
                     "Timeout waiting for schema change request from SchemaOperator.", e);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -75,10 +75,20 @@ public class SchemaCoordinator extends SchemaRegistry {
     /** Executor service to execute schema change. */
     private final ExecutorService schemaChangeThreadPool;
 
-    /** Sink writers which have sent flush success events for the request. */
+    /**
+     * Sink writers which have sent flush success events for the request.<br>
+     * {@code MapEntry.Key} is an {@code Integer}, indicating the upstream subTaskId that initiates
+     * this schema change request.<br>
+     * {@code MapEntry.Value} is a {@code Set<Integer>}, containing downstream subTasks' ID that
+     * have acknowledged and successfully flushed pending events for this schema change event.
+     */
     private transient ConcurrentHashMap<Integer, Set<Integer>> flushedSinkWriters;
 
-    /** Currently handling requests' completable future. */
+    /**
+     * Schema evolution requests that we're currently handling.<br>
+     * For each subTask executing in parallelism, they may initiate requests simultaneously, so we
+     * use each task's unique subTaskId as Map key to distinguish each of them.
+     */
     private transient Map<
                     Integer, Tuple2<SchemaChangeRequest, CompletableFuture<CoordinationResponse>>>
             pendingRequests;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/event/SchemaChangeResponse.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/event/SchemaChangeResponse.java
@@ -24,7 +24,6 @@ import org.apache.flink.cdc.runtime.operators.schema.regular.SchemaCoordinator;
 import org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,44 +43,11 @@ public class SchemaChangeResponse implements CoordinationResponse {
 
     private final Map<TableId, Schema> evolvedSchemas;
 
-    private final ResponseCode responseCode;
-
-    public static SchemaChangeResponse success(
-            List<SchemaChangeEvent> schemaChangeEvents, Map<TableId, Schema> evolvedSchemas) {
-        return new SchemaChangeResponse(ResponseCode.SUCCESS, schemaChangeEvents, evolvedSchemas);
-    }
-
-    public static SchemaChangeResponse duplicate() {
-        return new SchemaChangeResponse(ResponseCode.DUPLICATE);
-    }
-
-    public static SchemaChangeResponse ignored() {
-        return new SchemaChangeResponse(ResponseCode.IGNORED);
-    }
-
-    private SchemaChangeResponse(ResponseCode responseCode) {
-        this(responseCode, Collections.emptyList(), Collections.emptyMap());
-    }
-
-    private SchemaChangeResponse(
-            ResponseCode responseCode,
+    public SchemaChangeResponse(
             List<SchemaChangeEvent> appliedSchemaChangeEvents,
             Map<TableId, Schema> evolvedSchemas) {
-        this.responseCode = responseCode;
         this.appliedSchemaChangeEvents = appliedSchemaChangeEvents;
         this.evolvedSchemas = evolvedSchemas;
-    }
-
-    public boolean isSuccess() {
-        return ResponseCode.SUCCESS.equals(responseCode);
-    }
-
-    public boolean isDuplicate() {
-        return ResponseCode.DUPLICATE.equals(responseCode);
-    }
-
-    public boolean isIgnored() {
-        return ResponseCode.IGNORED.equals(responseCode);
     }
 
     public List<SchemaChangeEvent> getAppliedSchemaChangeEvents() {
@@ -102,39 +68,21 @@ public class SchemaChangeResponse implements CoordinationResponse {
         }
         SchemaChangeResponse response = (SchemaChangeResponse) o;
         return Objects.equals(appliedSchemaChangeEvents, response.appliedSchemaChangeEvents)
-                && responseCode == response.responseCode;
+                && Objects.equals(evolvedSchemas, response.evolvedSchemas);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(appliedSchemaChangeEvents, responseCode);
+        return Objects.hash(appliedSchemaChangeEvents, evolvedSchemas);
     }
 
     @Override
     public String toString() {
         return "SchemaChangeResponse{"
-                + "schemaChangeEvents="
+                + "appliedSchemaChangeEvents="
                 + appliedSchemaChangeEvents
-                + ", responseCode="
-                + responseCode
+                + ", evolvedSchemas="
+                + evolvedSchemas
                 + '}';
-    }
-
-    /**
-     * Schema Change Response status code.
-     *
-     * <p>- Accepted: Requested schema change request has been accepted exclusively. Any other
-     * schema change requests will be blocked.
-     *
-     * <p>- Duplicate: This schema change request has been submitted before, possibly by another
-     * paralleled subTask.
-     *
-     * <p>- Ignored: This schema change request has been assessed, but no actual evolution is
-     * required. Possibly caused by LENIENT mode or merging table strategies.
-     */
-    public enum ResponseCode {
-        SUCCESS,
-        DUPLICATE,
-        IGNORED
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/event/SchemaChangeResponse.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/event/SchemaChangeResponse.java
@@ -51,20 +51,12 @@ public class SchemaChangeResponse implements CoordinationResponse {
         return new SchemaChangeResponse(ResponseCode.SUCCESS, schemaChangeEvents, evolvedSchemas);
     }
 
-    public static SchemaChangeResponse busy() {
-        return new SchemaChangeResponse(ResponseCode.BUSY);
-    }
-
     public static SchemaChangeResponse duplicate() {
         return new SchemaChangeResponse(ResponseCode.DUPLICATE);
     }
 
     public static SchemaChangeResponse ignored() {
         return new SchemaChangeResponse(ResponseCode.IGNORED);
-    }
-
-    public static SchemaChangeResponse waitingForFlush() {
-        return new SchemaChangeResponse(ResponseCode.WAITING_FOR_FLUSH);
     }
 
     private SchemaChangeResponse(ResponseCode responseCode) {
@@ -84,20 +76,12 @@ public class SchemaChangeResponse implements CoordinationResponse {
         return ResponseCode.SUCCESS.equals(responseCode);
     }
 
-    public boolean isRegistryBusy() {
-        return ResponseCode.BUSY.equals(responseCode);
-    }
-
     public boolean isDuplicate() {
         return ResponseCode.DUPLICATE.equals(responseCode);
     }
 
     public boolean isIgnored() {
         return ResponseCode.IGNORED.equals(responseCode);
-    }
-
-    public boolean isWaitingForFlush() {
-        return ResponseCode.WAITING_FOR_FLUSH.equals(responseCode);
     }
 
     public List<SchemaChangeEvent> getAppliedSchemaChangeEvents() {
@@ -142,8 +126,6 @@ public class SchemaChangeResponse implements CoordinationResponse {
      * <p>- Accepted: Requested schema change request has been accepted exclusively. Any other
      * schema change requests will be blocked.
      *
-     * <p>- Busy: Schema registry is currently busy processing another schema change request.
-     *
      * <p>- Duplicate: This schema change request has been submitted before, possibly by another
      * paralleled subTask.
      *
@@ -152,9 +134,7 @@ public class SchemaChangeResponse implements CoordinationResponse {
      */
     public enum ResponseCode {
         SUCCESS,
-        BUSY,
         DUPLICATE,
-        IGNORED,
-        WAITING_FOR_FLUSH
+        IGNORED
     }
 }

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkOperatorWithSchemaEvolveTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkOperatorWithSchemaEvolveTest.java
@@ -87,16 +87,12 @@ public class DataSinkOperatorWithSchemaEvolveTest {
         // Create the flush event to process before the schema change event
         FlushEvent flushEvent = createFlushEvent(tableId, event);
 
-        // Send schema change request to coordinator
-        schemaOperatorHarness.requestSchemaChangeEvent(tableId, event);
-
         // Send flush event to SinkWriterOperator
         dataSinkWriterOperator.processElement(new StreamRecord<>(flushEvent));
 
-        // Wait for coordinator to complete the schema change and get the finished schema change
-        // events
+        // Send schema change request to coordinator
         SchemaChangeResponse schemaEvolveResponse =
-                schemaOperatorHarness.requestSchemaChangeResult(tableId, event);
+                schemaOperatorHarness.requestSchemaChangeEvent(tableId, event);
         List<SchemaChangeEvent> finishedSchemaChangeEvents =
                 schemaEvolveResponse.getAppliedSchemaChangeEvents();
 

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/RegularEventOperatorTestHarness.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/RegularEventOperatorTestHarness.java
@@ -23,6 +23,7 @@ import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.event.SchemaChangeEventTypeFamily;
 import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.pipeline.PipelineOptions;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.runtime.operators.schema.common.CoordinationResponseUtils;
@@ -91,6 +92,9 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
 
     public static final OperatorID SINK_OPERATOR_ID = new OperatorID(15214L, 15514L);
 
+    private static final Duration DEFAULT_RPC_TIMEOUT =
+            PipelineOptions.DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT;
+
     private final OP operator;
     private final int numOutputs;
     private final SchemaCoordinator schemaRegistry;
@@ -130,7 +134,7 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
                 operator,
                 numOutputs,
                 null,
-                null,
+                DEFAULT_RPC_TIMEOUT,
                 SchemaChangeBehavior.EVOLVE,
                 Arrays.stream(SchemaChangeEventTypeFamily.ALL).collect(Collectors.toSet()),
                 Collections.emptySet());
@@ -143,7 +147,7 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
                 operator,
                 numOutputs,
                 evolveDuration,
-                null,
+                DEFAULT_RPC_TIMEOUT,
                 SchemaChangeBehavior.EVOLVE,
                 Arrays.stream(SchemaChangeEventTypeFamily.ALL).collect(Collectors.toSet()),
                 Collections.emptySet());
@@ -159,7 +163,7 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
                 operator,
                 numOutputs,
                 evolveDuration,
-                null,
+                DEFAULT_RPC_TIMEOUT,
                 behavior,
                 Arrays.stream(SchemaChangeEventTypeFamily.ALL).collect(Collectors.toSet()),
                 Collections.emptySet());
@@ -176,7 +180,7 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
                 operator,
                 numOutputs,
                 evolveDuration,
-                null,
+                DEFAULT_RPC_TIMEOUT,
                 behavior,
                 enabledEventTypes,
                 Collections.emptySet());
@@ -195,7 +199,7 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
                 operator,
                 numOutputs,
                 evolveDuration,
-                null,
+                DEFAULT_RPC_TIMEOUT,
                 behavior,
                 enabledEventTypes,
                 errorOnEventTypes);


### PR DESCRIPTION
This closes FLINK-37278.

Currently, regular SE topology uses the following process to drain existing `DataChangeEvent`s in the pipeline:

1. SchemaOperator ("client") emits `FlushEvent` to downstream.
2. The "client" keeps polling the SchemaCoordinator ("server") with 1-second interval.
3. The "server" rejects all requests from clients until it has collected enough `FlushSuccessEvent` notifications from Sink.

As a result, all schema change requests will took at least 1 second to finish, after at least  one polling interval.

---

This PR replaces the polling code with maintaining a pending schema change request queue, where SchemaCoordinator could manage all pending clients and effectively blocking them from handling upstream events. Schema evolution process could start immediately after `FlushSuccessEvent` got reported, needless to wait for polling requests from clients.

---

With this change, time consumption of `testRegularTablesSourceInMultipleParallelism` test case has been reduced from ~6 minutes to ~50 seconds.