### PR TITLE
[FLINK-37306][tests] Fix MySQLSourceITCase failure in non-UTC timezone

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/converters/MysqlDebeziumTimeConverterITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/converters/MysqlDebeziumTimeConverterITCase.java
@@ -276,6 +276,11 @@ public class MysqlDebeziumTimeConverterITCase {
     }
 
     private String buildMySqlConfigWithTimezone(String timezone) {
+        // JVM timezone is in "GMT+XX:XX" or "GMT-XX:XX" format
+        // while MySQL configuration file requires "+XX:XX" or "-XX:XX"
+        if (timezone.startsWith("GMT")) {
+            timezone = timezone.substring(3);
+        }
         try {
             File folder = tempFolder.newFolder(String.valueOf(UUID.randomUUID()));
             Path cnf = Files.createFile(Paths.get(folder.getPath(), "my.cnf"));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceITCase.java
@@ -714,6 +714,7 @@ public class MySqlSourceITCase extends MySqlSourceTestBase {
                         .password(customDatabase.getPassword())
                         .deserializer(new StringDebeziumDeserializationSchema())
                         .serverId(getServerId())
+                        .serverTimeZone("UTC")
                         .build();
         DataStreamSource<String> stream =
                 env.fromSource(source, WatermarkStrategy.noWatermarks(), "MySQL CDC Source");

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/SpecificStartingOffsetITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/SpecificStartingOffsetITCase.java
@@ -512,6 +512,11 @@ public class SpecificStartingOffsetITCase {
     }
 
     private static String buildMySqlConfigWithTimezone(File resourceDirectory, String timezone) {
+        // JVM timezone is in "GMT+XX:XX" or "GMT-XX:XX" format
+        // while MySQL configuration file requires "+XX:XX" or "-XX:XX"
+        if (timezone.startsWith("GMT")) {
+            timezone = timezone.substring(3);
+        }
         try {
             TemporaryFolder tempFolder = new TemporaryFolder(resourceDirectory);
             tempFolder.create();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTimezoneITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTimezoneITCase.java
@@ -239,6 +239,11 @@ public class MySqlTimezoneITCase {
     }
 
     private String buildMySqlConfigWithTimezone(String timezone) {
+        // JVM timezone is in "GMT+XX:XX" or "GMT-XX:XX" format
+        // while MySQL configuration file requires "+XX:XX" or "-XX:XX"
+        if (timezone.startsWith("GMT")) {
+            timezone = timezone.substring(3);
+        }
         try {
             File folder = tempFolder.newFolder(String.valueOf(UUID.randomUUID()));
             Path cnf = Files.createFile(Paths.get(folder.getPath(), "my.cnf"));


### PR DESCRIPTION
This closes FLINK-37306.

The failing test cases were introduced in #3298 and #3876 (and more), but has not been exposed until we decided to run CI test cases in random timezones (#3650).

## `MySQLSourceITCase#testSourceMetrics`
MySQL docker container runs in UTC timezone by default, but `MySQLSourceITCase#testSourceMetrics` didn't specify `serverTimeZone` option explicitly like other test cases. As a result, running test cases in non-UTC timezone will fail with the following error:

> org.apache.flink.table.api.ValidationException: The MySQL server has a timezone offset (0 seconds ahead of UTC) which does not match the configured timezone GMT+XX:XX. Specify the right server-time-zone to avoid inconsistencies for time-related fields.

## `MySqlTimezoneITCase`, `MysqlDebeziumTimeConverterITCase`, and `SpecificStartingOffsetITCase`

These cases need to run MySQL container in specific timezones, so they all have a method called `buildMySqlConfigWithTimezone` to create MySQL container with the same timezone as JVM.

However, JVM timezone (fetched via `ZoneId.systemDefault()`) returns UTC-offset timezone in `GMT+04:30` format, while MySQL configuration file requires it in `+04:30` format. This would block the container from starting up.

## `MySqlMultipleTablesRenamingITCase`

This test case uses the same time-zone initialization code as `MySqlTimezoneITCase`. Removed these codes and stick to UTC considering this case is not time-zone sensitive.
