### PR TITLE
[FLINK-37578] Fix distributed schema registry exposes bad internal state accidentally

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaOperator.java
@@ -205,17 +205,11 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
         LOG.info("{}> Evolve request response: {}", subTaskId, response);
 
         // Update local evolved schema cache
-        response.getSchemaEvolveResult()
-                .forEach(
-                        schemaChangeEvent ->
-                                evolvedSchemaMap.compute(
-                                        schemaChangeEvent.tableId(),
-                                        (tableId, schema) ->
-                                                SchemaUtils.applySchemaChangeEvent(
-                                                        schema, schemaChangeEvent)));
+        evolvedSchemaMap.putAll(response.getEvolvedSchemas());
 
         // And emit schema change events to downstream
-        response.getSchemaEvolveResult().forEach(evt -> output.collect(new StreamRecord<>(evt)));
+        response.getEvolvedSchemaChangeEvents()
+                .forEach(evt -> output.collect(new StreamRecord<>(evt)));
         LOG.info(
                 "{}> Successfully updated evolved schema cache. Current state: {}",
                 subTaskId,

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/event/SchemaChangeRequest.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/event/SchemaChangeRequest.java
@@ -65,4 +65,16 @@ public class SchemaChangeRequest implements CoordinationRequest {
                 !isNoOpRequest(), "Unable to fetch source subTaskId for an align event.");
         return schemaChangeEvent;
     }
+
+    @Override
+    public String toString() {
+        return "SchemaChangeRequest{"
+                + "sourceSubTaskId="
+                + sourceSubTaskId
+                + ", sinkSubTaskId="
+                + sinkSubTaskId
+                + ", schemaChangeEvent="
+                + schemaChangeEvent
+                + '}';
+    }
 }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/event/SchemaChangeResponse.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/event/SchemaChangeResponse.java
@@ -18,23 +18,34 @@
 package org.apache.flink.cdc.runtime.operators.schema.distributed.event;
 
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.runtime.operators.schema.distributed.SchemaCoordinator;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /** Response from a {@link SchemaCoordinator} to broadcast a coordination consensus. */
 public class SchemaChangeResponse implements CoordinationResponse {
 
-    private final List<SchemaChangeEvent> schemaEvolveResult;
+    private final Map<TableId, Schema> evolvedSchemas;
+    private final List<SchemaChangeEvent> evolvedSchemaChangeEvents;
 
-    public SchemaChangeResponse(List<SchemaChangeEvent> schemaEvolveResult) {
-        this.schemaEvolveResult = schemaEvolveResult;
+    public SchemaChangeResponse(
+            Map<TableId, Schema> evolvedSchemas,
+            List<SchemaChangeEvent> evolvedSchemaChangeEvents) {
+        this.evolvedSchemas = evolvedSchemas;
+        this.evolvedSchemaChangeEvents = evolvedSchemaChangeEvents;
     }
 
-    public List<SchemaChangeEvent> getSchemaEvolveResult() {
-        return schemaEvolveResult;
+    public Map<TableId, Schema> getEvolvedSchemas() {
+        return evolvedSchemas;
+    }
+
+    public List<SchemaChangeEvent> getEvolvedSchemaChangeEvents() {
+        return evolvedSchemaChangeEvents;
     }
 
     @Override
@@ -43,16 +54,22 @@ public class SchemaChangeResponse implements CoordinationResponse {
             return false;
         }
         SchemaChangeResponse that = (SchemaChangeResponse) o;
-        return Objects.equals(schemaEvolveResult, that.schemaEvolveResult);
+        return Objects.equals(evolvedSchemas, that.evolvedSchemas)
+                && Objects.equals(evolvedSchemaChangeEvents, that.evolvedSchemaChangeEvents);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(schemaEvolveResult);
+        return Objects.hash(evolvedSchemas, evolvedSchemaChangeEvents);
     }
 
     @Override
     public String toString() {
-        return "SchemaChangeResponse{" + "schemaEvolveResult=" + schemaEvolveResult + '}';
+        return "SchemaChangeResponse{"
+                + "evolvedSchemas="
+                + evolvedSchemas
+                + ", evolvedSchemaChangeEvents="
+                + evolvedSchemaChangeEvents
+                + '}';
     }
 }


### PR DESCRIPTION
This closes FLINK-37578 and #3858.

There's a subtle sequential bug in both `SchemaCoordinator`s after a schema evolve coordination process finishes. Coordinator may finish operators' blocking state first before restoring internal state properly, which may accidentally expose unwanted internal states or freeze the entire pipeline job.

@linjianchang's optimization in #3858 is actually correct, however it increases the chance of this glitch. Baked the original commit into this PR to test if it works well.