### PR TITLE
[FLINK-37313] Fix the problem of reading binlog before the high and low watermarks during the snapshot process

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReader.java
@@ -213,7 +213,7 @@ public class SnapshotSplitReader implements DebeziumReader<SourceRecords, MySqlS
 
     private boolean isBackfillRequired(MySqlBinlogSplit backfillBinlogSplit) {
         return !statefulTaskContext.getSourceConfig().isSkipSnapshotBackfill()
-                && backfillBinlogSplit
+                || backfillBinlogSplit
                         .getEndingOffset()
                         .isAfter(backfillBinlogSplit.getStartingOffset());
     }


### PR DESCRIPTION
This closes [FLINK-37313](https://issues.apache.org/jira/browse/FLINK-37313).

# SnapshotSplitReader#isBackfillRequired
If the binlog has not changed during the snapshot split read, the binlog should not be read.

# MySqlStreamingChangeEventSource#handleChange
Even if you read the binlog of a table you don't care about, you should update the timestamp to avoid MySqlBinlogSplitReadTask#handleEvent reading a large amount of binlog