### PR TITLE
[FLINK-37371] Postgres CDC incremental source fails to handle upper-case table and column names

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialectTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialectTest.java
@@ -56,13 +56,13 @@ class PostgresDialectTest extends PostgresTestBase {
         // get table named 'customer.customers' from customDatabase which is actual in
         // inventoryDatabase
         PostgresSourceConfigFactory configFactoryOfCustomDatabase =
-                getMockPostgresSourceConfigFactory(customDatabase, "customer", "customers", 10);
+                getMockPostgresSourceConfigFactory(customDatabase, "customer", "Customers", 10);
         PostgresDialect dialectOfcustomDatabase =
                 new PostgresDialect(configFactoryOfCustomDatabase.create(0));
         List<TableId> tableIdsOfcustomDatabase =
                 dialectOfcustomDatabase.discoverDataCollections(
                         configFactoryOfCustomDatabase.create(0));
-        Assertions.assertThat(tableIdsOfcustomDatabase.get(0)).hasToString("customer.customers");
+        Assertions.assertThat(tableIdsOfcustomDatabase.get(0)).hasToString("customer.Customers");
 
         // get table named 'inventory.products' from customDatabase which is actual in
         // inventoryDatabase

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
@@ -805,8 +805,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                                 physical("phone_number", STRING())),
                         new ArrayList<>(),
                         UniqueConstraint.primaryKey("pk", Collections.singletonList("id")));
-        TestTable customerTable =
-                new TestTable(customDatabase, "customer", "customers", customersSchema);
+        TestTable customerTable = new TestTable("customer", "customers", customersSchema);
         String tableId = customerTable.getTableId();
 
         PostgresSourceBuilder.PostgresIncrementalSource source =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
@@ -159,7 +159,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 1,
                 PostgresTestUtils.FailoverType.NONE,
                 PostgresTestUtils.FailoverPhase.NEVER,
-                new String[] {"customers"},
+                new String[] {"Customers"},
                 scanStartupMode);
     }
 
@@ -170,7 +170,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 4,
                 PostgresTestUtils.FailoverType.NONE,
                 PostgresTestUtils.FailoverPhase.NEVER,
-                new String[] {"customers"},
+                new String[] {"Customers"},
                 scanStartupMode);
     }
 
@@ -181,7 +181,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 1,
                 PostgresTestUtils.FailoverType.NONE,
                 PostgresTestUtils.FailoverPhase.NEVER,
-                new String[] {"customers", "customers_1"},
+                new String[] {"Customers", "customers_1"},
                 scanStartupMode);
     }
 
@@ -192,7 +192,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 4,
                 PostgresTestUtils.FailoverType.NONE,
                 PostgresTestUtils.FailoverPhase.NEVER,
-                new String[] {"customers", "customers_1"},
+                new String[] {"Customers", "customers_1"},
                 scanStartupMode);
     }
 
@@ -203,7 +203,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         testPostgresParallelSource(
                 PostgresTestUtils.FailoverType.TM,
                 PostgresTestUtils.FailoverPhase.SNAPSHOT,
-                new String[] {"customers", "customers_1"},
+                new String[] {"Customers", "customers_1"},
                 scanStartupMode);
     }
 
@@ -213,7 +213,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         testPostgresParallelSource(
                 PostgresTestUtils.FailoverType.TM,
                 PostgresTestUtils.FailoverPhase.STREAM,
-                new String[] {"customers", "customers_1"},
+                new String[] {"Customers", "customers_1"},
                 scanStartupMode);
     }
 
@@ -223,7 +223,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         testPostgresParallelSource(
                 PostgresTestUtils.FailoverType.JM,
                 PostgresTestUtils.FailoverPhase.SNAPSHOT,
-                new String[] {"customers", "customers_1"},
+                new String[] {"Customers", "customers_1"},
                 scanStartupMode);
     }
 
