### PR TITLE
[hotfix][cdc-connector][test] Sleep to wait for the assign status to INITIAL_ASSIGNING_FINISHED so that newly added table won't be stuck.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MysqlPipelineNewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MysqlPipelineNewlyAddedTableITCase.java
@@ -351,6 +351,9 @@ class MysqlPipelineNewlyAddedTableITCase extends MySqlSourceTestBase {
             initialAddressTables(getConnection(), testParam.getSecondRoundInitTables());
         }
 
+        // sleep 1s to wait for the assign status to INITIAL_ASSIGNING_FINISHED.
+        // Otherwise, the restart job won't read newly added tables, and this test will be stuck.
+        Thread.sleep(1000L);
         // step 4: trigger a savepoint and cancel the job
         finishedSavePointPath = triggerSavepointWithRetry(jobClient, savepointDirectory);
         jobClient.cancel().get();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/NewlyAddedTableITCase.java
@@ -578,6 +578,10 @@ class NewlyAddedTableITCase extends MongoDBSourceTestBase {
             MongoDBTestUtils.waitForSinkSize("sink", fetchedDataList.size());
             MongoDBAssertUtils.assertEqualsInAnyOrder(
                     fetchedDataList, TestValuesTableFactory.getRawResultsAsStrings("sink"));
+            // sleep 1s to wait for the assign status to INITIAL_ASSIGNING_FINISHED.
+            // Otherwise, the restart job won't read newly added tables, and this test will be
+            // stuck.
+            Thread.sleep(1000L);
             finishedSavePointPath = triggerSavepointWithRetry(jobClient, savepointDirectory);
             jobClient.cancel().get();
         }
