### PR TITLE
[FLINK-37572] Shuffle Event by bucket and tableid to avoid data skew.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonEventSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonEventSink.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.connectors.paimon.sink.v2;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.connectors.paimon.sink.v2.bucket.BucketAssignOperator;
 import org.apache.flink.cdc.connectors.paimon.sink.v2.bucket.BucketWrapper;
+import org.apache.flink.cdc.connectors.paimon.sink.v2.bucket.BucketWrapperChangeEvent;
 import org.apache.flink.cdc.connectors.paimon.sink.v2.bucket.BucketWrapperEventTypeInfo;
 import org.apache.flink.cdc.connectors.paimon.sink.v2.bucket.FlushEventAlignmentOperator;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -64,7 +65,15 @@ public class PaimonEventSink extends PaimonSink<Event> implements WithPreWriteTo
                 // All Events after BucketAssignOperator are decorated with BucketWrapper.
                 .partitionCustom(
                         (bucket, numPartitions) -> bucket % numPartitions,
-                        (event) -> ((BucketWrapper) event).getBucket())
+                        (event) -> {
+                            if (event instanceof BucketWrapperChangeEvent) {
+                                // Add hash of tableId to avoid data skew.
+                                return ((BucketWrapperChangeEvent) event).getBucket()
+                                        + ((BucketWrapperChangeEvent) event).tableId().hashCode();
+                            } else {
+                                return ((BucketWrapper) event).getBucket();
+                            }
+                        })
                 // Avoid disorder of FlushEvent and DataChangeEvent.
                 .transform(
                         "FlushEventAlignment",

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonEventSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonEventSink.java
@@ -64,7 +64,7 @@ public class PaimonEventSink extends PaimonSink<Event> implements WithPreWriteTo
                 .name("Assign Bucket")
                 // All Events after BucketAssignOperator are decorated with BucketWrapper.
                 .partitionCustom(
-                        (bucket, numPartitions) -> Math.abs(bucket) % numPartitions,
+                        Math::floorMod,
                         (event) -> {
                             if (event instanceof BucketWrapperChangeEvent) {
                                 // Add hash of tableId to avoid data skew.

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonEventSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonEventSink.java
@@ -64,7 +64,7 @@ public class PaimonEventSink extends PaimonSink<Event> implements WithPreWriteTo
                 .name("Assign Bucket")
                 // All Events after BucketAssignOperator are decorated with BucketWrapper.
                 .partitionCustom(
-                        (bucket, numPartitions) -> bucket % numPartitions,
+                        (bucket, numPartitions) -> Math.abs(bucket) % numPartitions,
                         (event) -> {
                             if (event instanceof BucketWrapperChangeEvent) {
                                 // Add hash of tableId to avoid data skew.


### PR DESCRIPTION
BucketWrapper#getBucket is use to shuffle DataChangeEvent to avoid multiple subtasks writting in the same bucket.
However, in many cases, most tables may only have a few buckets, this way, the data will all fall on subtask1, subtask2... even if we have configured a high parallelism.

So I suggest allocating based on bucket+hash of TableId during shuffle, This way, there will be no conflict and data skew can be avoided to a certain extent.