@@ -233,7 +233,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         testPostgresParallelSource(
                 PostgresTestUtils.FailoverType.JM,
                 PostgresTestUtils.FailoverPhase.STREAM,
-                new String[] {"customers", "customers_1"},
+                new String[] {"Customers", "customers_1"},
                 scanStartupMode);
     }
 
@@ -244,7 +244,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 1,
                 PostgresTestUtils.FailoverType.TM,
                 PostgresTestUtils.FailoverPhase.SNAPSHOT,
-                new String[] {"customers"},
+                new String[] {"Customers"},
                 scanStartupMode);
     }
 
@@ -255,7 +255,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 1,
                 PostgresTestUtils.FailoverType.JM,
                 PostgresTestUtils.FailoverPhase.SNAPSHOT,
-                new String[] {"customers"},
+                new String[] {"Customers"},
                 scanStartupMode);
     }
 
@@ -300,7 +300,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 DEFAULT_SCAN_STARTUP_MODE,
                 PostgresTestUtils.FailoverType.TM,
                 PostgresTestUtils.FailoverPhase.SNAPSHOT,
-                new String[] {"customers"},
+                new String[] {"Customers"},
                 RestartStrategies.fixedDelayRestart(1, 0),
                 Collections.singletonMap("scan.incremental.snapshot.backfill.skip", "true"));
     }
@@ -317,11 +317,11 @@ class PostgresSourceITCase extends PostgresTestBase {
         String sourceDDL =
                 format(
                         "CREATE TABLE customers ("
-                                + " id BIGINT NOT NULL,"
-                                + " name STRING,"
+                                + " Id BIGINT NOT NULL,"
+                                + " Name STRING,"
                                 + " address STRING,"
                                 + " phone_number STRING,"
-                                + " primary key (id) not enforced"
+                                + " primary key (Id) not enforced"
                                 + ") WITH ("
                                 + " 'connector' = 'postgres-cdc',"
                                 + " 'scan.incremental.snapshot.enabled' = 'true',"
@@ -343,7 +343,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                         customDatabase.getPassword(),
                         customDatabase.getDatabaseName(),
                         SCHEMA_NAME,
-                        "customers",
+                        "Customers",
                         scanStartupMode,
                         slotName);
         tEnv.executeSql(sourceDDL);
@@ -355,7 +355,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                     tableResult,
                     PostgresTestUtils.FailoverType.JM,
                     PostgresTestUtils.FailoverPhase.STREAM,
-                    new String[] {"customers"});
+                    new String[] {"Customers"});
         }
 
         // second step: check the stream data
@@ -363,7 +363,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 tableResult,
                 PostgresTestUtils.FailoverType.JM,
                 PostgresTestUtils.FailoverPhase.STREAM,
-                new String[] {"customers"});
+                new String[] {"Customers"});
 
         Optional<JobClient> optionalJobClient = tableResult.getJobClient();
         assertThat(optionalJobClient).isPresent();
@@ -609,7 +609,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         int parallelism = 1;
         PostgresTestUtils.FailoverType failoverType = PostgresTestUtils.FailoverType.JM;
         PostgresTestUtils.FailoverPhase failoverPhase = PostgresTestUtils.FailoverPhase.STREAM;
-        String[] captureCustomerTables = new String[] {"customers"};
+        String[] captureCustomerTables = new String[] {"Customers"};
         RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration =
                 RestartStrategies.fixedDelayRestart(1, 0);
         boolean skipSnapshotBackfill = false;
