### PR TITLE
[FLINK-37409][cdc-connector/mysql] Catch throwable to exit reading binlog when error occurs

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -139,13 +139,13 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
                                 changeEventSourceContext,
                                 statefulTaskContext.getMySqlPartition(),
                                 statefulTaskContext.getOffsetContext());
-                    } catch (Exception e) {
+                    } catch (Throwable t) {
                         LOG.error(
                                 String.format(
                                         "Execute binlog read task for mysql split %s fail",
                                         currentBinlogSplit),
-                                e);
-                        readException = e;
+                                t);
+                        readException = t;
                     } finally {
                         stopBinlogReadTask();
                     }


### PR DESCRIPTION
This closes [FLINK-37409](https://issues.apache.org/jira/browse/FLINK-37409).