### PR TITLE
[code clean] clean unuse code for schema operator&coordinator.

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -464,15 +464,6 @@ public class SchemaCoordinator extends SchemaRegistry {
     }
 
     /**
-     * {@code IDLE}: Initial idling state, ready for requests. <br>
-     * {@code APPLYING}: When schema change application finishes (successfully or with exceptions)
-     */
-    private enum RequestStatus {
-        IDLE,
-        APPLYING
-    }
-
-    /**
      * Before Flink CDC 3.3, we store routing rules into {@link SchemaCoordinator}'s state, which
      * turns out to be unnecessary since data stream topology might change after stateful restarts,
      * and stale routing status is both unnecessary and erroneous. This function consumes these

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaOperator.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -240,12 +239,6 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
             throw new IllegalStateException(
                     "Failed to send request to coordinator: " + request.toString(), e);
         }
-    }
-
-    /** Visible for mocking in test cases. */
-    @VisibleForTesting
-    protected int getCurrentTimestamp() {
-        return (int) Instant.now().getEpochSecond();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
[code clean] clean unuse code for schema operator&coordinator.