### PR TITLE
[FLINK-37566] Avoid processing events of excluded tables.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlPipelineITCase.java
@@ -255,6 +255,149 @@ class MySqlPipelineITCase extends MySqlSourceTestBase {
                 .isEqualTo(expectedBinlog);
     }
 
+    @Test
+    void testExcludeTables() throws Exception {
+        inventoryDatabase.createAndInitialize();
+        String databaseName = inventoryDatabase.getDatabaseName();
+        MySqlSourceConfigFactory configFactory =
+                new MySqlSourceConfigFactory()
+                        .hostname(MYSQL8_CONTAINER.getHost())
+                        .port(MYSQL8_CONTAINER.getDatabasePort())
+                        .username(TEST_USER)
+                        .password(TEST_PASSWORD)
+                        .databaseList(databaseName)
+                        .tableList(databaseName + ".*")
+                        .excludeTableList(
+                                String.format(
+                                        "%s.customers, %s.orders, %s.multi_max_table",
+                                        databaseName, databaseName, databaseName))
+                        .startupOptions(StartupOptions.initial())
+                        .serverId(getServerId(env.getParallelism()))
+                        .serverTimeZone("UTC")
+                        .includeSchemaChanges(SCHEMA_CHANGE_ENABLED.defaultValue());
+
+        FlinkSourceProvider sourceProvider =
+                (FlinkSourceProvider) new MySqlDataSource(configFactory).getEventSourceProvider();
+        CloseableIterator<Event> events =
+                env.fromSource(
+                                sourceProvider.getSource(),
+                                WatermarkStrategy.noWatermarks(),
+                                MySqlDataSourceFactory.IDENTIFIER,
+                                new EventTypeInfo())
+                        .executeAndCollect();
+        Thread.sleep(10_000);
+
+        TableId tableId = TableId.tableId(databaseName, "products");
+        CreateTableEvent createTableEvent = getProductsCreateTableEvent(tableId);
+
+        // generate snapshot data
+        List<Event> expectedSnapshot = getSnapshotExpected(tableId);
+
+        List<Event> expectedBinlog = new ArrayList<>();
+        try (Connection connection = inventoryDatabase.getJdbcConnection();
+                Statement statement = connection.createStatement()) {
+            expectedBinlog.addAll(executeAlterAndProvideExpected(tableId, statement));
+
+            RowType rowType =
+                    RowType.of(
+                            new DataType[] {
+                                DataTypes.INT().notNull(),
+                                DataTypes.VARCHAR(255).notNull(),
+                                DataTypes.FLOAT(),
+                                DataTypes.VARCHAR(45),
+                                DataTypes.VARCHAR(55)
+                            },
+                            new String[] {"id", "name", "weight", "col1", "col2"});
+            BinaryRecordDataGenerator generator = new BinaryRecordDataGenerator(rowType);
+            // insert more data
+            statement.execute(
+                    String.format(
+                            "INSERT INTO `%s`.`products` VALUES (default,'scooter',5.5,'c-10','c-20');",
+                            databaseName)); // 110
+            expectedBinlog.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generator.generate(
+                                    new Object[] {
+                                        110,
+                                        BinaryStringData.fromString("scooter"),
+                                        5.5f,
+                                        BinaryStringData.fromString("c-10"),
+                                        BinaryStringData.fromString("c-20")
+                                    })));
+            statement.execute(
+                    String.format(
+                            "INSERT INTO `%s`.`products` VALUES (default,'football',6.6,'c-11','c-21');",
+                            databaseName)); // 111
+            expectedBinlog.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generator.generate(
+                                    new Object[] {
+                                        111,
+                                        BinaryStringData.fromString("football"),
+                                        6.6f,
+                                        BinaryStringData.fromString("c-11"),
+                                        BinaryStringData.fromString("c-21")
+                                    })));
+            statement.execute(
+                    String.format(
+                            "UPDATE `%s`.`products` SET `col1`='c-12', `col2`='c-22' WHERE id=110;",
+                            databaseName));
+            expectedBinlog.add(
+                    DataChangeEvent.updateEvent(
+                            tableId,
+                            generator.generate(
+                                    new Object[] {
+                                        110,
+                                        BinaryStringData.fromString("scooter"),
+                                        5.5f,
+                                        BinaryStringData.fromString("c-10"),
+                                        BinaryStringData.fromString("c-20")
+                                    }),
+                            generator.generate(
+                                    new Object[] {
+                                        110,
+                                        BinaryStringData.fromString("scooter"),
+                                        5.5f,
+                                        BinaryStringData.fromString("c-12"),
+                                        BinaryStringData.fromString("c-22")
+                                    })));
+            statement.execute(
+                    String.format("DELETE FROM `%s`.`products` WHERE `id` = 111;", databaseName));
+            expectedBinlog.add(
+                    DataChangeEvent.deleteEvent(
+                            tableId,
+                            generator.generate(
+                                    new Object[] {
+                                        111,
+                                        BinaryStringData.fromString("football"),
+                                        6.6f,
+                                        BinaryStringData.fromString("c-11"),
+                                        BinaryStringData.fromString("c-21")
+                                    })));
+            // Make some change of excluded tables.
+            statement.execute(
+                    String.format(
+                            "INSERT INTO `%s`.`customers` VALUES(1,\"Anne\",\"Kretchmar\",\"mark@noanswer.org\");",
+                            databaseName));
+            statement.execute(
+                    String.format(
+                            "INSERT INTO `%s`.`customers` VALUES(2,\"Anne\",\"Kretchmar\",\"mark2@noanswer.org\");",
+                            databaseName));
+        }
+        // In this configuration, several subtasks might emit their corresponding CreateTableEvent
+        // to downstream. Since it is not possible to predict how many CreateTableEvents should we
+        // expect, we simply filter them out from expected sets, and assert there's at least one.
+        List<Event> actual =
+                fetchResultsExcept(
+                        events, expectedSnapshot.size() + expectedBinlog.size(), createTableEvent);
+        assertThat(actual.subList(0, expectedSnapshot.size()))
+                .containsExactlyInAnyOrder(expectedSnapshot.toArray(new Event[0]));
+        assertThat(actual.subList(expectedSnapshot.size(), actual.size()))
+                .isEqualTo(expectedBinlog);
+    }
+
     private static <T> List<T> fetchResultsExcept(Iterator<T> iter, int size, T sideEvent) {
         List<T> result = new ArrayList<>(size);
         List<T> sideResults = new ArrayList<>();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.relational;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.Selectors.TableIdToStringMapper;
+import io.debezium.relational.Selectors.TableSelectionPredicateBuilder;
+import io.debezium.relational.Tables.TableFilter;
+import io.debezium.relational.history.DatabaseHistory;
+import io.debezium.schema.DataCollectionFilters;
+
+import java.util.function.Predicate;
+
+import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST;
+import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST;
+
+public class RelationalTableFilters implements DataCollectionFilters {
+
+    // Filter that filters tables based only on datbase/schema/system table filters but not table
+    // filters
+    // Represents the list of tables whose schema needs to be captured
+    private final TableFilter eligibleTableFilter;
+    // Filter that filters tables based on table filters
+    private TableFilter tableFilter;
+    private final Predicate<String> databaseFilter;
+    private final String excludeColumns;
+
+    /**
+     * Evaluate whether the table is eligible for schema snapshotting or not. This closely relates
+     * to fact whether only captured tables schema should be stored in database history or all
+     * tables schema.
+     */
+    private final TableFilter schemaSnapshotFilter;
+
+    public RelationalTableFilters(
+            Configuration config,
+            TableFilter systemTablesFilter,
+            TableIdToStringMapper tableIdMapper) {
+        // Define the filter that provides the list of tables that could be captured if configured
+        final TableSelectionPredicateBuilder eligibleTables =
+                Selectors.tableSelector()
+                        .includeDatabases(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.DATABASE_INCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.DATABASE_WHITELIST))
+                        .excludeDatabases(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.DATABASE_EXCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.DATABASE_BLACKLIST))
+                        .includeSchemas(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.SCHEMA_INCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.SCHEMA_WHITELIST))
+                        .excludeSchemas(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.SCHEMA_EXCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.SCHEMA_BLACKLIST));
+        final Predicate<TableId> eligibleTablePredicate = eligibleTables.build();
+
+        Predicate<TableId> finalEligibleTablePredicate =
+                config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
+                        ? eligibleTablePredicate.and(systemTablesFilter::isIncluded)
+                        : eligibleTablePredicate;
+
+        this.eligibleTableFilter = finalEligibleTablePredicate::test;
+
+        // Define the filter using the include and exclude lists for tables and database names ...
+        Predicate<TableId> tablePredicate =
+                eligibleTables
+                        .includeTables(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.TABLE_INCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.TABLE_WHITELIST),
+                                tableIdMapper)
+                        .excludeTables(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.TABLE_EXCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.TABLE_BLACKLIST),
+                                tableIdMapper)
+                        .build();
+
+        Predicate<TableId> finalTablePredicate =
+                config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
+                        ? tablePredicate.and(systemTablesFilter::isIncluded)
+                        : tablePredicate;
+
+        this.tableFilter = finalTablePredicate::test;
+
+        // Define the database filter using the include and exclude lists for database names ...
+        this.databaseFilter =
+                Selectors.databaseSelector()
+                        .includeDatabases(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.DATABASE_INCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.DATABASE_WHITELIST))
+                        .excludeDatabases(
+                                config.getFallbackStringProperty(
+                                        RelationalDatabaseConnectorConfig.DATABASE_EXCLUDE_LIST,
+                                        RelationalDatabaseConnectorConfig.DATABASE_BLACKLIST))
+                        .build();
+
+        Predicate<TableId> eligibleSchemaPredicate =
+                config.getBoolean(RelationalDatabaseConnectorConfig.TABLE_IGNORE_BUILTIN)
+                        ? systemTablesFilter::isIncluded
+                        : x -> true;
+
+        this.schemaSnapshotFilter =
+                config.getBoolean(DatabaseHistory.STORE_ONLY_CAPTURED_TABLES_DDL)
+                        ? eligibleSchemaPredicate.and(tableFilter::isIncluded)::test
+                        : eligibleSchemaPredicate::test;
+
+        this.excludeColumns =
+                config.getFallbackStringProperty(COLUMN_EXCLUDE_LIST, COLUMN_BLACKLIST);
+    }
+
+    @Override
+    public TableFilter dataCollectionFilter() {
+        return tableFilter;
+    }
+
+    public TableFilter eligibleDataCollectionFilter() {
+        return eligibleTableFilter;
+    }
+
+    public TableFilter eligibleForSchemaDataCollectionFilter() {
+        return schemaSnapshotFilter;
+    }
+
+    public Predicate<String> databaseFilter() {
+        return databaseFilter;
+    }
+
+    public String getExcludeColumns() {
+        return excludeColumns;
+    }
+
+    public void setDataCollectionFilters(TableFilter tableFilter) {
+        this.tableFilter = tableFilter;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
@@ -17,6 +17,11 @@ import java.util.function.Predicate;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_BLACKLIST;
 import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_EXCLUDE_LIST;
 
+/**
+ * Copied from Debezium 1.9.8.Final.
+ *
+ * <p>Line 146: add a method to update the tableFilter variable.
+ */
 public class RelationalTableFilters implements DataCollectionFilters {
 
     // Filter that filters tables based only on datbase/schema/system table filters but not table

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/DebeziumOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/DebeziumOptions.java
@@ -38,6 +38,11 @@ public class DebeziumOptions {
                                 debeziumProperties.put(subKey, value);
                             });
         }
+        if (properties.containsKey("table.include.list")
+                || properties.containsKey("table.exclude.list")) {
+            throw new IllegalArgumentException(
+                    "table.include.list and table.exclude.list are not supported to set manually, please remove these options.");
+        }
         return debeziumProperties;
     }
 


### PR DESCRIPTION
In binlog reading phase, we only use connectorConfig.getTableFilters().dataCollectionFilter() to filter Event.
However, if user has configured exclude.tables, we should use sourceConfig.getTableFilter() instead.