### PR TITLE
[FLINK-37386] Emit CreateTableEvent only when met the related SourceRecord.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -110,8 +110,8 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
                 // New created table in binlog reading phase.
                 if (createTableEvent != null) {
                     output.collect(createTableEvent);
-                    alreadySendCreateTableTables.add(tableId);
                 }
+                alreadySendCreateTableTables.add(tableId);
             }
         }
         super.processElement(element, output, splitState);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -32,7 +32,6 @@ import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
-import io.debezium.data.Envelope;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.Column;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -41,8 +40,6 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.text.ParsingException;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.kafka.connect.data.Field;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,9 +53,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static io.debezium.connector.AbstractSourceInfo.DATABASE_NAME_KEY;
-import static io.debezium.connector.AbstractSourceInfo.SCHEMA_NAME_KEY;
-import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;
 import static org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbcConnection;
 import static org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils.getTableId;
 import static org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils.isDataChangeRecord;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -27,13 +27,12 @@ import org.apache.flink.cdc.connectors.mysql.schema.MySqlTableDefinition;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import org.apache.flink.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitState;
-import org.apache.flink.cdc.connectors.mysql.table.StartupMode;
-import org.apache.flink.cdc.connectors.mysql.utils.MySqlSchemaUtils;
 import org.apache.flink.cdc.connectors.mysql.utils.MySqlTypeUtils;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 
 import io.debezium.connector.mysql.antlr.MySqlAntlrDdlParser;
+import io.debezium.data.Envelope;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.Column;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -42,17 +41,24 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.text.ParsingException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import static io.debezium.connector.AbstractSourceInfo.DATABASE_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.SCHEMA_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;
 import static org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbcConnection;
 import static org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils.isLowWatermarkEvent;
 import static org.apache.flink.cdc.connectors.mysql.source.utils.TableDiscoveryUtils.listTables;
@@ -68,9 +74,7 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
     // Used when startup mode is initial
     private Set<TableId> alreadySendCreateTableTables;
 
-    // Used when startup mode is not initial
-    private boolean alreadySendCreateTableForBinlogSplit = false;
-    private List<CreateTableEvent> createTableEventCache;
+    private Map<TableId, CreateTableEvent> createTableEventCache;
 
     public MySqlPipelineRecordEmitter(
             DebeziumDeserializationSchema<Event> debeziumDeserializationSchema,
@@ -99,26 +103,31 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
                     alreadySendCreateTableTables.add(tableId);
                 }
             }
-        } else if (splitState.isBinlogSplitState() && !alreadySendCreateTableForBinlogSplit) {
-            alreadySendCreateTableForBinlogSplit = true;
-            if (sourceConfig.getStartupOptions().startupMode.equals(StartupMode.INITIAL)) {
-                // In Snapshot -> Binlog transition of INITIAL startup mode, ensure all table
-                // schemas have been sent to downstream. We use previously cached schema instead of
-                // re-request latest schema because there might be some pending schema change events
-                // in the queue, and that may accidentally emit evolved schema before corresponding
-                // schema change events.
-                createTableEventCache.stream()
-                        .filter(
-                                event ->
-                                        !alreadySendCreateTableTables.contains(
-                                                MySqlSchemaUtils.toDbzTableId(event.tableId())))
-                        .forEach(output::collect);
-            } else {
-                // In Binlog only mode, we simply emit all schemas at once.
-                createTableEventCache.forEach(output::collect);
+        } else {
+            TableId tableId = getTableId(element);
+            if (!alreadySendCreateTableTables.contains(tableId)) {
+                CreateTableEvent createTableEvent = createTableEventCache.get(tableId);
+                // New created table in binlog reading phase.
+                if (createTableEvent != null) {
+                    output.collect(createTableEvent);
+                    alreadySendCreateTableTables.add(tableId);
+                }
             }
         }
         super.processElement(element, output, splitState);
+    }
+
+    public static TableId getTableId(SourceRecord dataRecord) {
+        Struct value = (Struct) dataRecord.value();
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        String dbName = source.getString(DATABASE_NAME_KEY);
+        Field field = source.schema().field(SCHEMA_NAME_KEY);
+        String schemaName = null;
+        if (field != null) {
+            schemaName = source.getString(SCHEMA_NAME_KEY);
+        }
+        String tableName = source.getString(TABLE_NAME_KEY);
+        return new TableId(dbName, schemaName, tableName);
     }
 
     private void sendCreateTableEvent(
@@ -246,15 +255,17 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
         return mySqlAntlrDdlParser;
     }
 
