### PR TITLE
[FLINK-37348][pipeline-paimon] fix paimon ArrayIndexOutOfBoundsException when add column first

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplier.java
@@ -270,11 +270,12 @@ public class PaimonMetadataApplier implements MetadataApplier {
         Table table = catalog.getTable(new Identifier(schemaName, tableName));
         List<String> columnNames = table.rowType().getFieldNames();
         int index = checkColumnPosition(existedColumnName, columnNames);
-        SchemaChange.Move after =
-                SchemaChange.Move.after(
-                        columnWithPosition.getAddColumn().getName(), columnNames.get(index - 1));
-
-        return SchemaChangeProvider.add(columnWithPosition, after);
+        String columnName = columnWithPosition.getAddColumn().getName();
+        return SchemaChangeProvider.add(
+                columnWithPosition,
+                (index == 0)
+                        ? SchemaChange.Move.first(columnName)
+                        : SchemaChange.Move.after(columnName, columnNames.get(index - 1)));
     }
 
     private int checkColumnPosition(String existedColumnName, List<String> columnNames) {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplierTest.java
@@ -441,6 +441,13 @@ public class PaimonMetadataApplierTest {
                 tableSchema, catalog.getTable(Identifier.fromString("test.table1")).rowType());
 
         addedColumns.clear();
+
+        addedColumns.add(
+                AddColumnEvent.before(
+                        Column.physicalColumn(
+                                "col4_first_before",
+                                org.apache.flink.cdc.common.types.DataTypes.STRING()),
+                        "col1"));
         addedColumns.add(
                 AddColumnEvent.first(
                         Column.physicalColumn(
@@ -463,27 +470,20 @@ public class PaimonMetadataApplierTest {
                                 "col7_after", org.apache.flink.cdc.common.types.DataTypes.STRING()),
                         "col2"));
 
-        addedColumns.add(
-                AddColumnEvent.before(
-                        Column.physicalColumn(
-                                "col4_first_before",
-                                org.apache.flink.cdc.common.types.DataTypes.STRING()),
-                        "col1"));
-
         addColumnEvent = new AddColumnEvent(TableId.parse("test.table1"), addedColumns);
         metadataApplier.applySchemaChange(addColumnEvent);
 
         tableSchema =
                 new RowType(
                         Arrays.asList(
-                                new DataField(7, "col4_first_before", DataTypes.STRING()),
-                                new DataField(3, "col4_first", DataTypes.STRING()),
+                                new DataField(4, "col4_first", DataTypes.STRING()),
+                                new DataField(3, "col4_first_before", DataTypes.STRING()),
                                 new DataField(0, "col1", DataTypes.STRING().notNull()),
-                                new DataField(5, "col6_before", DataTypes.STRING()),
+                                new DataField(6, "col6_before", DataTypes.STRING()),
                                 new DataField(1, "col2", DataTypes.INT()),
-                                new DataField(6, "col7_after", DataTypes.STRING()),
+                                new DataField(7, "col7_after", DataTypes.STRING()),
                                 new DataField(2, "col3", DataTypes.STRING()),
-                                new DataField(4, "col5_last", DataTypes.STRING())));
+                                new DataField(5, "col5_last", DataTypes.STRING())));
 
         Assertions.assertEquals(
                 tableSchema, catalog.getTable(Identifier.fromString("test.table1")).rowType());

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplierTest.java
@@ -463,12 +463,20 @@ public class PaimonMetadataApplierTest {
                                 "col7_after", org.apache.flink.cdc.common.types.DataTypes.STRING()),
                         "col2"));
 
