### PR TITLE
[FLINK-37506][transform] Print more descriptive error messages when TransformOperator throws an exception

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/DataChangeEvent.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/DataChangeEvent.java
@@ -24,6 +24,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 
 /**
  * Class {@code DataChangeEvent} represents the data change events of external systems, such as
@@ -206,6 +207,21 @@ public class DataChangeEvent implements ChangeEvent, Serializable {
         }
         stringBuilder.append(")");
         return stringBuilder.toString();
+    }
+
+    public String toReadableString(Function<RecordData, ?> extractor) {
+        return "DataChangeEvent{"
+                + "tableId="
+                + tableId
+                + ", before="
+                + extractor.apply(before)
+                + ", after="
+                + extractor.apply(after)
+                + ", op="
+                + op
+                + ", meta="
+                + describeMeta()
+                + '}';
     }
 
     @Override

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
@@ -75,6 +75,19 @@ public class SchemaUtils {
         return fieldGetters;
     }
 
+    /**
+     * create a list of {@link RecordData.FieldGetter} from given {@link Column} to get Object from
+     * RecordData.
+     */
+    @CheckReturnValue
+    public static List<RecordData.FieldGetter> createFieldGetters(DataType[] dataTypes) {
+        List<RecordData.FieldGetter> fieldGetters = new ArrayList<>(dataTypes.length);
+        for (int i = 0; i < dataTypes.length; i++) {
+            fieldGetters.add(RecordData.createFieldGetter(dataTypes[i], i));
+        }
+        return fieldGetters;
+    }
+
     /** Restore original data fields from RecordData structure. */
     @CheckReturnValue
     public static List<Object> restoreOriginalData(

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineTransformITCase.java
@@ -46,13 +46,18 @@ import org.apache.flink.cdc.connectors.values.sink.ValuesDataSink;
 import org.apache.flink.cdc.connectors.values.sink.ValuesDataSinkOptions;
 import org.apache.flink.cdc.connectors.values.source.ValuesDataSourceHelper;
 import org.apache.flink.cdc.connectors.values.source.ValuesDataSourceOptions;
+import org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException;
 import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 
+import org.apache.calcite.sql.validate.SqlValidatorException;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ThrowableAssert;
+import org.codehaus.commons.compiler.CompileException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -2412,6 +2417,158 @@ class FlinkPipelineTransformITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[-4, -4, -4, -4, -4, -4.44, -4.44, -4.44, 4, 4, 4, 4, 4.44, 4.44, 4.44], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[-9, -9, -9, -9, -9, -1.0E8, -9.999999999E7, -99999999.99, 9, 9, 9, 9, 1.0E8, 9.999999999E7, 99999999.99], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=[], after=[0, null, null, null, null, null, null, null, null, null, null, null, null, null, null], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testTransformErrorMessage() {
+        // Unexpected column in projection rule
+        assertThatThrownBy(expectTransformError("id1", null, "id"))
+                .cause()
+                .cause()
+                .cause()
+                .isExactlyInstanceOf(TransformException.class)
+                .hasStackTraceContaining(
+                        "Failed to post-transform with\n"
+                                + "\tCreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={}, primaryKeys=id, options=()}\n"
+                                + "for table\n"
+                                + "\tdefault_namespace.default_schema.mytable1\n"
+                                + "from schema\n"
+                                + "\t(Unknown)\n"
+                                + "to schema\n"
+                                + "\t(Unknown).")
+                .rootCause()
+                .isExactlyInstanceOf(SqlValidatorException.class)
+                .hasMessage("Column 'id1' not found in any table");
+
+        // Unexpected column in filter rule
+        assertThatThrownBy(expectTransformError("*", "id1 > 0", "id"))
+                .cause()
+                .cause()
+                .cause()
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessage(
+                        "Failed to post-transform with\n"
+                                + "\tDataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=null, after={id: INT -> 1, name: STRING -> Alice, age: INT -> 18}, op=INSERT, meta=()}\n"
+                                + "for table\n"
+                                + "\tdefault_namespace.default_schema.mytable1\n"
+                                + "from schema\n"
+                                + "\tcolumns={`id` INT,`name` STRING,`age` INT}, primaryKeys=id, options=()\n"
+                                + "to schema\n"
+                                + "\tcolumns={`id` INT NOT NULL,`name` STRING,`age` INT}, primaryKeys=id, options=().")
+                .cause()
+                .isExactlyInstanceOf(FlinkRuntimeException.class)
+                .hasMessage(
+                        "Failed to compile expression TransformExpressionKey{expression='import static org.apache.flink.cdc.runtime.functions.SystemFunctionUtils.*;greaterThan($0, 0)', argumentNames=[__time_zone__, __epoch_time__], argumentClasses=[class java.lang.String, class java.lang.Long], returnClass=class java.lang.Boolean, columnNameMap={id1=$0}}")
+                .cause()
+                .hasMessageContaining(
+                        "Expression: import static org.apache.flink.cdc.runtime.functions.SystemFunctionUtils.*;greaterThan($0, 0)")
+                .hasMessageContaining("Column name map: {$0 -> id1}")
+                .rootCause()
+                .isExactlyInstanceOf(CompileException.class)
+                .hasMessageContaining("Unknown variable or type \"$0\"");
+
+        // Unexpected column in filter rule
+        Assertions.assertThatThrownBy(expectTransformError("name", null, "id"))
+                .cause()
+                .cause()
+                .cause()
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessage(
+                        "Failed to post-transform with\n"
+                                + "\tCreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`name` STRING}, primaryKeys=id, options=()}\n"
+                                + "for table\n"
+                                + "\tdefault_namespace.default_schema.mytable1\n"
+                                + "from schema\n"
+                                + "\t(Unknown)\n"
+                                + "to schema\n"
+                                + "\t(Unknown).")
+                .rootCause()
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage("Unable to find column \"id\" which is defined as primary key");
+
+        // Unsupported operations in projection rule
+        Assertions.assertThatThrownBy(expectTransformError("id, name + 1 AS new_name", null, "id"))
+                .cause()
+                .cause()
+                .cause()
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessage(
+                        "Failed to post-transform with\n"
+                                + "\tDataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=null, after={id: INT -> 1, name: STRING -> Alice}, op=INSERT, meta=()}\n"
+                                + "for table\n"
+                                + "\tdefault_namespace.default_schema.mytable1\n"
+                                + "from schema\n"
+                                + "\tcolumns={`id` INT,`name` STRING}, primaryKeys=id, options=()\n"
+                                + "to schema\n"
+                                + "\tcolumns={`id` INT NOT NULL,`new_name` INT}, primaryKeys=id, options=().")
+                .cause()
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessageContaining(
+                        "Failed to evaluate projection expression `castToInteger($0) + 1` for column `new_name` in table `default_namespace.default_schema.mytable1`")
+                .hasMessageContaining("Column name map: {$0 -> name}");
+
+        // Unsupported operations in filter rule
+        assertThatThrownBy(expectTransformError("*", "name + 1 > 0", "id"))
+                .cause()
+                .cause()
+                .cause()
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessage(
+                        "Failed to post-transform with\n"
+                                + "\tDataChangeEvent{tableId=default_namespace.default_schema.mytable1, before=null, after={id: INT -> 1, name: STRING -> Alice, age: INT -> 18}, op=INSERT, meta=()}\n"
+                                + "for table\n"
+                                + "\tdefault_namespace.default_schema.mytable1\n"
+                                + "from schema\n"
+                                + "\tcolumns={`id` INT,`name` STRING,`age` INT}, primaryKeys=id, options=()\n"
+                                + "to schema\n"
+                                + "\tcolumns={`id` INT NOT NULL,`name` STRING,`age` INT}, primaryKeys=id, options=().")
+                .cause()
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessageContaining(
+                        "Failed to evaluate filtering expression `greaterThan($0 + 1, 0)` for table `default_namespace.default_schema.mytable1`")
+                .hasMessageContaining("Column name map: {$0 -> name}")
+                .rootCause()
+                .isExactlyInstanceOf(RuntimeException.class)
+                .hasMessage(
+                        "Comparison of unsupported data types: java.lang.String and java.lang.Integer");
+
+        // Unsupported operations in metadata rule
+        Assertions.assertThatThrownBy(expectTransformError("*", null, "not_even_exist"))
+                .cause()
+                .cause()
+                .cause()
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessage(
+                        "Failed to post-transform with\n"
+                                + "\tCreateTableEvent{tableId=default_namespace.default_schema.mytable1, schema=columns={`id` INT,`name` STRING,`age` INT}, primaryKeys=not_even_exist, options=()}\n"
+                                + "for table\n"
+                                + "\tdefault_namespace.default_schema.mytable1\n"
+                                + "from schema\n"
+                                + "\t(Unknown)\n"
+                                + "to schema\n"
+                                + "\t(Unknown).")
+                .rootCause()
+                .isExactlyInstanceOf(IllegalStateException.class)
+                .hasMessage(
+                        "Unable to find column \"not_even_exist\" which is defined as primary key");
+    }
+
+    private ThrowableAssert.ThrowingCallable expectTransformError(
+            String projectionRule, String filterRule, String primaryKeys) {
+        return () ->
+                runGenericTransformTest(
+                        ValuesDataSink.SinkApi.SINK_V2,
+                        Collections.singletonList(
+                                new TransformDef(
+                                        "default_namespace.default_schema.\\.*",
+                                        projectionRule,
+                                        filterRule,
+                                        primaryKeys,
+                                        null,
+                                        null,
+                                        null,
+                                        null)),
+                        Collections.emptyList());
     }
 
     private List<Event> generateFloorCeilAndRoundEvents(TableId tableId) {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperator.java
@@ -37,6 +37,7 @@ import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.source.SupportedMetadataColumn;
 import org.apache.flink.cdc.common.utils.Preconditions;
 import org.apache.flink.cdc.common.utils.SchemaUtils;
+import org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException;
 import org.apache.flink.cdc.runtime.parser.TransformParser;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -274,6 +275,28 @@ public class PreTransformOperator extends AbstractStreamOperator<Event>
     @Override
     public void processElement(StreamRecord<Event> element) throws Exception {
         Event event = element.getValue();
+        TableId tableId = null;
+        Schema schemaBefore = null;
+        Schema schemaAfter = null;
+
+        if (event instanceof ChangeEvent) {
+            tableId = ((ChangeEvent) event).tableId();
+            PreTransformChangeInfo info = preTransformChangeInfoMap.get(tableId);
+            if (info != null) {
+                schemaBefore = info.getSourceSchema();
+                schemaAfter = info.getPreTransformedSchema();
+            }
+        }
+
+        try {
+            processEvent(event);
+        } catch (Exception e) {
+            throw new TransformException(
+                    "pre-transform", event, tableId, schemaBefore, schemaAfter, e);
+        }
+    }
+
+    private void processEvent(Event event) {
         if (event instanceof CreateTableEvent) {
             CreateTableEvent createTableEvent = (CreateTableEvent) event;
             // CreateTableEvent from Source Contains the latest schema,

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumn.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumn.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.runtime.operators.transform;
 import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.utils.StringUtils;
+import org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -96,6 +97,10 @@ public class ProjectionColumn implements Serializable {
 
     public Map<String, String> getColumnNameMap() {
         return columnNameMap;
+    }
+
+    public String getColumnNameMapAsString() {
+        return TransformException.prettyPrintColumnNameMap(getColumnNameMap());
     }
 
     public boolean isValidTransformedProjectionColumn() {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumnProcessor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/ProjectionColumnProcessor.java
@@ -98,14 +98,15 @@ public class ProjectionColumnProcessor {
         try {
             return expressionEvaluator.evaluate(generateParams(record, epochTime, opType, meta));
         } catch (InvocationTargetException e) {
-            LOG.error(
-                    "Table:{} column:{} projection:{} column name map:{} execute failed. {}",
-                    tableInfo.getName(),
-                    projectionColumn.getColumnName(),
-                    projectionColumn.getScriptExpression(),
-                    projectionColumn.getColumnNameMap(),
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to evaluate projection expression `%s` for column `%s` in table `%s`.\n"
+                                    + "\tColumn name map: {%s}",
+                            projectionColumn.getScriptExpression(),
+                            projectionColumn.getColumnName(),
+                            tableInfo.getName(),
+                            projectionColumn.getColumnNameMapAsString()),
                     e);
-            throw new RuntimeException(e);
         }
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionCompiler.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.runtime.operators.transform;
 
 import org.apache.flink.api.common.InvalidProgramException;
+import org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.flink.shaded.guava31.com.google.common.cache.Cache;
@@ -75,14 +76,16 @@ public class TransformExpressionCompiler {
                         } catch (CompileException e) {
                             throw new InvalidProgramException(
                                     String.format(
-                                            "Expression cannot be compiled. This is a bug. Please file an issue.\nExpression: %s\nColumn name map: %s",
-                                            key.getExpression(), key.getColumnNameMap()),
+                                            "Expression cannot be compiled. This is a bug. Please file an issue.\n\tExpression: %s\n\tColumn name map: {%s}",
+                                            key.getExpression(),
+                                            TransformException.prettyPrintColumnNameMap(
+                                                    key.getColumnNameMap())),
                                     e);
                         }
                         return expressionEvaluator;
                     });
         } catch (Exception e) {
-            throw new FlinkRuntimeException(e.getMessage(), e);
+            throw new FlinkRuntimeException("Failed to compile expression " + key, e);
         }
     }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionKey.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionKey.java
@@ -107,4 +107,21 @@ public class TransformExpressionKey implements Serializable {
     public int hashCode() {
         return Objects.hash(expression, argumentNames, argumentClasses, returnClass, columnNameMap);
     }
+
+    @Override
+    public String toString() {
+        return "TransformExpressionKey{"
+                + "expression='"
+                + expression
+                + '\''
+                + ", argumentNames="
+                + argumentNames
+                + ", argumentClasses="
+                + argumentClasses
+                + ", returnClass="
+                + returnClass
+                + ", columnNameMap="
+                + columnNameMap
+                + '}';
+    }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformFilter.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformFilter.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.runtime.operators.transform;
 
 import org.apache.flink.cdc.common.utils.StringUtils;
+import org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException;
 import org.apache.flink.cdc.runtime.parser.TransformParser;
 
 import java.io.Serializable;
@@ -69,6 +70,10 @@ public class TransformFilter implements Serializable {
 
     public Map<String, String> getColumnNameMap() {
         return columnNameMap;
+    }
+
+    public String getColumnNameMapAsString() {
+        return TransformException.prettyPrintColumnNameMap(getColumnNameMap());
     }
 
     public static Optional<TransformFilter> of(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformFilterProcessor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformFilterProcessor.java
@@ -95,13 +95,14 @@ public class TransformFilterProcessor {
             return (Boolean)
                     expressionEvaluator.evaluate(generateParams(record, epochTime, opType, meta));
         } catch (InvocationTargetException e) {
-            LOG.error(
-                    "Table:{} filter:{} column name map:{} execute failed. {}",
-                    tableInfo.getName(),
-                    transformFilter.getExpression(),
-                    transformFilter.getColumnNameMap(),
+            throw new RuntimeException(
+                    String.format(
+                            "Failed to evaluate filtering expression `%s` for table `%s`.\n"
+                                    + "\tColumn name map: {%s}",
+                            transformFilter.getScriptExpression(),
+                            tableInfo.getName(),
+                            transformFilter.getColumnNameMapAsString()),
                     e);
-            throw new RuntimeException(e);
         }
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/exceptions/TransformException.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/exceptions/TransformException.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.runtime.operators.transform.exceptions;
+
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataExtractor;
+
+import javax.annotation.Nullable;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** A general {@link RuntimeException} thrown during transform failure. */
+public class TransformException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+    private static final String UNKNOWN_PLACEHOLDER = "(Unknown)";
+
+    public TransformException(
+            String command,
+            Event event,
+            @Nullable TableId tableId,
+            @Nullable Schema schemaBefore,
+            @Nullable Schema schemaAfter,
+            Throwable cause) {
+        super(
+                String.format(
+                        "Failed to %s with\n"
+                                + "\t%s\n"
+                                + "for table\n"
+                                + "\t%s\n"
+                                + "from schema\n"
+                                + "\t%s\n"
+                                + "to schema\n"
+                                + "\t%s.",
+                        command,
+                        prettyPrintEvent(event, schemaBefore),
+                        Optional.ofNullable(tableId)
+                                .map(Object::toString)
+                                .orElse(UNKNOWN_PLACEHOLDER),
+                        Optional.ofNullable(schemaBefore)
+                                .map(Object::toString)
+                                .orElse(UNKNOWN_PLACEHOLDER),
+                        Optional.ofNullable(schemaAfter)
+                                .map(Object::toString)
+                                .orElse(UNKNOWN_PLACEHOLDER)),
+                cause);
+    }
+
+    @VisibleForTesting
+    public static String prettyPrintEvent(Event event, @Nullable Schema schema) {
+        try {
+            if (event instanceof DataChangeEvent && schema != null) {
+                return ((DataChangeEvent) event)
+                        .toReadableString(
+                                rec -> BinaryRecordDataExtractor.extractRecord(rec, schema));
+            } else {
+                return event.toString();
+            }
+        } catch (Exception e) {
+            // Do not throw an exception if deserialization fails since we're already in an
+            // unexpected state.
+            return event.toString();
+        }
+    }
+
+    /** Prints an incrementally-sorted column name map like {@code $0 -> id, $1 -> name, ...}. */
+    public static String prettyPrintColumnNameMap(Map<String, String> columnNameMap) {
+        return columnNameMap.entrySet().stream()
+                .sorted(
+                        Comparator.comparingInt(
+                                entry -> Integer.parseInt(entry.getValue().substring(1))))
+                .map(entry -> String.format("%s -> %s", entry.getValue(), entry.getKey()))
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/typeutils/BinaryRecordDataExtractor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/typeutils/BinaryRecordDataExtractor.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.runtime.typeutils;
+
+import org.apache.flink.cdc.common.data.ArrayData;
+import org.apache.flink.cdc.common.data.MapData;
+import org.apache.flink.cdc.common.data.RecordData;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.ArrayType;
+import org.apache.flink.cdc.common.types.BinaryType;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.types.MapType;
+import org.apache.flink.cdc.common.types.RowType;
+import org.apache.flink.cdc.common.types.VarBinaryType;
+import org.apache.flink.cdc.common.utils.Preconditions;
+import org.apache.flink.cdc.common.utils.SchemaUtils;
+
+import org.apache.flink.shaded.guava31.com.google.common.io.BaseEncoding;
+
+import javax.annotation.CheckReturnValue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Utility methods for extracting human-readable objects from {@link RecordData}. */
+public class BinaryRecordDataExtractor {
+
+    /** Converts a binary record data with specific schema to Java objects. */
+    @CheckReturnValue
+    public static Object extractRecord(RecordData record, Schema schema) {
+        return extractRecord(record, schema.toRowDataType());
+    }
+
+    /** Converts a generic binary record data to Java objects. */
+    @CheckReturnValue
+    public static Object extractRecord(Object object, DataType dataType) {
+        if (object == null) {
+            return "null";
+        }
+        if (dataType instanceof BinaryType || dataType instanceof VarBinaryType) {
+            Preconditions.checkArgument(
+                    object instanceof byte[],
+                    "Column data of BinaryType and VarBinaryType should be `byte[]`, but was %s",
+                    object.getClass().getName());
+            return BaseEncoding.base64().encode((byte[]) object);
+        } else if (dataType instanceof MapType) {
+            Preconditions.checkArgument(
+                    object instanceof MapData,
+                    "Column data of MapType should be MapData, but was %s",
+                    object.getClass().getName());
+            MapType mapType = (MapType) dataType;
+            MapData mapData = (MapData) object;
+            List<?> keyArray =
+                    (List<?>)
+                            extractRecord(
+                                    mapData.keyArray(), DataTypes.ARRAY(mapType.getKeyType()));
+            List<?> valueArray =
+                    (List<?>)
+                            extractRecord(
+                                    mapData.valueArray(), DataTypes.ARRAY(mapType.getValueType()));
+            Preconditions.checkArgument(
+                    keyArray.size() == valueArray.size(),
+                    "Malformed MapData: keyArray size (%d) differs from valueArray (%d)",
+                    keyArray.size(),
+                    valueArray.size());
+            StringBuilder sb = new StringBuilder("{");
+            for (int i = 0; i < keyArray.size(); i++) {
+                sb.append(keyArray.get(i)).append(" -> ").append(valueArray.get(i)).append(", ");
+            }
+            sb.delete(sb.length() - 2, sb.length());
+            return sb.append("}").toString();
+        } else if (dataType instanceof ArrayType) {
+            Preconditions.checkArgument(
+                    object instanceof ArrayData,
+                    "Column data of ArrayType should be ArrayData, but was %s",
+                    object.getClass().getName());
+            ArrayType arrayType = (ArrayType) dataType;
+            ArrayData arrayData = (ArrayData) object;
+            ArrayData.ElementGetter getter =
+                    ArrayData.createElementGetter(arrayType.getElementType());
+            List<Object> results = new ArrayList<>();
+            for (int i = 0; i < arrayData.size(); i++) {
+                results.add(getter.getElementOrNull(arrayData, i));
+            }
+            return results;
+        } else if (dataType instanceof RowType) {
+            Preconditions.checkArgument(
+                    object instanceof RecordData,
+                    "Column data of RowType should be RecordData, but was %s",
+                    object.getClass().getName());
+            RowType rowType = (RowType) dataType;
+            RecordData binaryRecordData = (RecordData) object;
+            List<String> fieldNames = rowType.getFieldNames();
+            List<DataType> fieldTypes = rowType.getFieldTypes();
+            List<RecordData.FieldGetter> fieldGetters =
+                    SchemaUtils.createFieldGetters(fieldTypes.toArray(new DataType[0]));
+            StringBuilder sb = new StringBuilder("{");
+            for (int i = 0; i < rowType.getFieldCount(); i++) {
+                sb.append(fieldNames.get(i))
+                        .append(": ")
+                        .append(fieldTypes.get(i))
+                        .append(" -> ")
+                        .append(
+                                extractRecord(
+                                        fieldGetters.get(i).getFieldOrNull(binaryRecordData),
+                                        fieldTypes.get(i)))
+                        .append(", ");
+            }
+            sb.delete(sb.length() - 2, sb.length());
+            return sb.append("}").toString();
+        } else {
+            return object.toString();
+        }
+    }
+}

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/PostTransformOperatorTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.source.SupportedMetadataColumn;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.types.RowType;
+import org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException;
 import org.apache.flink.cdc.runtime.testutils.operators.RegularEventOperatorTestHarness;
 import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -2749,10 +2750,18 @@ public class PostTransformOperatorTest {
                         transformFunctionEventEventOperatorTestHarness.getOutputRecords().poll())
                 .isEqualTo(new StreamRecord<>(new CreateTableEvent(CAST_TABLEID, CAST_SCHEMA)));
         Assertions.assertThatThrownBy(
-                        () -> {
-                            transform.processElement(new StreamRecord<>(insertEvent1));
-                        })
-                .isExactlyInstanceOf(RuntimeException.class)
+                        () -> transform.processElement(new StreamRecord<>(insertEvent1)))
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessageContaining(
+                        "Failed to post-transform with\n"
+                                + "\tDataChangeEvent{tableId=my_company.my_branch.data_cast, before=null, after={col1: STRING NOT NULL -> 1, castInt: INT -> null, castBoolean: BOOLEAN -> null, castTinyint: TINYINT -> null, castSmallint: SMALLINT -> null, castBigint: BIGINT -> null, castFloat: FLOAT -> 1.0, castDouble: DOUBLE -> null, castChar: STRING -> null, castVarchar: STRING -> null, castDecimal: DECIMAL(4, 2) -> null, castTimestamp: TIMESTAMP(3) -> null}, op=INSERT, meta=()}\n"
+                                + "for table\n"
+                                + "\tmy_company.my_branch.data_cast\n"
+                                + "from schema\n"
+                                + "\tcolumns={`col1` STRING NOT NULL,`castInt` INT,`castBoolean` BOOLEAN,`castTinyint` TINYINT,`castSmallint` SMALLINT,`castBigint` BIGINT,`castFloat` FLOAT,`castDouble` DOUBLE,`castChar` STRING,`castVarchar` STRING,`castDecimal` DECIMAL(4, 2),`castTimestamp` TIMESTAMP(3)}, primaryKeys=col1, options=()\n"
+                                + "to schema\n"
+                                + "\tcolumns={`col1` STRING NOT NULL,`castInt` INT,`castBoolean` BOOLEAN,`castTinyint` TINYINT,`castSmallint` SMALLINT,`castBigint` BIGINT,`castFloat` FLOAT,`castDouble` DOUBLE,`castChar` STRING,`castVarchar` STRING,`castDecimal` DECIMAL(4, 2),`castTimestamp` TIMESTAMP(3)}, primaryKeys=col1, options=().")
+                .cause()
                 .hasRootCauseInstanceOf(DateTimeParseException.class)
                 .hasRootCauseMessage("Text '1.0' could not be parsed at index 0");
         transformFunctionEventEventOperatorTestHarness.close();
@@ -2850,6 +2859,17 @@ public class PostTransformOperatorTest {
                         () -> {
                             transform.processElement(new StreamRecord<>(createTableEvent));
                         })
+                .isExactlyInstanceOf(TransformException.class)
+                .hasMessageContaining(
+                        "Failed to post-transform with\n"
+                                + "\tCreateTableEvent{tableId=my_company.my_branch.compare_table, schema=columns={`col1` STRING NOT NULL,`numerical_equal` BOOLEAN,`string_equal` BOOLEAN,`time_equal` BOOLEAN,`timestamp_equal` BOOLEAN,`date_equal` BOOLEAN}, primaryKeys=col1, options=()}\n"
+                                + "for table\n"
+                                + "\tmy_company.my_branch.compare_table\n"
+                                + "from schema\n"
+                                + "\t(Unknown)\n"
+                                + "to schema\n"
+                                + "\t(Unknown).")
+                .cause()
                 .isExactlyInstanceOf(CalciteContextException.class)
                 .hasRootCauseInstanceOf(SqlValidatorException.class)
                 .hasRootCauseMessage(

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/typeutils/BinaryRecordDataExtractorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/typeutils/BinaryRecordDataExtractorTest.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.runtime.typeutils;
+
+import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.data.GenericArrayData;
+import org.apache.flink.cdc.common.data.GenericMapData;
+import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
+import org.apache.flink.cdc.common.data.RecordData;
+import org.apache.flink.cdc.common.data.TimestampData;
+import org.apache.flink.cdc.common.data.ZonedTimestampData;
+import org.apache.flink.cdc.common.data.binary.BinaryStringData;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+
+import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Test cases for {@link BinaryRecordDataExtractor}. */
+public class BinaryRecordDataExtractorTest {
+    public static final Schema SCHEMA =
+            Schema.newBuilder()
+                    .physicalColumn("id", DataTypes.INT().notNull())
+                    .physicalColumn("bool_col", DataTypes.BOOLEAN())
+                    .physicalColumn("tinyint_col", DataTypes.TINYINT())
+                    .physicalColumn("smallint_col", DataTypes.SMALLINT())
+                    .physicalColumn("int_col", DataTypes.INT())
+                    .physicalColumn("bigint_col", DataTypes.BIGINT())
+                    .physicalColumn("float_col", DataTypes.FLOAT())
+                    .physicalColumn("double_col", DataTypes.DOUBLE())
+                    .physicalColumn("decimal_col", DataTypes.DECIMAL(17, 10))
+                    .physicalColumn("char_col", DataTypes.CHAR(17))
+                    .physicalColumn("varchar_col", DataTypes.VARCHAR(17))
+                    .physicalColumn("bin_col", DataTypes.BINARY(17))
+                    .physicalColumn("varbin_col", DataTypes.VARBINARY(17))
+                    .physicalColumn("date_col", DataTypes.DATE())
+                    .physicalColumn("time_col", DataTypes.TIME())
+                    .physicalColumn("ts_col", DataTypes.TIMESTAMP(3))
+                    .physicalColumn("ts_tz_col", DataTypes.TIMESTAMP_TZ(3))
+                    .physicalColumn("ts_ltz_col", DataTypes.TIMESTAMP_LTZ(3))
+                    .physicalColumn("array_col", DataTypes.ARRAY(DataTypes.STRING()))
+                    .physicalColumn("map_col", DataTypes.MAP(DataTypes.INT(), DataTypes.STRING()))
+                    .physicalColumn("row_col", DataTypes.ROW(DataTypes.INT(), DataTypes.DOUBLE()))
+                    .build();
+
+    public static List<RecordData> generateEventWithAllTypes() {
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(SCHEMA.getColumnDataTypes().toArray(new DataType[0]));
+        BinaryRecordDataGenerator nestedGenerator =
+                new BinaryRecordDataGenerator(DataTypes.ROW(DataTypes.INT(), DataTypes.DOUBLE()));
+        List<RecordData> events = new ArrayList<>();
+        events.add(
+                generator.generate(
+                        new Object[] {
+                            1,
+                            true,
+                            (byte) 2,
+                            (short) 3,
+                            4,
+                            5L,
+                            6.0F,
+                            7.0D,
+                            DecimalData.fromUnscaledLong(1234567890, 17, 10),
+                            BinaryStringData.fromString("Eight"),
+                            BinaryStringData.fromString("Nine"),
+                            "Ten\1".getBytes(),
+                            "Eleven\2".getBytes(),
+                            19673,
+                            (8 * 3600 + 30 * 60 + 15) * 1000,
+                            TimestampData.fromLocalDateTime(
+                                    LocalDateTime.of(2023, 11, 11, 11, 11, 11, 11)),
+                            ZonedTimestampData.fromZonedDateTime(
+                                    LocalDateTime.of(2023, 11, 11, 11, 11, 11, 11)
+                                            .atZone(ZoneId.of("+05:00"))),
+                            LocalZonedTimestampData.fromInstant(
+                                    LocalDateTime.of(2023, 11, 11, 11, 11, 11, 11)
+                                            .atZone(ZoneId.of("+05:00"))
+                                            .toInstant()),
+                            new GenericArrayData(
+                                    new BinaryStringData[] {
+                                        BinaryStringData.fromString("One"),
+                                        BinaryStringData.fromString("Two"),
+                                        BinaryStringData.fromString("Three")
+                                    }),
+                            new GenericMapData(
+                                    ImmutableMap.of(
+                                            1,
+                                            BinaryStringData.fromString("yi"),
+                                            2,
+                                            BinaryStringData.fromString("er"),
+                                            3,
+                                            BinaryStringData.fromString("san"))),
+                            nestedGenerator.generate(new Object[] {3, .1415926})
+                        }));
+        events.add(
+                generator.generate(
+                        new Object[] {
+                            -1,
+                            false,
+                            (byte) -2,
+                            (short) -3,
+                            -4,
+                            -5L,
+                            -6.0F,
+                            -7.0D,
+                            DecimalData.fromUnscaledLong(-1234567890, 17, 10),
+                            BinaryStringData.fromString("-Eight"),
+                            BinaryStringData.fromString("-Nine"),
+                            "-Ten\1".getBytes(),
+                            "-Eleven\2".getBytes(),
+                            2000,
+                            (8 * 3600 + 30 * 60 + 17) * 1000,
+                            TimestampData.fromLocalDateTime(
+                                    LocalDateTime.of(2021, 11, 11, 11, 11, 11, 11)),
+                            ZonedTimestampData.fromZonedDateTime(
+                                    LocalDateTime.of(2021, 11, 11, 11, 11, 11, 11)
+                                            .atZone(ZoneId.of("+05:00"))),
+                            LocalZonedTimestampData.fromInstant(
+                                    LocalDateTime.of(2021, 11, 11, 11, 11, 11, 11)
+                                            .atZone(ZoneId.of("+05:00"))
+                                            .toInstant()),
+                            new GenericArrayData(
+                                    new BinaryStringData[] {
+                                        BinaryStringData.fromString("Ninety"),
+                                        BinaryStringData.fromString("Eighty"),
+                                        BinaryStringData.fromString("Seventy")
+                                    }),
+                            new GenericMapData(
+                                    ImmutableMap.of(
+                                            7, BinaryStringData.fromString("qi"),
+                                            8, BinaryStringData.fromString("ba"),
+                                            9, BinaryStringData.fromString("jiu"))),
+                            nestedGenerator.generate(new Object[] {2, .718281828})
+                        }));
+        events.add(
+                generator.generate(
+                        new Object[] {
+                            0, null, null, null, null, null, null, null, null, null, null, null,
+                            null, null, null, null, null, null, null, null, null
+                        }));
+        events.add(null);
+        return events;
+    }
+
+    @Test
+    void testConvertingBinaryRecordData() throws Exception {
+        Assertions.assertThat(generateEventWithAllTypes())
+                .map(e -> BinaryRecordDataExtractor.extractRecord(e, SCHEMA.toRowDataType()))
+                .containsExactly(
+                        "{id: INT NOT NULL -> 1, bool_col: BOOLEAN -> true, tinyint_col: TINYINT -> 2, smallint_col: SMALLINT -> 3, int_col: INT -> 4, bigint_col: BIGINT -> 5, float_col: FLOAT -> 6.0, double_col: DOUBLE -> 7.0, decimal_col: DECIMAL(17, 10) -> 0.1234567890, char_col: CHAR(17) -> Eight, varchar_col: VARCHAR(17) -> Nine, bin_col: BINARY(17) -> VGVuAQ==, varbin_col: VARBINARY(17) -> RWxldmVuAg==, date_col: DATE -> 19673, time_col: TIME(0) -> 30615000, ts_col: TIMESTAMP(3) -> 2023-11-11T11:11:11.000000011, ts_tz_col: TIMESTAMP(3) WITH TIME ZONE -> 2023-11-11T11:11:11.000000011+05:00, ts_ltz_col: TIMESTAMP_LTZ(3) -> 2023-11-11T06:11:11.000000011, array_col: ARRAY<STRING> -> [One, Two, Three], map_col: MAP<INT, STRING> -> {1 -> yi, 2 -> er, 3 -> san}, row_col: ROW<`f0` INT, `f1` DOUBLE> -> {f0: INT -> 3, f1: DOUBLE -> 0.1415926}}",
+                        "{id: INT NOT NULL -> -1, bool_col: BOOLEAN -> false, tinyint_col: TINYINT -> -2, smallint_col: SMALLINT -> -3, int_col: INT -> -4, bigint_col: BIGINT -> -5, float_col: FLOAT -> -6.0, double_col: DOUBLE -> -7.0, decimal_col: DECIMAL(17, 10) -> -0.1234567890, char_col: CHAR(17) -> -Eight, varchar_col: VARCHAR(17) -> -Nine, bin_col: BINARY(17) -> LVRlbgE=, varbin_col: VARBINARY(17) -> LUVsZXZlbgI=, date_col: DATE -> 2000, time_col: TIME(0) -> 30617000, ts_col: TIMESTAMP(3) -> 2021-11-11T11:11:11.000000011, ts_tz_col: TIMESTAMP(3) WITH TIME ZONE -> 2021-11-11T11:11:11.000000011+05:00, ts_ltz_col: TIMESTAMP_LTZ(3) -> 2021-11-11T06:11:11.000000011, array_col: ARRAY<STRING> -> [Ninety, Eighty, Seventy], map_col: MAP<INT, STRING> -> {7 -> qi, 8 -> ba, 9 -> jiu}, row_col: ROW<`f0` INT, `f1` DOUBLE> -> {f0: INT -> 2, f1: DOUBLE -> 0.718281828}}",
+                        "{id: INT NOT NULL -> 0, bool_col: BOOLEAN -> null, tinyint_col: TINYINT -> null, smallint_col: SMALLINT -> null, int_col: INT -> null, bigint_col: BIGINT -> null, float_col: FLOAT -> null, double_col: DOUBLE -> null, decimal_col: DECIMAL(17, 10) -> null, char_col: CHAR(17) -> null, varchar_col: VARCHAR(17) -> null, bin_col: BINARY(17) -> null, varbin_col: VARBINARY(17) -> null, date_col: DATE -> null, time_col: TIME(0) -> null, ts_col: TIMESTAMP(3) -> null, ts_tz_col: TIMESTAMP(3) WITH TIME ZONE -> null, ts_ltz_col: TIMESTAMP_LTZ(3) -> null, array_col: ARRAY<STRING> -> null, map_col: MAP<INT, STRING> -> null, row_col: ROW<`f0` INT, `f1` DOUBLE> -> null}",
+                        "null");
+    }
+
+    @Test
+    void testConvertingBinaryRecordDataWithSchema() throws Exception {
+        Assertions.assertThat(generateEventWithAllTypes())
+                .map(e -> BinaryRecordDataExtractor.extractRecord(e, SCHEMA))
+                .containsExactly(
+                        "{id: INT NOT NULL -> 1, bool_col: BOOLEAN -> true, tinyint_col: TINYINT -> 2, smallint_col: SMALLINT -> 3, int_col: INT -> 4, bigint_col: BIGINT -> 5, float_col: FLOAT -> 6.0, double_col: DOUBLE -> 7.0, decimal_col: DECIMAL(17, 10) -> 0.1234567890, char_col: CHAR(17) -> Eight, varchar_col: VARCHAR(17) -> Nine, bin_col: BINARY(17) -> VGVuAQ==, varbin_col: VARBINARY(17) -> RWxldmVuAg==, date_col: DATE -> 19673, time_col: TIME(0) -> 30615000, ts_col: TIMESTAMP(3) -> 2023-11-11T11:11:11.000000011, ts_tz_col: TIMESTAMP(3) WITH TIME ZONE -> 2023-11-11T11:11:11.000000011+05:00, ts_ltz_col: TIMESTAMP_LTZ(3) -> 2023-11-11T06:11:11.000000011, array_col: ARRAY<STRING> -> [One, Two, Three], map_col: MAP<INT, STRING> -> {1 -> yi, 2 -> er, 3 -> san}, row_col: ROW<`f0` INT, `f1` DOUBLE> -> {f0: INT -> 3, f1: DOUBLE -> 0.1415926}}",
+                        "{id: INT NOT NULL -> -1, bool_col: BOOLEAN -> false, tinyint_col: TINYINT -> -2, smallint_col: SMALLINT -> -3, int_col: INT -> -4, bigint_col: BIGINT -> -5, float_col: FLOAT -> -6.0, double_col: DOUBLE -> -7.0, decimal_col: DECIMAL(17, 10) -> -0.1234567890, char_col: CHAR(17) -> -Eight, varchar_col: VARCHAR(17) -> -Nine, bin_col: BINARY(17) -> LVRlbgE=, varbin_col: VARBINARY(17) -> LUVsZXZlbgI=, date_col: DATE -> 2000, time_col: TIME(0) -> 30617000, ts_col: TIMESTAMP(3) -> 2021-11-11T11:11:11.000000011, ts_tz_col: TIMESTAMP(3) WITH TIME ZONE -> 2021-11-11T11:11:11.000000011+05:00, ts_ltz_col: TIMESTAMP_LTZ(3) -> 2021-11-11T06:11:11.000000011, array_col: ARRAY<STRING> -> [Ninety, Eighty, Seventy], map_col: MAP<INT, STRING> -> {7 -> qi, 8 -> ba, 9 -> jiu}, row_col: ROW<`f0` INT, `f1` DOUBLE> -> {f0: INT -> 2, f1: DOUBLE -> 0.718281828}}",
+                        "{id: INT NOT NULL -> 0, bool_col: BOOLEAN -> null, tinyint_col: TINYINT -> null, smallint_col: SMALLINT -> null, int_col: INT -> null, bigint_col: BIGINT -> null, float_col: FLOAT -> null, double_col: DOUBLE -> null, decimal_col: DECIMAL(17, 10) -> null, char_col: CHAR(17) -> null, varchar_col: VARCHAR(17) -> null, bin_col: BINARY(17) -> null, varbin_col: VARBINARY(17) -> null, date_col: DATE -> null, time_col: TIME(0) -> null, ts_col: TIMESTAMP(3) -> null, ts_tz_col: TIMESTAMP(3) WITH TIME ZONE -> null, ts_ltz_col: TIMESTAMP_LTZ(3) -> null, array_col: ARRAY<STRING> -> null, map_col: MAP<INT, STRING> -> null, row_col: ROW<`f0` INT, `f1` DOUBLE> -> null}",
+                        "null");
+    }
+}


### PR DESCRIPTION
This closes FLINK-37506.

Currently, there's no much contextual information available (like currently handling Event, its tableId and schema, or BinaryRecordData) when transform operator throws an exception, making it very difficult to locating and debugging. Providing extra information would be useful for troubleshooting a crashed pipeline job.