### PR TITLE
[minor][pipeline-connectors][doris]Fix deprecated method usage in DorisSchemaChangeManager

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisSchemaChangeManager.java
@@ -23,7 +23,7 @@ import org.apache.doris.flink.sink.schema.SchemaChangeManager;
 
 import java.io.IOException;
 
-import static org.apache.doris.flink.catalog.doris.DorisSystem.identifier;
+import static org.apache.doris.flink.catalog.doris.DorisSchemaFactory.identifier;
 
 /** An enriched version of Doris' {@link SchemaChangeManager}. */
 public class DorisSchemaChangeManager extends SchemaChangeManager {


### PR DESCRIPTION
Fix deprecated method usage in DorisSchemaChangeManager

```
    org.apache.doris.flink.catalog.doris.DorisSystem#identifier
    /** @deprecated */
    @Deprecated
    public static String identifier(String name) {
        return DorisSchemaFactory.identifier(name);
    }
