### PR TITLE
[hotfix] remove test scope dependency commons-codec in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,13 +356,6 @@ limitations under the License.
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
The commons-codec dependency should not be declared in parent pom with test scope because connector module may depend on it as a transitive dependency, and it will not be packaged into connector jar because it is declared as test scope in parent pom.