@@ -623,11 +623,11 @@ class PostgresSourceITCase extends PostgresTestBase {
         String sourceDDL =
                 format(
                         "CREATE TABLE customers ("
-                                + " id BIGINT NOT NULL,"
-                                + " name STRING,"
+                                + " Id BIGINT NOT NULL,"
+                                + " Name STRING,"
                                 + " address STRING,"
                                 + " phone_number STRING,"
-                                + " primary key (id) not enforced"
+                                + " primary key (Id) not enforced"
                                 + ") WITH ("
                                 + " 'connector' = 'postgres-cdc-mock',"
                                 + " 'scan.incremental.snapshot.enabled' = 'true',"
@@ -683,7 +683,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                     scanStartupMode,
                     PostgresTestUtils.FailoverType.NONE,
                     PostgresTestUtils.FailoverPhase.NEVER,
-                    new String[] {"customers"},
+                    new String[] {"Customers"},
                     RestartStrategies.noRestart(),
                     Collections.singletonMap(
                             "scan.incremental.snapshot.chunk.key-column", chunkColumn));
@@ -692,7 +692,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                     .hasStackTraceContaining(
                             String.format(
                                     "Chunk key column '%s' doesn't exist in the primary key [%s] of the table %s.",
-                                    chunkColumn, "id", "customer.customers"));
+                                    chunkColumn, "Id", "customer.Customers"));
         }
     }
 
@@ -717,7 +717,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 scanStartupMode,
                 PostgresTestUtils.FailoverType.NONE,
                 PostgresTestUtils.FailoverPhase.NEVER,