+        addedColumns.add(
+                AddColumnEvent.before(
+                        Column.physicalColumn(
+                                "col4_first_before",
+                                org.apache.flink.cdc.common.types.DataTypes.STRING()),
+                        "col1"));
+
         addColumnEvent = new AddColumnEvent(TableId.parse("test.table1"), addedColumns);
         metadataApplier.applySchemaChange(addColumnEvent);
 
         tableSchema =
                 new RowType(
                         Arrays.asList(
+                                new DataField(7, "col4_first_before", DataTypes.STRING()),
                                 new DataField(3, "col4_first", DataTypes.STRING()),
                                 new DataField(0, "col1", DataTypes.STRING().notNull()),
                                 new DataField(5, "col6_before", DataTypes.STRING()),

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MysqlE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MysqlE2eITCase.java
@@ -300,6 +300,12 @@ public class MysqlE2eITCase extends PipelineTestEnvironment {
             stat.execute(
                     "INSERT INTO products VALUES (default,'evangelion','Eva',2.1728, null, null, null);"); // 114
 
+            // Test Batch AddColumnEvent
+            stat.execute(
+                    "ALTER TABLE products ADD COLUMN (batch_new_col1 INT,batch_new_col2 INT);");
+            stat.execute(
+                    "ALTER TABLE products ADD COLUMN batch_new_col3 INT,ADD COLUMN batch_new_col4 INT after batch_new_col3;");
+
             // Test TruncateTableEvent
             stat.execute("TRUNCATE TABLE products;");
 
@@ -330,6 +336,9 @@ public class MysqlE2eITCase extends PipelineTestEnvironment {
                 "DataChangeEvent{tableId=%s.products, before=[], after=[113, dynazenon, SSSS, 2.1728, null, null, null, 2147483649], op=INSERT, meta=()}",
                 "DropColumnEvent{tableId=%s.products, droppedColumnNames=[new_column]}",
                 "DataChangeEvent{tableId=%s.products, before=[], after=[114, evangelion, Eva, 2.1728, null, null, null], op=INSERT, meta=()}",
+                "AddColumnEvent{tableId=%s.products, addedColumns=[ColumnWithPosition{column=`batch_new_col1` INT, position=LAST, existedColumnName=null}, ColumnWithPosition{column=`batch_new_col2` INT, position=LAST, existedColumnName=null}]}",
+                "AddColumnEvent{tableId=%s.products, addedColumns=[ColumnWithPosition{column=`batch_new_col3` INT, position=LAST, existedColumnName=null}]}",
+                "AddColumnEvent{tableId=%s.products, addedColumns=[ColumnWithPosition{column=`batch_new_col4` INT, position=AFTER, existedColumnName=batch_new_col3}]}",
                 "TruncateTableEvent{tableId=%s.products}",
                 "DropTableEvent{tableId=%s.products}");
     }


### PR DESCRIPTION
Repeat step：
1. ALTER TABLE table_name add  COLUMN new_first_column bigint first
2. throw ArrayIndexOutOfBoundsException(Because the [add column first] event will be converted into an [add column before] event, ArrayIndexOutOfBoundsException is thrown when getting the existingColumnIndex)

log:
```
2025-02-19 11:32:16,586 INFO  org.apache.flink.cdc.runtime.operators.schema.regular.SchemaCoordinator [] - All sink subtask have flushed for table dw_app.cdc_sink19. Start to apply schema change request: 
    SchemaChangeRequest{tableId=dw_app.cdc_sink19, schemaChangeEvent=AddColumnEvent{tableId=dw_app.cdc_sink19, addedColumns=[ColumnWithPosition{column=`new_first_column` BIGINT, position=BEFORE, existedColumnName=first_column}]}, subTaskId=0}
that extracts to:
    AddColumnEvent{tableId=rt_ods.cdc_sink19_add_column_EVOLVE4, addedColumns=[ColumnWithPosition{column=`new_first_column` BIGINT, position=BEFORE, existedColumnName=first_column}]}
2025-02-19 11:32:16,716 ERROR org.apache.flink.cdc.runtime.operators.schema.common.SchemaRegistry [] - An exception was triggered from Schema change applying task. Job will fail now.
org.apache.flink.util.FlinkRuntimeException: Failed to apply schema change event.
    at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaCoordinator.lambda$startSchemaChangesEvolve$0(SchemaCoordinator.java:290) ~[flink-cdc-dist-3.3.0.jar:3.3.0]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_65]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_65]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [?:1.8.0_65]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [?:1.8.0_65]
    at java.lang.Thread.run(Thread.java:745) [?:1.8.0_65]
Caused by: java.lang.ArrayIndexOutOfBoundsException: -1
    at java.util.ArrayList.elementData(ArrayList.java:418) ~[?:1.8.0_65]
    at java.util.ArrayList.get(ArrayList.java:431) ~[?:1.8.0_65]
    at org.apache.flink.cdc.connectors.paimon.sink.PaimonMetadataApplier.applyAddColumnWithBeforePosition(PaimonMetadataApplier.java:275) ~[flink-cdc-pipeline-connector-paimon-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.connectors.paimon.sink.PaimonMetadataApplier.applyAddColumnEventWithPosition(PaimonMetadataApplier.java:237) ~[flink-cdc-pipeline-connector-paimon-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.connectors.paimon.sink.PaimonMetadataApplier.applyAddColumn(PaimonMetadataApplier.java:206) ~[flink-cdc-pipeline-connector-paimon-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.connectors.paimon.sink.PaimonMetadataApplier.lambda$applySchemaChange$0(PaimonMetadataApplier.java:127) ~[flink-cdc-pipeline-connector-paimon-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.common.event.visitor.SchemaChangeEventVisitor.visit(SchemaChangeEventVisitor.java:47) ~[flink-cdc-dist-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.connectors.paimon.sink.PaimonMetadataApplier.applySchemaChange(PaimonMetadataApplier.java:124) ~[flink-cdc-pipeline-connector-paimon-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaCoordinator.applyAndUpdateEvolvedSchemaChange(SchemaCoordinator.java:434) ~[flink-cdc-dist-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaCoordinator.applySchemaChange(SchemaCoordinator.java:401) ~[flink-cdc-dist-3.3.0.jar:3.3.0]
    at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaCoordinator.lambda$startSchemaChangesEvolve$0(SchemaCoordinator.java:288) ~[flink-cdc-dist-3.3.0.jar:3.3.0]
    ... 5 more 
```