### PR TITLE
[FLINK-37577][paimon] Set waitCompaction=true in PaimonWriter only when deletion-vectors.enabled option enabled

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonWriter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonWriter.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.runtime.io.disk.iomanager.IOManagerAsync;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 
+import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
 import org.apache.paimon.data.GenericRow;
@@ -158,7 +159,12 @@ public class PaimonWriter<InputT>
                                 boolean waitCompaction =
                                         Boolean.parseBoolean(
                                                 table.options()
-                                                        .getOrDefault("deletion-vectors.enabled", "false"));
+                                                        .getOrDefault(
+                                                                CoreOptions.DELETION_VECTORS_ENABLED
+                                                                        .key(),
+                                                                CoreOptions.DELETION_VECTORS_ENABLED
+                                                                        .defaultValue()
+                                                                        .toString()));
                                 StoreSinkWriteImpl storeSinkWrite =
                                         new StoreSinkWriteImpl(
                                                 table,

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonWriter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonWriter.java
@@ -107,7 +107,7 @@ public class PaimonWriter<InputT>
                                         // avoid prepareCommit the same checkpointId with the first
                                         // round.
                                         return entry.getValue()
-                                                .prepareCommit(true, lastCheckpointId + 1).stream()
+                                                .prepareCommit(false, lastCheckpointId + 1).stream()
                                                 .map(
                                                         committable ->
                                                                 MultiTableCommittable
@@ -155,13 +155,17 @@ public class PaimonWriter<InputT>
                     writes.computeIfAbsent(
                             tableId,
                             id -> {
+                                boolean waitCompaction =
+                                        Boolean.parseBoolean(
+                                                table.options()
+                                                        .getOrDefault("deletion-vectors.enabled", "false"));
                                 StoreSinkWriteImpl storeSinkWrite =
                                         new StoreSinkWriteImpl(
                                                 table,
                                                 commitUser,
                                                 ioManager,
                                                 false,
-                                                false,
+                                                waitCompaction,
                                                 true,
                                                 memoryPoolFactory,
                                                 metricGroup);


### PR DESCRIPTION
Set waitCompaction=true in PaimonWriter only when deletion-vectors.enabled of table option is true.