-                new String[] {"customers"},
+                new String[] {"Customers"},
                 RestartStrategies.noRestart(),
                 options);
         try (PostgresConnection connection = getConnection()) {
@@ -731,7 +731,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         int parallelism = 1;
         PostgresTestUtils.FailoverType failoverType = PostgresTestUtils.FailoverType.TM;
         PostgresTestUtils.FailoverPhase failoverPhase = PostgresTestUtils.FailoverPhase.STREAM;
-        String[] captureCustomerTables = new String[] {"customers"};
+        String[] captureCustomerTables = new String[] {"Customers"};
         RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration =
                 RestartStrategies.fixedDelayRestart(1, 0);
         boolean skipSnapshotBackfill = false;
@@ -745,11 +745,11 @@ class PostgresSourceITCase extends PostgresTestBase {
         String sourceDDL =
                 format(
                         "CREATE TABLE customers ("
-                                + " id BIGINT NOT NULL,"
-                                + " name STRING,"
+                                + " Id BIGINT NOT NULL,"
+                                + " Name STRING,"
                                 + " address STRING,"
                                 + " phone_number STRING,"
-                                + " primary key (id) not enforced"
+                                + " primary key (Id) not enforced"
                                 + ") WITH ("
                                 + " 'connector' = 'postgres-cdc',"
                                 + " 'scan.incremental.snapshot.enabled' = 'true',"
@@ -809,13 +809,13 @@ class PostgresSourceITCase extends PostgresTestBase {
         ResolvedSchema customersSchema =
                 new ResolvedSchema(
                         Arrays.asList(
-                                physical("id", BIGINT().notNull()),
-                                physical("name", STRING()),
+                                physical("Id", BIGINT().notNull()),
+                                physical("Name", STRING()),
                                 physical("address", STRING()),
                                 physical("phone_number", STRING())),
                         new ArrayList<>(),
                         UniqueConstraint.primaryKey("pk", Collections.singletonList("id")));
-        TestTableId tableId = new TestTableId("customer", "customers");
+        TestTableId tableId = new TestTableId("customer", "Customers");
         TestTable table = new TestTable(customersSchema);
 
         PostgresSourceBuilder.PostgresIncrementalSource<RowData> source =
@@ -841,8 +841,9 @@ class PostgresSourceITCase extends PostgresTestBase {
                             "INSERT INTO %s VALUES (15213, 'user_15213', 'Shanghai', '123567891234')",
                             tableId.toSql()),
                     String.format(
-                            "UPDATE %s SET address='Pittsburgh' WHERE id=2000", tableId.toSql()),
-                    String.format("DELETE FROM %s WHERE id=1019", tableId.toSql())
+                            "UPDATE %s SET address = 'Pittsburgh' WHERE \"Id\" = 2000",
+                            tableId.toSql()),
+                    String.format("DELETE FROM %s WHERE \"Id\" = 1019", tableId.toSql())
                 };
         SnapshotPhaseHook snapshotPhaseHook =
                 (sourceConfig, split) -> {
@@ -946,11 +947,11 @@ class PostgresSourceITCase extends PostgresTestBase {
         String sourceDDL =
                 format(
                         "CREATE TABLE customers ("
-                                + " id BIGINT NOT NULL,"
-                                + " name STRING,"
+                                + " Id BIGINT NOT NULL,"
+                                + " Name STRING,"
                                 + " address STRING,"
                                 + " phone_number STRING,"
-                                + " primary key (id) not enforced"
+                                + " primary key (Id) not enforced"
                                 + ") WITH ("
                                 + " 'connector' = 'postgres-cdc',"
                                 + " 'scan.incremental.snapshot.enabled' = 'true',"
@@ -1310,12 +1311,12 @@ class PostgresSourceITCase extends PostgresTestBase {
 
             // make stream events for the first split
             connection.execute(
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 103",
+                    "DELETE FROM " + tableId.toSql() + " where \"Id\" = 102",
                     "INSERT INTO "
                             + tableId.toSql()
                             + " VALUES(102, 'user_2', 'Shanghai', '123567891234')",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103");
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where \"Id\" = 103");
             connection.commit();
         } finally {
             connection.close();
@@ -1333,7 +1334,7 @@ class PostgresSourceITCase extends PostgresTestBase {
 
             // make stream events for split-1
             connection.execute(
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 1010");
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 1010");
             connection.commit();
 
             // make stream events for the last split

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -36,13 +36,13 @@ import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConf
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
 import org.apache.flink.cdc.connectors.postgres.source.offset.PostgresOffsetFactory;
 import org.apache.flink.cdc.connectors.postgres.testutils.RecordsFormatter;
+import org.apache.flink.cdc.connectors.postgres.testutils.TestTableId;
 import org.apache.flink.cdc.connectors.postgres.testutils.UniqueDatabase;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 
 import io.debezium.connector.postgresql.connection.PostgresConnection;
-import io.debezium.relational.TableId;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -74,15 +74,17 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     void testChangingDataInSnapshotScan() throws Exception {
         customDatabase.createAndInitialize();
 
-        String tableId = schemaName + "." + tableName;
+        TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] changingDataSql =
                 new String[] {
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId + " where id = 102",
-                    "INSERT INTO " + tableId + " VALUES(102, 'user_2','hangzhou','123567891234')",
-                    "UPDATE " + tableId + " SET address = 'Shanghai' where id = 103",
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 110",
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 111",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
+                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "INSERT INTO "
+                            + tableId.toSql()
+                            + " VALUES(102, 'user_2','hangzhou','123567891234')",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 110",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 111",
                 };
 
         String[] expected =
@@ -106,11 +108,15 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     @Test
     void testInsertDataInSnapshotScan() throws Exception {
         customDatabase.createAndInitialize();
-        String tableId = schemaName + "." + tableName;
+        TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] insertDataSql =
                 new String[] {
-                    "INSERT INTO " + tableId + " VALUES(112, 'user_12','Shanghai','123567891234')",
-                    "INSERT INTO " + tableId + " VALUES(113, 'user_13','Shanghai','123567891234')",
+                    "INSERT INTO "
+                            + tableId.toSql()
+                            + " VALUES(112, 'user_12','Shanghai','123567891234')",
+                    "INSERT INTO "
+                            + tableId.toSql()
+                            + " VALUES(113, 'user_13','Shanghai','123567891234')",
                 };
         String[] expected =
                 new String[] {
@@ -135,11 +141,11 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     @Test
     void testDeleteDataInSnapshotScan() throws Exception {
         customDatabase.createAndInitialize();
-        String tableId = schemaName + "." + tableName;
+        TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] deleteDataSql =
                 new String[] {
-                    "DELETE FROM " + tableId + " where id = 101",
-                    "DELETE FROM " + tableId + " where id = 102",
+                    "DELETE FROM " + tableId.toSql() + " where id = 101",
+                    "DELETE FROM " + tableId.toSql() + " where id = 102",
                 };
         String[] expected =
                 new String[] {
@@ -161,15 +167,17 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     void testSnapshotScanSkipBackfillWithPostLowWatermark() throws Exception {
         customDatabase.createAndInitialize();
 
-        String tableId = schemaName + "." + tableName;
+        TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] changingDataSql =
                 new String[] {
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId + " where id = 102",
-                    "INSERT INTO " + tableId + " VALUES(102, 'user_2','hangzhou','123567891234')",
-                    "UPDATE " + tableId + " SET address = 'Shanghai' where id = 103",
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 110",
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 111",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
+                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "INSERT INTO "
+                            + tableId.toSql()
+                            + " VALUES(102, 'user_2','hangzhou','123567891234')",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 110",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 111",
                 };
 
         String[] expected =
@@ -196,15 +204,17 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     void testSnapshotScanSkipBackfillWithPreHighWatermark() throws Exception {
         customDatabase.createAndInitialize();
 
-        String tableId = schemaName + "." + tableName;
+        TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] changingDataSql =
                 new String[] {
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId + " where id = 102",
-                    "INSERT INTO " + tableId + " VALUES(102, 'user_2','hangzhou','123567891234')",
-                    "UPDATE " + tableId + " SET address = 'Shanghai' where id = 103",
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 110",
-                    "UPDATE " + tableId + " SET address = 'Hangzhou' where id = 111",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
+                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "INSERT INTO "
+                            + tableId.toSql()
+                            + " VALUES(102, 'user_2','hangzhou','123567891234')",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 110",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 111",
                 };
 
         String[] expected =
@@ -318,7 +328,8 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     private List<SnapshotSplit> getSnapshotSplits(
             PostgresSourceConfig sourceConfig, JdbcDataSourceDialect sourceDialect)
             throws Exception {
-        List<TableId> discoverTables = sourceDialect.discoverDataCollections(sourceConfig);
+        List<io.debezium.relational.TableId> discoverTables =
+                sourceDialect.discoverDataCollections(sourceConfig);
         OffsetFactory offsetFactory = new PostgresOffsetFactory();
         final SnapshotSplitAssigner snapshotSplitAssigner =
                 new SnapshotSplitAssigner<JdbcSourceConfig>(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -60,7 +60,7 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
     private static final int USE_PRE_HIGHWATERMARK_HOOK = 2;
 
     private static final String schemaName = "customer";
-    private static final String tableName = "customers";
+    private static final String tableName = "Customers";
 
     private final UniqueDatabase customDatabase =
             new UniqueDatabase(
@@ -77,14 +77,14 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
         TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] changingDataSql =
                 new String[] {
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 103",
+                    "DELETE FROM " + tableId.toSql() + " where \"Id\" = 102",
                     "INSERT INTO "
                             + tableId.toSql()
                             + " VALUES(102, 'user_2','hangzhou','123567891234')",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 110",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 111",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where \"Id\" = 103",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 110",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 111",
                 };
 
         String[] expected =
@@ -144,8 +144,8 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
         TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] deleteDataSql =
                 new String[] {
-                    "DELETE FROM " + tableId.toSql() + " where id = 101",
-                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "DELETE FROM " + tableId.toSql() + " where \"Id\" = 101",
+                    "DELETE FROM " + tableId.toSql() + " where \"Id\" = 102",
                 };
         String[] expected =
                 new String[] {
@@ -170,14 +170,14 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
         TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] changingDataSql =
                 new String[] {
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 103",
+                    "DELETE FROM " + tableId.toSql() + " where \"Id\" = 102",
                     "INSERT INTO "
                             + tableId.toSql()
                             + " VALUES(102, 'user_2','hangzhou','123567891234')",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 110",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 111",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where \"Id\" = 103",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 110",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 111",
                 };
 
         String[] expected =
@@ -207,14 +207,14 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
         TestTableId tableId = new TestTableId(schemaName, tableName);
         String[] changingDataSql =
                 new String[] {
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 103",
-                    "DELETE FROM " + tableId.toSql() + " where id = 102",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 103",
+                    "DELETE FROM " + tableId.toSql() + " where \"Id\" = 102",
                     "INSERT INTO "
                             + tableId.toSql()
                             + " VALUES(102, 'user_2','hangzhou','123567891234')",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where id = 103",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 110",
-                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where id = 111",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Shanghai' where \"Id\" = 103",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 110",
+                    "UPDATE " + tableId.toSql() + " SET address = 'Hangzhou' where \"Id\" = 111",
                 };
 
         String[] expected =
@@ -271,8 +271,8 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
 
             final DataType dataType =
                     DataTypes.ROW(
-                            DataTypes.FIELD("id", DataTypes.BIGINT()),
-                            DataTypes.FIELD("name", DataTypes.STRING()),
+                            DataTypes.FIELD("Id", DataTypes.BIGINT()),
+                            DataTypes.FIELD("Name", DataTypes.STRING()),
                             DataTypes.FIELD("address", DataTypes.STRING()),
                             DataTypes.FIELD("phone_number", DataTypes.STRING()));
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresSourceReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresSourceReaderTest.java
@@ -80,7 +80,6 @@ class PostgresSourceReaderTest {
         configFactory.setLsnCommitCheckpointsDelay(lsnCommitCheckpointsDelay);
         final TestTable customerTable =
                 new TestTable(
-                        "pgdb",
                         "customer",
                         "customers",
                         ResolvedSchema.of(Column.physical("id", BIGINT())));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresSourceReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresSourceReaderTest.java
@@ -79,10 +79,7 @@ class PostgresSourceReaderTest {
         configFactory.password("password");
         configFactory.setLsnCommitCheckpointsDelay(lsnCommitCheckpointsDelay);
         final TestTable customerTable =
-                new TestTable(
-                        "customer",
-                        "customers",
-                        ResolvedSchema.of(Column.physical("id", BIGINT())));
+                new TestTable(ResolvedSchema.of(Column.physical("id", BIGINT())));
         final DebeziumDeserializationSchema<?> deserializer = customerTable.getDeserializer();
         MockPostgresDialect dialect = new MockPostgresDialect(configFactory.create(0));
         final PostgresSourceBuilder.PostgresIncrementalSource<?> source =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/testutils/TestTable.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/testutils/TestTable.java
@@ -34,7 +34,6 @@ import java.util.List;
  */
 public class TestTable {
 
-    private final String databaseName;
     private final String tableName;
 
     private final String schemaName;
@@ -46,14 +45,7 @@ public class TestTable {
     private RowDataDebeziumDeserializeSchema deserializer;
     private RecordsFormatter recordsFormatter;
 
-    public TestTable(
-            UniqueDatabase database, String schemaName, String tableName, ResolvedSchema schema) {
-        this(database.getDatabaseName(), schemaName, tableName, schema);
-    }
-
-    public TestTable(
-            String databaseName, String schemaName, String tableName, ResolvedSchema schema) {
-        this.databaseName = databaseName;
+    public TestTable(String schemaName, String tableName, ResolvedSchema schema) {
         this.schemaName = schemaName;
         this.tableName = tableName;
         this.schema = schema;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/testutils/TestTable.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/testutils/TestTable.java
@@ -34,10 +34,6 @@ import java.util.List;
  */
 public class TestTable {
 
-    private final String tableName;
-
-    private final String schemaName;
-
     private final ResolvedSchema schema;
 
     // Lazily initialized components
@@ -45,14 +41,8 @@ public class TestTable {
     private RowDataDebeziumDeserializeSchema deserializer;
     private RecordsFormatter recordsFormatter;
 
-    public TestTable(String schemaName, String tableName, ResolvedSchema schema) {
-        this.schemaName = schemaName;
-        this.tableName = tableName;
+    public TestTable(ResolvedSchema schema) {
         this.schema = schema;
-    }
-
-    public String getTableId() {
-        return String.format("%s.%s", schemaName, tableName);
     }
 
     public RowType getRowType() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/testutils/TestTableId.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/testutils/TestTableId.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.testutils;
+
+import static org.apache.flink.cdc.connectors.postgres.source.utils.PostgresQueryUtils.quote;
+
+/** Represents a qualified table name. */
+public class TestTableId {
+    private final String schemaName;
+    private final String tableName;
+
+    public TestTableId(String schemaName, String tableName) {
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+    }
+
+    /** Returns the qualified name to be used in connector configuration. */
+    public String toString() {
+        return String.format("%s.%s", schemaName, tableName);
+    }
+
+    /** Returns the qualified name to be used in SQL. */
+    public String toSql() {
+        return String.format("%s.%s", quote(schemaName), quote(tableName));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/customer.sql
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/customer.sql
@@ -18,15 +18,15 @@ CREATE SCHEMA customer;
 SET search_path TO customer;
 
 -- Create and populate our users using a single insert with many rows
-CREATE TABLE customers (
-  id INTEGER NOT NULL PRIMARY KEY,
-  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+CREATE TABLE "Customers" (
+  "Id" INTEGER NOT NULL PRIMARY KEY,
+  "Name" VARCHAR(255) NOT NULL DEFAULT 'flink',
   address VARCHAR(1024),
   phone_number VARCHAR(512)
 );
-ALTER TABLE customers REPLICA IDENTITY FULL;
+ALTER TABLE "Customers" REPLICA IDENTITY FULL;
 
-INSERT INTO customers
+INSERT INTO "Customers"
 VALUES (101,'user_1','Shanghai','123567891234'),
        (102,'user_2','Shanghai','123567891234'),
        (103,'user_3','Shanghai','123567891234'),
@@ -51,8 +51,8 @@ VALUES (101,'user_1','Shanghai','123567891234'),
 
 -- table has same name prefix with 'customers.*'
 CREATE TABLE customers_1 (
-  id INTEGER NOT NULL PRIMARY KEY,
-  name VARCHAR(255) NOT NULL DEFAULT 'flink',
+  "Id" INTEGER NOT NULL PRIMARY KEY,
+  "Name" VARCHAR(255) NOT NULL DEFAULT 'flink',
   address VARCHAR(1024),
   phone_number VARCHAR(512)
 );
@@ -82,8 +82,8 @@ VALUES (101,'user_1','Shanghai','123567891234'),
        (2000,'user_21','Shanghai','123567891234');
 
 CREATE TABLE customers_no_pk (
-   id INTEGER NOT NULL,
-   name VARCHAR(255) NOT NULL DEFAULT 'flink',
+   "Id" INTEGER NOT NULL,
+   "Name" VARCHAR(255) NOT NULL DEFAULT 'flink',
    address VARCHAR(1024),
    phone_number VARCHAR(512)
 );


### PR DESCRIPTION
## Problem summary

There are two problems in the code:
1. The table name passed to `to_regclass()` isn't quoted, so the upper-case letters get lower-cased.
2. The column names used in snapshot queries aren't quoted, so the upper-case letters get lower-cased.

There's also a minor issue with the `quote()` implementation that it doesn't double the double quotes. So if the table name or column name contains double quote, it will result in a SQL syntax error.

## Connector code changes

1. Instead of quoting the table name passed to `to_regclass()`, pass the schema name and table name individually. This way, they are interpreted as literals don't get automatically lower-cased.
2. Use prepared statement parameters in the query against `pg_class`. Otherwise, the table and schema name would have to be additionally quoted.
3. Quote column names used in snapshot queries.
4. Replace double quote with two double quotes in `quote()` per SQL standard.

## Test changes

I don't think that handling upper-case name should be covered by a special test case. Ideally, it should be tested exhaustively, so I decided to modify an existing test. Prior to that:

1. Building SQL queries in tests has been refactored to enable using upper-case name. The new `TableId` class represents a qualified table name (schema name + table name). Its `toSql()` method generates a valid SQL name that can be used to build queries.
2. `PostgresSourceITCase` has been cleaned up to eliminate some warnings (e.g. raw usage of parameterized types or non-closed `Closable`).
3. Tests have been updated to use upper-case table and column names.