### PR TITLE
[FLINK-35599] Introduce JDBC pipeline sink connector

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -97,3 +97,5 @@ iceberg-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/**/*
 postgres-pipeline-connector:
   - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/**/*
+jdbc-pipeline-connector:
+  - flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/**/*

--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -135,6 +135,11 @@ env:
   MODULES_FLUSS: "\
   flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss"
 
+  MODULES_JDBC: "\
+  flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc,\
+  flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core,\
+  flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql"
+
   MODULES_PIPELINE_E2E: "\
   flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests"
 
@@ -261,6 +266,9 @@ jobs:
               ;;
               ("fluss")
                modules=${{ env.MODULES_FLUSS }}
+              ;;
+              ("jdbc")
+               modules=${{ env.MODULES_JDBC }}
               ;;
               ("pipeline_e2e")
                compile_modules="${{ env.MODULES_CORE }},${{ env.MODULES_PIPELINE_CONNECTORS }},${{ env.MODULES_MYSQL_SOURCE }},${{ env.MODULES_POSTGRES_SOURCE }},${{ env.MODULES_ORACLE }},${{ env.MODULES_MONGODB }},${{ env.MODULES_SQLSERVER }},${{ env.MODULES_TIDB }},${{ env.MODULES_OCEANBASE_SOURCE }},${{ env.MODULES_DB2 }},${{ env.MODULES_VITESS }},${{ env.MODULES_PIPELINE_E2E }}"

--- a/.github/workflows/flink_cdc_ci.yml
+++ b/.github/workflows/flink_cdc_ci.yml
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/flink_cdc_base.yml
     with:
       java-versions: "[8]"
-      modules: "['mysql-pipeline', 'postgres-pipeline', 'oceanbase-pipeline', 'doris', 'elasticsearch', 'iceberg', 'kafka', 'maxcompute', 'paimon', 'starrocks', 'fluss']"
+      modules: "['mysql-pipeline', 'postgres-pipeline', 'oceanbase-pipeline', 'doris', 'elasticsearch', 'iceberg', 'kafka', 'maxcompute', 'paimon', 'starrocks', 'fluss', 'jdbc']"
   source-ut:
     name: Source Unit Tests
     uses: ./.github/workflows/flink_cdc_base.yml

--- a/.github/workflows/flink_cdc_ci_nightly.yml
+++ b/.github/workflows/flink_cdc_ci_nightly.yml
@@ -60,7 +60,7 @@ jobs:
     uses: ./.github/workflows/flink_cdc_base.yml
     with:
       java-versions: "[11]"
