### PR TITLE
[FLINK-37507] Fix MySQL CDC accidentally captures common-prefix database when `scan.binlog.newly-added-table` is enabled

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -517,16 +517,12 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
      * literally instead of the meta-character.
      */
     private String validateTableAndReturnDebeziumStyle(String tables) {
-        // MySQL table names are not allowed to have `,` character.
-        if (tables.contains(",")) {
-            throw new IllegalArgumentException(
-                    "the `,` in "
-                            + tables
-                            + " is not supported when "
-                            + SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED
-                            + " was enabled.");
-        }
         LOG.info("Rewriting CDC style table capture list: {}", tables);
+
+        // In CDC-style table matching, table names could be separated by `,` character.
+        // Convert it to `|` as it's standard RegEx syntax.
+        tables = tables.replace(",", "|");
+        LOG.info("Expression after replacing comma with vert separator: {}", tables);
 
         // Essentially, we're just trying to swap escaped `\\.` and unescaped `.`.
         // In our table matching syntax, `\\.` means RegEx token matcher and `.` means database &

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
@@ -32,9 +32,9 @@ import org.apache.flink.cdc.connectors.values.factory.ValuesDataFactory;
 import org.apache.flink.cdc.connectors.values.sink.ValuesDataSinkOptions;
 
 import org.assertj.core.api.Assertions;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -63,7 +63,7 @@ import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtil
 import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.loopCheck;
 
 /** Test cases for matching MySQL source tables. */
-public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
+class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
 
     private final PrintStream standardOut = System.out;
 
@@ -77,18 +77,18 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                     Tuple2.of("db3", "tbl3"),
                     Tuple2.of("db4", "tbl4"));
 
