### PR TITLE
[FLINK-37358][kafka] Support to pass format options

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/factories/FactoryHelper.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/factories/FactoryHelper.java
@@ -21,11 +21,14 @@ import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.common.configuration.ConfigOption;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.utils.Preconditions;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -143,6 +146,20 @@ public class FactoryHelper {
 
         validateFactoryOptions(factory, context.getFactoryConfiguration());
         validateUnconsumedKeys(factory.identifier(), filteredOptionKeys, allOptionKeys);
+    }
+
+    public ReadableConfig getFormatConfig(String formatPrefix) {
+        final String prefix = formatPrefix + ".";
+        Map<String, String> formatConfigMap = new HashMap<>();
+        context.getFactoryConfiguration()
+                .toMap()
+                .forEach(
+                        (k, v) -> {
+                            if (k.startsWith(prefix)) {
+                                formatConfigMap.put(k.substring(prefix.length()), v);
+                            }
+                        });
+        return org.apache.flink.configuration.Configuration.fromMap(formatConfigMap);
     }
 
     /** Default implementation of {@link Factory.Context}. */


### PR DESCRIPTION
This closes [FLINK-37358](https://issues.apache.org/jira/browse/FLINK-37358).

Currently, we cannot pass format options (e.g. `csv.write-null-properties`) to kafka pipeline sink because format options are not defined in `KafkaDataSinkFactory`.

Fix it by validating options except those with format prefix.