### PR TITLE
[hotfix][tests] Fix MySQL test case failure in exact UTC timezone

### DIFF
--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -149,7 +149,7 @@ jobs:
           maven-version: 3.8.6
 
       - name: Compile and test
-        timeout-minutes: 90
+        timeout-minutes: 60
         run: |
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)

--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -149,7 +149,7 @@ jobs:
           maven-version: 3.8.6
 
       - name: Compile and test
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           . .github/workflows/utils.sh
           jvm_timezone=$(random_timezone)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/converters/MysqlDebeziumTimeConverterITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/converters/MysqlDebeziumTimeConverterITCase.java
@@ -281,6 +281,14 @@ public class MysqlDebeziumTimeConverterITCase {
         if (timezone.startsWith("GMT")) {
             timezone = timezone.substring(3);
         }
+
+        // But if we run JVM with -Duser.timezone=GMT+0:00, the timezone String will be set to "GMT"
+        // (without redundant offset part). We can't pass an empty string to MySQL, or it will
+        // panic.
+        if (timezone.isEmpty()) {
+            timezone = "UTC";
+        }
+
         try {
             File folder = tempFolder.newFolder(String.valueOf(UUID.randomUUID()));
             Path cnf = Files.createFile(Paths.get(folder.getPath(), "my.cnf"));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/SpecificStartingOffsetITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/SpecificStartingOffsetITCase.java
@@ -517,6 +517,14 @@ public class SpecificStartingOffsetITCase {
         if (timezone.startsWith("GMT")) {
             timezone = timezone.substring(3);
         }
+
+        // But if we run JVM with -Duser.timezone=GMT+0:00, the timezone String will be set to "GMT"
+        // (without redundant offset part). We can't pass an empty string to MySQL, or it will
+        // panic.
+        if (timezone.isEmpty()) {
+            timezone = "UTC";
+        }
+
         try {
             TemporaryFolder tempFolder = new TemporaryFolder(resourceDirectory);
             tempFolder.create();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTimezoneITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTimezoneITCase.java
@@ -244,6 +244,14 @@ public class MySqlTimezoneITCase {
         if (timezone.startsWith("GMT")) {
             timezone = timezone.substring(3);
         }
+
+        // But if we run JVM with -Duser.timezone=GMT+0:00, the timezone String will be set to "GMT"
+        // (without redundant offset part). We can't pass an empty string to MySQL, or it will
+        // panic.
+        if (timezone.isEmpty()) {
+            timezone = "UTC";
+        }
+
         try {
             File folder = tempFolder.newFolder(String.valueOf(UUID.randomUUID()));
             Path cnf = Files.createFile(Paths.get(folder.getPath(), "my.cnf"));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/polardbx/PolardbxCharsetITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/polardbx/PolardbxCharsetITCase.java
@@ -28,6 +28,7 @@ import org.apache.flink.util.StringUtils;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -38,6 +39,7 @@ import java.util.Arrays;
 
 /** Test supporting different column charsets for Polardbx. */
 @RunWith(Parameterized.class)
+@Ignore("Temporarily disable Polardbx Tests until FLINK-37362 fixed")
 public class PolardbxCharsetITCase extends PolardbxSourceTestBase {
     private static final String DATABASE = "charset_test";
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/polardbx/PolardbxSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/polardbx/PolardbxSourceITCase.java
@@ -27,6 +27,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.sql.Connection;
@@ -42,6 +43,7 @@ import static java.lang.String.format;
  * we added fallback in {@link MySqlSchema} when parsing ddl failed and provided these cases to
  * test.
  */
+@Ignore("Temporarily disable Polardbx Tests until FLINK-37362 fixed")
 public class PolardbxSourceITCase extends PolardbxSourceTestBase {
     private static final String DATABASE = "polardbx_ddl_test";
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/resources/log4j2-test.properties
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/resources/log4j2-test.properties
@@ -18,6 +18,12 @@
 rootLogger.level=ERROR
 rootLogger.appenderRef.test.ref = TestLogger
 
+# Set INFO level for the package of polardbx
+logger.polardbx.name = org.apache.flink.cdc.connectors.polardbx
+logger.polardbx.level = INFO
+logger.polardbx.additivity = false
+logger.polardbx.appenderRef.test.ref = TestLogger
+
 appender.testlogger.name = TestLogger
 appender.testlogger.type = CONSOLE
 appender.testlogger.target = SYSTEM_ERR


### PR DESCRIPTION
As noted in https://github.com/apache/flink-cdc/actions/runs/13623293435/job/38139886612?pr=3912, if JVM timezone is randomly set to GMT+0:00, it will be "smartly" converted to `"GMT"` (w/o offset part). As a result, we're configuring MySQL to start up with an empty timezone string, causing the CI failure.

Extra checking has been added to cover such case.