-    @BeforeClass
-    public static void initializeDatabase() throws Exception {
+    @BeforeAll
+    static void initializeDatabase() throws Exception {
         initializeMySqlTables(TEST_TABLES);
     }
 
-    @AfterClass
-    public static void tearDownDatabase() throws Exception {
+    @AfterAll
+    static void tearDownDatabase() throws Exception {
         tearDownMySqlTables(TEST_TABLES);
     }
 
     @Test
-    public void testWildcardMatching() throws Exception {
+    void testWildcardMatching() throws Exception {
         Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", null, false))
                 .containsExactlyInAnyOrder(
                         "db.tbl1",
@@ -104,7 +104,7 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingDatabases() throws Exception {
+    void testWildcardMatchingDatabases() throws Exception {
         Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", null, false))
                 .containsExactlyInAnyOrder("db.tbl3", "db.tbl4", "db3.tbl3", "db4.tbl4");
 
@@ -113,7 +113,7 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingTables() throws Exception {
+    void testWildcardMatchingTables() throws Exception {
         Assertions.assertThat(testGenericTableMatching("db.\\.*", null, false))
                 .containsExactlyInAnyOrder("db.tbl1", "db.tbl2", "db.tbl3", "db.tbl4");
 
@@ -122,7 +122,7 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingPartialDatabases() throws Exception {
+    void testWildcardMatchingPartialDatabases() throws Exception {
         // `db.` matches `db2`, `db3`, `db4` but not `db`
         Assertions.assertThat(testGenericTableMatching("db\\..\\.*", null, false))
                 .containsExactlyInAnyOrder("db2.tbl2", "db3.tbl3", "db4.tbl4");
@@ -132,33 +132,33 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingWithExclusion() throws Exception {
+    void testWildcardMatchingWithExclusion() throws Exception {
         Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", "db.tbl3", false))
                 .containsExactlyInAnyOrder(
                         "db.tbl1", "db.tbl2", "db.tbl4", "db2.tbl2", "db3.tbl3", "db4.tbl4");
     }
 
     @Test
-    public void testWildcardMatchingDatabasesWithExclusion() throws Exception {
+    void testWildcardMatchingDatabasesWithExclusion() throws Exception {
         Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", "db.tbl[3-4]", false))
                 .containsExactlyInAnyOrder("db3.tbl3", "db4.tbl4");
     }
 
     @Test
-    public void testWildcardMatchingTablesWithExclusion() throws Exception {
+    void testWildcardMatchingTablesWithExclusion() throws Exception {
         Assertions.assertThat(testGenericTableMatching("db.\\.*", "db.tbl4", false))
                 .containsExactlyInAnyOrder("db.tbl1", "db.tbl2", "db.tbl3");
     }
 
     @Test
-    public void testWildcardMatchingPartialDatabasesWithExclusion() throws Exception {
+    void testWildcardMatchingPartialDatabasesWithExclusion() throws Exception {
         // `db.` matches `db2`, `db3`, `db4` but not `db`
         Assertions.assertThat(testGenericTableMatching("db\\..\\.*", "db3.\\.*", false))
                 .containsExactlyInAnyOrder("db2.tbl2", "db4.tbl4");
     }
 
     @Test
-    public void testWildcardMatchingRealTables() throws Exception {
+    void testWildcardMatchingRealTables() throws Exception {
         String[] expected =
                 new String[] {
                     "CreateTableEvent{tableId=db.tbl1, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
@@ -185,7 +185,7 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingDatabasesRealTables() throws Exception {
+    void testWildcardMatchingDatabasesRealTables() throws Exception {
         String[] expected =
                 new String[] {
                     "CreateTableEvent{tableId=db.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
@@ -208,7 +208,7 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingTablesRealTables() throws Exception {
+    void testWildcardMatchingTablesRealTables() throws Exception {
         String[] expected =
                 new String[] {
                     "CreateTableEvent{tableId=db.tbl1, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
@@ -229,7 +229,7 @@ public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    public void testWildcardMatchingPartialDatabasesRealTables() throws Exception {
+    void testWildcardMatchingPartialDatabasesRealTables() throws Exception {
         String[] expected =
                 new String[] {
                     "CreateTableEvent{tableId=db2.tbl2, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
@@ -78,17 +78,17 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                     Tuple2.of("db4", "tbl4"));
 
     @BeforeAll
-    static void initializeDatabase() throws Exception {
+    static void initializeDatabase() {
         initializeMySqlTables(TEST_TABLES);
     }
 
     @AfterAll
-    static void tearDownDatabase() throws Exception {
+    static void tearDownDatabase() {
         tearDownMySqlTables(TEST_TABLES);
     }
 
     @Test
-    void testWildcardMatching() throws Exception {
+    void testWildcardMatching() {
         Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", null, false))
                 .containsExactlyInAnyOrder(
                         "db.tbl1",
@@ -104,7 +104,7 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    void testWildcardMatchingDatabases() throws Exception {
+    void testWildcardMatchingDatabases() {
         Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", null, false))
                 .containsExactlyInAnyOrder("db.tbl3", "db.tbl4", "db3.tbl3", "db4.tbl4");
 
@@ -113,7 +113,7 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    void testWildcardMatchingTables() throws Exception {
+    void testWildcardMatchingTables() {
         Assertions.assertThat(testGenericTableMatching("db.\\.*", null, false))
                 .containsExactlyInAnyOrder("db.tbl1", "db.tbl2", "db.tbl3", "db.tbl4");
 
@@ -122,7 +122,7 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    void testWildcardMatchingPartialDatabases() throws Exception {
+    void testWildcardMatchingPartialDatabases() {
         // `db.` matches `db2`, `db3`, `db4` but not `db`
         Assertions.assertThat(testGenericTableMatching("db\\..\\.*", null, false))
                 .containsExactlyInAnyOrder("db2.tbl2", "db3.tbl3", "db4.tbl4");
@@ -132,29 +132,38 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     @Test
-    void testWildcardMatchingWithExclusion() throws Exception {
+    void testWildcardMatchingWithExclusion() {
         Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", "db.tbl3", false))
                 .containsExactlyInAnyOrder(
                         "db.tbl1", "db.tbl2", "db.tbl4", "db2.tbl2", "db3.tbl3", "db4.tbl4");
     }
 
     @Test
-    void testWildcardMatchingDatabasesWithExclusion() throws Exception {
+    void testWildcardMatchingDatabasesWithExclusion() {
         Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", "db.tbl[3-4]", false))
                 .containsExactlyInAnyOrder("db3.tbl3", "db4.tbl4");
     }
 
     @Test
-    void testWildcardMatchingTablesWithExclusion() throws Exception {
+    void testWildcardMatchingTablesWithExclusion() {
         Assertions.assertThat(testGenericTableMatching("db.\\.*", "db.tbl4", false))
                 .containsExactlyInAnyOrder("db.tbl1", "db.tbl2", "db.tbl3");
     }
 
     @Test
-    void testWildcardMatchingPartialDatabasesWithExclusion() throws Exception {
+    void testWildcardMatchingPartialDatabasesWithExclusion() {
         // `db.` matches `db2`, `db3`, `db4` but not `db`
         Assertions.assertThat(testGenericTableMatching("db\\..\\.*", "db3.\\.*", false))
                 .containsExactlyInAnyOrder("db2.tbl2", "db4.tbl4");
+    }
+
+    @Test
+    void testMatchingTablesWithMultipleRules() {
+        Assertions.assertThat(testGenericTableMatching("db.tbl1,db2.tbl\\.*,db3.tbl3", null, false))
+                .containsExactlyInAnyOrder("db.tbl1", "db2.tbl2", "db3.tbl3");
+
+        Assertions.assertThat(testGenericTableMatching("db.tbl1,db2.tbl\\.*,db3.tbl3", null, true))
+                .containsExactlyInAnyOrder("db\\.tbl1|db2\\.tbl.*|db3\\.tbl3");
     }
 
     @Test
@@ -177,10 +186,10 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                     "DataChangeEvent{tableId=db4.tbl4, before=[], after=[17], op=INSERT, meta=()}"
                 };
 
-        Assertions.assertThat(testRealWorldTableMatching("\\.*.\\.*", null, false, expected.length))
+        Assertions.assertThat(getRealWorldMatchedTables("\\.*.\\.*", null, false, expected.length))
                 .containsExactlyInAnyOrder(expected);
 
-        Assertions.assertThat(testRealWorldTableMatching("\\.*.\\.*", null, true, expected.length))
+        Assertions.assertThat(getRealWorldMatchedTables("\\.*.\\.*", null, true, expected.length))
                 .containsExactlyInAnyOrder(expected);
     }
 
@@ -199,11 +208,11 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                 };
 
         Assertions.assertThat(
-                        testRealWorldTableMatching("\\.*.tbl[3-4]", null, false, expected.length))
+                        getRealWorldMatchedTables("\\.*.tbl[3-4]", null, false, expected.length))
                 .containsExactlyInAnyOrder(expected);
 
         Assertions.assertThat(
-                        testRealWorldTableMatching("\\.*.tbl[3-4]", null, true, expected.length))
+                        getRealWorldMatchedTables("\\.*.tbl[3-4]", null, true, expected.length))
                 .containsExactlyInAnyOrder(expected);
     }
 
@@ -221,10 +230,10 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                     "DataChangeEvent{tableId=db.tbl4, before=[], after=[17], op=INSERT, meta=()}"
                 };
 
-        Assertions.assertThat(testRealWorldTableMatching("db.\\.*", null, false, expected.length))
+        Assertions.assertThat(getRealWorldMatchedTables("db.\\.*", null, false, expected.length))
                 .containsExactlyInAnyOrder(expected);
 
-        Assertions.assertThat(testRealWorldTableMatching("db.\\.*", null, true, expected.length))
+        Assertions.assertThat(getRealWorldMatchedTables("db.\\.*", null, true, expected.length))
                 .containsExactlyInAnyOrder(expected);
     }
 
@@ -241,16 +250,37 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                 };
 
         // `db.` matches `db2`, `db3`, `db4` but not `db`
-        Assertions.assertThat(
-                        testRealWorldTableMatching("db\\..\\.*", null, false, expected.length))
+        Assertions.assertThat(getRealWorldMatchedTables("db\\..\\.*", null, false, expected.length))
                 .containsExactlyInAnyOrder(expected);
 
-        Assertions.assertThat(testRealWorldTableMatching("db\\..\\.*", null, true, expected.length))
+        Assertions.assertThat(getRealWorldMatchedTables("db\\..\\.*", null, true, expected.length))
                 .containsExactlyInAnyOrder(expected);
     }
 
-    private static void initializeMySqlTables(List<Tuple2<String, String>> tableNames)
-            throws Exception {
+    @Test
+    void testMultipleRulesWithRealTables() throws Exception {
+        String[] expected =
+                new String[] {
+                    "CreateTableEvent{tableId=db.tbl1, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl1, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db2.tbl2, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db2.tbl2, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db3.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db3.tbl3, before=[], after=[17], op=INSERT, meta=()}"
+                };
+
+        Assertions.assertThat(
+                        getRealWorldMatchedTables(
+                                "db.tbl1,db2.tbl\\.*,db3.tbl3", null, false, expected.length))
+                .containsExactlyInAnyOrder(expected);
+
+        Assertions.assertThat(
+                        getRealWorldMatchedTables(
+                                "db.tbl1,db2.tbl\\.*,db3.tbl3", null, true, expected.length))
+                .containsExactlyInAnyOrder(expected);
+    }
+
+    private static void initializeMySqlTables(List<Tuple2<String, String>> tableNames) {
         tableNames.forEach(
                 tableName -> {
                     try (Connection connection =
@@ -276,8 +306,7 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
                 });
     }
 
-    private static void tearDownMySqlTables(List<Tuple2<String, String>> tableNames)
-            throws Exception {
+    private static void tearDownMySqlTables(List<Tuple2<String, String>> tableNames) {
         tableNames.forEach(
                 tableName -> {
                     try (Connection connection =
@@ -295,8 +324,9 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
     }
 
     private List<String> testGenericTableMatching(
-            String tablesConfig, @Nullable String tablesExclude, boolean scanBinlogNewlyAddedTable)
-            throws Exception {
+            String tablesConfig,
+            @Nullable String tablesExclude,
+            boolean scanBinlogNewlyAddedTable) {
         Map<String, String> options = new HashMap<>();
         options.put(HOSTNAME.key(), MYSQL_CONTAINER.getHost());
         options.put(PORT.key(), String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
@@ -340,7 +370,7 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
         }
     }
 
-    private List<String> testRealWorldTableMatching(
+    private List<String> getRealWorldMatchedTables(
             String tables,
             @Nullable String tablesExclude,
             boolean scanBinlogNewlyAddedTable,

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.factories.Factory;
+import org.apache.flink.cdc.common.pipeline.PipelineOptions;
+import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
+import org.apache.flink.cdc.composer.PipelineExecution;
+import org.apache.flink.cdc.composer.definition.PipelineDef;
+import org.apache.flink.cdc.composer.definition.SinkDef;
+import org.apache.flink.cdc.composer.definition.SourceDef;
+import org.apache.flink.cdc.composer.flink.FlinkPipelineComposer;
+import org.apache.flink.cdc.connectors.mysql.factory.MySqlDataSourceFactory;
+import org.apache.flink.cdc.connectors.values.factory.ValuesDataFactory;
+import org.apache.flink.cdc.connectors.values.sink.ValuesDataSinkOptions;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.HOSTNAME;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.PASSWORD;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.PORT;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.TABLES_EXCLUDE;
+import static org.apache.flink.cdc.connectors.mysql.source.MySqlDataSourceOptions.USERNAME;
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_PASSWORD;
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.TEST_USER;
+import static org.apache.flink.cdc.connectors.mysql.testutils.MySqSourceTestUtils.loopCheck;
+
+/** Test cases for matching MySQL source tables. */
+public class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
+
+    private final PrintStream standardOut = System.out;
+
+    private static final List<Tuple2<String, String>> TEST_TABLES =
+            Arrays.asList(
+                    Tuple2.of("db", "tbl1"),
+                    Tuple2.of("db", "tbl2"),
+                    Tuple2.of("db", "tbl3"),
+                    Tuple2.of("db", "tbl4"),
+                    Tuple2.of("db2", "tbl2"),
+                    Tuple2.of("db3", "tbl3"),
+                    Tuple2.of("db4", "tbl4"));
+
+    @BeforeClass
+    public static void initializeDatabase() throws Exception {
+        initializeMySqlTables(TEST_TABLES);
+    }
+
+    @AfterClass
+    public static void tearDownDatabase() throws Exception {
+        tearDownMySqlTables(TEST_TABLES);
+    }
+
+    @Test
+    public void testWildcardMatching() throws Exception {
+        Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", null, false))
+                .containsExactlyInAnyOrder(
+                        "db.tbl1",
+                        "db.tbl2",
+                        "db.tbl3",
+                        "db.tbl4",
+                        "db2.tbl2",
+                        "db3.tbl3",
+                        "db4.tbl4");
+
+        Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", null, true))
+                .containsExactlyInAnyOrder(".*\\..*");
+    }
+
+    @Test
+    public void testWildcardMatchingDatabases() throws Exception {
+        Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", null, false))
+                .containsExactlyInAnyOrder("db.tbl3", "db.tbl4", "db3.tbl3", "db4.tbl4");
+
+        Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", null, true))
+                .containsExactlyInAnyOrder(".*\\.tbl[3-4]");
+    }
+
+    @Test
+    public void testWildcardMatchingTables() throws Exception {
+        Assertions.assertThat(testGenericTableMatching("db.\\.*", null, false))
+                .containsExactlyInAnyOrder("db.tbl1", "db.tbl2", "db.tbl3", "db.tbl4");
+
+        Assertions.assertThat(testGenericTableMatching("db.\\.*", null, true))
+                .containsExactlyInAnyOrder("db\\..*");
+    }
+
+    @Test
+    public void testWildcardMatchingPartialDatabases() throws Exception {
+        // `db.` matches `db2`, `db3`, `db4` but not `db`
+        Assertions.assertThat(testGenericTableMatching("db\\..\\.*", null, false))
+                .containsExactlyInAnyOrder("db2.tbl2", "db3.tbl3", "db4.tbl4");
+
+        Assertions.assertThat(testGenericTableMatching("db\\..\\.*", null, true))
+                .containsExactlyInAnyOrder("db.\\..*");
+    }
+
+    @Test
+    public void testWildcardMatchingWithExclusion() throws Exception {
+        Assertions.assertThat(testGenericTableMatching("\\.*.\\.*", "db.tbl3", false))
+                .containsExactlyInAnyOrder(
+                        "db.tbl1", "db.tbl2", "db.tbl4", "db2.tbl2", "db3.tbl3", "db4.tbl4");
+    }
+
+    @Test
+    public void testWildcardMatchingDatabasesWithExclusion() throws Exception {
+        Assertions.assertThat(testGenericTableMatching("\\.*.tbl[3-4]", "db.tbl[3-4]", false))
+                .containsExactlyInAnyOrder("db3.tbl3", "db4.tbl4");
+    }
+
+    @Test
+    public void testWildcardMatchingTablesWithExclusion() throws Exception {
+        Assertions.assertThat(testGenericTableMatching("db.\\.*", "db.tbl4", false))
+                .containsExactlyInAnyOrder("db.tbl1", "db.tbl2", "db.tbl3");
+    }
+
+    @Test
+    public void testWildcardMatchingPartialDatabasesWithExclusion() throws Exception {
+        // `db.` matches `db2`, `db3`, `db4` but not `db`
+        Assertions.assertThat(testGenericTableMatching("db\\..\\.*", "db3.\\.*", false))
+                .containsExactlyInAnyOrder("db2.tbl2", "db4.tbl4");
+    }
+
+    @Test
+    public void testWildcardMatchingRealTables() throws Exception {
+        String[] expected =
+                new String[] {
+                    "CreateTableEvent{tableId=db.tbl1, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl1, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl2, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl2, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl3, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl4, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl4, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db2.tbl2, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db2.tbl2, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db3.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db3.tbl3, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db4.tbl4, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db4.tbl4, before=[], after=[17], op=INSERT, meta=()}"
+                };
+
+        Assertions.assertThat(testRealWorldTableMatching("\\.*.\\.*", null, false, expected.length))
+                .containsExactlyInAnyOrder(expected);
+
+        Assertions.assertThat(testRealWorldTableMatching("\\.*.\\.*", null, true, expected.length))
+                .containsExactlyInAnyOrder(expected);
+    }
+
+    @Test
+    public void testWildcardMatchingDatabasesRealTables() throws Exception {
+        String[] expected =
+                new String[] {
+                    "CreateTableEvent{tableId=db.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl3, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl4, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl4, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db3.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db3.tbl3, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db4.tbl4, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db4.tbl4, before=[], after=[17], op=INSERT, meta=()}"
+                };
+
+        Assertions.assertThat(
+                        testRealWorldTableMatching("\\.*.tbl[3-4]", null, false, expected.length))
+                .containsExactlyInAnyOrder(expected);
+
+        Assertions.assertThat(
+                        testRealWorldTableMatching("\\.*.tbl[3-4]", null, true, expected.length))
+                .containsExactlyInAnyOrder(expected);
+    }
+
+    @Test
+    public void testWildcardMatchingTablesRealTables() throws Exception {
+        String[] expected =
+                new String[] {
+                    "CreateTableEvent{tableId=db.tbl1, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl1, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl2, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl2, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl3, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db.tbl4, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db.tbl4, before=[], after=[17], op=INSERT, meta=()}"
+                };
+
+        Assertions.assertThat(testRealWorldTableMatching("db.\\.*", null, false, expected.length))
+                .containsExactlyInAnyOrder(expected);
+
+        Assertions.assertThat(testRealWorldTableMatching("db.\\.*", null, true, expected.length))
+                .containsExactlyInAnyOrder(expected);
+    }
+
+    @Test
+    public void testWildcardMatchingPartialDatabasesRealTables() throws Exception {
+        String[] expected =
+                new String[] {
+                    "CreateTableEvent{tableId=db2.tbl2, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db2.tbl2, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db3.tbl3, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db3.tbl3, before=[], after=[17], op=INSERT, meta=()}",
+                    "CreateTableEvent{tableId=db4.tbl4, schema=columns={`id` INT NOT NULL}, primaryKeys=id, options=()}",
+                    "DataChangeEvent{tableId=db4.tbl4, before=[], after=[17], op=INSERT, meta=()}"
+                };
+
+        // `db.` matches `db2`, `db3`, `db4` but not `db`
+        Assertions.assertThat(
+                        testRealWorldTableMatching("db\\..\\.*", null, false, expected.length))
+                .containsExactlyInAnyOrder(expected);
+
+        Assertions.assertThat(testRealWorldTableMatching("db\\..\\.*", null, true, expected.length))
+                .containsExactlyInAnyOrder(expected);
+    }
+
+    private static void initializeMySqlTables(List<Tuple2<String, String>> tableNames)
+            throws Exception {
+        tableNames.forEach(
+                tableName -> {
+                    try (Connection connection =
+                                    DriverManager.getConnection(
+                                            MYSQL_CONTAINER.getJdbcUrl(),
+                                            TEST_USER,
+                                            TEST_PASSWORD);
+                            Statement statement = connection.createStatement()) {
+                        statement.execute(
+                                String.format("CREATE DATABASE IF NOT EXISTS `%s`;", tableName.f0));
+                        statement.execute(
+                                String.format(
+                                        "CREATE TABLE IF NOT EXISTS `%s`.`%s` (id INT PRIMARY KEY NOT NULL);",
+                                        tableName.f0, tableName.f1));
+
+                        statement.execute(
+                                String.format(
+                                        "INSERT INTO `%s`.`%s` VALUES (17);",
+                                        tableName.f0, tableName.f1));
+                    } catch (SQLException e) {
+                        throw new RuntimeException("Failed to initialize databases and tables", e);
+                    }
+                });
+    }
+
+    private static void tearDownMySqlTables(List<Tuple2<String, String>> tableNames)
+            throws Exception {
+        tableNames.forEach(
+                tableName -> {
+                    try (Connection connection =
+                                    DriverManager.getConnection(
+                                            MYSQL_CONTAINER.getJdbcUrl(),
+                                            TEST_USER,
+                                            TEST_PASSWORD);
+                            Statement statement = connection.createStatement()) {
+                        statement.execute(
+                                String.format("DROP DATABASE IF EXISTS `%s`;", tableName.f0));
+                    } catch (SQLException e) {
+                        throw new RuntimeException("Failed to clean-up databases", e);
+                    }
+                });
+    }
+
+    private List<String> testGenericTableMatching(
+            String tablesConfig, @Nullable String tablesExclude, boolean scanBinlogNewlyAddedTable)
+            throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put(HOSTNAME.key(), MYSQL_CONTAINER.getHost());
+        options.put(PORT.key(), String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
+        options.put(USERNAME.key(), TEST_USER);
+        options.put(PASSWORD.key(), TEST_PASSWORD);
+        options.put(TABLES.key(), tablesConfig);
+        options.put(
+                SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED.key(),
+                String.valueOf(scanBinlogNewlyAddedTable));
+        if (tablesExclude != null) {
+            options.put(TABLES_EXCLUDE.key(), tablesExclude);
+        }
+        Factory.Context context = new MockContext(Configuration.fromMap(options));
+
+        MySqlDataSourceFactory factory = new MySqlDataSourceFactory();
+        MySqlDataSource dataSource = (MySqlDataSource) factory.createDataSource(context);
+        return dataSource.getSourceConfig().getTableList();
+    }
+
+    class MockContext implements Factory.Context {
+
+        Configuration factoryConfiguration;
+
+        public MockContext(Configuration factoryConfiguration) {
+            this.factoryConfiguration = factoryConfiguration;
+        }
+
+        @Override
+        public Configuration getFactoryConfiguration() {
+            return factoryConfiguration;
+        }
+
+        @Override
+        public Configuration getPipelineConfiguration() {
+            return null;
+        }
+
+        @Override
+        public ClassLoader getClassLoader() {
+            return this.getClassLoader();
+        }
+    }
+
+    private List<String> testRealWorldTableMatching(
+            String tables,
+            @Nullable String tablesExclude,
+            boolean scanBinlogNewlyAddedTable,
+            int expectedCount)
+            throws Exception {
+        try (ByteArrayOutputStream outCaptor = new ByteArrayOutputStream()) {
+            System.setOut(new PrintStream(outCaptor));
+            FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
+
+            // Setup MySQL source
+            Configuration sourceConfig = new Configuration();
+            sourceConfig.set(MySqlDataSourceOptions.HOSTNAME, MYSQL_CONTAINER.getHost());
+            sourceConfig.set(MySqlDataSourceOptions.PORT, MYSQL_CONTAINER.getDatabasePort());
+            sourceConfig.set(MySqlDataSourceOptions.USERNAME, TEST_USER);
+            sourceConfig.set(MySqlDataSourceOptions.PASSWORD, TEST_PASSWORD);
+            sourceConfig.set(MySqlDataSourceOptions.SERVER_TIME_ZONE, "UTC");
+            sourceConfig.set(MySqlDataSourceOptions.TABLES, tables);
+            if (tablesExclude != null) {
+                sourceConfig.set(MySqlDataSourceOptions.TABLES_EXCLUDE, tablesExclude);
+            }
+            sourceConfig.set(
+                    MySqlDataSourceOptions.SCAN_BINLOG_NEWLY_ADDED_TABLE_ENABLED,
+                    scanBinlogNewlyAddedTable);
+            sourceConfig.set(MySqlDataSourceOptions.SERVER_ID, getServerId(1));
+
+            SourceDef sourceDef =
+                    new SourceDef(MySqlDataSourceFactory.IDENTIFIER, "MySQL Source", sourceConfig);
+
+            // Setup value sink
+            Configuration sinkConfig = new Configuration();
+            sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+            SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
+
+            // Setup pipeline
+            Configuration pipelineConfig = new Configuration();
+            pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, 1);
+            pipelineConfig.set(
+                    PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR, SchemaChangeBehavior.EVOLVE);
+            PipelineDef pipelineDef =
+                    new PipelineDef(
+                            sourceDef,
+                            sinkDef,
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            pipelineConfig);
+
+            // Execute the pipeline
+            PipelineExecution execution = composer.compose(pipelineDef);
+            Thread executeThread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    execution.execute();
+                                } catch (InterruptedException ignored) {
+
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+
+            executeThread.start();
+
+            try {
+                loopCheck(
+                        () -> outCaptor.toString().trim().split("\n").length >= expectedCount,
+                        "collect enough rows",
+                        Duration.ofSeconds(120),
+                        Duration.ofSeconds(1));
+            } finally {
+                executeThread.interrupt();
+            }
+            return Arrays.asList(outCaptor.toString().trim().split("\n"));
+        } finally {
+            System.setOut(standardOut);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceTestBase.java
@@ -43,6 +43,7 @@ import org.testcontainers.lifecycle.Startables;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Stream;
 
 /** Basic class for testing {@link MySqlSource}. */
@@ -179,5 +180,11 @@ public abstract class MySqlSourceTestBase extends TestLogger {
                 return 0;
             }
         }
+    }
+
+    protected static String getServerId(int parallelism) {
+        final Random random = new Random();
+        int serverId = random.nextInt(100) + 5400;
+        return serverId + "-" + (serverId + parallelism);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceTestBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceTestBase.java
@@ -182,7 +182,7 @@ public abstract class MySqlSourceTestBase extends TestLogger {
         }
     }
 
-    protected static String getServerId(int parallelism) {
+    protected String getServerId(int parallelism) {
         final Random random = new Random();
         int serverId = random.nextInt(100) + 5400;
         return serverId + "-" + (serverId + parallelism);


### PR DESCRIPTION
This closes FLINK-37507.

Currently, MySQL CDC pipeline connector will accidentally capture database that should have been excluded from capture RegExp list when scan.binlog.newly-added-table option is enabled. 

For example, `tables: db.\.*` will also include all tables in databases like `dbnew` (with the same common prefix `db`), which is unexpected.