-      modules: "['mysql-pipeline', 'postgres-pipeline', 'oceanbase-pipeline', 'doris', 'elasticsearch', 'iceberg', 'kafka', 'maxcompute', 'paimon', 'starrocks', 'fluss']"
+      modules: "['mysql-pipeline', 'postgres-pipeline', 'oceanbase-pipeline', 'doris', 'elasticsearch', 'iceberg', 'kafka', 'maxcompute', 'paimon', 'starrocks', 'fluss', 'jdbc']"
   source-ut:
     if: github.repository == 'apache/flink-cdc'
     name: Source Unit Tests

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
@@ -254,6 +254,7 @@ public class FlinkPipelineComposer implements PipelineComposer {
         sinkTranslator.translate(
                 pipelineDef.getSink(),
                 stream,
+                parallelism,
                 dataSink,
                 isBatchMode,
                 schemaOperatorIDGenerator.generate(),

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslatorTest.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/translator/DataSinkTranslatorTest.java
@@ -51,6 +51,7 @@ class DataSinkTranslatorTest {
                 new MockPreWriteWithoutCommitSink(uid);
         translator.sinkTo(
                 inputStream,
+                1,
                 mockPreWriteWithoutCommitSink,
                 "testPreWriteWithoutCommitSink",
                 false,

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/pom.xml
@@ -28,7 +28,6 @@ limitations under the License.
 
     <properties>
         <doris.connector.version>25.0.0</doris.connector.version>
-        <mysql.connector.version>8.0.26</mysql.connector.version>
     </properties>
 
     <dependencies>
@@ -99,7 +98,7 @@ limitations under the License.
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>${mysql.connector.version}</version>
+            <version>${mysql.driver.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierITCase.java
@@ -572,6 +572,7 @@ class DorisMetadataApplierITCase extends DorisSinkTestBase {
         sinkTranslator.translate(
                 new SinkDef("doris", "Dummy Doris Sink", config),
                 stream,
+                DEFAULT_PARALLELISM,
                 dorisSink,
                 schemaOperatorIDGenerator.generate(),
                 new OperatorUidGenerator());

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-cdc-pipeline-connector-jdbc-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>flink-cdc-pipeline-connector-jdbc-core</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/config/JdbcSinkConfig.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/config/JdbcSinkConfig.java
@@ -1,0 +1,272 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.config;
+
+import org.apache.flink.cdc.common.utils.Preconditions;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Properties;
+
+/** Generic configuration class for JDBC-like sinks. */
+public class JdbcSinkConfig implements Serializable {
+    private final String connUrl;
+    private final String username;
+    private final String password;
+    private final String table;
+    private final String driverClassName;
+    private final String serverTimeZone;
+    private final Duration connectTimeout;
+    private final int connectMaxRetries;
+    private final int connectionPoolSize;
+    private final long writeBatchIntervalMs;
+    private final int writeBatchSize;
+    private final int writeMaxRetries;
+    private final Properties jdbcProperties;
+
+    private final String dialect;
+    private final String hostname;
+    private final int port;
+
+    protected JdbcSinkConfig(Builder<?> builder) {
+        this.connUrl = builder.connUrl;
+        this.username = builder.username;
+        this.password = builder.password;
+        this.table = builder.table;
+        this.driverClassName = builder.driverClassName;
+        this.serverTimeZone = builder.serverTimeZone;
+        this.connectTimeout = builder.connectTimeout;
+        this.connectMaxRetries = builder.connectMaxRetries;
+        this.connectionPoolSize = builder.connectionPoolSize;
+        this.writeBatchIntervalMs = builder.writeBatchIntervalMs;
+        this.writeBatchSize = builder.writeBatchSize;
+        this.writeMaxRetries = builder.writeMaxRetries;
+        this.jdbcProperties = builder.jdbcProperties;
+
+        Preconditions.checkArgument(
+                connUrl.startsWith("jdbc:"), "JDBC connection string should start with `jdbc:`.");
+        String cleanURI = connUrl.substring(5);
+
+        URI uri = URI.create(cleanURI);
+        this.dialect = uri.getScheme();
+        this.hostname = uri.getHost();
+        this.port = uri.getPort();
+    }
+
+    /** Builder class for JDBC Sink Config. */
+    public static class Builder<T extends Builder<T>> {
+        private String connUrl;
+        private String username;
+        private String password;
+        private String table;
+        private String driverClassName;
+        private String serverTimeZone;
+        private Duration connectTimeout;
+        private int connectMaxRetries;
+        private int connectionPoolSize;
+        private long writeBatchIntervalMs;
+        private int writeBatchSize;
+        private int writeMaxRetries;
+        private Properties jdbcProperties;
+
+        public T connUrl(String connUrl) {
+            this.connUrl = connUrl;
+            return self();
+        }
+
+        public T username(String username) {
+            this.username = username;
+            return self();
+        }
+
+        public T password(String password) {
+            this.password = password;
+            return self();
+        }
+
+        public T table(String table) {
+            this.table = table;
+            return self();
+        }
+
+        public T driverClassName(String driverClassName) {
+            this.driverClassName = driverClassName;
+            return self();
+        }
+
+        public T serverTimeZone(String serverTimeZone) {
+            this.serverTimeZone = serverTimeZone;
+            return self();
+        }
+
+        public T connectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return self();
+        }
+
+        public T connectMaxRetries(int connectMaxRetries) {
+            this.connectMaxRetries = connectMaxRetries;
+            return self();
+        }
+
+        public T connectionPoolSize(int connectionPoolSize) {
+            this.connectionPoolSize = connectionPoolSize;
+            return self();
+        }
+
+        public T writeBatchIntervalMs(long writeBatchIntervalMs) {
+            this.writeBatchIntervalMs = writeBatchIntervalMs;
+            return self();
+        }
+
+        public T writeBatchSize(int writeBatchSize) {
+            this.writeBatchSize = writeBatchSize;
+            return self();
+        }
+
+        public T writeMaxRetries(int writeMaxRetries) {
+            this.writeMaxRetries = writeMaxRetries;
+            return self();
+        }
+
+        public T jdbcProperties(Properties jdbcProperties) {
+            this.jdbcProperties = jdbcProperties;
+            return self();
+        }
+
+        protected T self() {
+            return (T) this;
+        }
+
+        public JdbcSinkConfig build() {
+            return new JdbcSinkConfig(this);
+        }
+    }
+
+    public String getConnUrl() {
+        return connUrl;
+    }
+
+    public String getDialect() {
+        return dialect;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    public String getServerTimeZone() {
+        return serverTimeZone;
+    }
+
+    public Duration getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    public int getConnectMaxRetries() {
+        return connectMaxRetries;
+    }
+
+    public int getConnectionPoolSize() {
+        return connectionPoolSize;
+    }
+
+    public long getWriteBatchIntervalMs() {
+        return writeBatchIntervalMs;
+    }
+
+    public int getWriteBatchSize() {
+        return writeBatchSize;
+    }
+
+    public int getWriteMaxRetries() {
+        return writeMaxRetries;
+    }
+
+    public Properties getJdbcProperties() {
+        return jdbcProperties;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof JdbcSinkConfig)) {
+            return false;
+        }
+
+        JdbcSinkConfig that = (JdbcSinkConfig) o;
+        return connectMaxRetries == that.connectMaxRetries
+                && connectionPoolSize == that.connectionPoolSize
+                && writeBatchIntervalMs == that.writeBatchIntervalMs
+                && writeBatchSize == that.writeBatchSize
+                && writeMaxRetries == that.writeMaxRetries
+                && port == that.port
+                && connUrl.equals(that.connUrl)
+                && Objects.equals(username, that.username)
+                && Objects.equals(password, that.password)
+                && Objects.equals(table, that.table)
+                && Objects.equals(driverClassName, that.driverClassName)
+                && Objects.equals(serverTimeZone, that.serverTimeZone)
+                && Objects.equals(connectTimeout, that.connectTimeout)
+                && Objects.equals(jdbcProperties, that.jdbcProperties)
+                && Objects.equals(dialect, that.dialect)
+                && Objects.equals(hostname, that.hostname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                connUrl,
+                username,
+                password,
+                table,
+                driverClassName,
+                serverTimeZone,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                writeBatchIntervalMs,
+                writeBatchSize,
+                writeMaxRetries,
+                jdbcProperties,
+                dialect,
+                hostname,
+                port);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/ConnectionPoolId.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/ConnectionPoolId.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.connection;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** A unique identifier of connection pool. */
+public class ConnectionPoolId implements Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String host;
+    private final int port;
+    private final String username;
+
+    private final String dataSourcePoolFactoryIdentifier;
+
+    public ConnectionPoolId(
+            String host,
+            int port,
+            String username,
+            @Nullable String database,
+            String dataSourcePoolFactoryIdentifier) {
+        this.host = host;
+        this.port = port;
+        this.username = username;
+        this.dataSourcePoolFactoryIdentifier = dataSourcePoolFactoryIdentifier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConnectionPoolId)) {
+            return false;
+        }
+        ConnectionPoolId that = (ConnectionPoolId) o;
+        return Objects.equals(host, that.host)
+                && Objects.equals(port, that.port)
+                && Objects.equals(username, that.username)
+                && Objects.equals(
+                        dataSourcePoolFactoryIdentifier, that.dataSourcePoolFactoryIdentifier);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(host, port, username, dataSourcePoolFactoryIdentifier);
+    }
+
+    @Override
+    public String toString() {
+        return username
+                + '@'
+                + host
+                + ':'
+                + port
+                + ", dataSourcePoolFactoryIdentifier="
+                + dataSourcePoolFactoryIdentifier;
+    }
+
+    public String getDataSourcePoolFactoryIdentifier() {
+        return dataSourcePoolFactoryIdentifier;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/ConnectionPools.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/ConnectionPools.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.connection;
+
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+
+/** Factory class for creating connection pools. */
+public interface ConnectionPools<P, C extends JdbcSinkConfig> extends AutoCloseable {
+
+    /**
+     * Create a new pool if the pool does not exist, or get existing connection pool with given
+     * identifier.
+     */
+    P getOrCreateConnectionPool(ConnectionPoolId poolId, C sinkConfig);
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/JdbcConnectionFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/JdbcConnectionFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.connection;
+
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/** Factory class for creating JDBC {@link Connection}s. */
+public class JdbcConnectionFactory implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionFactory.class);
+
+    private final JdbcSinkConfig sinkConfig;
+
+    public JdbcConnectionFactory(JdbcSinkConfig sinkConfig) {
+        this.sinkConfig = sinkConfig;
+    }
+
+    public Connection connect() throws SQLException {
+        final int connectRetryTimes = sinkConfig.getConnectMaxRetries();
+
+        final ConnectionPoolId connectionPoolId =
+                JdbcConnectionPoolFactory.getPoolId(
+                        sinkConfig, JdbcConnectionPoolFactory.class.getName());
+
+        HikariDataSource dataSource =
+                JdbcConnectionPools.getInstance()
+                        .getOrCreateConnectionPool(connectionPoolId, sinkConfig);
+
+        int i = 0;
+        while (i < connectRetryTimes) {
+            try {
+                return dataSource.getConnection();
+            } catch (SQLException e) {
+                if (i < connectRetryTimes - 1) {
+                    try {
+                        Thread.sleep(300);
+                    } catch (InterruptedException ie) {
+                        throw new FlinkRuntimeException(
+                                "Failed to get connection, interrupted while doing another attempt",
+                                ie);
+                    }
+                    LOG.warn("Get connection failed, retry times {}", i + 1);
+                } else {
+                    LOG.error("Get connection failed after retry {} times", i + 1);
+                    throw new FlinkRuntimeException(e);
+                }
+            }
+            i++;
+        }
+        return dataSource.getConnection();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/JdbcConnectionPoolFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/JdbcConnectionPoolFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.connection;
+
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+
+import java.io.Serializable;
+import java.sql.DriverManager;
+
+/** A factory class for creating pooled {@link HikariDataSource}. */
+public abstract class JdbcConnectionPoolFactory implements Serializable {
+
+    public static final String CONNECTION_POOL_PREFIX = "connection-pool-";
+    public static final String SERVER_TIMEZONE_KEY = "serverTimezone";
+    public static final int MINIMUM_POOL_SIZE = 1;
+
+    public static HikariDataSource createPooledDataSource(JdbcSinkConfig sinkConfig) {
+        final HikariConfig config = new HikariConfig();
+        DriverManager.getDrivers();
+
+        String hostName = sinkConfig.getHostname();
+        int port = sinkConfig.getPort();
+
+        config.setPoolName(CONNECTION_POOL_PREFIX + hostName + ":" + port);
+        config.setJdbcUrl(sinkConfig.getConnUrl());
+        config.setUsername(sinkConfig.getUsername());
+        config.setPassword(sinkConfig.getPassword());
+        config.setMinimumIdle(MINIMUM_POOL_SIZE);
+        config.setMaximumPoolSize(sinkConfig.getConnectionPoolSize());
+        config.setConnectionTimeout(sinkConfig.getConnectTimeout().toMillis());
+        config.setDriverClassName(sinkConfig.getDriverClassName());
+
+        // note: the following properties should be optional (only applied to MySQL)
+        config.addDataSourceProperty(SERVER_TIMEZONE_KEY, sinkConfig.getServerTimeZone());
+        // optional optimization configurations for pooled DataSource
+        config.addDataSourceProperty("cachePrepStmts", "true");
+        config.addDataSourceProperty("prepStmtCacheSize", "250");
+        config.addDataSourceProperty("prepStmtCacheSqlLimit", "2048");
+
+        return new HikariDataSource(config);
+    }
+
+    /**
+     * The reuse strategy of connection pools. In most situations, connections to different
+     * databases in same instance (which means same host and port) can reuse same connection pool.
+     * However, in some situations when different databases in same instance cannot reuse same
+     * connection pool to connect, such as postgresql, this method should be overridden.
+     */
+    public static ConnectionPoolId getPoolId(
+            JdbcSinkConfig sinkConfig, String dataSourcePoolFactoryIdentifier) {
+        return new ConnectionPoolId(
+                sinkConfig.getHostname(),
+                sinkConfig.getPort(),
+                sinkConfig.getUsername(),
+                null,
+                dataSourcePoolFactoryIdentifier);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/JdbcConnectionPools.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/connection/JdbcConnectionPools.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.connection;
+
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** A Jdbc Connection pools implementation. */
+public class JdbcConnectionPools implements ConnectionPools<HikariDataSource, JdbcSinkConfig> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcConnectionPools.class);
+
+    private static JdbcConnectionPools instance;
+    private final Map<ConnectionPoolId, HikariDataSource> pools = new HashMap<>();
+
+    private JdbcConnectionPools() {}
+
+    public static synchronized JdbcConnectionPools getInstance() {
+        if (instance == null) {
+            instance = new JdbcConnectionPools();
+        }
+        return instance;
+    }
+
+    @Override
+    public HikariDataSource getOrCreateConnectionPool(
+            ConnectionPoolId poolId, JdbcSinkConfig sourceConfig) {
+        synchronized (pools) {
+            if (!pools.containsKey(poolId)) {
+                LOG.info("Create and register connection pool {}", poolId);
+                pools.put(poolId, JdbcConnectionPoolFactory.createPooledDataSource(sourceConfig));
+            }
+            return pools.get(poolId);
+        }
+    }
+
+    @Override
+    public void close() {
+        pools.values().forEach(HikariDataSource::close);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/dialect/JdbcColumn.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/dialect/JdbcColumn.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.dialect;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+
+/** Column descriptor class for generic JDBC-like sinks. */
+public class JdbcColumn implements Serializable {
+    /** The name of the column. */
+    private final String name;
+
+    /** The type of the column. e.g. `VARCHAR(10)` for MySQL. */
+    private final String columnType;
+
+    /** The type of the column data. e.g. `VARCHAR` for MySQL. */
+    private final String dataType;
+
+    /** The position of the column within the table (starting at 0). */
+    private final int position;
+
+    /** The column nullability.IS_NULLABLE in information_schema.COLUMNS. */
+    private final boolean isNullable;
+
+    /** The length of the column type. e.g. `VARCHAR(10)` length is 10 */
+    private final Integer length;
+
+    /** The precision of the column type e.g. `decimal(10, 2)` precision is 10 */
+    protected Integer precision;
+
+    /** The precision of the column type. e.g. `DECIMAL(10, 2)` scale is 2 */
+    @Nullable private final Integer scale;
+
+    /** The column comment. */
+    @Nullable private final String comment;
+
+    /** The default value for the column. */
+    @Nullable private final String defaultValue;
+
+    public JdbcColumn(
+            String name,
+            String columnType,
+            String dataType,
+            int position,
+            boolean isNullable,
+            @Nullable Integer length,
+            @Nullable Integer precision,
+            @Nullable Integer scale,
+            @Nullable String comment,
+            @Nullable String defaultValue) {
+        this.name = name;
+        this.columnType = columnType;
+        this.dataType = dataType;
+        this.position = position;
+        this.isNullable = isNullable;
+        this.length = length;
+        this.precision = precision;
+        this.scale = scale;
+        this.comment = comment;
+        this.defaultValue = defaultValue;
+    }
+
+    private JdbcColumn(Builder builder) {
+        this.name = builder.name;
+        this.columnType = builder.columnType;
+        this.dataType = builder.dataType;
+        this.position = builder.position;
+        this.isNullable = builder.isNullable;
+        this.length = builder.length;
+        this.precision = builder.precision;
+        this.scale = builder.scale;
+        this.comment = builder.comment;
+        this.defaultValue = builder.defaultValue;
+    }
+
+    /** Builder for Jdbc JdbcColumn. */
+    public static class Builder {
+        private String name;
+        private String columnType;
+        private String dataType;
+        private int position;
+        private boolean isNullable;
+        private Integer length;
+        private Integer precision;
+        private Integer scale;
+        private String comment;
+        private String defaultValue;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder columnType(String columnType) {
+            this.columnType = columnType;
+            return this;
+        }
+
+        public Builder dataType(String dataType) {
+            this.dataType = dataType;
+            return this;
+        }
+
+        public Builder position(int position) {
+            this.position = position;
+            return this;
+        }
+
+        public Builder isNullable(boolean isNullable) {
+            this.isNullable = isNullable;
+            return this;
+        }
+
+        public Builder length(@Nullable Integer length) {
+            this.length = length;
+            return this;
+        }
+
+        public Builder precision(@Nullable Integer precision) {
+            this.precision = precision;
+            return this;
+        }
+
+        public Builder scale(@Nullable Integer scale) {
+            this.scale = scale;
+            return this;
+        }
+
+        public Builder comment(@Nullable String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        public Builder defaultValue(@Nullable String defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        public JdbcColumn build() {
+            return new JdbcColumn(this);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColumnType() {
+        return columnType;
+    }
+
+    public String getDataType() {
+        return dataType;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+
+    public boolean isNullable() {
+        return isNullable;
+    }
+
+    public Integer getLength() {
+        return length;
+    }
+
+    public Integer getPrecision() {
+        return precision;
+    }
+
+    @Nullable
+    public Integer getScale() {
+        return scale;
+    }
+
+    @Nullable
+    public String getComment() {
+        return comment;
+    }
+
+    @Nullable
+    public String getDefaultValue() {
+        return defaultValue;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/dialect/JdbcSinkDialect.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/dialect/JdbcSinkDialect.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.dialect;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DropColumnEvent;
+import org.apache.flink.cdc.common.event.DropTableEvent;
+import org.apache.flink.cdc.common.event.RenameColumnEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.event.TruncateTableEvent;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.utils.Preconditions;
+import org.apache.flink.cdc.common.utils.StringUtils;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.connection.JdbcConnectionFactory;
+import org.apache.flink.cdc.connectors.jdbc.exception.JdbcSinkDialectException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+
+/** An abstract base class for various JDBC-like sinks. */
+public abstract class JdbcSinkDialect implements Serializable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcSinkDialect.class);
+
+    private final String dialectName;
+    protected final JdbcConnectionFactory connectionFactory;
+
+    public JdbcSinkDialect(String dialectName, JdbcSinkConfig sinkConfig) {
+        this.dialectName = dialectName;
+        this.connectionFactory = new JdbcConnectionFactory(sinkConfig);
+    }
+
+    /** Returns a unique identifier of this dialect. */
+    public String getDialectName() {
+        return dialectName;
+    }
+
+    // Rewritable methods that could be overwritten by subclasses.
+
+    /** Creates a single row of SQL that upserts into {@code tableId} with given {@code schema}. */
+    protected abstract String buildUpsertSql(TableId tableId, Schema schema);
+
+    /** Creates a single row of SQL that deletes from {@code tableId} with given {@code schema}. */
+    protected abstract String buildDeleteSql(TableId tableId, Schema schema);
+
+    /**
+     * Creates a single row of SQL that creates a table with {@code tableId} with given {@code
+     * schema}.
+     */
+    protected abstract String buildCreateTableSql(
+            TableId tableId, Schema schema, boolean ignoreIfExists);
+
+    /**
+     * Creates a single row of SQL that adds multiple columns like {@code addedColumns} into table
+     * {@code tableId}.
+     */
+    protected abstract String buildAlterAddColumnsSql(
+            TableId tableId, List<AddColumnEvent.ColumnWithPosition> addedColumns);
+
+    /**
+     * Creates a single row of SQL that renames column {@code oldName} to {@code newName} in table
+     * {@code tableId}.
+     */
+    protected abstract String buildRenameColumnSql(TableId tableId, String oldName, String newName);
+
+    /**
+     * Creates a single row of SQL that drops specific column with name {@code column} in table
+     * {@code tableId}.
+     */
+    protected abstract String buildDropColumnSql(TableId tableId, String column);
+
+    /**
+     * Creates a single row of SQL that alters a specific column {@code columnName}'type to {@code
+     * columnType} in table {@code tableId}.
+     */
+    protected abstract String buildAlterColumnTypeSql(
+            TableId tableId, String columnName, DataType columnType);
+
+    /** Creates a single row of SQL that truncates given table {@code tableId}. */
+    protected abstract String buildTruncateTableSql(TableId tableId);
+
+    /** Creates a single row of SQL that drops given table {@code tableId}. */
+    protected abstract String buildDropTableSql(TableId tableId, boolean ignoreIfNotExist);
+
+    // Final methods that are not meant to be overwritten.
+    public final void createTable(CreateTableEvent createTableEvent, boolean ignoreIfExists)
+            throws JdbcSinkDialectException {
+        TableId tableId = createTableEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        Schema schema = createTableEvent.getSchema();
+        String createTableSql = buildCreateTableSql(tableId, schema, ignoreIfExists);
+
+        try {
+            executeUpdate(createTableSql);
+            LOG.info(
+                    "Successfully created table `{}`.`{}`. Raw SQL: {}",
+                    tableId.getSchemaName(),
+                    tableId.getTableName(),
+                    createTableSql);
+        } catch (SQLException e) {
+            throw new JdbcSinkDialectException(
+                    String.format(
+                            "Failed to create table `%s`.`%s`. Raw SQL: %s",
+                            tableId.getSchemaName(), tableId.getTableName(), createTableSql),
+                    e);
+        }
+    }
+
+    public final void addColumn(AddColumnEvent addColumnEvent) throws JdbcSinkDialectException {
+        TableId tableId = addColumnEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        Preconditions.checkArgument(
+                !addColumnEvent.getAddedColumns().isEmpty(), "Added columns should not be empty.");
+
+        String addColumnSql = buildAlterAddColumnsSql(tableId, addColumnEvent.getAddedColumns());
+        try {
+            executeUpdate(addColumnSql);
+            LOG.info(
+                    "Successfully added column in table `{}`.`{}`. Raw SQL: {}",
+                    tableId.getSchemaName(),
+                    tableId.getTableName(),
+                    addColumnSql);
+        } catch (Exception e) {
+            throw new JdbcSinkDialectException(
+                    String.format(
+                            "Failed to add column in table `%s`.`%s`. Raw SQL: %s",
+                            tableId.getSchemaName(), tableId.getTableName(), addColumnSql),
+                    e);
+        }
+    }
+
+    public final void dropColumn(DropColumnEvent dropColumnEvent) throws JdbcSinkDialectException {
+        TableId tableId = dropColumnEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        List<String> droppedColumnNames = dropColumnEvent.getDroppedColumnNames();
+        Preconditions.checkArgument(
+                !droppedColumnNames.isEmpty(), "Dropped columns should not be empty.");
+
+        droppedColumnNames.forEach(
+                column -> {
+                    String dropColumnSql = buildDropColumnSql(tableId, column);
+                    try {
+                        executeUpdate(dropColumnSql);
+                        LOG.info(
+                                "Successfully dropped column in table `{}`.`{}`. Raw SQL: {}",
+                                tableId.getSchemaName(),
+                                tableId.getTableName(),
+                                dropColumnSql);
+                    } catch (Exception e) {
+                        throw new JdbcSinkDialectException(
+                                String.format(
+                                        "Failed to drop column in table `%s`.`%s`. Raw SQL: %s",
+                                        tableId.getSchemaName(),
+                                        tableId.getTableName(),
+                                        dropColumnSql),
+                                e);
+                    }
+                });
+    }
+
+    public final void renameColumn(RenameColumnEvent renameColumnEvent)
+            throws JdbcSinkDialectException {
+        TableId tableId = renameColumnEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        Map<String, String> nameMapping = renameColumnEvent.getNameMapping();
+        for (Map.Entry<String, String> entry : nameMapping.entrySet()) {
+            String renameColumnSql =
+                    buildRenameColumnSql(tableId, entry.getKey(), entry.getValue());
+            try {
+                executeUpdate(renameColumnSql);
+                LOG.info(
+                        "Successfully renamed column in table `{}`.`{}`. Raw SQL: {}",
+                        tableId.getSchemaName(),
+                        tableId.getTableName(),
+                        renameColumnSql);
+            } catch (Exception e) {
+                throw new JdbcSinkDialectException(
+                        String.format(
+                                "Failed to rename column in table `%s`.`%s`. Raw SQL: %s",
+                                tableId.getSchemaName(), tableId.getTableName(), renameColumnSql),
+                        e);
+            }
+        }
+    }
+
+    public final void alterColumnType(AlterColumnTypeEvent alterColumnTypeEvent)
+            throws JdbcSinkDialectException {
+        TableId tableId = alterColumnTypeEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        Map<String, DataType> typeMapping = alterColumnTypeEvent.getTypeMapping();
+        for (Map.Entry<String, DataType> entry : typeMapping.entrySet()) {
+            String alterColumnTypeSql =
+                    buildAlterColumnTypeSql(tableId, entry.getKey(), entry.getValue());
+
+            try {
+                executeUpdate(alterColumnTypeSql);
+                LOG.info(
+                        "Successfully altered column type in table `{}`.`{}`. Raw SQL: {}",
+                        tableId.getSchemaName(),
+                        tableId.getTableName(),
+                        alterColumnTypeSql);
+            } catch (Exception e) {
+                throw new JdbcSinkDialectException(
+                        String.format(
+                                "Failed to alter column type in table `%s`.`%s`. Raw SQL: %s",
+                                tableId.getSchemaName(),
+                                tableId.getTableName(),
+                                alterColumnTypeSql),
+                        e);
+            }
+        }
+    }
+
+    public final void truncateTable(TruncateTableEvent truncateTableEvent)
+            throws JdbcSinkDialectException {
+        TableId tableId = truncateTableEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        String truncateTableSql = buildTruncateTableSql(tableId);
+
+        try {
+            executeUpdate(truncateTableSql);
+            LOG.info(
+                    "Successfully truncated table `{}`.`{}`. Raw SQL: {}",
+                    tableId.getSchemaName(),
+                    tableId.getTableName(),
+                    truncateTableSql);
+        } catch (SQLException e) {
+            throw new JdbcSinkDialectException(
+                    String.format(
+                            "Failed to truncate table `%s`.`%s`. Raw SQL: %s",
+                            tableId.getSchemaName(), tableId.getTableName(), truncateTableSql),
+                    e);
+        }
+    }
+
+    public final void dropTable(DropTableEvent dropTableEvent, boolean ignoreIfNotExist)
+            throws JdbcSinkDialectException {
+        TableId tableId = dropTableEvent.tableId();
+        checkTableIdArguments(tableId);
+
+        String dropTableSql = buildDropTableSql(tableId, ignoreIfNotExist);
+
+        try {
+            executeUpdate(dropTableSql);
+            LOG.info(
+                    "Successfully dropped table `{}`.`{}`. Raw SQL: {}",
+                    tableId.getSchemaName(),
+                    tableId.getTableName(),
+                    dropTableSql);
+        } catch (SQLException e) {
+            throw new JdbcSinkDialectException(
+                    String.format(
+                            "Failed to drop table `%s`.`%s`. Raw SQL: %s",
+                            tableId.getSchemaName(), tableId.getTableName(), dropTableSql),
+                    e);
+        }
+    }
+
+    public final String getUpsertStatement(TableId tableId, Schema schema) {
+        checkTableIdArguments(tableId);
+        return buildUpsertSql(tableId, schema);
+    }
+
+    public final String getDeleteStatement(TableId tableId, Schema schema) {
+        checkTableIdArguments(tableId);
+        return buildDeleteSql(tableId, schema);
+    }
+
+    protected final void checkTableIdArguments(TableId tableId) {
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(tableId.getSchemaName()),
+                "database name cannot be null or empty.");
+        Preconditions.checkArgument(
+                !StringUtils.isNullOrWhitespaceOnly(tableId.getTableName()),
+                "table name cannot be null or empty.");
+    }
+
+    protected final void executeUpdate(String sql) throws SQLException {
+        try (Connection connection = connectionFactory.connect();
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate(sql);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/dialect/JdbcSinkDialectFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/dialect/JdbcSinkDialectFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.dialect;
+
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+
+/** Factory class for creating {@link JdbcSinkDialect}s. */
+public interface JdbcSinkDialectFactory<T extends JdbcSinkConfig> {
+
+    /** Gets the identifier string of JDBC sink dialect. */
+    String identifier();
+
+    /** Creates a {@link JdbcSinkDialect} using {@link JdbcSinkConfig}s. */
+    JdbcSinkDialect createDialect(T option);
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/exception/JdbcSinkDialectException.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/exception/JdbcSinkDialectException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.exception;
+
+/**
+ * A {@link RuntimeException} thrown by specific {@link
+ * org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect}.
+ */
+public class JdbcSinkDialectException extends RuntimeException {
+    public JdbcSinkDialectException(String message) {
+        super(message);
+    }
+
+    public JdbcSinkDialectException(Throwable cause) {
+        super(cause);
+    }
+
+    public JdbcSinkDialectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/factory/JdbcDataSinkFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/factory/JdbcDataSinkFactory.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.factory;
+
+import org.apache.flink.cdc.common.configuration.ConfigOption;
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.factories.DataSinkFactory;
+import org.apache.flink.cdc.common.factories.FactoryHelper;
+import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.common.utils.Preconditions;
+import org.apache.flink.cdc.connectors.base.utils.OptionUtils;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory;
+import org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions;
+import org.apache.flink.cdc.connectors.jdbc.sink.JdbcDataSink;
+import org.apache.flink.configuration.ConfigurationUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZoneId;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.CONNECTION_POOL_SIZE;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.CONNECT_MAX_RETRIES;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.CONNECT_TIMEOUT;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.CONN_URL;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.DRIVER_CLASS_NAME;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.JDBC_PROPERTIES_PROP_PREFIX;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.PASSWORD;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.SERVER_TIME_ZONE;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.USERNAME;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.WRITE_BATCH_INTERVAL_MS;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.WRITE_BATCH_SIZE;
+import static org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions.WRITE_MAX_RETRIES;
+
+/** A {@link DataSinkFactory} for creating JDBC sinks. */
+public class JdbcDataSinkFactory implements DataSinkFactory {
+
+    public static final String IDENTIFIER = "jdbc";
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcDataSinkFactory.class);
+
+    @Override
+    public DataSink createDataSink(Context context) {
+        FactoryHelper.createFactoryHelper(this, context)
+                .validateExcept(JDBC_PROPERTIES_PROP_PREFIX);
+
+        // Construct JdbcSinkConfig from FactoryConfigurations
+        final Configuration config = context.getFactoryConfiguration();
+        JdbcSinkConfig.Builder<?> builder = new JdbcSinkConfig.Builder<>();
+
+        List<JdbcSinkDialectFactory<JdbcSinkConfig>> dialectFactories =
+                discoverDialectFactories(getClass().getClassLoader());
+
+        builder.connUrl(config.get(CONN_URL))
+                .username(config.get(USERNAME))
+                .password(config.get(PASSWORD))
+                .serverTimeZone(
+                        config.getOptional(SERVER_TIME_ZONE)
+                                .orElse(ZoneId.systemDefault().toString()))
+                .connectTimeout(config.get(CONNECT_TIMEOUT))
+                .connectionPoolSize(config.get(CONNECTION_POOL_SIZE))
+                .connectMaxRetries(config.get(CONNECT_MAX_RETRIES))
+                .writeBatchIntervalMs(config.get(WRITE_BATCH_INTERVAL_MS))
+                .writeBatchSize(config.get(WRITE_BATCH_SIZE))
+                .writeMaxRetries(config.get(WRITE_MAX_RETRIES))
+                .driverClassName(config.get(DRIVER_CLASS_NAME));
+
+        Properties properties = new Properties();
+        Map<String, String> jdbcProperties =
+                JdbcSinkOptions.getPropertiesByPrefix(config, JDBC_PROPERTIES_PROP_PREFIX);
+        properties.putAll(jdbcProperties);
+        builder.jdbcProperties(properties);
+        JdbcSinkConfig jdbcSinkConfig = builder.build();
+
+        // Discover corresponding factory
+        String dialect = jdbcSinkConfig.getDialect();
+
+        List<JdbcSinkDialectFactory<JdbcSinkConfig>> availableFactories =
+                dialectFactories.stream()
+                        .filter(d -> dialect.equalsIgnoreCase(d.identifier()))
+                        .collect(Collectors.toList());
+
+        Preconditions.checkArgument(
+                availableFactories.size() == 1,
+                "There must be exactly one factory for dialect %s, but %s found.\nMatched dialects: %s\nAvailable dialects: %s",
+                dialect,
+                availableFactories.size(),
+                availableFactories.stream().map(Object::getClass).collect(Collectors.toList()),
+                dialectFactories.stream()
+                        .map(JdbcSinkDialectFactory::identifier)
+                        .collect(Collectors.toList()));
+
+        JdbcSinkDialectFactory<JdbcSinkConfig> dialectFactory = availableFactories.get(0);
+
+        if (LOG.isInfoEnabled()) {
+            OptionUtils.printOptions(
+                    IDENTIFIER, ConfigurationUtils.hideSensitiveValues(config.toMap()));
+        }
+
+        return new JdbcDataSink(dialectFactory.createDialect(jdbcSinkConfig), jdbcSinkConfig);
+    }
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(CONN_URL);
+        options.add(USERNAME);
+        options.add(PASSWORD);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(DRIVER_CLASS_NAME);
+        options.add(SERVER_TIME_ZONE);
+        options.add(CONNECT_TIMEOUT);
+        options.add(CONNECTION_POOL_SIZE);
+        options.add(CONNECT_MAX_RETRIES);
+        options.add(WRITE_BATCH_INTERVAL_MS);
+        options.add(WRITE_BATCH_SIZE);
+        options.add(WRITE_MAX_RETRIES);
+        return options;
+    }
+
+    private List<JdbcSinkDialectFactory<JdbcSinkConfig>> discoverDialectFactories(
+            ClassLoader classLoader) {
+        try {
+            final List<JdbcSinkDialectFactory<JdbcSinkConfig>> result = new LinkedList<>();
+            ServiceLoader.load(JdbcSinkDialectFactory.class, classLoader)
+                    .iterator()
+                    .forEachRemaining(result::add);
+            return result;
+        } catch (ServiceConfigurationError e) {
+            throw new RuntimeException(
+                    "Could not load service provider for JdbcSinkDialectFactory.", e);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/options/JdbcSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/options/JdbcSinkOptions.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.options;
+
+import org.apache.flink.cdc.common.configuration.ConfigOption;
+import org.apache.flink.cdc.common.configuration.ConfigOptions;
+import org.apache.flink.cdc.common.configuration.Configuration;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Configurations for JDBC data source. */
+public class JdbcSinkOptions {
+    public static final ConfigOption<String> CONN_URL =
+            ConfigOptions.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("JDBC connection URL for sink database.");
+
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Name of the database to use when connecting to the database server.");
+
+    public static final ConfigOption<String> PASSWORD =
+            ConfigOptions.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Password to use when connecting to the database server.");
+    public static final ConfigOption<String> DRIVER_CLASS_NAME =
+            ConfigOptions.key("driver-class-name")
+                    .stringType()
+                    .defaultValue("com.mysql.cj.jdbc.Driver")
+                    .withDescription("Table name of the database connection to driver class.");
+
+    public static final ConfigOption<String> SERVER_TIME_ZONE =
+            ConfigOptions.key("server-time-zone")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The session time zone in database server. If not set, then "
+                                    + "ZoneId.systemDefault() is used to determine the server time zone.");
+
+    public static final ConfigOption<Duration> CONNECT_TIMEOUT =
+            ConfigOptions.key("connect.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "The maximum time that the connector should wait after trying to connect to the database server before timing out.");
+
+    public static final ConfigOption<Integer> CONNECTION_POOL_SIZE =
+            ConfigOptions.key("connection.pool.size")
+                    .intType()
+                    .defaultValue(20)
+                    .withDescription("The connection pool size.");
+
+    public static final ConfigOption<Integer> CONNECT_MAX_RETRIES =
+            ConfigOptions.key("connect.max-retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "The max retry times that the connector should retry to build database server connection.");
+
+    public static final ConfigOption<Long> WRITE_BATCH_INTERVAL_MS =
+            ConfigOptions.key("write.batch.interval.ms")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription(
+                            "The flush interval mills, over this time, asynchronous threads will flush data. Can be set to '0' to disable it.");
+
+    public static final ConfigOption<Integer> WRITE_BATCH_SIZE =
+            ConfigOptions.key("write.batch.size")
+                    .intType()
+                    .defaultValue(512)
+                    .withDescription(
+                            "The maximum amount of records in a single writing batch. Batching is only supported for tables with primary keys.");
+
+    public static final ConfigOption<Integer> WRITE_MAX_RETRIES =
+            ConfigOptions.key("write.max.retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("The max retry times if writing records to database failed.");
+
+    public static final String JDBC_PROPERTIES_PROP_PREFIX = "jdbc.properties.";
+
+    public static Map<String, String> getPropertiesByPrefix(
+            Configuration tableOptions, String prefix) {
+        final Map<String, String> props = new HashMap<>();
+
+        for (Map.Entry<String, String> entry : tableOptions.toMap().entrySet()) {
+            if (entry.getKey().startsWith(prefix)) {
+                String subKey = entry.getKey().substring(prefix.length());
+                props.put(subKey, entry.getValue());
+            }
+        }
+        return props;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/JdbcDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/JdbcDataSink.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink;
+
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.common.sink.EventSinkProvider;
+import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+import org.apache.flink.cdc.connectors.jdbc.sink.v2.EventRecordSerializationSchema;
+import org.apache.flink.cdc.connectors.jdbc.sink.v2.JdbcSink;
+import org.apache.flink.cdc.connectors.jdbc.sink.v2.JdbcSinkBuilder;
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+
+import java.io.Serializable;
+
+/** Writing data to JDBC-like sinks. */
+public class JdbcDataSink implements DataSink, Serializable {
+    private final JdbcSinkDialect dialect;
+    private final JdbcSinkConfig sinkConfig;
+
+    public JdbcDataSink(JdbcSinkDialect dialect, JdbcSinkConfig sinkConfig) {
+        this.dialect = dialect;
+        this.sinkConfig = sinkConfig;
+    }
+
+    @Override
+    public EventSinkProvider getEventSinkProvider() {
+        JdbcConnectionOptions connectionOptions =
+                new JdbcConnectionOptions.JdbcConnectionOptionsBuilder()
+                        .withUrl(sinkConfig.getConnUrl())
+                        .withUsername(sinkConfig.getUsername())
+                        .withPassword(sinkConfig.getPassword())
+                        .withDriverName(sinkConfig.getDriverClassName())
+                        .build();
+
+        JdbcSink<Event> jdbcSink =
+                new JdbcSinkBuilder<Event>()
+                        .withExecutionOptions(
+                                JdbcExecutionOptions.builder()
+                                        .withBatchSize(sinkConfig.getWriteBatchSize())
+                                        .withBatchIntervalMs(sinkConfig.getWriteBatchIntervalMs())
+                                        .withMaxRetries(sinkConfig.getWriteMaxRetries())
+                                        .build())
+                        .withSerializationSchema(new EventRecordSerializationSchema())
+                        .withDialect(dialect)
+                        .withSinkConfig(sinkConfig)
+                        .buildAtLeastOnce(connectionOptions);
+
+        return FlinkSinkProvider.of(jdbcSink);
+    }
+
+    @Override
+    public MetadataApplier getMetadataApplier() {
+        return new JdbcMetadataApplier(dialect);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/JdbcMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/JdbcMetadataApplier.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DropColumnEvent;
+import org.apache.flink.cdc.common.event.DropTableEvent;
+import org.apache.flink.cdc.common.event.RenameColumnEvent;
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TruncateTableEvent;
+import org.apache.flink.cdc.common.exceptions.SchemaEvolveException;
+import org.apache.flink.cdc.common.exceptions.UnsupportedSchemaChangeEventException;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Apply schema change events to JDBC-like sinks. */
+public class JdbcMetadataApplier implements MetadataApplier {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcMetadataApplier.class);
+
+    private final JdbcSinkDialect dialect;
+
+    public JdbcMetadataApplier(JdbcSinkDialect dialect) {
+        this.dialect = dialect;
+    }
+
+    @Override
+    public void applySchemaChange(SchemaChangeEvent event) {
+        LOG.info("Applying schema change event: {}", event);
+        try {
+            if (event instanceof CreateTableEvent) {
+                applyCreateTableEvent((CreateTableEvent) event);
+            } else if (event instanceof AddColumnEvent) {
+                applyAddColumnEvent((AddColumnEvent) event);
+            } else if (event instanceof DropColumnEvent) {
+                applyDropColumnEvent((DropColumnEvent) event);
+            } else if (event instanceof RenameColumnEvent) {
+                applyRenameColumnEvent((RenameColumnEvent) event);
+            } else if (event instanceof AlterColumnTypeEvent) {
+                applyAlterColumnType((AlterColumnTypeEvent) event);
+            } else if (event instanceof TruncateTableEvent) {
+                applyTruncateTableEvent((TruncateTableEvent) event);
+            } else if (event instanceof DropTableEvent) {
+                applyDropTableEvent((DropTableEvent) event);
+            } else {
+                throw new UnsupportedSchemaChangeEventException(event);
+            }
+        } catch (Exception ex) {
+            throw new SchemaEvolveException(event, "Failed to apply schema change event. ", ex);
+        }
+    }
+
+    private void applyCreateTableEvent(CreateTableEvent event) {
+        dialect.createTable(event, true);
+    }
+
+    private void applyAddColumnEvent(AddColumnEvent event) {
+        dialect.addColumn(event);
+    }
+
+    private void applyAlterColumnType(AlterColumnTypeEvent event) {
+        dialect.alterColumnType(event);
+    }
+
+    private void applyRenameColumnEvent(RenameColumnEvent event) {
+        dialect.renameColumn(event);
+    }
+
+    private void applyDropColumnEvent(DropColumnEvent event) {
+        dialect.dropColumn(event);
+    }
+
+    private void applyTruncateTableEvent(TruncateTableEvent event) {
+        dialect.truncateTable(event);
+    }
+
+    private void applyDropTableEvent(DropTableEvent event) {
+        dialect.dropTable(event, true);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/utils/JsonWrapper.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/utils/JsonWrapper.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.utils;
+
+import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.data.TimestampData;
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonSerializer;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.SerializerProvider;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.module.SimpleModule;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.format.DateTimeFormatter;
+
+/** JSON wrapper class for serializing / deserializing row data. */
+public class JsonWrapper implements Serializable {
+    private transient ObjectMapper objectMapper;
+
+    public JsonWrapper() {
+        objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(BinaryStringData.class, new BinaryStringDataSerializer());
+        module.addSerializer(DecimalData.class, new DecimalDataSerializer());
+        module.addSerializer(TimestampData.class, new TimestampDataSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    public byte[] toJSONBytes(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsBytes(object);
+    }
+
+    public String toJSONString(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+
+    public <T> T parse(String text, Class<T> clazz) throws JsonProcessingException {
+        return objectMapper.readValue(text, clazz);
+    }
+
+    public <T> T parseObject(byte[] bytes, Class<T> clazz) throws IOException {
+        return objectMapper.readValue(bytes, clazz);
+    }
+
+    // Add method to parse using TypeReference
+    public <T> T parseObject(byte[] bytes, TypeReference<T> typeReference) throws IOException {
+        return objectMapper.readValue(bytes, typeReference);
+    }
+
+    // Method to parse String using TypeReference
+    public <T> T parseObject(String text, TypeReference<T> typeReference) throws IOException {
+        return objectMapper.readValue(text, typeReference);
+    }
+
+    // BinaryStringData Serializer
+    static final class BinaryStringDataSerializer extends JsonSerializer<BinaryStringData> {
+        @Override
+        public void serialize(
+                BinaryStringData value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeString(value.toString());
+        }
+    }
+
+    // DecimalData Serializer
+    static final class DecimalDataSerializer extends JsonSerializer<DecimalData> {
+        @Override
+        public void serialize(DecimalData value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeString(value.toBigDecimal().toPlainString());
+        }
+    }
+
+    // TimestampData Serializer
+    static final class TimestampDataSerializer extends JsonSerializer<TimestampData> {
+        private final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+        @Override
+        public void serialize(
+                TimestampData value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            gen.writeString(value.toLocalDateTime().format(formatter));
+        }
+    }
+
+    private void readObject(java.io.ObjectInputStream stream)
+            throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        if (objectMapper == null) {
+            objectMapper = new ObjectMapper();
+            SimpleModule module = new SimpleModule();
+            module.addSerializer(BinaryStringData.class, new BinaryStringDataSerializer());
+            module.addSerializer(DecimalData.class, new DecimalDataSerializer());
+            module.addSerializer(TimestampData.class, new TimestampDataSerializer());
+            objectMapper.registerModule(module);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/BatchedStatementExecutor.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/BatchedStatementExecutor.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+/** A batched statement executor of {@link JdbcRowData}. */
+public class BatchedStatementExecutor implements JdbcBatchStatementExecutor<JdbcRowData> {
+
+    private final JdbcBatchStatementExecutor<JdbcRowData> upsertExecutor;
+    private final JdbcBatchStatementExecutor<JdbcRowData> deleteExecutor;
+    private final Function<JdbcRowData, JdbcRowData> keyExtractor;
+
+    // A buffer holding batched records. The key is the upserting / deleting column row data, and
+    // its value could be overwritten.
+    private final Map<JdbcRowData, Tuple2<Boolean, JdbcRowData>> reduceBuffer;
+
+    public BatchedStatementExecutor(
+            JdbcBatchStatementExecutor<JdbcRowData> upsertExecutor,
+            JdbcBatchStatementExecutor<JdbcRowData> deleteExecutor,
+            Function<JdbcRowData, JdbcRowData> keyExtractor) {
+        this.upsertExecutor = upsertExecutor;
+        this.deleteExecutor = deleteExecutor;
+        this.keyExtractor = keyExtractor;
+        this.reduceBuffer = new HashMap<>();
+    }
+
+    @Override
+    public void prepareStatements(Connection connection) throws SQLException {
+        upsertExecutor.prepareStatements(connection);
+        deleteExecutor.prepareStatements(connection);
+    }
+
+    @Override
+    public void addToBatch(JdbcRowData record) {
+        JdbcRowData key = keyExtractor.apply(record);
+        boolean flag = changeFlag(record.getRowKind());
+        reduceBuffer.put(key, Tuple2.of(flag, record));
+    }
+
+    /**
+     * Returns true if the row kind is INSERT or UPDATE_AFTER, returns false if the row kind is
+     * DELETE or UPDATE_BEFORE.
+     */
+    private boolean changeFlag(RowKind rowKind) {
+        switch (rowKind) {
+            case INSERT:
+            case UPDATE_AFTER:
+                return true;
+            case DELETE:
+            case UPDATE_BEFORE:
+                return false;
+            default:
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Unknown row kind, the supported row kinds is: INSERT, UPDATE_BEFORE, UPDATE_AFTER,"
+                                        + " DELETE, but get: %s.",
+                                rowKind));
+        }
+    }
+
+    @Override
+    public void executeBatch() throws SQLException {
+        if (!reduceBuffer.isEmpty()) {
+            for (Map.Entry<JdbcRowData, Tuple2<Boolean, JdbcRowData>> entry :
+                    reduceBuffer.entrySet()) {
+                if (entry.getValue().f0) {
+                    upsertExecutor.addToBatch(entry.getValue().f1);
+                } else {
+                    // delete by key
+                    deleteExecutor.addToBatch(entry.getKey());
+                }
+            }
+            upsertExecutor.executeBatch();
+            deleteExecutor.executeBatch();
+            reduceBuffer.clear();
+        }
+    }
+
+    @Override
+    public void closeStatements() throws SQLException {
+        upsertExecutor.closeStatements();
+        deleteExecutor.closeStatements();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/EventRecordSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/EventRecordSerializationSchema.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.cdc.common.data.RecordData;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Column;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.utils.Preconditions;
+import org.apache.flink.cdc.common.utils.SchemaUtils;
+import org.apache.flink.cdc.connectors.jdbc.sink.utils.JsonWrapper;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Serialization schema between {@link Event} and {@link JdbcRowData}. */
+public class EventRecordSerializationSchema implements RecordSerializationSchema<Event> {
+    /** Keeping the relationship of TableId and table information. */
+    private final Map<TableId, TableInfo> tableInfoMap;
+
+    private final JsonWrapper jsonWrapper = new JsonWrapper();
+
+    public EventRecordSerializationSchema() {
+        tableInfoMap = new HashMap<>();
+    }
+
+    @Override
+    public JdbcRowData[] serialize(Event record) throws IOException {
+        if (record instanceof SchemaChangeEvent) {
+            return new JdbcRowData[] {applySchemaChangeEvent((SchemaChangeEvent) record)};
+        } else if (record instanceof DataChangeEvent) {
+            return applyDataChangeEvent((DataChangeEvent) record);
+        } else {
+            throw new UnsupportedOperationException("Unsupported event record type: " + record);
+        }
+    }
+
+    private JdbcRowData applySchemaChangeEvent(SchemaChangeEvent event) {
+        TableId tableId = event.tableId();
+        Schema newSchema;
+        if (event instanceof CreateTableEvent) {
+            newSchema = ((CreateTableEvent) event).getSchema();
+        } else {
+            TableInfo tableInfo = tableInfoMap.get(tableId);
+            if (tableInfo == null) {
+                throw new RuntimeException("schema of " + tableId + " is not existed.");
+            }
+            newSchema = SchemaUtils.applySchemaChangeEvent(tableInfo.schema, event);
+        }
+        TableInfo tableInfo = new TableInfo(newSchema);
+        tableInfoMap.put(tableId, tableInfo);
+
+        return new RichJdbcRowData.Builder()
+                .setRowKind(RowKind.SCHEMA_CHANGE)
+                .setTableId(event.tableId())
+                .build();
+    }
+
+    private JdbcRowData[] applyDataChangeEvent(DataChangeEvent event)
+            throws JsonProcessingException {
+        TableInfo tableInfo = tableInfoMap.get(event.tableId());
+        Preconditions.checkNotNull(tableInfo, event.tableId() + " does not exist");
+
+        RichJdbcRowData.Builder builder =
+                new RichJdbcRowData.Builder()
+                        .setTableId(event.tableId())
+                        .setSchema(tableInfo.schema);
+
+        List<JdbcRowData> rows = new ArrayList<>(2);
+
+        if (event.before() != null) {
+            builder.setRowKind(RowKind.DELETE);
+            builder.setRows(serializeRecord(event.tableId(), tableInfo, event.before()));
+            rows.add(builder.build());
+        }
+
+        if (event.after() != null) {
+            builder.setRowKind(RowKind.INSERT);
+            builder.setRows(serializeRecord(event.tableId(), tableInfo, event.after()));
+            rows.add(builder.build());
+        }
+
+        return rows.toArray(new JdbcRowData[0]);
+    }
+
+    private byte[] serializeRecord(TableId tableId, TableInfo tableInfo, RecordData record)
+            throws JsonProcessingException {
+        Preconditions.checkNotNull(record, tableId + " record is null");
+
+        List<Column> columns = tableInfo.schema.getColumns();
+        Preconditions.checkArgument(columns.size() == record.getArity());
+
+        Map<String, Object> rowMap = new HashMap<>(record.getArity() + 1);
+        for (int i = 0; i < record.getArity(); i++) {
+            rowMap.put(columns.get(i).getName(), tableInfo.fieldGetters[i].getFieldOrNull(record));
+        }
+
+        return jsonWrapper.toJSONBytes(rowMap);
+    }
+
+    /** Table information. */
+    private static class TableInfo {
+        Schema schema;
+        RecordData.FieldGetter[] fieldGetters;
+
+        public TableInfo(Schema schema) {
+            this.schema = schema;
+            this.fieldGetters =
+                    SchemaUtils.createFieldGetters(schema).toArray(new RecordData.FieldGetter[0]);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcRowData.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcRowData.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+
+import java.io.Serializable;
+
+/** JdbcRowData represents extracting a row of data from a table in the database. */
+public interface JdbcRowData extends Serializable {
+    TableId getTableId();
+
+    Schema getSchema();
+
+    RowKind getRowKind();
+
+    byte[] getRows();
+
+    boolean hasPrimaryKey();
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcSink.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.JdbcOutputSerializer;
+import org.apache.flink.connector.jdbc.sink.writer.JdbcWriterState;
+import org.apache.flink.connector.jdbc.sink.writer.JdbcWriterStateSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Implementation class of the {@link StatefulSink} interface. */
+public class JdbcSink<IN> implements StatefulSink<IN, JdbcWriterState> {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcSink.class);
+
+    private final JdbcConnectionProvider connectionProvider;
+
+    private final JdbcExecutionOptions executionOptions;
+
+    private final RecordSerializationSchema<IN> serializationSchema;
+
+    private final JdbcSinkDialect dialect;
+
+    private final JdbcSinkConfig sinkConfig;
+
+    public JdbcSink(
+            JdbcExecutionOptions executionOptions,
+            JdbcConnectionProvider connectionProvider,
+            RecordSerializationSchema<IN> serializationSchema,
+            JdbcSinkDialect dialect,
+            JdbcSinkConfig sinkConfig) {
+        this.executionOptions = executionOptions;
+        this.connectionProvider = connectionProvider;
+        this.serializationSchema = serializationSchema;
+        this.dialect = dialect;
+        this.sinkConfig = sinkConfig;
+    }
+
+    @Override
+    public StatefulSinkWriter<IN, JdbcWriterState> createWriter(InitContext context)
+            throws IOException {
+        return restoreWriter(context, Collections.emptyList());
+    }
+
+    @Override
+    public StatefulSinkWriter<IN, JdbcWriterState> restoreWriter(
+            InitContext context, Collection<JdbcWriterState> collection) throws IOException {
+        JdbcOutputSerializer<Object> outputSerializer =
+                JdbcOutputSerializer.of(
+                        context.createInputSerializer(), context.isObjectReuseEnabled());
+
+        return new JdbcWriter<>(
+                context,
+                executionOptions,
+                connectionProvider,
+                outputSerializer,
+                serializationSchema,
+                dialect,
+                sinkConfig);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<JdbcWriterState> getWriterStateSerializer() {
+        return new JdbcWriterStateSerializer();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcSinkBuilder.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcSinkBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+import org.apache.flink.connector.jdbc.JdbcConnectionOptions;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.datasource.connections.SimpleJdbcConnectionProvider;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Builder to construct {@link JdbcSink}. */
+@PublicEvolving
+public class JdbcSinkBuilder<IN> {
+    private JdbcExecutionOptions executionOptions;
+    private JdbcSinkDialect dialect;
+    private JdbcSinkConfig sinkConfig;
+    private RecordSerializationSchema<IN> serializationSchema;
+
+    public JdbcSinkBuilder() {
+        this.executionOptions = JdbcExecutionOptions.defaults();
+    }
+
+    public JdbcSinkBuilder<IN> withExecutionOptions(JdbcExecutionOptions executionOptions) {
+        this.executionOptions = checkNotNull(executionOptions, "executionOptions cannot be null");
+        return this;
+    }
+
+    public JdbcSinkBuilder<IN> withDialect(JdbcSinkDialect dialect) {
+        this.dialect = checkNotNull(dialect, "dialect cannot be null");
+        return this;
+    }
+
+    public JdbcSinkBuilder<IN> withSinkConfig(JdbcSinkConfig sinkConfig) {
+        this.sinkConfig = checkNotNull(sinkConfig, "sink config cannot be null");
+        return this;
+    }
+
+    public JdbcSinkBuilder<IN> withSerializationSchema(
+            RecordSerializationSchema<IN> serializationSchema) {
+        this.serializationSchema =
+                checkNotNull(serializationSchema, "serializationSchema cannot be null");
+        return this;
+    }
+
+    public JdbcSink<IN> buildAtLeastOnce(JdbcConnectionOptions connectionOptions) {
+        checkNotNull(connectionOptions, "connectionOptions cannot be null");
+
+        return buildAtLeastOnce(new SimpleJdbcConnectionProvider(connectionOptions));
+    }
+
+    public JdbcSink<IN> buildAtLeastOnce(JdbcConnectionProvider connectionProvider) {
+        checkNotNull(connectionProvider, "connectionProvider cannot be null");
+
+        return build(checkNotNull(connectionProvider, "connectionProvider cannot be null"));
+    }
+
+    private JdbcSink<IN> build(JdbcConnectionProvider connectionProvider) {
+
+        return new JdbcSink<>(
+                executionOptions, connectionProvider, serializationSchema, dialect, sinkConfig);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcWriter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/JdbcWriter.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.StatefulSink;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+import org.apache.flink.cdc.connectors.jdbc.sink.utils.JsonWrapper;
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.JdbcStatementBuilder;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
+import org.apache.flink.connector.jdbc.internal.JdbcOutputSerializer;
+import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor;
+import org.apache.flink.connector.jdbc.sink.writer.JdbcWriterState;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.cdc.connectors.jdbc.sink.v2.RowKind.PK_ROW;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Implementation class of the {@link StatefulSink.StatefulSinkWriter} interface. */
+public class JdbcWriter<IN> implements StatefulSink.StatefulSinkWriter<IN, JdbcWriterState> {
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcWriter.class);
+
+    private final JdbcExecutionOptions executionOptions;
+    private final JdbcConnectionProvider connectionProvider;
+    private final JdbcOutputSerializer<Object> outputSerializer;
+    private final RecordSerializationSchema<IN> serializationSchema;
+    private final JsonWrapper jsonWrapper;
+
+    private final JdbcSinkDialect dialect;
+    private final Map<TableId, RichJdbcOutputFormat> outputHandlers;
+
+    public JdbcWriter(
+            Sink.InitContext initContext,
+            JdbcExecutionOptions executionOptions,
+            JdbcConnectionProvider connectionProvider,
+            JdbcOutputSerializer<Object> outputSerializer,
+            RecordSerializationSchema<IN> serializationSchema,
+            JdbcSinkDialect dialect,
+            JdbcSinkConfig sinkConfig) {
+
+        checkNotNull(initContext, "initContext must be defined");
+        checkNotNull(executionOptions, "executionOptions must be defined");
+        checkNotNull(connectionProvider, "connectionProvider must be defined");
+        checkNotNull(outputSerializer, "outputSerializer must be defined");
+        checkNotNull(serializationSchema, "serializationSchema must be defined");
+        checkNotNull(sinkConfig, "sinkConfig must be defined");
+
+        this.jsonWrapper = new JsonWrapper();
+        this.executionOptions = executionOptions;
+        this.connectionProvider = connectionProvider;
+        this.outputSerializer = outputSerializer;
+        this.serializationSchema = serializationSchema;
+        this.dialect = dialect;
+        this.outputHandlers = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public List<JdbcWriterState> snapshotState(long checkpointId) {
+        // Jdbc sink supports at-least-once semantic only. No state snapshotting & restoring
+        // required.
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void write(IN event, Context context) throws IOException {
+        JdbcRowData[] rowDataElements = serializationSchema.serialize(event);
+        for (JdbcRowData rowData : rowDataElements) {
+            TableId tableId = rowData.getTableId();
+            if (RowKind.SCHEMA_CHANGE.is(rowData.getRowKind())) {
+                // All previous outputHandlers would expire after schema changes.
+                flush(false);
+                Optional.ofNullable(outputHandlers.remove(tableId))
+                        .ifPresent(JdbcOutputFormat::close);
+            } else {
+                RichJdbcOutputFormat outputFormat =
+                        getOrCreateHandler(tableId, rowData.getSchema());
+                outputFormat.writeRecord(rowData);
+                if (!rowData.hasPrimaryKey()) {
+                    // For non-PK table, we must flush immediately to avoid data consistency issues.
+                    outputFormat.flush();
+                }
+            }
+        }
+    }
+
+    private RichJdbcOutputFormat getJdbcOutputFormat(
+            JdbcSinkDialect dialect, TableId tableId, Schema schema) {
+        RichJdbcOutputFormat jdbcOutputFormat =
+                new RichJdbcOutputFormat(
+                        connectionProvider,
+                        executionOptions,
+                        () -> createBatchedStatementExecutor(dialect, tableId, schema));
+        try {
+            jdbcOutputFormat.open(outputSerializer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return jdbcOutputFormat;
+    }
+
+    @Override
+    public void flush(boolean endOfInput) throws IOException {
+        for (RichJdbcOutputFormat handler : outputHandlers.values()) {
+            handler.flush();
+            if (endOfInput) {
+                handler.close();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        flush(true);
+    }
+
+    private RichJdbcOutputFormat getOrCreateHandler(TableId tableId, Schema schema) {
+        if (outputHandlers.containsKey(tableId)) {
+            return outputHandlers.get(tableId);
+        }
+        RichJdbcOutputFormat outputFormat = getJdbcOutputFormat(dialect, tableId, schema);
+        outputHandlers.put(tableId, outputFormat);
+        return outputFormat;
+    }
+
+    private JdbcStatementBuilder<JdbcRowData> getStatementBuilder(List<String> primaryKeys) {
+        return (ps, rowData) -> {
+            Map<String, Object> recordMap = parseRowData(rowData.getRows());
+
+            if (!recordMap.isEmpty()) {
+                for (int i = 0; i < primaryKeys.size(); i++) {
+                    String pk = primaryKeys.get(i);
+                    ps.setObject(i + 1, recordMap.get(pk));
+                }
+            }
+        };
+    }
+
+    private Map<String, Object> parseRowData(byte[] rowData) {
+        try {
+            return jsonWrapper.parseObject(rowData, new TypeReference<Map<String, Object>>() {});
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private BatchedStatementExecutor createBatchedStatementExecutor(
+            JdbcSinkDialect dialect, TableId tableId, Schema schema) {
+        JdbcBatchStatementExecutor<JdbcRowData> upsertExecutor =
+                JdbcBatchStatementExecutor.simple(
+                        dialect.getUpsertStatement(tableId, schema),
+                        getStatementBuilder(schema.getColumnNames()));
+        JdbcBatchStatementExecutor<JdbcRowData> deleteExecutor =
+                JdbcBatchStatementExecutor.simple(
+                        dialect.getDeleteStatement(tableId, schema),
+                        getStatementBuilder(
+                                schema.primaryKeys().isEmpty()
+                                        ? schema.getColumnNames()
+                                        : schema.primaryKeys()));
+        Function<JdbcRowData, JdbcRowData> keyExtractor = createRowKeyExtractor(tableId, schema);
+        return new BatchedStatementExecutor(upsertExecutor, deleteExecutor, keyExtractor);
+    }
+
+    private Function<JdbcRowData, JdbcRowData> createRowKeyExtractor(
+            TableId tableId, Schema schema) {
+
+        List<String> primaryKeys = schema.primaryKeys();
+
+        // Return full-line for non-PK tables
+        if (primaryKeys.isEmpty()) {
+            return row ->
+                    new RichJdbcRowData.Builder()
+                            .setRowKind(PK_ROW)
+                            .setTableId(row.getTableId())
+                            .setSchema(row.getSchema())
+                            .setRows(row.getRows())
+                            .build();
+        }
+
+        Schema pkOnlySchema =
+                schema.copy(
+                        schema.getColumns().stream()
+                                .filter(col -> primaryKeys.contains(col.getName()))
+                                .collect(Collectors.toList()));
+
+        return row -> {
+            Map<String, Object> rowData = parseRowData(row.getRows());
+            Map<String, Object> pkOnlyRowData = new HashMap<>();
+            for (String pk : schema.primaryKeys()) {
+                pkOnlyRowData.put(pk, rowData.get(pk));
+            }
+            try {
+                byte[] rowBytes = jsonWrapper.toJSONBytes(pkOnlyRowData);
+                return new RichJdbcRowData.Builder()
+                        .setRowKind(PK_ROW)
+                        .setTableId(tableId)
+                        .setSchema(pkOnlySchema)
+                        .setRows(rowBytes)
+                        .build();
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to extract primary key row from row: " + row, e);
+            }
+        };
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RecordSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RecordSerializationSchema.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Abstract base serialization schema class between generic type {@code T} and {@link JdbcRowData}.
+ */
+public interface RecordSerializationSchema<IN> extends Serializable {
+    JdbcRowData[] serialize(IN record) throws IOException;
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RichJdbcOutputFormat.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RichJdbcOutputFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.connector.jdbc.JdbcExecutionOptions;
+import org.apache.flink.connector.jdbc.datasource.connections.JdbcConnectionProvider;
+import org.apache.flink.connector.jdbc.internal.JdbcOutputFormat;
+import org.apache.flink.connector.jdbc.internal.executor.JdbcBatchStatementExecutor;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Merely a wrapper of {@code JdbcOutputFormat<Object, JdbcRowData,
+ * JdbcBatchStatementExecutor<JdbcRowData>>} to avoid typing such a long generic type arguments
+ * again and again.
+ */
+public class RichJdbcOutputFormat
+        extends JdbcOutputFormat<Object, JdbcRowData, JdbcBatchStatementExecutor<JdbcRowData>> {
+    public RichJdbcOutputFormat(
+            @Nonnull JdbcConnectionProvider connectionProvider,
+            @Nonnull JdbcExecutionOptions executionOptions,
+            @Nonnull
+                    StatementExecutorFactory<JdbcBatchStatementExecutor<JdbcRowData>>
+                            statementExecutorFactory) {
+        super(connectionProvider, executionOptions, statementExecutorFactory);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RichJdbcRowData.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RichJdbcRowData.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.utils.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Enriched {@link JdbcRowData} for serializing {@link org.apache.flink.cdc.common.event.Event}s.
+ */
+public class RichJdbcRowData implements JdbcRowData {
+    protected final TableId tableId;
+    protected final RowKind rowKind;
+    protected final @Nullable byte[] rows;
+    protected final @Nullable Schema schema;
+    protected final @Nullable Boolean hasPrimaryKey;
+
+    protected RichJdbcRowData(
+            RowKind rowKind, TableId tableId, @Nullable Schema schema, @Nullable byte[] rows) {
+        this.tableId = tableId;
+        this.schema = schema;
+        this.rowKind = rowKind;
+        this.rows = rows;
+
+        if (schema != null) {
+            this.hasPrimaryKey = !schema.primaryKeys().isEmpty();
+        } else {
+            this.hasPrimaryKey = null;
+        }
+    }
+
+    /** Builder clas for {@link RichJdbcRowData}. */
+    public static class Builder {
+        private TableId tableId;
+        private Schema schema;
+        private RowKind rowKind;
+        private byte[] rows;
+
+        public Builder setTableId(TableId tableId) {
+            this.tableId = tableId;
+            return this;
+        }
+
+        public Builder setSchema(Schema schema) {
+            this.schema = schema;
+            return this;
+        }
+
+        public Builder setRowKind(RowKind rowKind) {
+            this.rowKind = rowKind;
+            return this;
+        }
+
+        public Builder setRows(byte[] rows) {
+            this.rows = rows;
+            return this;
+        }
+
+        public RichJdbcRowData build() {
+            Preconditions.checkNotNull(rowKind, "No Row Kind provided for JdbcRowData.");
+            Preconditions.checkNotNull(tableId, "No Table Id provided for JdbcRowData.");
+            return new RichJdbcRowData(rowKind, tableId, schema, rows);
+        }
+    }
+
+    @Override
+    public TableId getTableId() {
+        return tableId;
+    }
+
+    @Override
+    public Schema getSchema() {
+        return schema;
+    }
+
+    @Override
+    public RowKind getRowKind() {
+        return rowKind;
+    }
+
+    @Override
+    public byte[] getRows() {
+        return rows;
+    }
+
+    public boolean hasPrimaryKey() {
+        return Boolean.TRUE.equals(hasPrimaryKey);
+    }
+
+    @Override
+    public String toString() {
+        return "RichJdbcRowData{"
+                + "tableId="
+                + tableId
+                + ", schema="
+                + schema
+                + ", rowKind="
+                + rowKind
+                + ", rows="
+                + (rows != null ? new String(rows) : "null")
+                + ", hasPrimaryKey="
+                + hasPrimaryKey
+                + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof RichJdbcRowData)) {
+            return false;
+        }
+
+        RichJdbcRowData that = (RichJdbcRowData) o;
+        return hasPrimaryKey == that.hasPrimaryKey
+                && Objects.equals(tableId, that.tableId)
+                && Objects.equals(schema, that.schema)
+                && rowKind == that.rowKind
+                && Arrays.equals(rows, that.rows);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableId, schema, rowKind, Arrays.hashCode(rows), hasPrimaryKey);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RowKind.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/RowKind.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+/** Row kind for event operator. */
+public enum RowKind {
+    INSERT,
+    UPDATE_BEFORE,
+    UPDATE_AFTER,
+    DELETE,
+    SCHEMA_CHANGE,
+    PK_ROW;
+
+    public boolean is(RowKind otherKind) {
+        return this == otherKind;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/resources/META-INF/services/org.apache.flink.cdc.common.factories.Factory
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/main/resources/META-INF/services/org.apache.flink.cdc.common.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.cdc.connectors.jdbc.factory.JdbcDataSinkFactory

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/test/java/org/apache/flink/cdc/connectors/jdbc/config/JdbcSinkConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/test/java/org/apache/flink/cdc/connectors/jdbc/config/JdbcSinkConfigTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test class for {@link JdbcSinkConfig}. */
+class JdbcSinkConfigTest {
+    private static final String TEST_HOSTNAME = "localhost";
+    private static final int TEST_PORT = 5432;
+    private static final String TEST_CONN_URL = "jdbc:mysql://" + TEST_HOSTNAME + ":" + TEST_PORT;
+    private static final String TEST_USERNAME = "admin";
+    private static final String TEST_PASSWORD = "password";
+    private static final String TEST_TABLE = "testtable";
+    private static final String TEST_DRIVER_CLASS_NAME = "org.postgresql.Driver";
+    private static final String TEST_SERVER_TIME_ZONE = "UTC";
+    private static final Duration TEST_CONNECT_TIMEOUT = Duration.ofSeconds(10);
+    private static final int TEST_CONNECT_MAX_RETRIES = 3;
+    private static final int TEST_CONNECTION_POOL_SIZE = 5;
+    private static final long TEST_WRITE_INTERVAL_MS = 31415926;
+    private static final int TEST_WRITE_BATCH_SIZE = 17;
+    private static final int TEST_WRITE_MAX_RETRIES = 5;
+
+    private JdbcSinkConfig.Builder<?> builder;
+
+    @BeforeEach
+    void setUp() {
+        builder =
+                new JdbcSinkConfig.Builder<>()
+                        .connUrl(TEST_CONN_URL)
+                        .username(TEST_USERNAME)
+                        .password(TEST_PASSWORD)
+                        .table(TEST_TABLE)
+                        .driverClassName(TEST_DRIVER_CLASS_NAME)
+                        .serverTimeZone(TEST_SERVER_TIME_ZONE)
+                        .connectTimeout(TEST_CONNECT_TIMEOUT)
+                        .connectMaxRetries(TEST_CONNECT_MAX_RETRIES)
+                        .connectionPoolSize(TEST_CONNECTION_POOL_SIZE)
+                        .writeBatchIntervalMs(TEST_WRITE_INTERVAL_MS)
+                        .writeBatchSize(TEST_WRITE_BATCH_SIZE)
+                        .writeMaxRetries(TEST_WRITE_MAX_RETRIES);
+    }
+
+    @Test
+    void testJdbcSinkConfigBuilder() {
+        JdbcSinkConfig config = builder.build();
+
+        assertThat(config.getConnUrl()).isEqualTo(TEST_CONN_URL);
+        assertThat(config.getUsername()).isEqualTo(TEST_USERNAME);
+        assertThat(config.getPassword()).isEqualTo(TEST_PASSWORD);
+        assertThat(config.getTable()).isEqualTo(TEST_TABLE);
+        assertThat(config.getDriverClassName()).isEqualTo(TEST_DRIVER_CLASS_NAME);
+        assertThat(config.getServerTimeZone()).isEqualTo(TEST_SERVER_TIME_ZONE);
+        assertThat(config.getConnectTimeout()).isEqualTo(TEST_CONNECT_TIMEOUT);
+        assertThat(config.getConnectMaxRetries()).isEqualTo(TEST_CONNECT_MAX_RETRIES);
+        assertThat(config.getConnectionPoolSize()).isEqualTo(TEST_CONNECTION_POOL_SIZE);
+        assertThat(config.getWriteBatchIntervalMs()).isEqualTo(TEST_WRITE_INTERVAL_MS);
+        assertThat(config.getWriteBatchSize()).isEqualTo(TEST_WRITE_BATCH_SIZE);
+        assertThat(config.getWriteMaxRetries()).isEqualTo(TEST_WRITE_MAX_RETRIES);
+    }
+
+    @Test
+    void testJdbcSinkConfigProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("key", "value");
+
+        JdbcSinkConfig config = builder.jdbcProperties(properties).build();
+
+        assertThat(config.getJdbcProperties()).isEqualTo(properties);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/test/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/EventRecordSerializationSchemaTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/test/java/org/apache/flink/cdc/connectors/jdbc/sink/v2/EventRecordSerializationSchemaTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.sink.v2;
+
+import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
+import org.apache.flink.cdc.common.data.TimestampData;
+import org.apache.flink.cdc.common.data.binary.BinaryRecordData;
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/** Test class for {@link EventRecordSerializationSchema}. */
+class EventRecordSerializationSchemaTest {
+
+    private static final TableId TABLE_ID = TableId.tableId("foo", "bar", "baz");
+
+    private static final Schema SCHEMA =
+            Schema.newBuilder()
+                    .physicalColumn("id", DataTypes.BIGINT().notNull())
+                    .physicalColumn("boolean_col", DataTypes.BOOLEAN())
+                    .physicalColumn("decimal_col", DataTypes.DECIMAL(20, 0))
+                    .physicalColumn("tinyint_col", DataTypes.TINYINT())
+                    .physicalColumn("smallint_col", DataTypes.SMALLINT())
+                    .physicalColumn("int_col", DataTypes.INT())
+                    .physicalColumn("bigint_col", DataTypes.BIGINT())
+                    .physicalColumn("float_col", DataTypes.FLOAT())
+                    .physicalColumn("double_col", DataTypes.DOUBLE())
+                    .physicalColumn("char_col", DataTypes.CHAR(255))
+                    .physicalColumn("varchar_col", DataTypes.VARCHAR(255))
+                    .physicalColumn("string_col", DataTypes.STRING())
+                    .physicalColumn("binary_col", DataTypes.BINARY(255))
+                    .physicalColumn("varbinary_col", DataTypes.VARBINARY(255))
+                    .physicalColumn("bytes_col", DataTypes.BYTES())
+                    .physicalColumn("ts_col", DataTypes.TIMESTAMP(6))
+                    .physicalColumn("ts_ltz_col", DataTypes.TIMESTAMP_LTZ(6))
+                    .primaryKey("id")
+                    .build();
+
+    private static final BinaryRecordDataGenerator GENERATOR =
+            new BinaryRecordDataGenerator(SCHEMA.getColumnDataTypes().toArray(new DataType[0]));
+
+    private static final CreateTableEvent CREATE_TABLE_EVENT =
+            new CreateTableEvent(TABLE_ID, SCHEMA);
+
+    private static final BinaryRecordData RECORD_NON_NULL =
+            GENERATOR.generate(
+                    new Object[] {
+                        1L,
+                        true,
+                        DecimalData.fromBigDecimal(new BigDecimal("12345678901234567890"), 20, 0),
+                        (byte) 17,
+                        (short) 91102,
+                        1234567890,
+                        1234567890123456L,
+                        123.456f,
+                        123.456d,
+                        BinaryStringData.fromString("Alice"),
+                        BinaryStringData.fromString("Zorro"),
+                        BinaryStringData.fromString("A long long long story..."),
+                        "Cicada".getBytes(),
+                        "Vera".getBytes(),
+                        "...that never ends ends ends".getBytes(),
+                        TimestampData.fromTimestamp(
+                                Timestamp.valueOf("2020-07-17 18:00:22.123456")),
+                        LocalZonedTimestampData.fromInstant(toInstant("2020-07-17 18:00:22")),
+                    });
+
+    private static final BinaryRecordData RECORD_NULL =
+            GENERATOR.generate(
+                    new Object[] {
+                        0L, null, null, null, null, null, null, null, null, null, null, null, null,
+                        null, null, null, null
+                    });
+
+    private static final String RECORD_NON_NULL_IN_JSON =
+            "{\"int_col\":1234567890,\"char_col\":\"Alice\",\"bytes_col\":\"Li4udGhhdCBuZXZlciBlbmRzIGVuZHMgZW5kcw==\",\"binary_col\":\"Q2ljYWRh\",\"bigint_col\":1234567890123456,\"boolean_col\":true,\"float_col\":123.456,\"varchar_col\":\"Zorro\",\"string_col\":\"A long long long story...\",\"ts_col\":\"2020-07-17T18:00:22.123456\",\"smallint_col\":25566,\"ts_ltz_col\":{\"epochMillisecond\":1595008822000,\"epochNanoOfMillisecond\":0},\"tinyint_col\":17,\"id\":1,\"double_col\":123.456,\"varbinary_col\":\"VmVyYQ==\",\"decimal_col\":\"12345678901234567890\"}";
+
+    private static final String RECORD_NULL_IN_JSON =
+            "{\"int_col\":null,\"char_col\":null,\"bytes_col\":null,\"binary_col\":null,\"bigint_col\":null,\"boolean_col\":null,\"float_col\":null,\"varchar_col\":null,\"string_col\":null,\"ts_col\":null,\"smallint_col\":null,\"ts_ltz_col\":null,\"tinyint_col\":null,\"id\":0,\"double_col\":null,\"varbinary_col\":null,\"decimal_col\":null}";
+
+    @Test
+    void testSerialization() throws Exception {
+        EventRecordSerializationSchema schema = new EventRecordSerializationSchema();
+
+        Assertions.assertThat(schema.serialize(CREATE_TABLE_EVENT))
+                .singleElement()
+                .extracting("tableId", "schema", "rowKind", "rows")
+                .containsExactly(TABLE_ID, null, RowKind.SCHEMA_CHANGE, null);
+
+        Assertions.assertThat(
+                        schema.serialize(DataChangeEvent.insertEvent(TABLE_ID, RECORD_NON_NULL)))
+                .singleElement()
+                .extracting("tableId", "schema", "rowKind", "rows")
+                .containsExactly(
+                        TABLE_ID, SCHEMA, RowKind.INSERT, RECORD_NON_NULL_IN_JSON.getBytes());
+
+        Assertions.assertThat(schema.serialize(DataChangeEvent.insertEvent(TABLE_ID, RECORD_NULL)))
+                .singleElement()
+                .extracting("tableId", "schema", "rowKind", "rows")
+                .containsExactly(TABLE_ID, SCHEMA, RowKind.INSERT, RECORD_NULL_IN_JSON.getBytes());
+
+        Assertions.assertThat(
+                        schema.serialize(
+                                DataChangeEvent.updateEvent(
+                                        TABLE_ID, RECORD_NON_NULL, RECORD_NULL)))
+                .hasSize(2)
+                .extracting("tableId", "schema", "rowKind", "rows")
+                .containsExactly(
+                        Tuple.tuple(
+                                TABLE_ID,
+                                SCHEMA,
+                                RowKind.DELETE,
+                                RECORD_NON_NULL_IN_JSON.getBytes()),
+                        Tuple.tuple(
+                                TABLE_ID, SCHEMA, RowKind.INSERT, RECORD_NULL_IN_JSON.getBytes()));
+
+        Assertions.assertThat(
+                        schema.serialize(
+                                DataChangeEvent.updateEvent(
+                                        TABLE_ID, RECORD_NULL, RECORD_NON_NULL)))
+                .hasSize(2)
+                .extracting("tableId", "schema", "rowKind", "rows")
+                .containsExactly(
+                        Tuple.tuple(
+                                TABLE_ID, SCHEMA, RowKind.DELETE, RECORD_NULL_IN_JSON.getBytes()),
+                        Tuple.tuple(
+                                TABLE_ID,
+                                SCHEMA,
+                                RowKind.INSERT,
+                                RECORD_NON_NULL_IN_JSON.getBytes()));
+
+        Assertions.assertThat(schema.serialize(DataChangeEvent.deleteEvent(TABLE_ID, RECORD_NULL)))
+                .singleElement()
+                .extracting("tableId", "schema", "rowKind", "rows")
+                .containsExactly(TABLE_ID, SCHEMA, RowKind.DELETE, RECORD_NULL_IN_JSON.getBytes());
+    }
+
+    private static Instant toInstant(String ts) {
+        return Timestamp.valueOf(ts).toLocalDateTime().atZone(ZoneId.of("UTC")).toInstant();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-core/src/test/resources/log4j2-test.properties
@@ -1,0 +1,25 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to ERROR to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=ERROR
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-cdc-pipeline-connector-jdbc-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>flink-cdc-pipeline-connector-jdbc-mysql</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-jdbc-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>${mysql.driver.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- For IT cases only. -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-composer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-mysql</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlDataSinkConfig.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlDataSinkConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql;
+
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+
+import java.io.Serializable;
+
+/** Configurations for MySQL Data Sink. */
+public class MySqlDataSinkConfig extends JdbcSinkConfig implements Serializable {
+    private MySqlDataSinkConfig(Builder builder) {
+        super(builder);
+    }
+
+    /** Builder for {@link MySqlDataSinkConfig}. */
+    public static class Builder extends JdbcSinkConfig.Builder<Builder> {
+        @Override
+        protected Builder self() {
+            return this;
+        }
+
+        @Override
+        public MySqlDataSinkConfig build() {
+            return new MySqlDataSinkConfig(this);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlDataSinkOptions.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql;
+
+import org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions;
+
+/** Collections of MySQL Data Sink Options. */
+public class MySqlDataSinkOptions extends JdbcSinkOptions {}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/dialect/MySqlJdbcSinkDialect.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/dialect/MySqlJdbcSinkDialect.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql.dialect;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+
+import java.util.List;
+
+/** A JDBC sink variant for MySQL dialect. */
+public class MySqlJdbcSinkDialect extends JdbcSinkDialect {
+
+    public MySqlJdbcSinkDialect(String name, JdbcSinkConfig sinkConfig) {
+        super(name, sinkConfig);
+    }
+
+    @Override
+    protected String buildUpsertSql(TableId tableId, Schema schema) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildUpsertSql(tableId, schema.getColumns());
+    }
+
+    @Override
+    protected String buildDeleteSql(TableId tableId, Schema schema) {
+        if (schema.primaryKeys().isEmpty()) {
+            return MySqlStmtCreatorFactory.INSTANCE.buildDeleteSql(
+                    tableId, schema.getColumnNames());
+        } else {
+            return MySqlStmtCreatorFactory.INSTANCE.buildDeleteSql(tableId, schema.primaryKeys());
+        }
+    }
+
+    @Override
+    protected String buildCreateTableSql(TableId tableId, Schema schema, boolean ignoreIfExists) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildCreateTableSql(
+                tableId, schema, ignoreIfExists);
+    }
+
+    @Override
+    protected String buildAlterAddColumnsSql(
+            TableId tableId, List<AddColumnEvent.ColumnWithPosition> addColumnEvent) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildAlterAddColumnsSql(tableId, addColumnEvent);
+    }
+
+    @Override
+    protected String buildRenameColumnSql(TableId tableId, String oldName, String newName) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildRenameColumnSql(tableId, oldName, newName);
+    }
+
+    @Override
+    protected String buildDropColumnSql(TableId tableId, String column) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildDropColumnSql(tableId, column);
+    }
+
+    @Override
+    protected String buildAlterColumnTypeSql(
+            TableId tableId, String columnName, DataType columnType) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildAlterColumnTypeSql(
+                tableId, columnName, columnType);
+    }
+
+    @Override
+    protected String buildTruncateTableSql(TableId tableId) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildTruncateTableSql(tableId);
+    }
+
+    @Override
+    protected String buildDropTableSql(TableId tableId, boolean ignoreIfNotExist) {
+        return MySqlStmtCreatorFactory.INSTANCE.buildDropTableSql(tableId, ignoreIfNotExist);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/dialect/MySqlStmtCreatorFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/dialect/MySqlStmtCreatorFactory.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql.dialect;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Column;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.utils.StringUtils;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcColumn;
+import org.apache.flink.cdc.connectors.jdbc.mysql.type.MySqlTypeTransformer;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** A factory class for creating statements in MySQL dialect. */
+public class MySqlStmtCreatorFactory {
+    public static final MySqlStmtCreatorFactory INSTANCE = new MySqlStmtCreatorFactory();
+
+    private static final String RENAME_DDL = "ALTER TABLE %s RENAME COLUMN `%s` TO `%s`;";
+    private static final String DROP_COLUMN_DDL = "ALTER TABLE %s DROP COLUMN `%s`;";
+
+    public String buildUpsertSql(TableId tableId, List<Column> columns) {
+        String tableName = tableId.identifier();
+        // Building column names and value placeholders
+        String columnNames =
+                columns.stream().map(Column::getName).collect(Collectors.joining(", "));
+
+        String valuePlaceholders =
+                columns.stream().map(column -> "?").collect(Collectors.joining(", "));
+
+        // Building the initial insert part
+        StringBuilder query = new StringBuilder();
+        query.append("INSERT INTO ")
+                .append(tableName)
+                .append(" (")
+                .append(columnNames)
+                .append(") VALUES (")
+                .append(valuePlaceholders)
+                .append(") ON DUPLICATE KEY UPDATE ");
+
+        // Building the update part
+        String updatePart =
+                columns.stream()
+                        .map(column -> column.getName() + " = VALUES(" + column.getName() + ")")
+                        .collect(Collectors.joining(", "));
+
+        query.append(updatePart).append(";");
+
+        return query.toString();
+    }
+
+    public String buildDeleteSql(TableId tableId, List<String> deleteByKeys) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("DELETE FROM %s ", tableId.identifier()));
+        builder.append("WHERE ");
+        deleteByKeys.forEach(
+                pk -> {
+                    builder.append(pk).append(" = ? AND ");
+                });
+        // remove latest " AND "
+        builder.setLength(builder.length() - 5);
+        return builder.toString();
+    }
+
+    public String buildAlterAddColumnsSql(
+            TableId tableId, List<AddColumnEvent.ColumnWithPosition> addedColumns) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("ALTER TABLE %s ", tableId.identifier()));
+
+        String columnsStmt =
+                addedColumns.stream()
+                        .map(this::buildAddColumnStmt)
+                        .collect(Collectors.joining(", "));
+
+        builder.append(columnsStmt);
+        builder.append(";");
+
+        return builder.toString();
+    }
+
+    public String buildAlterColumnTypeSql(TableId tableId, String columnName, DataType columnType) {
+        JdbcColumn.Builder columnBuilder = new JdbcColumn.Builder();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(columnBuilder);
+        columnType.accept(transformer);
+        JdbcColumn type = columnBuilder.build();
+
+        return String.format(
+                "ALTER TABLE %s MODIFY COLUMN %s %s;",
+                tableId.identifier(), columnName, type.getColumnType());
+    }
+
+    private String buildAddColumnStmt(AddColumnEvent.ColumnWithPosition columnWithPosition) {
+        Column column = columnWithPosition.getAddColumn();
+        StringBuilder builder = new StringBuilder();
+
+        JdbcColumn.Builder columnBuilder = new JdbcColumn.Builder();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(columnBuilder);
+        column.getType().accept(transformer);
+        JdbcColumn type = columnBuilder.build();
+
+        builder.append("ADD COLUMN `")
+                .append(column.getName())
+                .append("` ")
+                .append(type.getColumnType());
+
+        if (column.getComment() != null) {
+            builder.append(" COMMENT '").append(column.getComment()).append("'");
+        }
+
+        switch (columnWithPosition.getPosition()) {
+            case FIRST:
+                builder.append(" FIRST");
+                break;
+            case AFTER:
+                builder.append(" AFTER `")
+                        .append(columnWithPosition.getExistedColumnName())
+                        .append("`");
+                break;
+            case BEFORE:
+                builder.append(" BEFORE `")
+                        .append(columnWithPosition.getExistedColumnName())
+                        .append("`");
+                break;
+            case LAST:
+            default:
+                break;
+        }
+
+        return builder.toString();
+    }
+
+    public String buildRenameColumnSql(
+            TableId tableId, String oldColumnName, String newColumnName) {
+        return String.format(RENAME_DDL, tableId.identifier(), oldColumnName, newColumnName);
+    }
+
+    public String buildDropColumnSql(TableId tableId, String columnName) {
+        return String.format(DROP_COLUMN_DDL, tableId.identifier(), columnName);
+    }
+
+    public String buildCreateTableSql(TableId tableId, Schema schema, boolean ignoreIfExists) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(
+                String.format(
+                        "CREATE TABLE %s %s",
+                        ignoreIfExists ? "IF NOT EXISTS" : "", tableId.identifier()));
+        builder.append(" (\n");
+        String columnsStmt =
+                schema.getColumns().stream()
+                        .map(this::buildColumnStmt)
+                        .collect(Collectors.joining(",\n"));
+        builder.append(columnsStmt);
+
+        if (!schema.primaryKeys().isEmpty()) {
+            builder.append(",\n");
+            String tableKeys =
+                    schema.primaryKeys().stream()
+                            .map(key -> "`" + key + "`")
+                            .collect(Collectors.joining(", "));
+            builder.append(String.format("PRIMARY KEY (%s)", tableKeys));
+        }
+        builder.append("\n) ");
+        builder.append(";");
+        return builder.toString();
+    }
+
+    public String buildTruncateTableSql(TableId tableId) {
+        return String.format("TRUNCATE TABLE %s;", tableId.identifier());
+    }
+
+    public String buildDropTableSql(TableId tableId, boolean ignoreIfNotExist) {
+        return String.format(
+                "DROP TABLE %s %s;", ignoreIfNotExist ? "IF EXISTS" : "", tableId.identifier());
+    }
+
+    private static final Set<String> COLUMN_TYPES_THAT_DO_NOT_SUPPORT_DEFAULT_VALUE =
+            ImmutableSet.of("BLOB", "TEXT", "GEOMETRY", "JSON");
+
+    public String buildColumnStmt(Column column) {
+        StringBuilder builder = new StringBuilder();
+
+        // Column name
+        builder.append("`");
+        builder.append(column.getName());
+        builder.append("` ");
+
+        // Column type
+        JdbcColumn.Builder columnBuilder = new JdbcColumn.Builder();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(columnBuilder);
+        column.getType().accept(transformer);
+        JdbcColumn type = columnBuilder.build();
+        builder.append(type.getColumnType());
+
+        // Extra attributes
+        if (!StringUtils.isNullOrWhitespaceOnly(column.getComment())) {
+            builder.append(String.format(" COMMENT '%s'", column.getComment()));
+        }
+
+        // MySQL doesn't support specifying a default value to BLOB, TEXT, GEOMETRY, and JSON typed
+        // columns. See https://bugs.mysql.com/bug.php?id=107349 for more details.
+        if (!COLUMN_TYPES_THAT_DO_NOT_SUPPORT_DEFAULT_VALUE.contains(type.getColumnType())) {
+            if (!StringUtils.isNullOrWhitespaceOnly(column.getDefaultValueExpression())) {
+                builder.append(String.format(" DEFAULT '%s'", column.getDefaultValueExpression()));
+            }
+        }
+        return builder.toString();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/factory/JdbcMySqlSinkDialectFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/factory/JdbcMySqlSinkDialectFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql.factory;
+
+import org.apache.flink.cdc.common.utils.Preconditions;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory;
+import org.apache.flink.cdc.connectors.jdbc.mysql.dialect.MySqlJdbcSinkDialect;
+
+/** A {@link JdbcSinkDialectFactory} for MySQL variants. */
+public class JdbcMySqlSinkDialectFactory implements JdbcSinkDialectFactory<JdbcSinkConfig> {
+    public static final String IDENTIFIER = "mysql";
+
+    @Override
+    public String identifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public JdbcSinkDialect createDialect(JdbcSinkConfig config) {
+        Preconditions.checkArgument(
+                IDENTIFIER.equalsIgnoreCase(config.getDialect()),
+                "JDBC sink with `%s` dialect doesn't work with specified dialect %s (inferred from connection URL: %s)",
+                IDENTIFIER,
+                config.getDialect(),
+                config.getConnUrl());
+        return new MySqlJdbcSinkDialect(IDENTIFIER, config);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/type/MySqlTypeTransformer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/java/org/apache/flink/cdc/connectors/jdbc/mysql/type/MySqlTypeTransformer.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql.type;
+
+import org.apache.flink.cdc.common.types.BigIntType;
+import org.apache.flink.cdc.common.types.BinaryType;
+import org.apache.flink.cdc.common.types.BooleanType;
+import org.apache.flink.cdc.common.types.CharType;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypeDefaultVisitor;
+import org.apache.flink.cdc.common.types.DateType;
+import org.apache.flink.cdc.common.types.DecimalType;
+import org.apache.flink.cdc.common.types.DoubleType;
+import org.apache.flink.cdc.common.types.FloatType;
+import org.apache.flink.cdc.common.types.IntType;
+import org.apache.flink.cdc.common.types.LocalZonedTimestampType;
+import org.apache.flink.cdc.common.types.SmallIntType;
+import org.apache.flink.cdc.common.types.TimeType;
+import org.apache.flink.cdc.common.types.TimestampType;
+import org.apache.flink.cdc.common.types.TinyIntType;
+import org.apache.flink.cdc.common.types.VarBinaryType;
+import org.apache.flink.cdc.common.types.VarCharType;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcColumn;
+
+import com.mysql.cj.MysqlType;
+
+/** MySQL type transformer from CDC {@link DataType}s to {@link JdbcColumn}. */
+public class MySqlTypeTransformer extends DataTypeDefaultVisitor<JdbcColumn.Builder> {
+    private final JdbcColumn.Builder builder;
+    public static final int POWER_2_8 = (int) Math.pow(2, 8);
+    public static final int POWER_2_16 = (int) Math.pow(2, 16);
+    public static final int POWER_2_24 = (int) Math.pow(2, 24);
+    public static final int POWER_2_32 = (int) Math.pow(2, 32);
+
+    public MySqlTypeTransformer(JdbcColumn.Builder builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(CharType charType) {
+        builder.length(charType.getLength());
+        builder.dataType(MysqlType.CHAR.name());
+        builder.columnType(charType.asSerializableString());
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(VarCharType varCharType) {
+        int length = varCharType.getLength();
+
+        if (length < POWER_2_16 - 1) {
+            builder.dataType(MysqlType.VARCHAR.name());
+            builder.columnType(String.format("%s(%s)", MysqlType.VARCHAR, length));
+        } else if (length < POWER_2_24) {
+            builder.dataType(MysqlType.MEDIUMTEXT.name());
+            builder.columnType(MysqlType.MEDIUMTEXT.name());
+        } else if (length < POWER_2_32) {
+            builder.dataType(MysqlType.LONGTEXT.name());
+            builder.columnType(MysqlType.LONGTEXT.name());
+        } else {
+            builder.dataType(MysqlType.TEXT.name());
+            builder.columnType(MysqlType.TEXT.name());
+        }
+
+        builder.length(length);
+        builder.isNullable(varCharType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(BooleanType booleanType) {
+        builder.dataType(MysqlType.TINYINT.name());
+        builder.columnType("TINYINT(1)");
+        builder.isNullable(booleanType.isNullable());
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(DecimalType decimalType) {
+        int precision = decimalType.getPrecision();
+        int scale = decimalType.getScale();
+
+        builder.dataType(MysqlType.DECIMAL.name());
+        builder.columnType(decimalType.asSerializableString());
+        builder.length(precision);
+        builder.scale(scale);
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(TinyIntType tinyIntType) {
+        builder.dataType(MysqlType.TINYINT.name());
+        builder.columnType(tinyIntType.asSerializableString());
+        builder.isNullable(tinyIntType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(SmallIntType smallIntType) {
+        builder.dataType(MysqlType.SMALLINT.name());
+        builder.columnType(smallIntType.asSerializableString());
+        builder.isNullable(smallIntType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(IntType intType) {
+        builder.dataType(MysqlType.INT.name());
+        builder.columnType(intType.asSerializableString());
+        builder.isNullable(intType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(BigIntType bigIntType) {
+        builder.dataType(MysqlType.BIGINT.name());
+        builder.columnType(bigIntType.asSerializableString());
+        builder.isNullable(bigIntType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(FloatType floatType) {
+        builder.dataType(MysqlType.FLOAT.name());
+        builder.columnType(floatType.asSerializableString());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(DoubleType doubleType) {
+        builder.dataType(MysqlType.DOUBLE.name());
+        builder.columnType(doubleType.asSerializableString());
+        builder.isNullable(doubleType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(BinaryType binaryType) {
+        builder.dataType(MysqlType.BINARY.name());
+        builder.length(binaryType.getLength());
+        builder.columnType(binaryType.asSerializableString());
+        builder.isNullable(binaryType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(VarBinaryType bytesType) {
+        int length = bytesType.getLength();
+
+        if (length <= POWER_2_16 - 1) {
+            builder.dataType(MysqlType.VARBINARY.name());
+            builder.columnType(String.format("%s(%d)", MysqlType.VARBINARY.name(), length));
+        } else if (length < POWER_2_24) {
+            builder.dataType(MysqlType.MEDIUMBLOB.name());
+            builder.columnType(MysqlType.MEDIUMBLOB.name());
+        } else if (length < POWER_2_32) {
+            builder.dataType(MysqlType.LONGBLOB.name());
+            builder.columnType(MysqlType.LONGBLOB.name());
+        } else {
+            builder.dataType(MysqlType.LONGBLOB.name());
+            builder.columnType(MysqlType.LONGBLOB.name());
+        }
+
+        builder.length(length);
+        builder.isNullable(bytesType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(DateType dateType) {
+        builder.dataType(MysqlType.DATE.name());
+        builder.columnType(dateType.asSerializableString());
+        builder.isNullable(dateType.isNullable());
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(TimeType timeType) {
+        int precision = timeType.getPrecision();
+        builder.length(precision);
+        builder.dataType(MysqlType.TIME.name());
+        if (precision > 0) {
+            builder.columnType(timeType.asSerializableString());
+        } else {
+            builder.columnType("TIME");
+        }
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(TimestampType timestampType) {
+        int precision = timestampType.getPrecision();
+        builder.dataType(MysqlType.DATETIME.name());
+        builder.length(precision);
+        builder.isNullable(timestampType.isNullable());
+        if (precision > 0) {
+            builder.columnType(timestampType.asSerializableString());
+        } else {
+            builder.columnType("TIMESTAMP");
+        }
+
+        return builder;
+    }
+
+    @Override
+    public JdbcColumn.Builder visit(LocalZonedTimestampType localZonedTimestampType) {
+        int precision = localZonedTimestampType.getPrecision();
+        builder.dataType(MysqlType.TIMESTAMP.name());
+        builder.length(precision);
+        builder.isNullable(localZonedTimestampType.isNullable());
+        if (precision > 0) {
+            builder.columnType(String.format("TIMESTAMP(%d)", precision));
+        } else {
+            builder.columnType("TIMESTAMP");
+        }
+
+        return builder;
+    }
+
+    @Override
+    protected JdbcColumn.Builder defaultMethod(DataType dataType) {
+        throw new UnsupportedOperationException("Unsupported CDC data type " + dataType);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/resources/META-INF/services/org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/main/resources/META-INF/services/org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.cdc.connectors.jdbc.mysql.factory.JdbcMySqlSinkDialectFactory

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/dialect/MySqlStmtCreatorTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/dialect/MySqlStmtCreatorTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql.dialect;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Column;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataTypes;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test class for {@link MySqlStmtCreatorFactory}. */
+class MySqlStmtCreatorTest {
+    @Test
+    void testBuildCreateTableSql() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+        boolean ignoreIfExists = true;
+
+        Column column1 = Column.physicalColumn("id", DataTypes.INT(), "Primary Key");
+        Column column2 = Column.physicalColumn("name", DataTypes.VARCHAR(32), "Name of the entity");
+        Column column3 = Column.physicalColumn("age", DataTypes.INT(), null);
+
+        List<Column> columns = Arrays.asList(column1, column2, column3);
+        List<String> primaryKeys = Collections.singletonList("id");
+
+        Schema schema = Schema.newBuilder().setColumns(columns).primaryKey(primaryKeys).build();
+
+        String createTableSql =
+                MySqlStmtCreatorFactory.INSTANCE.buildCreateTableSql(tableId, schema, true);
+
+        String expectedSql =
+                "CREATE TABLE IF NOT EXISTS test_schema.test_table (\n"
+                        + "`id` INT COMMENT 'Primary Key',\n"
+                        + "`name` VARCHAR(32) COMMENT 'Name of the entity',\n"
+                        + "`age` INT,\n"
+                        + "PRIMARY KEY (`id`)\n"
+                        + ") ;";
+
+        assertThat(createTableSql).isEqualTo(expectedSql);
+    }
+
+    @Test
+    void testBuildCreateTableSqlWithoutPrimaryKey() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+        boolean ignoreIfExists = true;
+
+        Column column1 = Column.physicalColumn("id", DataTypes.INT(), "Primary Key");
+        Column column2 = Column.physicalColumn("name", DataTypes.VARCHAR(32), "Name of the entity");
+        Column column3 = Column.physicalColumn("age", DataTypes.INT(), null);
+
+        List<Column> columns = Arrays.asList(column1, column2, column3);
+
+        Schema schema = Schema.newBuilder().setColumns(columns).build();
+
+        String createTableSql =
+                MySqlStmtCreatorFactory.INSTANCE.buildCreateTableSql(tableId, schema, true);
+
+        String expectedSql =
+                "CREATE TABLE IF NOT EXISTS test_schema.test_table (\n"
+                        + "`id` INT COMMENT 'Primary Key',\n"
+                        + "`name` VARCHAR(32) COMMENT 'Name of the entity',\n"
+                        + "`age` INT\n"
+                        + ") ;";
+
+        assertThat(createTableSql).isEqualTo(expectedSql);
+    }
+
+    @Test
+    void testBuildDeleteSql() {
+        TableId tableId = TableId.tableId("my_schema", "my_table");
+        List<String> primaryKeys = Arrays.asList("id", "name");
+
+        String expectedSql = "DELETE FROM my_schema.my_table WHERE id = ? AND name = ?";
+        String actualSql = buildDeleteSql(tableId, primaryKeys);
+
+        assertThat(actualSql).isEqualTo(expectedSql);
+    }
+
+    private String buildDeleteSql(TableId tableId, List<String> primaryKeys) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("DELETE FROM %s ", tableId.identifier()));
+        builder.append("WHERE ");
+        primaryKeys.forEach(pk -> builder.append(pk).append(" = ? AND "));
+        // remove latest " AND "
+        builder.setLength(builder.length() - 5);
+        return builder.toString();
+    }
+
+    @Test
+    void testBuildRenameColumnSql() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+        String oldName = "old_name";
+        String newName = "new_name";
+
+        String renameColumnSql =
+                MySqlStmtCreatorFactory.INSTANCE.buildRenameColumnSql(tableId, oldName, newName);
+        String expectedSql =
+                "ALTER TABLE test_schema.test_table RENAME COLUMN `old_name` TO `new_name`;";
+        assertThat(renameColumnSql).isEqualTo(expectedSql);
+    }
+
+    @Test
+    void testBuildRenameColumnSqlWithoutTypeChange() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+        String oldColumnName = "description";
+        String newColumnName = "details";
+
+        String renameColumnSql =
+                MySqlStmtCreatorFactory.INSTANCE.buildRenameColumnSql(
+                        tableId, oldColumnName, newColumnName);
+
+        String expectedSql =
+                "ALTER TABLE test_schema.test_table RENAME COLUMN `description` TO `details`;";
+
+        assertThat(renameColumnSql).isEqualTo(expectedSql);
+    }
+
+    @Test
+    void testBuildAlterAddColumnsSql() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+
+        Column column1 =
+                Column.physicalColumn("new_column1", DataTypes.VARCHAR(255), "New column 1");
+        Column column2 = Column.physicalColumn("new_column2", DataTypes.INT(), "New column 2");
+
+        AddColumnEvent.ColumnWithPosition addColumn1 = AddColumnEvent.last(column1);
+        AddColumnEvent.ColumnWithPosition addColumn2 = AddColumnEvent.first(column2);
+
+        List<AddColumnEvent.ColumnWithPosition> addColumns = Arrays.asList(addColumn1, addColumn2);
+
+        String alterAddColumnsSql =
+                MySqlStmtCreatorFactory.INSTANCE.buildAlterAddColumnsSql(tableId, addColumns);
+
+        String expectedSql =
+                "ALTER TABLE test_schema.test_table ADD COLUMN `new_column1` VARCHAR(255) COMMENT 'New column 1', ADD COLUMN `new_column2` INT COMMENT 'New column 2' FIRST;";
+
+        assertThat(alterAddColumnsSql).isEqualTo(expectedSql);
+    }
+
+    @Test
+    void testBuildAlterAddColumnsSqlWithBeforePosition() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+
+        Column column1 =
+                Column.physicalColumn("new_column1", DataTypes.VARCHAR(255), "New column 1");
+        Column column2 = Column.physicalColumn("new_column2", DataTypes.INT(), "New column 2");
+
+        AddColumnEvent.ColumnWithPosition addColumn1 =
+                AddColumnEvent.before(column1, "existing_column");
+        AddColumnEvent.ColumnWithPosition addColumn2 =
+                AddColumnEvent.after(column2, "another_column");
+
+        List<AddColumnEvent.ColumnWithPosition> addColumns = Arrays.asList(addColumn1, addColumn2);
+
+        String alterAddColumnsSql =
+                MySqlStmtCreatorFactory.INSTANCE.buildAlterAddColumnsSql(tableId, addColumns);
+
+        String expectedSql =
+                "ALTER TABLE test_schema.test_table ADD COLUMN `new_column1` VARCHAR(255) COMMENT 'New column 1' BEFORE `existing_column`, ADD COLUMN `new_column2` INT COMMENT 'New column 2' AFTER `another_column`;";
+
+        assertThat(alterAddColumnsSql).isEqualTo(expectedSql);
+    }
+
+    @Test
+    void testGenerateUpsertQueryWithNamespaceAndSchema() {
+        TableId tableId = TableId.tableId("test_schema", "test_table");
+        Column column1 = Column.physicalColumn("id", DataTypes.INT(), "New column 1");
+        Column column2 = Column.physicalColumn("name", DataTypes.VARCHAR(32), "New column 2");
+        Column column3 = Column.physicalColumn("age", DataTypes.INT(), "New column 3");
+
+        List<Column> columns = Arrays.asList(column1, column2, column3);
+
+        String expectedQuery =
+                "INSERT INTO test_schema.test_table (id, name, age) "
+                        + "VALUES (?, ?, ?) "
+                        + "ON DUPLICATE KEY UPDATE id = VALUES(id), name = VALUES(name), age = VALUES(age);";
+        String actualQuery = MySqlStmtCreatorFactory.INSTANCE.buildUpsertSql(tableId, columns);
+
+        assertThat(actualQuery).isEqualTo(expectedQuery);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/type/MySqlTypeTransformerTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/type/MySqlTypeTransformerTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql.type;
+
+import org.apache.flink.cdc.common.types.BigIntType;
+import org.apache.flink.cdc.common.types.BooleanType;
+import org.apache.flink.cdc.common.types.CharType;
+import org.apache.flink.cdc.common.types.DecimalType;
+import org.apache.flink.cdc.common.types.DoubleType;
+import org.apache.flink.cdc.common.types.FloatType;
+import org.apache.flink.cdc.common.types.IntType;
+import org.apache.flink.cdc.common.types.SmallIntType;
+import org.apache.flink.cdc.common.types.TinyIntType;
+import org.apache.flink.cdc.common.types.VarBinaryType;
+import org.apache.flink.cdc.common.types.VarCharType;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcColumn;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Test class for {@link MySqlTypeTransformer}. */
+class MySqlTypeTransformerTest {
+    public static final int POWER_2_8 = (int) Math.pow(2, 8);
+    public static final int POWER_2_16 = (int) Math.pow(2, 16);
+    public static final int POWER_2_32 = (int) Math.pow(2, 32);
+    public static final int POWER_2_24 = (int) Math.pow(2, 24);
+
+    @Test
+    void testTinyintType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        TinyIntType charType = new TinyIntType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("TINYINT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("TINYINT");
+    }
+
+    @Test
+    void testSmallIntType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        SmallIntType charType = new SmallIntType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("SMALLINT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("SMALLINT");
+    }
+
+    @Test
+    void testIntType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        IntType charType = new IntType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("INT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("INT");
+    }
+
+    @Test
+    void testBigIntType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        BigIntType charType = new BigIntType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("BIGINT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("BIGINT");
+    }
+
+    @Test
+    void testFloatType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        FloatType charType = new FloatType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("FLOAT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("FLOAT");
+    }
+
+    @Test
+    void testDoubleType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        DoubleType charType = new DoubleType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("DOUBLE");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("DOUBLE");
+    }
+
+    @Test
+    void testDecimalType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        DecimalType charType = new DecimalType(10, 2);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("DECIMAL(10, 2)");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("DECIMAL");
+        assertThat(jdbcColumn.getLength()).isEqualTo(10);
+        assertThat(jdbcColumn.getScale()).isEqualTo(2);
+    }
+
+    @Test
+    void testVisitCharType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        CharType charType = new CharType(10);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(charType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("CHAR(10)");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("CHAR");
+        assertThat(jdbcColumn.getLength()).isEqualTo(10);
+    }
+
+    // Add similar tests for other types, e.g., VarCharType, BooleanType, DecimalType, etc.
+
+    // Example test for BooleanType
+    @Test
+    void testVisitBooleanType() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        BooleanType booleanType = new BooleanType();
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(booleanType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("TINYINT(1)");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("TINYINT");
+    }
+
+    @Test
+    void testVisitVarCharTypeLengthLessThan256() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarCharType varCharType = new VarCharType(false, 100);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varCharType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("VARCHAR(100)");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("VARCHAR");
+        assertThat(jdbcColumn.isNullable()).isFalse();
+    }
+
+    @Test
+    void testVisitVarCharTypeLengthLessThan65536() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarCharType varCharType = new VarCharType(true, POWER_2_8 + 1);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varCharType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("VARCHAR(257)");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("VARCHAR");
+        assertThat(jdbcColumn.isNullable()).isTrue();
+    }
+
+    @Test
+    void testVisitVarCharTypeLengthLessThan16777216() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarCharType varCharType = new VarCharType(false, POWER_2_16 + 1);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varCharType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("MEDIUMTEXT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("MEDIUMTEXT");
+        assertThat(jdbcColumn.isNullable()).isFalse();
+    }
+
+    @Test
+    void testVisitVarCharTypeLengthGreaterThanOrEqualTo16777216() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarCharType varCharType = new VarCharType(true, POWER_2_24 + 1);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varCharType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("LONGTEXT");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("LONGTEXT");
+        assertThat(jdbcColumn.isNullable()).isTrue();
+    }
+
+    @Test
+    void testVisitVarBinaryTypeLengthLessThan65536() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarBinaryType varBinaryType = new VarBinaryType(true, POWER_2_16 - 1);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varBinaryType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("VARBINARY(65535)");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("VARBINARY");
+        assertThat(jdbcColumn.isNullable()).isTrue();
+    }
+
+    @Test
+    void testVisitVarBinaryTypeLengthLessThan16777216() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarBinaryType varBinaryType = new VarBinaryType(false, POWER_2_16);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varBinaryType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("MEDIUMBLOB");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("MEDIUMBLOB");
+        assertThat(jdbcColumn.isNullable()).isFalse();
+    }
+
+    @Test
+    void testVisitVarBinaryTypeLengthLessThan4294967296() {
+        JdbcColumn.Builder builder = new JdbcColumn.Builder();
+        VarBinaryType varBinaryType = new VarBinaryType(true, POWER_2_24);
+        MySqlTypeTransformer transformer = new MySqlTypeTransformer(builder);
+        transformer.visit(varBinaryType);
+
+        JdbcColumn jdbcColumn = builder.build();
+        assertThat(jdbcColumn.getColumnType()).isEqualTo("LONGBLOB");
+        assertThat(jdbcColumn.getDataType()).isEqualTo("LONGBLOB");
+        assertThat(jdbcColumn.isNullable()).isTrue();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc-mysql/src/test/resources/log4j2-test.properties
@@ -1,0 +1,25 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to ERROR to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=ERROR
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/pom.xml
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-cdc-pipeline-connector-jdbc-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <packaging>jar</packaging>
+
+    <artifactId>flink-cdc-pipeline-connector-jdbc</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-jdbc-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-jdbc-mysql</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-composer</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-mysql</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadeTestJar>true</shadeTestJar>
+                            <filters combine.children="append">
+                                <filter combine.children="append">
+                                    <artifact>*:*</artifact>
+                                    <excludes combine.children="append">
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.apache.flink:flink-core</exclude>
+                                    <exclude>org.apache.flink:flink-connector-base</exclude>
+                                    <exclude>org.apache.flink:flink-streaming-java</exclude>
+                                    <exclude>org.apache.flink:flink-table-api-java-bridge</exclude>
+                                    <exclude>org.apache.flink:flink-table-common</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/JdbcSinkGenericITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/JdbcSinkGenericITCase.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc;
+
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.connectors.jdbc.common.JdbcSinkTestBase;
+import org.apache.flink.cdc.connectors.jdbc.config.JdbcSinkConfig;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialect;
+import org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory;
+import org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+/** Integrated test cases for generic Jdbc sink connector. */
+class JdbcSinkGenericITCase extends JdbcSinkTestBase {
+
+    @Test
+    void testRunJdbcWithUnknownDialect() {
+        Configuration sinkConfig = new Configuration();
+
+        sinkConfig.set(JdbcSinkOptions.CONN_URL, "jdbc:unexpected://localhost:3306");
+        sinkConfig.set(JdbcSinkOptions.USERNAME, "username");
+        sinkConfig.set(JdbcSinkOptions.PASSWORD, "password");
+
+        Assertions.assertThatThrownBy(() -> runJobWithEvents(sinkConfig, Collections.emptyList()))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "There must be exactly one factory for dialect unexpected, but 0 found.\n"
+                                + "Matched dialects: []\n"
+                                + "Available dialects: [dummy, dummy, mysql]");
+    }
+
+    @Test
+    void testRunJdbcWithDuplicatedDialect() throws Exception {
+        Configuration sinkConfig = new Configuration();
+
+        sinkConfig.set(JdbcSinkOptions.CONN_URL, "jdbc:dummy://localhost:3306");
+        sinkConfig.set(JdbcSinkOptions.USERNAME, "username");
+        sinkConfig.set(JdbcSinkOptions.PASSWORD, "password");
+
+        Assertions.assertThatThrownBy(() -> runJobWithEvents(sinkConfig, Collections.emptyList()))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "There must be exactly one factory for dialect dummy, but 2 found.\n"
+                                + "Matched dialects: [class org.apache.flink.cdc.connectors.jdbc.JdbcSinkGenericITCase$DummyFactoryA, class org.apache.flink.cdc.connectors.jdbc.JdbcSinkGenericITCase$DummyFactoryB]\n"
+                                + "Available dialects: [dummy, dummy, mysql]");
+    }
+
+    public static class DummyFactoryA implements JdbcSinkDialectFactory<JdbcSinkConfig> {
+
+        @Override
+        public String identifier() {
+            return "dummy";
+        }
+
+        @Override
+        public JdbcSinkDialect createDialect(JdbcSinkConfig option) {
+            throw new UnsupportedOperationException(
+                    "This is a dummy dialect factory and is not meant to be instantiated.");
+        }
+    }
+
+    public static class DummyFactoryB implements JdbcSinkDialectFactory<JdbcSinkConfig> {
+        @Override
+        public String identifier() {
+            return "dummy";
+        }
+
+        @Override
+        public JdbcSinkDialect createDialect(JdbcSinkConfig option) {
+            throw new UnsupportedOperationException(
+                    "This is a dummy dialect factory and is not meant to be instantiated.");
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/common/JdbcSinkTestBase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/common/JdbcSinkTestBase.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.common;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.factories.Factory;
+import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
+import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.composer.definition.SinkDef;
+import org.apache.flink.cdc.composer.flink.coordination.OperatorIDGenerator;
+import org.apache.flink.cdc.composer.flink.translator.DataSinkTranslator;
+import org.apache.flink.cdc.composer.flink.translator.OperatorUidGenerator;
+import org.apache.flink.cdc.composer.flink.translator.SchemaOperatorTranslator;
+import org.apache.flink.cdc.connectors.jdbc.factory.JdbcDataSinkFactory;
+import org.apache.flink.cdc.connectors.jdbc.mysql.MySqlSinkTestBase;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.cdc.common.pipeline.PipelineOptions.DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT;
+
+/** An abstract base class for running Jdbc sink tests. */
+@ExtendWith(MiniClusterExtension.class)
+public abstract class JdbcSinkTestBase {
+
+    protected static final int DEFAULT_PARALLELISM = 1;
+
+    protected static final StreamExecutionEnvironment ENV =
+            StreamExecutionEnvironment.getExecutionEnvironment();
+
+    @BeforeAll
+    static void before() {
+        ENV.setParallelism(MySqlSinkTestBase.DEFAULT_PARALLELISM);
+        ENV.enableCheckpointing(3000);
+        ENV.setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    protected static DataSink createDataSink(Configuration factoryConfiguration) {
+        JdbcDataSinkFactory factory = new JdbcDataSinkFactory();
+        return factory.createDataSink(new MockContext(factoryConfiguration));
+    }
+
+    protected void runJobWithEvents(Configuration configuration, List<Event> events)
+            throws Exception {
+        DataStream<Event> stream = ENV.fromData(events, TypeInformation.of(Event.class));
+        SinkDef sinkDef =
+                new SinkDef(JdbcDataSinkFactory.IDENTIFIER, "JDBC MySQL Sink", configuration);
+        DataSink dataSink = createDataSink(configuration);
+        SchemaOperatorTranslator schemaOperatorTranslator =
+                new SchemaOperatorTranslator(
+                        SchemaChangeBehavior.EVOLVE,
+                        "$$_schema_operator_$$",
+                        DEFAULT_SCHEMA_OPERATOR_RPC_TIMEOUT,
+                        "UTC");
+        OperatorIDGenerator schemaOperatorIDGenerator =
+                new OperatorIDGenerator(schemaOperatorTranslator.getSchemaOperatorUid());
+        OperatorUidGenerator operatorUidGenerator = new OperatorUidGenerator("jdbc_");
+        stream =
+                schemaOperatorTranslator.translateRegular(
+                        stream,
+                        MySqlSinkTestBase.DEFAULT_PARALLELISM,
+                        dataSink.getMetadataApplier(),
+                        new ArrayList<>());
+
+        DataSinkTranslator sinkTranslator = new DataSinkTranslator();
+        sinkTranslator.translate(
+                sinkDef,
+                stream,
+                MySqlSinkTestBase.DEFAULT_PARALLELISM,
+                dataSink,
+                schemaOperatorIDGenerator.generate(),
+                operatorUidGenerator);
+        ENV.execute("MySql Schema Evolution Test");
+    }
+
+    /** A mocked factory context. */
+    protected static class MockContext implements Factory.Context {
+
+        Configuration factoryConfiguration;
+
+        public MockContext(Configuration factoryConfiguration) {
+            this.factoryConfiguration = factoryConfiguration;
+        }
+
+        @Override
+        public Configuration getFactoryConfiguration() {
+            return factoryConfiguration;
+        }
+
+        @Override
+        public Configuration getPipelineConfiguration() {
+            return Configuration.fromMap(Collections.singletonMap("local-time-zone", "UTC"));
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return getClass().getClassLoader();
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlDataSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlDataSinkITCase.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql;
+
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.PhysicalColumn;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+/** IT cases for MySQL Data Sink. */
+class MySqlDataSinkITCase extends MySqlSinkTestBase {
+
+    private static final TableId TABLE_ID =
+            TableId.tableId(
+                    MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName(), "data_sink_test_table");
+
+    @BeforeEach
+    void initializeDatabase() {
+        MySqlSinkTestBase.executeSql(
+                String.format(
+                        "CREATE DATABASE IF NOT EXISTS `%s`;",
+                        MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName()));
+        LOG.info("Database {} created.", MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName());
+    }
+
+    @AfterEach
+    void destroyDatabase() {
+        MySqlSinkTestBase.executeSql(
+                String.format(
+                        "DROP DATABASE %s;", MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName()));
+        LOG.info("Database {} destroyed.", MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName());
+    }
+
+    @Test
+    void testSyncInsertEvents() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        runJobThatSinksToMySqlWithEvents(
+                Arrays.asList(
+                        new CreateTableEvent(TABLE_ID, schema),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            19, 2.718281828, BinaryStringData.fromString("Bob")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            23, 1.41421356, BinaryStringData.fromString("Cicada")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            29, 9.973627192, BinaryStringData.fromString("Derrida")
+                                        }))));
+
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3))
+                .containsExactly(
+                        "17 | 3.141592653 | Alice",
+                        "19 | 2.718281828 | Bob",
+                        "23 | 1.41421356 | Cicada",
+                        "29 | 9.973627192 | Derrida");
+    }
+
+    @Test
+    void testSyncUpdateEvents() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        runJobThatSinksToMySqlWithEvents(
+                Arrays.asList(
+                        new CreateTableEvent(TABLE_ID, schema),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        })),
+                        DataChangeEvent.updateEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        }),
+                                generator.generate(
+                                        new Object[] {
+                                            17, 2.718281828, BinaryStringData.fromString("Bob")
+                                        }))));
+
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3))
+                .containsExactly("17 | 2.718281828 | Bob");
+    }
+
+    @Test
+    void testSyncDeleteEvents() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        runJobThatSinksToMySqlWithEvents(
+                Arrays.asList(
+                        new CreateTableEvent(TABLE_ID, schema),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            19, 2.718281828, BinaryStringData.fromString("Bob")
+                                        })),
+                        DataChangeEvent.deleteEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            19, 2.718281828, BinaryStringData.fromString("Bob")
+                                        }))));
+
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3))
+                .containsExactly("17 | 3.141592653 | Alice");
+    }
+
+    @Test
+    void testSyncInsertEventsWithoutPk() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        runJobThatSinksToMySqlWithEvents(
+                Arrays.asList(
+                        new CreateTableEvent(TABLE_ID, schema),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            19, 2.718281828, BinaryStringData.fromString("Bob")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            23, 1.41421356, BinaryStringData.fromString("Cicada")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            29, 9.973627192, BinaryStringData.fromString("Derrida")
+                                        }))));
+
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO |  | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3))
+                .containsExactly(
+                        "17 | 3.141592653 | Alice",
+                        "19 | 2.718281828 | Bob",
+                        "23 | 1.41421356 | Cicada",
+                        "29 | 9.973627192 | Derrida");
+    }
+
+    @Test
+    void testSyncUpdateEventsWithoutPk() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        runJobThatSinksToMySqlWithEvents(
+                Arrays.asList(
+                        new CreateTableEvent(TABLE_ID, schema),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        })),
+                        DataChangeEvent.updateEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        }),
+                                generator.generate(
+                                        new Object[] {
+                                            17, 2.718281828, BinaryStringData.fromString("Bob")
+                                        }))));
+
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO |  | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3))
+                .containsExactly("17 | 2.718281828 | Bob");
+    }
+
+    @Test
+    void testSyncDeleteEventsWithoutPk() throws Exception {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        runJobThatSinksToMySqlWithEvents(
+                Arrays.asList(
+                        new CreateTableEvent(TABLE_ID, schema),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            17, 3.141592653, BinaryStringData.fromString("Alice")
+                                        })),
+                        DataChangeEvent.insertEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            19, 2.718281828, BinaryStringData.fromString("Bob")
+                                        })),
+                        DataChangeEvent.deleteEvent(
+                                TABLE_ID,
+                                generator.generate(
+                                        new Object[] {
+                                            19, 2.718281828, BinaryStringData.fromString("Bob")
+                                        }))));
+
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO |  | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3))
+                .containsExactly("17 | 3.141592653 | Alice");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlMetadataApplierITCase.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql;
+
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.DropColumnEvent;
+import org.apache.flink.cdc.common.event.DropTableEvent;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.RenameColumnEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.event.TruncateTableEvent;
+import org.apache.flink.cdc.common.schema.Column;
+import org.apache.flink.cdc.common.schema.PhysicalColumn;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLSyntaxErrorException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/** IT cases for MySQL Metadata Applier. */
+class MySqlMetadataApplierITCase extends MySqlSinkTestBase {
+
+    private static final TableId TABLE_ID =
+            TableId.tableId(
+                    MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName(),
+                    "metadata_applier_test_table");
+
+    private static final StreamExecutionEnvironment env =
+            StreamExecutionEnvironment.getExecutionEnvironment();
+
+    @BeforeAll
+    static void before() {
+        env.setParallelism(MySqlSinkTestBase.DEFAULT_PARALLELISM);
+        env.enableCheckpointing(3000);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    @BeforeEach
+    void initializeDatabase() {
+        MySqlSinkTestBase.executeSql(
+                String.format(
+                        "CREATE DATABASE IF NOT EXISTS `%s`;",
+                        MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName()));
+        MySqlSinkTestBase.LOG.info(
+                "Database {} created.", MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName());
+    }
+
+    @AfterEach
+    void destroyDatabase() {
+        MySqlSinkTestBase.executeSql(
+                String.format(
+                        "DROP DATABASE %s;", MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName()));
+        MySqlSinkTestBase.LOG.info(
+                "Database {} destroyed.", MySqlSinkTestBase.MYSQL_CONTAINER.getDatabaseName());
+    }
+
+    private List<Event> generateAddColumnEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                new AddColumnEvent(
+                        tableId,
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        new PhysicalColumn("extra_date", DataTypes.DATE(), null)))),
+                new AddColumnEvent(
+                        tableId,
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        new PhysicalColumn(
+                                                "extra_bool", DataTypes.BOOLEAN(), null)))),
+                new AddColumnEvent(
+                        tableId,
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        new PhysicalColumn(
+                                                "extra_decimal",
+                                                DataTypes.DECIMAL(17, 0),
+                                                null)))));
+    }
+
+    private List<Event> generateDropColumnEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                new DropColumnEvent(tableId, Collections.singletonList("number")));
+    }
+
+    private List<Event> generateRenameColumnEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                new RenameColumnEvent(tableId, Collections.singletonMap("number", "kazu")),
+                new RenameColumnEvent(tableId, Collections.singletonMap("name", "namae")));
+    }
+
+    private List<Event> generateAlterColumnTypeEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                new AlterColumnTypeEvent(
+                        tableId, Collections.singletonMap("name", DataTypes.VARCHAR(19))));
+    }
+
+    private List<Event> generateNarrowingAlterColumnTypeEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                // Double -> Float is a narrowing cast, should fail
+                new AlterColumnTypeEvent(
+                        tableId, Collections.singletonMap("number", DataTypes.FLOAT())));
+    }
+
+    private List<Event> generateAddColumnWithPosition(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("col1", DataTypes.VARCHAR(10), null))
+                        .column(new PhysicalColumn("col2", DataTypes.VARCHAR(10), null))
+                        .column(new PhysicalColumn("col3", DataTypes.VARCHAR(10), null))
+                        .build();
+
+        List<AddColumnEvent.ColumnWithPosition> addedColumns = new ArrayList<>();
+        addedColumns.add(
+                AddColumnEvent.first(Column.physicalColumn("col4_first", DataTypes.VARCHAR(10))));
+        addedColumns.add(
+                AddColumnEvent.last(Column.physicalColumn("col5_last", DataTypes.VARCHAR(10))));
+
+        addedColumns.add(
+                AddColumnEvent.after(
+                        Column.physicalColumn("col7_after", DataTypes.VARCHAR(10)), "col2"));
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema), new AddColumnEvent(tableId, addedColumns));
+    }
+
+    private List<Event> generateTruncateTableEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                DataChangeEvent.insertEvent(
+                        tableId,
+                        generator.generate(
+                                new Object[] {
+                                    17, 3.1415926, BinaryStringData.fromString("Alice")
+                                })),
+                new TruncateTableEvent(tableId));
+    }
+
+    private List<Event> generateDropTableEvents(TableId tableId) {
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("number", DataTypes.DOUBLE(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(17), null))
+                        .primaryKey("id")
+                        .build();
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        return Arrays.asList(
+                new CreateTableEvent(tableId, schema),
+                DataChangeEvent.insertEvent(
+                        tableId,
+                        generator.generate(
+                                new Object[] {
+                                    17, 3.1415926, BinaryStringData.fromString("Alice")
+                                })),
+                new DropTableEvent(tableId));
+    }
+
+    @Test
+    void testMySqlAddColumn() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateAddColumnEvents(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null",
+                        "extra_date | date | YES |  | null",
+                        "extra_bool | tinyint(1) | YES |  | null",
+                        "extra_decimal | decimal(17,0) | YES |  | null");
+    }
+
+    @Test
+    void testMySqlDropColumn() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateDropColumnEvents(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null", "name | varchar(17) | YES |  | null");
+    }
+
+    @Test
+    void testMySqlRenameColumn() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateRenameColumnEvents(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "kazu | double | YES |  | null",
+                        "namae | varchar(17) | YES |  | null");
+    }
+
+    @Test
+    void testMySqlAlterColumnType() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateAlterColumnTypeEvents(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(19) | YES |  | null");
+    }
+
+    @Test
+    void testMySqlNarrowingAlterColumnType() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateNarrowingAlterColumnTypeEvents(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | float | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+    }
+
+    @Test
+    void testAddColumnWithPosition() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateAddColumnWithPosition(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "col4_first | varchar(10) | YES |  | null",
+                        "col1 | varchar(10) | YES |  | null",
+                        "col2 | varchar(10) | YES |  | null",
+                        "col7_after | varchar(10) | YES |  | null",
+                        "col3 | varchar(10) | YES |  | null",
+                        "col5_last | varchar(10) | YES |  | null");
+    }
+
+    @Test
+    void testMySqlTruncateTable() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateTruncateTableEvents(TABLE_ID));
+        Assertions.assertThat(inspectTableSchema(TABLE_ID))
+                .containsExactly(
+                        "id | int | NO | PRI | null",
+                        "number | double | YES |  | null",
+                        "name | varchar(17) | YES |  | null");
+
+        Assertions.assertThat(inspectTableContent(TABLE_ID, 3)).isEmpty();
+    }
+
+    @Test
+    void testMySqlDropTable() throws Exception {
+        runJobThatSinksToMySqlWithEvents(generateDropTableEvents(TABLE_ID));
+
+        Assertions.assertThatThrownBy(() -> inspectTableSchema(TABLE_ID))
+                .isExactlyInstanceOf(SQLSyntaxErrorException.class)
+                .hasMessage("Table '" + TABLE_ID + "' doesn't exist");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlSinkTestBase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/java/org/apache/flink/cdc/connectors/jdbc/mysql/MySqlSinkTestBase.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.jdbc.mysql;
+
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.connectors.jdbc.common.JdbcSinkTestBase;
+import org.apache.flink.cdc.connectors.jdbc.options.JdbcSinkOptions;
+import org.apache.flink.cdc.connectors.mysql.testutils.MySqlContainer;
+import org.apache.flink.cdc.connectors.mysql.testutils.MySqlVersion;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.lifecycle.Startables;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
+
+/** Mysql sink test base. */
+public class MySqlSinkTestBase extends JdbcSinkTestBase {
+    protected static final Logger LOG = LoggerFactory.getLogger(MySqlSinkTestBase.class);
+    protected static final Duration DEFAULT_STARTUP_TIMEOUT_SECONDS = Duration.ofMinutes(4);
+    protected static final MySqlContainer MYSQL_CONTAINER = createMySqlContainer();
+
+    private static MySqlContainer createMySqlContainer() {
+        return new MySqlContainer(MySqlVersion.V8_0);
+    }
+
+    @BeforeAll
+    protected static void startContainers() throws Exception {
+        LOG.info("Starting containers...");
+        Startables.deepStart(Stream.of(MYSQL_CONTAINER)).join();
+        LOG.info("Waiting for backends to be available");
+        waitForMySqlContainerToBeReady(MYSQL_CONTAINER);
+        LOG.info("Containers are started.");
+    }
+
+    @AfterAll
+    protected static void stopContainers() {
+        LOG.info("Stopping containers...");
+        MYSQL_CONTAINER.stop();
+        LOG.info("Containers are stopped.");
+    }
+
+    protected void runJobThatSinksToMySqlWithEvents(List<Event> events) throws Exception {
+        Configuration sinkConfig = new Configuration();
+        String host = MySqlSinkTestBase.MYSQL_CONTAINER.getHost();
+        int port = MySqlSinkTestBase.MYSQL_CONTAINER.getDatabasePort();
+        sinkConfig.set(JdbcSinkOptions.CONN_URL, "jdbc:mysql://" + host + ":" + port);
+        sinkConfig.set(JdbcSinkOptions.USERNAME, MySqlSinkTestBase.MYSQL_CONTAINER.getUsername());
+        sinkConfig.set(JdbcSinkOptions.PASSWORD, MySqlSinkTestBase.MYSQL_CONTAINER.getPassword());
+        sinkConfig.set(JdbcSinkOptions.SERVER_TIME_ZONE, "UTC");
+
+        runJobWithEvents(sinkConfig, events);
+    }
+
+    protected static void executeSql(String sql) {
+        try {
+            Container.ExecResult rs =
+                    MYSQL_CONTAINER.execInContainer(
+                            "mysql",
+                            "--protocol=TCP",
+                            "-h127.0.0.1",
+                            "-P" + MySqlContainer.MYSQL_PORT,
+                            "-u" + MYSQL_CONTAINER.getUsername(),
+                            "-p" + MYSQL_CONTAINER.getPassword(),
+                            "-e " + sql);
+
+            if (rs.getExitCode() != 0) {
+                throw new RuntimeException("Failed to execute SQL." + rs.getStderr());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to execute SQL.", e);
+        }
+    }
+
+    public static void waitForMySqlContainerToBeReady(MySqlContainer container)
+            throws InterruptedException, TimeoutException {
+        long deadline = System.currentTimeMillis() + DEFAULT_STARTUP_TIMEOUT_SECONDS.toMillis();
+
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                Container.ExecResult rs =
+                        container.execInContainer(
+                                "mysql",
+                                "--protocol=TCP",
+                                "-P" + MySqlContainer.MYSQL_PORT,
+                                "-u" + container.getUsername(),
+                                "-p" + container.getPassword(),
+                                "-h127.0.0.1",
+                                "-e SELECT 72067");
+
+                if (rs.getExitCode() != 0) {
+                    return;
+                }
+                String output = rs.getStdout();
+                LOG.info("MySQL backend status: {}", output);
+                if (output.contains("72067")) {
+                    return;
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to check backend status.", e);
+            }
+            Thread.sleep(1000);
+        }
+        throw new TimeoutException("Failed to wait for container to start.");
+    }
+
+    protected List<String> inspectTableSchema(TableId tableId) throws SQLException {
+        List<String> results = new ArrayList<>();
+        ResultSet rs =
+                MYSQL_CONTAINER
+                        .createConnection("")
+                        .createStatement()
+                        .executeQuery(
+                                String.format(
+                                        "DESCRIBE `%s`.`%s`",
+                                        tableId.getSchemaName(), tableId.getTableName()));
+
+        while (rs.next()) {
+            List<String> columns = new ArrayList<>();
+            for (int i = 1; i <= 5; i++) {
+                columns.add(rs.getString(i));
+            }
+            results.add(String.join(" | ", columns));
+        }
+        return results;
+    }
+
+    protected List<String> inspectTableContent(TableId tableId, int columnCount)
+            throws SQLException {
+        List<String> results = new ArrayList<>();
+        ResultSet rs =
+                MYSQL_CONTAINER
+                        .createConnection("")
+                        .createStatement()
+                        .executeQuery(
+                                String.format(
+                                        "SELECT * FROM `%s`.`%s`",
+                                        tableId.getSchemaName(), tableId.getTableName()));
+
+        while (rs.next()) {
+            List<String> columns = new ArrayList<>();
+            for (int i = 1; i <= columnCount; i++) {
+                columns.add(rs.getString(i));
+            }
+            results.add(String.join(" | ", columns));
+        }
+        return results;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/resources/META-INF/services/org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/resources/META-INF/services/org.apache.flink.cdc.connectors.jdbc.dialect.JdbcSinkDialectFactory
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.cdc.connectors.jdbc.JdbcSinkGenericITCase$DummyFactoryA
+org.apache.flink.cdc.connectors.jdbc.JdbcSinkGenericITCase$DummyFactoryB

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/flink-cdc-pipeline-connector-jdbc/src/test/resources/log4j2-test.properties
@@ -1,0 +1,25 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to ERROR to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level=ERROR
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c - %m%n

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-jdbc-parent/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-cdc-pipeline-connectors</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <packaging>pom</packaging>
+    <modules>
+        <module>flink-cdc-pipeline-connector-jdbc-core</module>
+        <module>flink-cdc-pipeline-connector-jdbc-mysql</module>
+        <module>flink-cdc-pipeline-connector-jdbc</module>
+    </modules>
+
+    <properties>
+        <!-- TODO: Bump JDBC connector version after it supports Flink 1.20 -->
+        <flink.jdbc.connector.version>3.2.0-1.19</flink.jdbc.connector.version>
+    </properties>
+
+    <artifactId>flink-cdc-pipeline-connector-jdbc-parent</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-jdbc</artifactId>
+            <version>${flink.jdbc.connector.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/pom.xml
@@ -28,9 +28,6 @@ limitations under the License.
 
     <artifactId>flink-cdc-pipeline-connector-mysql</artifactId>
 
-    <properties>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSinkITCase.java
@@ -706,6 +706,7 @@ public class PaimonSinkITCase {
         sinkTranslator.translate(
                 new SinkDef("paimon", "Paimon Sink", conf),
                 stream,
+                DEFAULT_PARALLELISM,
                 paimonSink,
                 isBatchMode,
                 schemaOperatorIDGenerator.generate(),

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
@@ -462,6 +462,7 @@ class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
         sinkTranslator.translate(
                 new SinkDef("starrocks", "Dummy StarRocks Sink", config),
                 stream,
+                DEFAULT_PARALLELISM,
                 starRocksSink,
                 schemaOperatorIDGenerator.generate(),
                 new OperatorUidGenerator());

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/pom.xml
@@ -27,9 +27,6 @@ limitations under the License.
 
     <artifactId>flink-cdc-pipeline-connector-values</artifactId>
 
-    <properties>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/pom.xml
@@ -40,6 +40,7 @@ limitations under the License.
         <module>flink-cdc-pipeline-connector-maxcompute</module>
         <module>flink-cdc-pipeline-connector-iceberg</module>
         <module>flink-cdc-pipeline-connector-fluss</module>
+        <module>flink-cdc-pipeline-connector-jdbc-parent</module>
     </modules>
 
     <dependencies>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
@@ -50,7 +50,7 @@ limitations under the License.
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>4.0.3</version>
+            <version>${hikari.version}</version>
         </dependency>
 
         <dependency>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/pom.xml
@@ -72,7 +72,7 @@ limitations under the License.
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>4.0.3</version>
+            <version>${hikari.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -205,8 +205,6 @@ limitations under the License.
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
-
 </project>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/pom.xml
@@ -64,7 +64,7 @@ limitations under the License.
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.27</version>
+            <version>${mysql.driver.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/pom.xml
@@ -133,7 +133,7 @@ limitations under the License.
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
             </exclusions>
-            <version>8.0.27</version>
+            <version>${mysql.driver.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-vitess-cdc/pom.xml
@@ -76,7 +76,7 @@ limitations under the License.
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.26</version>
+            <version>${mysql.driver.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
@@ -25,14 +25,14 @@ limitations under the License.
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>flink-cdc-pipeline-e2e-tests</artifactId>
-
     <properties>
         <flink-1.19>1.19.2</flink-1.19>
         <flink-1.20>1.20.1</flink-1.20>
         <flink-major-1.19>1.19</flink-major-1.19>
         <flink-major-1.20>1.20</flink-major-1.20>
-        <mysql.driver.version>8.0.27</mysql.driver.version>
+        <jdbc.version-1.19>3.2.0-1.19</jdbc.version-1.19>
+        <!-- TODO: Bump JDBC connector version after it supports Flink 1.20 -->
+        <jdbc.version-1.20>3.2.0-1.19</jdbc.version-1.20>
         <!-- TODO: Update this, when StarRocks releases a 1.20 compatible connector. -->
         <starrocks.connector.version>1.2.10_flink-${flink-major-1.19}</starrocks.connector.version>
         <paimon.version>1.2.0</paimon.version>
@@ -44,6 +44,8 @@ limitations under the License.
         <hive.version>2.3.9</hive.version>
         <fluss.version>0.7.0</fluss.version>
     </properties>
+
+    <artifactId>flink-cdc-pipeline-e2e-tests</artifactId>
 
     <dependencies>
         <dependency>
@@ -80,6 +82,12 @@ limitations under the License.
             <artifactId>flink-connector-mysql-cdc</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-connector-jdbc</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -528,6 +536,26 @@ limitations under the License.
 
                         <artifactItem>
                             <groupId>org.apache.flink</groupId>
+                            <artifactId>flink-connector-jdbc</artifactId>
+                            <version>${jdbc.version-1.19}</version>
+                            <destFileName>jdbc-connector_${flink-1.19}.jar</destFileName>
+                            <type>jar</type>
+                            <outputDirectory>${project.build.directory}/dependencies
+                            </outputDirectory>
+                        </artifactItem>
+
+                        <artifactItem>
+                            <groupId>org.apache.flink</groupId>
+                            <artifactId>flink-connector-jdbc</artifactId>
+                            <version>${jdbc.version-1.20}</version>
+                            <destFileName>jdbc-connector_${flink-1.20}.jar</destFileName>
+                            <type>jar</type>
+                            <outputDirectory>${project.build.directory}/dependencies
+                            </outputDirectory>
+                        </artifactItem>
+
+                        <artifactItem>
+                            <groupId>org.apache.flink</groupId>
                             <artifactId>flink-cdc-pipeline-connector-doris</artifactId>
                             <version>${project.version}</version>
                             <destFileName>doris-cdc-pipeline-connector.jar</destFileName>
@@ -590,6 +618,15 @@ limitations under the License.
                             <artifactId>flink-cdc-pipeline-connector-paimon</artifactId>
                             <version>${project.version}</version>
                             <destFileName>paimon-cdc-pipeline-connector.jar</destFileName>
+                            <type>jar</type>
+                            <outputDirectory>${project.build.directory}/dependencies
+                            </outputDirectory>
+                        </artifactItem>
+                        <artifactItem>
+                            <groupId>org.apache.flink</groupId>
+                            <artifactId>flink-cdc-pipeline-connector-jdbc</artifactId>
+                            <version>${project.version}</version>
+                            <destFileName>jdbc-cdc-pipeline-connector.jar</destFileName>
                             <type>jar</type>
                             <outputDirectory>${project.build.directory}/dependencies
                             </outputDirectory>

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MySqlToJdbcMySqlE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MySqlToJdbcMySqlE2eITCase.java
@@ -1,0 +1,662 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.pipeline.tests;
+
+import org.apache.flink.cdc.common.test.utils.TestUtils;
+import org.apache.flink.cdc.common.utils.TestCaseUtils;
+import org.apache.flink.cdc.connectors.mysql.testutils.MySqlContainer;
+import org.apache.flink.cdc.connectors.mysql.testutils.MySqlVersion;
+import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
+import org.apache.flink.cdc.pipeline.tests.utils.PipelineTestEnvironment;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** E2e test case from MySQL source to MySQL sink (JDBC). */
+class MySqlToJdbcMySqlE2eITCase extends PipelineTestEnvironment {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MySqlToJdbcMySqlE2eITCase.class);
+
+    private static final Duration TESTCASE_TIMEOUT = Duration.ofMinutes(5);
+    private static final String TEST_USERNAME = "mysqluser";
+    private static final String TEST_PASSWORD = "mysqlpw";
+    private static final String SOURCE_NETWORK_NAME = "mysqlsource";
+    private static final String SINK_NETWORK_NAME = "mysqlsink";
+
+    @Container
+    private static final MySqlContainer MYSQL_SOURCE =
+            (MySqlContainer)
+                    new MySqlContainer(MySqlVersion.V8_0)
+                            .withConfigurationOverride("docker/mysql/my.cnf")
+                            .withSetupSQL("docker/mysql/setup.sql")
+                            .withDatabaseName("flink-test")
+                            .withUsername("flinkuser")
+                            .withPassword("flinkpw")
+                            .withNetwork(NETWORK)
+                            .withNetworkAliases(SOURCE_NETWORK_NAME)
+                            .withExposedPorts(3306)
+                            .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    @Container
+    private static final MySqlContainer MYSQL_SINK =
+            (MySqlContainer)
+                    new MySqlContainer(MySqlVersion.V8_0)
+                            .withConfigurationOverride("docker/mysql/my.cnf")
+                            .withSetupSQL("docker/mysql/setup.sql")
+                            .withDatabaseName("flink-test")
+                            .withUsername("flinkuser")
+                            .withPassword("flinkpw")
+                            .withNetwork(NETWORK)
+                            .withNetworkAliases(SINK_NETWORK_NAME)
+                            .withExposedPorts(3306)
+                            .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    protected final UniqueDatabase mysqlInventoryDatabase =
+            new UniqueDatabase(MYSQL_SOURCE, "mysql_inventory", TEST_USERNAME, TEST_PASSWORD);
+
+    protected final UniqueDatabase batchedWriteDatabase =
+            new UniqueDatabase(MYSQL_SOURCE, "batched_write", TEST_USERNAME, TEST_PASSWORD);
+
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        mysqlInventoryDatabase.createAndInitialize();
+        // Create sink database manually, as JDBC sink does not support DB auto-creation
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                MYSQL_SINK.getJdbcUrl(), TEST_USERNAME, TEST_PASSWORD);
+                Statement stat = conn.createStatement()) {
+            stat.execute(
+                    String.format("CREATE DATABASE %s;", mysqlInventoryDatabase.getDatabaseName()));
+            stat.execute(
+                    String.format("CREATE DATABASE %s;", batchedWriteDatabase.getDatabaseName()));
+        }
+    }
+
+    @AfterEach
+    public void after() {
+        super.after();
+        mysqlInventoryDatabase.dropDatabase();
+        batchedWriteDatabase.dropDatabase();
+    }
+
+    @Test
+    void testSyncSchemaChanges() throws Exception {
+        String databaseName = mysqlInventoryDatabase.getDatabaseName();
+        String pipelineJob =
+                String.format(
+                        "source:\n"
+                                + "  type: mysql\n"
+                                + "  hostname: %s\n"
+                                + "  port: 3306\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "  tables: %s.\\.*\n"
+                                + "  server-id: 5400-5404\n"
+                                + "  server-time-zone: UTC\n"
+                                + "  jdbc.properties.useSSL: false\n"
+                                + "  jdbc.properties.allowPublicKeyRetrieval: true\n"
+                                + "\n"
+                                + "sink:\n"
+                                + "  type: jdbc\n"
+                                + "  url: jdbc:mysql://%s:%d\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "\n"
+                                + "pipeline:\n"
+                                + "  parallelism: %d",
+                        SOURCE_NETWORK_NAME,
+                        TEST_USERNAME,
+                        TEST_PASSWORD,
+                        databaseName,
+                        SINK_NETWORK_NAME,
+                        MySqlContainer.MYSQL_PORT,
+                        TEST_USERNAME,
+                        TEST_PASSWORD,
+                        parallelism);
+
+        Path mysqlCdcJar = TestUtils.getResource("mysql-cdc-pipeline-connector.jar");
+        Path jdbcConnectorJar = TestUtils.getResource("jdbc-cdc-pipeline-connector.jar");
+        Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
+        submitPipelineJob(pipelineJob, mysqlCdcJar, jdbcConnectorJar, mysqlDriverJar);
+        waitUntilJobRunning(Duration.ofSeconds(30));
+        LOG.info("Pipeline job is running");
+
+        // Verify snapshot results
+        validateSinkResult(
+                databaseName,
+                "products",
+                "*",
+                7,
+                Arrays.asList(
+                        "101 | scooter | Small 2-wheel scooter | 3.14 | red | {\"key1\": \"value1\"} | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102 | car battery | 12V car battery | 8.1 | white | {\"key2\": \"value2\"} | {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.8 | red | {\"key3\": \"value3\"} | {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104 | hammer | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105 | hammer | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106 | hammer | 16oz carpenter's hammer | 1.0 | null | null | null",
+                        "107 | rocks | box of assorted rocks | 5.3 | null | null | null",
+                        "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
+                        "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null"));
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | int | NO | PRI | null",
+                        "name | varchar(255) | YES |  | flink",
+                        "description | varchar(512) | YES |  | null",
+                        "weight | float | YES |  | null",
+                        "enum_c | text | YES |  | null",
+                        "json_c | text | YES |  | null",
+                        "point_c | text | YES |  | null"));
+
+        // Verify incremental binlog results
+        runBinlogEvents();
+        validateSinkResult(
+                databaseName,
+                "products",
+                "*",
+                7,
+                Arrays.asList(
+                        "101 | scooter | Small 2-wheel scooter | 3.14 | red | {\"key1\": \"value1\"} | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102 | car battery | 12V car battery | 8.1 | white | {\"key2\": \"value2\"} | {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103 | 12-pack drill bits | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.8 | red | {\"key3\": \"value3\"} | {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104 | hammer | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105 | hammer | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106 | hammer | 16oz carpenter's hammer | 1.0 | null | null | null",
+                        "107 | rocks | box of assorted rocks | 5.3 | null | null | null",
+                        "108 | jacket | water resistent black wind breaker | 0.1 | null | null | null",
+                        "109 | spare tire | 24 inch spare tire | 22.2 | null | null | null",
+                        "1001 | Alice | a dreaming novelist | 0.017 | red | null | null",
+                        "1099 | Zink | the end of everything | 993.0 | white | null | null"));
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | int | NO | PRI | null",
+                        "name | varchar(255) | YES |  | flink",
+                        "description | varchar(512) | YES |  | null",
+                        "weight | float | YES |  | null",
+                        "enum_c | text | YES |  | null",
+                        "json_c | text | YES |  | null",
+                        "point_c | text | YES |  | null"));
+
+        // Verify AddColumnEvent results
+        runAddColumnEvents();
+        validateSinkResult(
+                databaseName,
+                "products",
+                "*",
+                8,
+                Arrays.asList(
+                        "101 | scooter | null | Small 2-wheel scooter | 3.14 | red | {\"key1\": \"value1\"} | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102 | car battery | null | 12V car battery | 8.1 | white | {\"key2\": \"value2\"} | {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103 | 12-pack drill bits | null | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.8 | red | {\"key3\": \"value3\"} | {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104 | hammer | null | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105 | hammer | null | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106 | hammer | null | 16oz carpenter's hammer | 1.0 | null | null | null",
+                        "107 | rocks | null | box of assorted rocks | 5.3 | null | null | null",
+                        "108 | jacket | null | water resistent black wind breaker | 0.1 | null | null | null",
+                        "109 | spare tire | null | 24 inch spare tire | 22.2 | null | null | null",
+                        "1001 | Alice | null | a dreaming novelist | 0.017 | red | null | null",
+                        "1099 | Zink | null | the end of everything | 993.0 | white | null | null",
+                        "1100 | Romeo | R | loves juliet | 0.0 | red | null | null",
+                        "9900 | Juliet | J | loves romeo | 0.0 | white | null | null"));
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | int | NO | PRI | null",
+                        "name | varchar(255) | YES |  | flink",
+                        "nickname | varchar(17) | YES |  | null",
+                        "description | varchar(512) | YES |  | null",
+                        "weight | float | YES |  | null",
+                        "enum_c | text | YES |  | null",
+                        "json_c | text | YES |  | null",
+                        "point_c | text | YES |  | null"));
+
+        // Verify AlterColumnTypeEvent results
+        runAlterColumnTypeEvents();
+        validateSinkResult(
+                databaseName,
+                "products",
+                "*",
+                8,
+                Arrays.asList(
+                        "101 | scooter | null | Small 2-wheel scooter | 3.140000104904175 | red | {\"key1\": \"value1\"} | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102 | car battery | null | 12V car battery | 8.100000381469727 | white | {\"key2\": \"value2\"} | {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103 | 12-pack drill bits | null | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.800000011920929 | red | {\"key3\": \"value3\"} | {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104 | hammer | null | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105 | hammer | null | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106 | hammer | null | 16oz carpenter's hammer | 1.0 | null | null | null",
+                        "107 | rocks | null | box of assorted rocks | 5.300000190734863 | null | null | null",
+                        "108 | jacket | null | water resistent black wind breaker | 0.10000000149011612 | null | null | null",
+                        "109 | spare tire | null | 24 inch spare tire | 22.200000762939453 | null | null | null",
+                        "1001 | Alice | null | a dreaming novelist | 0.017000000923871994 | red | null | null",
+                        "1099 | Zink | null | the end of everything | 993.0 | white | null | null",
+                        "1100 | Romeo | R | loves juliet | 0.0 | red | null | null",
+                        "9900 | Juliet | J | loves romeo | 0.0 | white | null | null",
+                        "10001 | Sierra | S | macOS 10.12 | 3.141592653589793 | white | null | null"));
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | int | NO | PRI | null",
+                        "name | varchar(255) | YES |  | flink",
+                        "nickname | varchar(17) | YES |  | null",
+                        "description | varchar(512) | YES |  | null",
+                        "weight | double | YES |  | null",
+                        "enum_c | text | YES |  | null",
+                        "json_c | text | YES |  | null",
+                        "point_c | text | YES |  | null"));
+
+        // Verify RenameColumnEvent results
+        runRenameColumnEvents();
+        validateSinkResult(
+                databaseName,
+                "products",
+                "*",
+                8,
+                Arrays.asList(
+                        "101 | scooter | null | Small 2-wheel scooter | 3.140000104904175 | red | {\"key1\": \"value1\"} | {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102 | car battery | null | 12V car battery | 8.100000381469727 | white | {\"key2\": \"value2\"} | {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103 | 12-pack drill bits | null | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.800000011920929 | red | {\"key3\": \"value3\"} | {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104 | hammer | null | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"} | {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105 | hammer | null | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"} | {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106 | hammer | null | 16oz carpenter's hammer | 1.0 | null | null | null",
+                        "107 | rocks | null | box of assorted rocks | 5.300000190734863 | null | null | null",
+                        "108 | jacket | null | water resistent black wind breaker | 0.10000000149011612 | null | null | null",
+                        "109 | spare tire | null | 24 inch spare tire | 22.200000762939453 | null | null | null",
+                        "1001 | Alice | null | a dreaming novelist | 0.017000000923871994 | red | null | null",
+                        "1099 | Zink | null | the end of everything | 993.0 | white | null | null",
+                        "1100 | Romeo | R | loves juliet | 0.0 | red | null | null",
+                        "9900 | Juliet | J | loves romeo | 0.0 | white | null | null",
+                        "10001 | Sierra | S | macOS 10.12 | 3.141592653589793 | white | null | null",
+                        "10002 | High Sierra | HS | macOS 10.13 | 2.718281828 | white | null | null"));
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | int | NO | PRI | null",
+                        "name | varchar(255) | YES |  | flink",
+                        "nickname | varchar(17) | YES |  | null",
+                        "description | varchar(512) | YES |  | null",
+                        "weight | double | YES |  | null",
+                        "enumerable_c | text | YES |  | null",
+                        "json_c | text | YES |  | null",
+                        "point_c | text | YES |  | null"));
+
+        // Verify DropColumnEvent results
+        runDropColumnEvents();
+        validateSinkResult(
+                databaseName,
+                "products",
+                "*",
+                7,
+                Arrays.asList(
+                        "101 | scooter | null | Small 2-wheel scooter | 3.140000104904175 | red | {\"key1\": \"value1\"}",
+                        "102 | car battery | null | 12V car battery | 8.100000381469727 | white | {\"key2\": \"value2\"}",
+                        "103 | 12-pack drill bits | null | 12-pack of drill bits with sizes ranging from #40 to #3 | 0.800000011920929 | red | {\"key3\": \"value3\"}",
+                        "104 | hammer | null | 12oz carpenter's hammer | 0.75 | white | {\"key4\": \"value4\"}",
+                        "105 | hammer | null | 14oz carpenter's hammer | 0.875 | red | {\"k1\": \"v1\", \"k2\": \"v2\"}",
+                        "106 | hammer | null | 16oz carpenter's hammer | 1.0 | null | null",
+                        "107 | rocks | null | box of assorted rocks | 5.300000190734863 | null | null",
+                        "108 | jacket | null | water resistent black wind breaker | 0.10000000149011612 | null | null",
+                        "109 | spare tire | null | 24 inch spare tire | 22.200000762939453 | null | null",
+                        "1001 | Alice | null | a dreaming novelist | 0.017000000923871994 | red | null",
+                        "1099 | Zink | null | the end of everything | 993.0 | white | null",
+                        "1100 | Romeo | R | loves juliet | 0.0 | red | null",
+                        "9900 | Juliet | J | loves romeo | 0.0 | white | null",
+                        "10001 | Sierra | S | macOS 10.12 | 3.141592653589793 | white | null",
+                        "10002 | High Sierra | HS | macOS 10.13 | 2.718281828 | white | null",
+                        "10003 | Mojave | M | macOS 10.14 | 1.414 | white | null"));
+        validateSinkSchema(
+                databaseName,
+                "products",
+                Arrays.asList(
+                        "id | int | NO | PRI | null",
+                        "name | varchar(255) | YES |  | flink",
+                        "nickname | varchar(17) | YES |  | null",
+                        "description | varchar(512) | YES |  | null",
+                        "weight | double | YES |  | null",
+                        "enumerable_c | text | YES |  | null",
+                        "json_c | text | YES |  | null"));
+    }
+
+    @ParameterizedTest(name = "hasPK: {0}")
+    @ValueSource(booleans = {true, false})
+    void testWriteBatchedRecords(boolean hasPrimaryKey) throws Exception {
+        String databaseName = batchedWriteDatabase.getDatabaseName();
+        int recordsCount = 10240;
+        runBatchedDataReadPhaseOne(recordsCount, hasPrimaryKey);
+        String pipelineJob =
+                String.format(
+                        "source:\n"
+                                + "  type: mysql\n"
+                                + "  hostname: %s\n"
+                                + "  port: 3306\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "  tables: %s.\\.*\n"
+                                + "  server-id: 5400-5404\n"
+                                + "  server-time-zone: UTC\n"
+                                + "  scan.incremental.snapshot.chunk.key-column: \\.*.\\.*:id\n"
+                                + "  jdbc.properties.useSSL: false\n"
+                                + "  jdbc.properties.allowPublicKeyRetrieval: true\n"
+                                + "\n"
+                                + "sink:\n"
+                                + "  type: jdbc\n"
+                                + "  url: jdbc:mysql://%s:%d\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "  write.batch.size: 512\n"
+                                + "\n"
+                                + "pipeline:\n"
+                                + "  parallelism: %d",
+                        SOURCE_NETWORK_NAME,
+                        TEST_USERNAME,
+                        TEST_PASSWORD,
+                        databaseName,
+                        SINK_NETWORK_NAME,
+                        MySqlContainer.MYSQL_PORT,
+                        TEST_USERNAME,
+                        TEST_PASSWORD,
+                        parallelism);
+
+        Path mysqlCdcJar = TestUtils.getResource("mysql-cdc-pipeline-connector.jar");
+        Path jdbcConnectorJar = TestUtils.getResource("jdbc-cdc-pipeline-connector.jar");
+        Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
+        submitPipelineJob(pipelineJob, mysqlCdcJar, jdbcConnectorJar, mysqlDriverJar);
+        waitUntilJobRunning(Duration.ofSeconds(30));
+
+        validateSinkResult(
+                databaseName,
+                "batch_table",
+                "COUNT(id)",
+                1,
+                Collections.singletonList(String.valueOf(recordsCount)));
+        validateSinkSchema(
+                databaseName,
+                "batch_table",
+                Arrays.asList(
+                        hasPrimaryKey
+                                ? "id | varchar(255) | NO | PRI | null"
+                                : "id | varchar(255) | YES |  | null",
+                        "number | int | YES |  | null"));
+
+        // Check incremental writing
+        runBatchedDataReadPhaseTwo(recordsCount);
+        validateSinkResult(
+                databaseName,
+                "batch_table",
+                "COUNT(id)",
+                1,
+                Collections.singletonList(String.valueOf(recordsCount * 2)));
+
+        // Check updating
+        runBatchedDataReadPhaseThree();
+        validateSinkResult(
+                databaseName,
+                "batch_table",
+                "SUM(number)",
+                1,
+                Collections.singletonList(String.valueOf(recordsCount * (recordsCount + 3))));
+
+        runBatchedDataReadPhaseFour();
+        validateSinkResult(
+                databaseName, "batch_table", "COUNT(*)", 1, Collections.singletonList("0"));
+    }
+
+    private void runBinlogEvents() throws Exception {
+        executeSql(
+                MYSQL_SOURCE,
+                mysqlInventoryDatabase.getDatabaseName(),
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Arrays.asList(
+                        "INSERT INTO products VALUES (1001, 'Alice', 'a dreaming novelist', 0.017, 'red', null, null);",
+                        "INSERT INTO products VALUES (1099, 'Zink', 'the end of everything', 993, 'white', null, null);"));
+    }
+
+    private void runAddColumnEvents() throws Exception {
+        executeSql(
+                MYSQL_SOURCE,
+                mysqlInventoryDatabase.getDatabaseName(),
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Arrays.asList(
+                        "ALTER TABLE products ADD COLUMN nickname VARCHAR(17) NULL AFTER name;",
+                        "INSERT INTO products VALUES (1100, 'Romeo', 'R', 'loves juliet', 0, 'red', null, null);",
+                        "INSERT INTO products VALUES (9900, 'Juliet', 'J', 'loves romeo', 0, 'white', null, null);"));
+    }
+
+    private void runAlterColumnTypeEvents() throws Exception {
+        executeSql(
+                MYSQL_SOURCE,
+                mysqlInventoryDatabase.getDatabaseName(),
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Arrays.asList(
+                        "ALTER TABLE products MODIFY COLUMN weight DOUBLE;",
+                        "INSERT INTO products VALUES (10001, 'Sierra', 'S', 'macOS 10.12', 3.141592653589793238, 'white', null, null);"));
+    }
+
+    private void runRenameColumnEvents() throws Exception {
+        executeSql(
+                MYSQL_SOURCE,
+                mysqlInventoryDatabase.getDatabaseName(),
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Arrays.asList(
+                        "ALTER TABLE products RENAME COLUMN `enum_c` TO `enumerable_c`;",
+                        "INSERT INTO products VALUES (10002, 'High Sierra', 'HS', 'macOS 10.13', 2.718281828, 'white', null, null);"));
+    }
+
+    private void runDropColumnEvents() throws Exception {
+        executeSql(
+                MYSQL_SOURCE,
+                mysqlInventoryDatabase.getDatabaseName(),
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Arrays.asList(
+                        "ALTER TABLE products DROP COLUMN `point_c`;",
+                        "INSERT INTO products VALUES (10003, 'Mojave', 'M', 'macOS 10.14', 1.414, 'white', null);"));
+    }
+
+    private void runBatchedDataReadPhaseOne(int count, boolean hasPrimaryKey) throws Exception {
+        String databaseName = batchedWriteDatabase.getDatabaseName();
+        executeSql(
+                MYSQL_SOURCE,
+                "",
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Collections.singletonList("CREATE DATABASE " + databaseName));
+
+        executeSql(
+                MYSQL_SOURCE,
+                databaseName,
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Collections.singletonList(
+                        "CREATE TABLE batch_table (id VARCHAR(255) "
+                                + (hasPrimaryKey ? "PRIMARY KEY" : "")
+                                + ", number INT);"));
+
+        executeSql(
+                MYSQL_SOURCE,
+                databaseName,
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                IntStream.rangeClosed(1, count)
+                        .mapToObj(
+                                i ->
+                                        String.format(
+                                                "INSERT INTO batch_table VALUES ('name%d', %d)",
+                                                i, i))
+                        .collect(Collectors.toList()));
+    }
+
+    private void runBatchedDataReadPhaseTwo(int count) throws Exception {
+        String databaseName = batchedWriteDatabase.getDatabaseName();
+        executeSql(
+                MYSQL_SOURCE,
+                databaseName,
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                IntStream.rangeClosed(1, count)
+                        .mapToObj(
+                                i ->
+                                        String.format(
+                                                "INSERT INTO batch_table VALUES ('name%d', %d)",
+                                                100_000 + i, i))
+                        .collect(Collectors.toList()));
+    }
+
+    private void runBatchedDataReadPhaseThree() throws Exception {
+        String databaseName = batchedWriteDatabase.getDatabaseName();
+        executeSql(
+                MYSQL_SOURCE,
+                databaseName,
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Collections.singletonList("UPDATE batch_table SET number = number + 1;"));
+    }
+
+    private void runBatchedDataReadPhaseFour() throws Exception {
+        String databaseName = batchedWriteDatabase.getDatabaseName();
+        executeSql(
+                MYSQL_SOURCE,
+                databaseName,
+                TEST_USERNAME,
+                TEST_PASSWORD,
+                Collections.singletonList("DELETE FROM batch_table;"));
+    }
+
+    private void executeSql(
+            MySqlContainer container,
+            String databaseName,
+            String username,
+            String password,
+            List<String> sql)
+            throws Exception {
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                container.getJdbcUrl(databaseName), username, password);
+                Statement stmt = conn.createStatement()) {
+            for (String s : sql) {
+                stmt.execute(s);
+            }
+        }
+    }
+
+    private List<String> validateSinkSchema(
+            String databaseName, String tableName, List<String> expected) throws SQLException {
+        List<String> results = new ArrayList<>();
+        ResultSet rs =
+                MYSQL_SINK
+                        .createConnection("")
+                        .createStatement()
+                        .executeQuery(String.format("DESCRIBE `%s`.`%s`", databaseName, tableName));
+
+        while (rs.next()) {
+            List<String> columns = new ArrayList<>();
+            for (int i = 1; i <= 5; i++) {
+                columns.add(rs.getString(i));
+            }
+            results.add(String.join(" | ", columns));
+        }
+
+        Assertions.assertThat(results).containsExactlyElementsOf(expected);
+        return results;
+    }
+
+    private void validateSinkResult(
+            String databaseName,
+            String tableName,
+            String expression,
+            int columnCount,
+            List<String> expected) {
+        TestCaseUtils.repeatedCheckAndValidate(
+                () -> {
+                    List<String> results = new ArrayList<>();
+                    try (Connection conn =
+                                    DriverManager.getConnection(
+                                            MYSQL_SINK.getJdbcUrl(databaseName),
+                                            TEST_USERNAME,
+                                            TEST_PASSWORD);
+                            Statement stmt = conn.createStatement()) {
+                        ResultSet rs =
+                                stmt.executeQuery(
+                                        String.format(
+                                                "SELECT %s FROM `%s`.`%s`;",
+                                                expression, databaseName, tableName));
+
+                        while (rs.next()) {
+                            List<String> columns = new ArrayList<>();
+                            for (int i = 1; i <= columnCount; i++) {
+                                try {
+                                    columns.add(rs.getString(i));
+                                } catch (SQLException ignored) {
+                                    // Column count could change after schema evolution
+                                    columns.add(null);
+                                }
+                            }
+                            results.add(String.join(" | ", columns));
+                        }
+                    }
+                    LOG.info("Fetched results: {}", results);
+                    return results;
+                },
+                (results) -> {
+                    try {
+                        Assertions.assertThat(results)
+                                .containsExactlyInAnyOrderElementsOf(expected);
+                        LOG.info("Validated successfully.");
+                        return true;
+                    } catch (AssertionError e) {
+                        LOG.warn("Validation failed, waiting for the next turn...", e);
+                        return false;
+                    }
+                },
+                TESTCASE_TIMEOUT,
+                Duration.ofSeconds(1),
+                Collections.singletonList(SQLException.class));
+    }
+}

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/utils/PipelineTestEnvironment.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/utils/PipelineTestEnvironment.java
@@ -386,6 +386,7 @@ public abstract class PipelineTestEnvironment extends TestLogger {
                 JobStatusMessage message = jobStatusMessages.iterator().next();
                 JobStatus jobStatus = message.getJobState();
                 if (!expectedStatus.isTerminalState() && jobStatus.isTerminalState()) {
+                    LOG.error(jobManagerConsumer.toUtf8String());
                     throw new ValidationException(
                             String.format(
                                     "Job has been terminated! JobName: %s, JobID: %s, Status: %s",

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/pom.xml
@@ -31,8 +31,8 @@ limitations under the License.
         <flink-1.19>1.19.2</flink-1.19>
         <flink-1.20>1.20.1</flink-1.20>
         <jdbc.version-1.19>3.2.0-1.19</jdbc.version-1.19>
+        <!-- TODO: Bump JDBC connector version after it supports Flink 1.20 -->
         <jdbc.version-1.20>3.2.0-1.19</jdbc.version-1.20>
-        <mysql.driver.version>8.0.27</mysql.driver.version>
         <postgresql.driver.version>42.7.3</postgresql.driver.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,8 @@ limitations under the License.
         <iceberg.version>1.6.1</iceberg.version>
         <hive.version>2.3.9</hive.version>
         <hadoop.version>3.3.4</hadoop.version>
+        <hikari.version>4.0.3</hikari.version>
+        <mysql.driver.version>8.0.27</mysql.driver.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This closes FLINK-35599 by implementing the long-awaited JDBC pipeline sink connector, largely based on @kissycn's work in #3433.

---

Compared to Zhou's original PR, some changes have been made to address @lvyanquan's comments in #3433:

* Supports batch writing for PK tables
* * Added support for `TruncateTableEvent` and `DropTableEvent`
* Added missing SerializationSchemaTest and ITCase
* Simplified code structure, removed a few redundant classes
* Rebased with `master` and resolved conflicts