### PR TITLE
[FLINK-37529][cdc-connector] Add flink-cdc-commo to the package to al…

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-mongodb-cdc/pom.xml
@@ -56,6 +56,7 @@ limitations under the License.
                                     <include>io.debezium:debezium-embedded</include>
                                     <include>io.debezium:debezium-core</include>
                                     <include>org.apache.flink:flink-cdc-base</include>
+                                    <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-mongodb-cdc</include>
                                     <include>org.mongodb.kafka:mongo-kafka-connect</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oceanbase-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oceanbase-cdc/pom.xml
@@ -56,6 +56,7 @@ limitations under the License.
                                     <include>io.debezium:debezium-embedded</include>
                                     <include>io.debezium:debezium-core</include>
                                     <include>org.apache.flink:flink-cdc-base</include>
+                                    <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-oceanbase-cdc</include>
                                     <include>com.oceanbase:*</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
@@ -59,6 +59,7 @@ limitations under the License.
                                     <include>io.debezium:debezium-connector-oracle</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-cdc-base</include>
+                                    <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-oracle-cdc</include>
                                     <include>org.antlr:antlr4-runtime</include>
                                     <include>com.github.jsqlparser:jsqlparser</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-postgres-cdc/pom.xml
@@ -57,6 +57,7 @@ limitations under the License.
                                     <include>io.debezium:debezium-core</include>
                                     <include>io.debezium:debezium-connector-postgres</include>
                                     <include>org.apache.flink:flink-cdc-base</include>
+                                    <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-connector-postgres-cdc</include>
                                     <include>com.zaxxer:HikariCP</include>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-sqlserver-cdc/pom.xml
@@ -58,6 +58,7 @@ limitations under the License.
                                     <include>io.debezium:debezium-connector-sqlserver</include>
                                     <include>org.apache.flink:flink-connector-debezium</include>
                                     <include>org.apache.flink:flink-cdc-base</include>
+                                    <include>org.apache.flink:flink-cdc-common</include>
                                     <include>org.apache.flink:flink-connector-sqlserver-cdc</include>
                                     <include>com.microsoft.sqlserver:*</include>
                                     <include>org.apache.kafka:*</include>


### PR DESCRIPTION
As discussed in https://issues.apache.org/jira/browse/FLINK-37529 :
Currently, flink-cdc-base dependends on flink-cdc-common. Thus, all its children module( such as flink-connector-postgres-cdc, flink-connector-mongo-cdc).




However, flink-cdc-base  is not a uber jar. Thus, If  children module(such as flink-sql-connector-postgres-cdc and flink-sql-connector-mongo-cdc) doesn't include flink-cdc-common when shading, it will lack it.

 
IncrementalSourceSplitReader will thrown exception when invoking 
```java
org.apache.flink.cdc.common.utils.Preconditions#checkState(boolean).

private ChangeEventRecords pollSplitRecords() throws InterruptedException {
checkState(reusedScanFetcher != null);
} 

```