-    private List<CreateTableEvent> generateCreateTableEvent(MySqlSourceConfig sourceConfig) {
+    private Map<TableId, CreateTableEvent> generateCreateTableEvent(
+            MySqlSourceConfig sourceConfig) {
         try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
-            List<CreateTableEvent> createTableEventCache = new ArrayList<>();
+            Map<TableId, CreateTableEvent> createTableEventCache = new HashMap<>();
             List<TableId> capturedTableIds =
                     listTables(
                             jdbc, sourceConfig.getDatabaseFilter(), sourceConfig.getTableFilter());
             for (TableId tableId : capturedTableIds) {
                 Schema schema = getSchema(jdbc, tableId);
-                createTableEventCache.add(
+                createTableEventCache.put(
+                        tableId,
                         new CreateTableEvent(
                                 org.apache.flink.cdc.common.event.TableId.tableId(
                                         tableId.catalog(), tableId.table()),

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlPipelineITCase.java
@@ -634,9 +634,7 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
                         .executeAndCollect();
         Thread.sleep(5_000);
 
-        List<Event> expected =
-                new ArrayList<>(
-                        getInventoryCreateAllTableEvents(inventoryDatabase.getDatabaseName()));
+        List<Event> expected = new ArrayList<>();
 
         try (Connection connection = inventoryDatabase.getJdbcConnection();
                 Statement statement = connection.createStatement()) {
@@ -645,6 +643,16 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
                     String.format(
                             "ALTER TABLE `%s`.`customers` ADD COLUMN `newcol1` INT NULL;",
                             inventoryDatabase.getDatabaseName()));
+            expected.add(
+                    new CreateTableEvent(
+                            TableId.tableId(inventoryDatabase.getDatabaseName(), "customers"),
+                            Schema.newBuilder()
+                                    .physicalColumn("id", DataTypes.INT().notNull())
+                                    .physicalColumn("first_name", DataTypes.VARCHAR(255).notNull())
+                                    .physicalColumn("last_name", DataTypes.VARCHAR(255).notNull())
+                                    .physicalColumn("email", DataTypes.VARCHAR(255).notNull())
+                                    .primaryKey(Collections.singletonList("id"))
+                                    .build()));
             expected.add(
                     new AddColumnEvent(
                             TableId.tableId(inventoryDatabase.getDatabaseName(), "customers"),
@@ -737,7 +745,17 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
             statement.execute(
                     String.format(
                             "TRUNCATE TABLE `%s`.`orders`;", inventoryDatabase.getDatabaseName()));
-
+            expected.add(
+                    new CreateTableEvent(
+                            TableId.tableId(inventoryDatabase.getDatabaseName(), "orders"),
+                            Schema.newBuilder()
+                                    .physicalColumn("order_number", DataTypes.INT().notNull())
+                                    .physicalColumn("order_date", DataTypes.DATE().notNull())
+                                    .physicalColumn("purchaser", DataTypes.INT().notNull())
+                                    .physicalColumn("quantity", DataTypes.INT().notNull())
+                                    .physicalColumn("product_id", DataTypes.INT().notNull())
+                                    .primaryKey(Collections.singletonList("order_number"))
+                                    .build()));
             expected.add(
                     new TruncateTableEvent(
                             TableId.tableId(inventoryDatabase.getDatabaseName(), "orders")));
@@ -1005,9 +1023,7 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
                         .executeAndCollect();
         Thread.sleep(5_000);
 
-        List<Event> expectedEvents =
-                new ArrayList<>(
-                        getInventoryCreateAllTableEvents(inventoryDatabase.getDatabaseName()));
+        List<Event> expectedEvents = new ArrayList<>();
 
         expectedEvents.add(
                 new DropTableEvent(
@@ -1190,46 +1206,6 @@ public class MySqlPipelineITCase extends MySqlSourceTestBase {
                         .physicalColumn("weight", DataTypes.FLOAT())
                         .primaryKey(Collections.singletonList("id"))
                         .build());
-    }
-
-    private List<CreateTableEvent> getInventoryCreateAllTableEvents(String databaseName) {
-        return Arrays.asList(
-                new CreateTableEvent(
-                        TableId.tableId(databaseName, "products"),
-                        Schema.newBuilder()
-                                .physicalColumn("id", DataTypes.INT().notNull())
-                                .physicalColumn("name", DataTypes.VARCHAR(255).notNull(), "flink")
-                                .physicalColumn("description", DataTypes.VARCHAR(512))
-                                .physicalColumn("weight", DataTypes.FLOAT())
-                                .primaryKey(Collections.singletonList("id"))
-                                .build()),
-                new CreateTableEvent(
-                        TableId.tableId(databaseName, "customers"),
-                        Schema.newBuilder()
-                                .physicalColumn("id", DataTypes.INT().notNull())
-                                .physicalColumn("first_name", DataTypes.VARCHAR(255).notNull())
-                                .physicalColumn("last_name", DataTypes.VARCHAR(255).notNull())
-                                .physicalColumn("email", DataTypes.VARCHAR(255).notNull())
-                                .primaryKey(Collections.singletonList("id"))
-                                .build()),
-                new CreateTableEvent(
-                        TableId.tableId(databaseName, "orders"),
-                        Schema.newBuilder()
-                                .physicalColumn("order_number", DataTypes.INT().notNull())
-                                .physicalColumn("order_date", DataTypes.DATE().notNull())
-                                .physicalColumn("purchaser", DataTypes.INT().notNull())
-                                .physicalColumn("quantity", DataTypes.INT().notNull())
-                                .physicalColumn("product_id", DataTypes.INT().notNull())
-                                .primaryKey(Collections.singletonList("order_number"))
-                                .build()),
-                new CreateTableEvent(
-                        TableId.tableId(databaseName, "multi_max_table"),
-                        Schema.newBuilder()
-                                .physicalColumn("order_id", DataTypes.VARCHAR(128).notNull())
-                                .physicalColumn("index", DataTypes.INT().notNull())
-                                .physicalColumn("desc", DataTypes.VARCHAR(512).notNull())
-                                .primaryKey(Arrays.asList("order_id", "index"))
-                                .build()));
     }
 
     private List<Event> getSnapshotExpected(TableId tableId) {

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MysqlE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/MysqlE2eITCase.java
@@ -545,9 +545,7 @@ public class MysqlE2eITCase extends PipelineTestEnvironment {
         Path mysqlDriverJar = TestUtils.getResource("mysql-driver.jar");
         submitPipelineJob(pipelineJob, mysqlCdcJar, valuesCdcJar, mysqlDriverJar);
         waitUntilJobRunning(Duration.ofSeconds(30));
-        validateResult(
-                "CreateTableEvent{tableId=%s.customers, schema=columns={`id` INT NOT NULL,`name` VARCHAR(255) NOT NULL 'flink',`address` VARCHAR(1024),`phone_number` VARCHAR(512)}, primaryKeys=id, options=()}",
-                "CreateTableEvent{tableId=%s.products, schema=columns={`id` INT NOT NULL,`name` VARCHAR(255) NOT NULL 'flink',`description` VARCHAR(512),`weight` FLOAT,`enum_c` STRING 'red',`json_c` STRING,`point_c` STRING}, primaryKeys=id, options=()}");
+        validateResult("");
     }
 
     private void validateResult(String... expectedEvents) throws Exception {

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/log4j2-test.properties
@@ -15,7 +15,7 @@
 
 # Set root logger level to ERROR to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level=ERROR
+rootLogger.level=INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/log4j2-test.properties
@@ -15,7 +15,7 @@
 
 # Set root logger level to ERROR to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level=INFO
+rootLogger.level=ERROR
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkWriterOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/sink/DataSinkWriterOperator.java
@@ -199,7 +199,8 @@ public class DataSinkWriterOperator<CommT> extends AbstractStreamOperator<Commit
 
     private void handleFlushEvent(FlushEvent event) throws Exception {
         copySinkWriter.flush(false);
-        if (event.getSchemaChangeEventType() != SchemaChangeEventType.CREATE_TABLE) {
+        if (event.getSchemaChangeEventType() != SchemaChangeEventType.CREATE_TABLE
+                && event.getSchemaChangeEventType() != SchemaChangeEventType.DROP_TABLE) {
             event.getTableIds().stream()
                     .filter(tableId -> !processedTableIds.contains(tableId))
                     .forEach(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
@@ -280,6 +280,7 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
             // which may be different with the schema currently being processed.
             if (!preTransformProcessorMap.containsKey(createTableEvent.tableId())) {
                 output.collect(new StreamRecord<>(cacheCreateTable(createTableEvent)));
+                alreadySentCreateTableEvents.add(createTableEvent.tableId());
             }
         } else if (event instanceof DropTableEvent) {
             preTransformProcessorMap.remove(((DropTableEvent) event).tableId());


### PR DESCRIPTION
Emit CreateTableEvent only when met the related SourceRecord to avoid downstream backpressure.