@@ -824,7 +828,7 @@ class NewlyAddedTableITCase extends MongoDBSourceTestBase {
             waitForUpsertSinkSize("sink", fetchedDataList.size());
             // the result size of sink may arrive fetchedDataList.size() with old data, wait one
             // checkpoint to wait retract old record and send new record
-            Thread.sleep(1000);
+            Thread.sleep(1000L);
             MongoDBAssertUtils.assertEqualsInAnyOrder(
                     fetchedDataList, TestValuesTableFactory.getResultsAsStrings("sink"));
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/NewlyAddedTableITCase.java
@@ -636,6 +636,11 @@ class NewlyAddedTableITCase extends MySqlSourceTestBase {
             waitForSinkSize("sink", fetchedDataList.size());
             assertEqualsInAnyOrder(
                     fetchedDataList, TestValuesTableFactory.getRawResultsAsStrings("sink"));
+
+            // sleep 1s to wait for the assign status to INITIAL_ASSIGNING_FINISHED.
+            // Otherwise, the restart job won't read newly added tables, and this test will be
+            // stuck.
+            Thread.sleep(1000L);
             finishedSavePointPath = triggerSavepointWithRetry(jobClient, savepointDirectory);
             jobClient.cancel().get();
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlConnectorITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlConnectorITCase.java
@@ -65,7 +65,7 @@ import java.util.stream.Stream;
 import static org.apache.flink.api.common.JobStatus.RUNNING;
 import static org.apache.flink.cdc.connectors.mysql.LegacyMySqlSourceTest.currentMySqlLatestOffset;
 import static org.apache.flink.cdc.connectors.mysql.MySqlTestUtils.waitForJobStatus;
-import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Integration tests for MySQL Table source. */
 class MySqlConnectorITCase extends MySqlSourceTestBase {
@@ -330,8 +330,8 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
 
         // async submit job
         TableResult result = tEnv.executeSql("INSERT INTO sink SELECT * FROM debezium_source");
-        // wait until the snapshot phase finished
-        waitForSinkSize("sink", 11);
+        // wait until the snapshot phase finished so that binlog will be read later in binlog phase.
+        waitForSinkSize("sink", 12);
 
         try (Connection connection = inventoryDatabase.getJdbcConnection();
                 Statement statement = connection.createStatement()) {
@@ -410,7 +410,7 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
     void testCheckpointIsOptionalUnderSingleParallelism(boolean incrementalSnapshot)
             throws Exception {
         setup(incrementalSnapshot);
-        assumeThat(incrementalSnapshot).isTrue();
+        assertThat(incrementalSnapshot).isTrue();
         env.setParallelism(1);
         // check the checkpoint is optional when parallelism is 1
         env.getCheckpointConfig().disableCheckpointing();
@@ -917,7 +917,7 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
                 Lists.newArrayList("+U[0, 1024]", "+U[1, 1025]", "+U[2, 2048]", "+U[3, 2049]"));
 
         List<String> actual = TestValuesTableFactory.getRawResultsAsStrings("sink");
-        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
         result.getJobClient().get().cancel().get();
     }
 
@@ -1021,7 +1021,7 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
         //  keyby shuffle before "values" upsert sink. We should assert merged result once
         //  https://issues.apache.org/jira/browse/FLINK-24511 is fixed.
         List<String> actual = TestValuesTableFactory.getRawResultsAsStrings("sink");
-        Assertions.assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
         result.getJobClient().get().cancel().get();
     }
 
@@ -2004,7 +2004,7 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
     @ValueSource(booleans = {true, false})
     void testReadingWithMultiMaxValue(boolean incrementalSnapshot) throws Exception {
         setup(incrementalSnapshot);
-        assumeThat(incrementalSnapshot).isTrue();
+        assertThat(incrementalSnapshot).isTrue();
         inventoryDatabase.createAndInitialize();
         String sourceDDL =
                 String.format(
@@ -2134,7 +2134,7 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
     @ValueSource(booleans = {true, false})
     void testBinlogTableMetadataDeserialization(boolean incrementalSnapshot) throws Exception {
         setup(incrementalSnapshot);
-        assumeThat(incrementalSnapshot).isTrue();
+        assertThat(incrementalSnapshot).isTrue();
         binlogDatabase.createAndInitialize();
         String sourceDDL =
                 String.format(
@@ -2284,7 +2284,7 @@ class MySqlConnectorITCase extends MySqlSourceTestBase {
     @ParameterizedTest(name = "incrementalSnapshot = {0}")
     @ValueSource(booleans = {true, false})
     void testBinaryHandlingModeWithBase64(boolean incrementalSnapshot) throws Exception {
-        assumeThat(incrementalSnapshot).isTrue();
+        assertThat(incrementalSnapshot).isTrue();
         setup(incrementalSnapshot);
         inventoryDatabase.createAndInitialize();
         String sourceDDL =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/NewlyAddedTableITCase.java
@@ -492,7 +492,9 @@ class NewlyAddedTableITCase extends OracleSourceTestBase {
             waitForSinkSize("sink", fetchedDataList.size());
             assertEqualsInAnyOrder(
                     fetchedDataList, TestValuesTableFactory.getRawResultsAsStrings("sink"));
-            // wait task to stream phase
+            // sleep 10s to wait for the assign status to INITIAL_ASSIGNING_FINISHED.
+            // Otherwise, the restart job won't read newly added tables, and this test will be
+            // stuck.
             sleepMs(10000);
             finishedSavePointPath = triggerSavepointWithRetry(jobClient, savepointDirectory);
             jobClient.cancel().get();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/NewlyAddedTableITCase.java
@@ -525,6 +525,10 @@ class NewlyAddedTableITCase extends PostgresTestBase {
             waitForSinkSize("sink", fetchedDataList.size());
             assertEqualsInAnyOrder(
                     fetchedDataList, TestValuesTableFactory.getRawResultsAsStrings("sink"));
+            // sleep 1s to wait for the assign status to INITIAL_ASSIGNING_FINISHED.
+            // Otherwise, the restart job won't read newly added tables, and this test will be
+            // stuck.
+            Thread.sleep(1000L);
             finishedSavePointPath = triggerSavepointWithRetry(jobClient, savepointDirectory);
             jobClient.cancel().get();
         }


### PR DESCRIPTION
Currenly, tests are often stuck in removing table test . The reason, when getting all the data of snapshot split, the assigned status maybe still not changed to INITIAL_ASSIGNING_FINISHED. If stop and restart job now, the table won't be removed.

<img width="675" alt="image" src="https://github.com/user-attachments/assets/288ef6fb-2188-41f3-bb59-70a50c1dea25" />
