### PR TITLE
[FLINK-37653] Refactor incremental snapshot framework to support multiple stream splits

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/dialect/DataSourceDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/dialect/DataSourceDialect.java
@@ -85,6 +85,11 @@ public interface DataSourceDialect<C extends SourceConfig> extends Serializable,
     /** Check if the tableId is included in SourceConfig. */
     boolean isIncludeDataCollection(C sourceConfig, TableId tableId);
 
+    /** Determine the number of stream splits. */
+    default int getNumberOfStreamSplits(C sourceConfig) {
+        return 1;
+    }
+
     @Override
     default void close() throws IOException {}
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/IncrementalSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/IncrementalSource.java
@@ -168,12 +168,16 @@ public class IncrementalSource<T, C extends SourceConfig>
             }
         } else {
             splitAssigner =
-                    new StreamSplitAssigner(
+                    new StreamSplitAssigner<>(
                             sourceConfig, dataSourceDialect, offsetFactory, enumContext);
         }
 
         return new IncrementalSourceEnumerator(
-                enumContext, sourceConfig, splitAssigner, getBoundedness());
+                enumContext,
+                sourceConfig,
+                splitAssigner,
+                getBoundedness(),
+                dataSourceDialect.getNumberOfStreamSplits(sourceConfig));
     }
 
     @Override
@@ -205,7 +209,11 @@ public class IncrementalSource<T, C extends SourceConfig>
         }
 
         return new IncrementalSourceEnumerator(
-                enumContext, sourceConfig, splitAssigner, getBoundedness());
+                enumContext,
+                sourceConfig,
+                splitAssigner,
+                getBoundedness(),
+                dataSourceDialect.getNumberOfStreamSplits(sourceConfig));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -28,6 +28,7 @@ import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSp
 import org.apache.flink.cdc.connectors.base.source.meta.split.SchemalessSnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.base.source.metrics.SourceEnumeratorMetrics;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
@@ -628,7 +629,7 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
     }
 
     @Override
-    public void onStreamSplitUpdated() {
+    public void onStreamSplitUpdated(StreamSplit streamSplit) {
         Preconditions.checkState(
                 isNewlyAddedAssigningSnapshotFinished(assignerStatus),
                 "Invalid assigner status %s",

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SplitAssigner.java
@@ -23,6 +23,7 @@ import org.apache.flink.cdc.connectors.base.source.assigner.state.PendingSplitsS
 import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
 import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -116,7 +117,7 @@ public interface SplitAssigner extends Closeable {
      * Callback to handle the stream split has been updated in the newly added tables process. This
      * is useful to check the newly added tables has been finished or not.
      */
-    void onStreamSplitUpdated();
+    void onStreamSplitUpdated(StreamSplit streamSplit);
 
     /**
      * Called to close the assigner, in case it holds on to any resources, like threads or network

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitAssignedEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitAssignedEvent.java
@@ -22,13 +22,43 @@ import org.apache.flink.cdc.connectors.base.source.enumerator.IncrementalSourceE
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReader;
 
+import java.util.Objects;
+
 /**
  * The {@link SourceEvent} that {@link IncrementalSourceReader} sends to {@link
  * IncrementalSourceEnumerator} to notify the {@link StreamSplit} assigned to itself.
  */
 public class StreamSplitAssignedEvent implements SourceEvent {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    public StreamSplitAssignedEvent() {}
+    private final StreamSplit streamSplit;
+
+    public StreamSplitAssignedEvent(StreamSplit streamSplit) {
+        this.streamSplit = streamSplit;
+    }
+
+    public StreamSplit getStreamSplit() {
+        return streamSplit;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof StreamSplitAssignedEvent)) {
+            return false;
+        }
+
+        StreamSplitAssignedEvent that = (StreamSplitAssignedEvent) o;
+        return Objects.equals(streamSplit, that.streamSplit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(streamSplit);
+    }
+
+    @Override
+    public String toString() {
+        return "StreamSplitAssignedEvent{" + "streamSplit=" + streamSplit + '}';
+    }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitUpdateAckEvent.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/events/StreamSplitUpdateAckEvent.java
@@ -19,7 +19,10 @@ package org.apache.flink.cdc.connectors.base.source.meta.events;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReader;
+
+import java.util.Objects;
 
 /**
  * The {@link SourceEvent} that {@link IncrementalSourceReader} sends to {@link
@@ -27,7 +30,35 @@ import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReade
  */
 public class StreamSplitUpdateAckEvent implements SourceEvent {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
-    public StreamSplitUpdateAckEvent() {}
+    private final StreamSplit streamSplit;
+
+    public StreamSplitUpdateAckEvent(StreamSplit streamSplit) {
+        this.streamSplit = streamSplit;
+    }
+
+    public StreamSplit getStreamSplit() {
+        return streamSplit;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof StreamSplitUpdateAckEvent)) {
+            return false;
+        }
+
+        StreamSplitUpdateAckEvent that = (StreamSplitUpdateAckEvent) o;
+        return Objects.equals(streamSplit, that.streamSplit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(streamSplit);
+    }
+
+    @Override
+    public String toString() {
+        return "StreamSplitUpdateAckEvent{" + "streamSplit=" + streamSplit + '}';
+    }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceReader.java
@@ -312,7 +312,7 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
 
                 LOG.info(
                         "Source reader {} received the stream split : {}.", subtaskId, streamSplit);
-                context.sendSourceEventToCoordinator(new StreamSplitAssignedEvent());
+                context.sendSourceEventToCoordinator(new StreamSplitAssignedEvent(streamSplit));
             }
         }
         // notify split enumerator again about the finished unacked snapshot splits
@@ -488,7 +488,7 @@ public class IncrementalSourceReader<T, C extends SourceConfig>
             suspendedStreamSplit = null;
             this.addSplits(Collections.singletonList(streamSplit), false);
 
-            context.sendSourceEventToCoordinator(new StreamSplitUpdateAckEvent());
+            context.sendSourceEventToCoordinator(new StreamSplitUpdateAckEvent(streamSplit));
             LOG.info(
                     "Source reader {} notifies enumerator that stream split has been updated.",
                     subtaskId);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/IncrementalSourceSplitReader.java
@@ -198,7 +198,7 @@ public class IncrementalSourceSplitReader<C extends SourceConfig>
                     LOG.info("It's turn to switch next fetch reader to snapshot split reader");
                     submitSnapshotSplit(nextSplit);
                 }
-                return ChangeEventRecords.forRecords(STREAM_SPLIT_ID, dataIt);
+                return ChangeEventRecords.forRecords(currentSplitId, dataIt);
             } else {
                 // null will be returned after receiving suspend stream event
                 // finish current stream split reading

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedChunkSplitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedChunkSplitter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.source.assigner.splitter.ChunkSplitter;
+import org.apache.flink.cdc.connectors.base.source.assigner.state.ChunkSplitterState;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.logical.RowType;
+
+import io.debezium.relational.TableId;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/** Mocked {@link ChunkSplitter}. */
+public class MockedChunkSplitter implements ChunkSplitter {
+
+    private final MockedConfig sourceConfig;
+    private final MockedDatabase mockedDatabase;
+
+    public MockedChunkSplitter(MockedConfig sourceConfig, MockedDatabase mockedDatabase) {
+        this.sourceConfig = sourceConfig;
+        this.mockedDatabase = mockedDatabase;
+    }
+
+    @Override
+    public Collection<SnapshotSplit> generateSplits(TableId tableId) {
+        long recordCount = sourceConfig.getRecordCount();
+        int chunkSize = sourceConfig.getSplitSize();
+
+        if (recordCount < chunkSize) {
+            return Collections.singletonList(
+                    new SnapshotSplit(
+                            tableId,
+                            0,
+                            RowType.of(DataTypes.BIGINT().getLogicalType()),
+                            new Object[] {Long.MIN_VALUE},
+                            new Object[] {Long.MAX_VALUE},
+                            null,
+                            mockedDatabase.retrieveSchemas(Collections.singletonList(tableId))));
+        }
+
+        int splitCount = (int) Math.ceil((double) recordCount / chunkSize);
+        List<SnapshotSplit> splits = new ArrayList<>(splitCount);
+
+        for (int i = 0; i < splitCount; i++) {
+            long currentMin = i == 0 ? Long.MIN_VALUE : (long) chunkSize * i;
+            long currentMax = i == splitCount - 1 ? Long.MAX_VALUE : (long) chunkSize * (i + 1);
+            splits.add(
+                    new SnapshotSplit(
+                            tableId,
+                            0,
+                            RowType.of(DataTypes.BIGINT().getLogicalType()),
+                            new Object[] {currentMin},
+                            new Object[] {currentMax},
+                            null,
+                            mockedDatabase.retrieveSchemas(Collections.singletonList(tableId))));
+        }
+
+        return splits;
+    }
+
+    @Override
+    public void open() {}
+
+    @Override
+    public void close() throws Exception {}
+
+    // Mocked chunk splitter doesn't support asynchronously split.
+    @Override
+    public boolean hasNextChunk() {
+        return false;
+    }
+
+    @Override
+    public ChunkSplitterState snapshotState(long checkpointId) {
+        return ChunkSplitterState.NO_SPLITTING_TABLE_STATE;
+    }
+
+    @Override
+    public TableId getCurrentSplittingTableId() {
+        return null;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedConfig.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.config.SourceConfig;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/** Mocked {@link SourceConfig}. */
+public class MockedConfig implements SourceConfig {
+
+    private final long tableCount;
+    private final long recordCount;
+    private final Duration refreshInterval;
+    private final StartupOptions startupOptions;
+    private final int splitSize;
+    private final int splitMetaGroupSize;
+    private final boolean closeIdleReaders;
+    private final boolean skipSnapshotBackfill;
+    private final boolean scanNewlyAddedTableEnabled;
+    private final boolean assignUnboundedChunkFirst;
+    private final boolean multipleStreamSplitsEnabled;
+
+    MockedConfig(
+            long tableCount,
+            long recordCount,
+            Duration refreshInterval,
+            StartupOptions startupOptions,
+            int splitSize,
+            int splitMetaGroupSize,
+            boolean closeIdleReaders,
+            boolean skipSnapshotBackfill,
+            boolean scanNewlyAddedTableEnabled,
+            boolean assignUnboundedChunkFirst,
+            boolean multipleStreamSplitsEnabled) {
+        this.tableCount = tableCount;
+        this.recordCount = recordCount;
+        this.refreshInterval = refreshInterval;
+        this.startupOptions = startupOptions;
+        this.splitSize = splitSize;
+        this.splitMetaGroupSize = splitMetaGroupSize;
+        this.closeIdleReaders = closeIdleReaders;
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
+        this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
+        this.assignUnboundedChunkFirst = assignUnboundedChunkFirst;
+        this.multipleStreamSplitsEnabled = multipleStreamSplitsEnabled;
+    }
+
+    public long getTableCount() {
+        return tableCount;
+    }
+
+    public long getRecordCount() {
+        return recordCount;
+    }
+
+    public Duration getRefreshInterval() {
+        return refreshInterval;
+    }
+
+    @Override
+    public StartupOptions getStartupOptions() {
+        return startupOptions;
+    }
+
+    @Override
+    public int getSplitSize() {
+        return splitSize;
+    }
+
+    @Override
+    public int getSplitMetaGroupSize() {
+        return splitMetaGroupSize;
+    }
+
+    @Override
+    public boolean isIncludeSchemaChanges() {
+        return false;
+    }
+
+    @Override
+    public boolean isCloseIdleReaders() {
+        return closeIdleReaders;
+    }
+
+    @Override
+    public boolean isSkipSnapshotBackfill() {
+        return skipSnapshotBackfill;
+    }
+
+    @Override
+    public boolean isScanNewlyAddedTableEnabled() {
+        return scanNewlyAddedTableEnabled;
+    }
+
+    @Override
+    public boolean isAssignUnboundedChunkFirst() {
+        return assignUnboundedChunkFirst;
+    }
+
+    public boolean isMultipleStreamSplitsEnabled() {
+        return multipleStreamSplitsEnabled;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (!(o instanceof MockedConfig)) {
+            return false;
+        }
+
+        MockedConfig that = (MockedConfig) o;
+        return tableCount == that.tableCount
+                && recordCount == that.recordCount
+                && splitSize == that.splitSize
+                && splitMetaGroupSize == that.splitMetaGroupSize
+                && closeIdleReaders == that.closeIdleReaders
+                && skipSnapshotBackfill == that.skipSnapshotBackfill
+                && scanNewlyAddedTableEnabled == that.scanNewlyAddedTableEnabled
+                && assignUnboundedChunkFirst == that.assignUnboundedChunkFirst
+                && Objects.equals(refreshInterval, that.refreshInterval)
+                && Objects.equals(startupOptions, that.startupOptions)
+                && multipleStreamSplitsEnabled == that.multipleStreamSplitsEnabled;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                tableCount,
+                recordCount,
+                refreshInterval,
+                startupOptions,
+                splitSize,
+                splitMetaGroupSize,
+                closeIdleReaders,
+                skipSnapshotBackfill,
+                scanNewlyAddedTableEnabled,
+                assignUnboundedChunkFirst,
+                multipleStreamSplitsEnabled);
+    }
+
+    @Override
+    public String toString() {
+        return "MockedConfig{"
+                + "tableCount="
+                + tableCount
+                + ", recordCount="
+                + recordCount
+                + ", refreshInterval="
+                + refreshInterval
+                + ", startupOptions="
+                + startupOptions
+                + ", splitSize="
+                + splitSize
+                + ", splitMetaGroupSize="
+                + splitMetaGroupSize
+                + ", closeIdleReaders="
+                + closeIdleReaders
+                + ", skipSnapshotBackfill="
+                + skipSnapshotBackfill
+                + ", scanNewlyAddedTableEnabled="
+                + scanNewlyAddedTableEnabled
+                + ", assignUnboundedChunkFirst="
+                + assignUnboundedChunkFirst
+                + ", multipleStreamSplitsEnabled="
+                + multipleStreamSplitsEnabled
+                + '}';
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedConfigFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.config.SourceConfig.Factory;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+
+import java.time.Duration;
+
+/** {@link Factory} class for {@link MockedConfig}. */
+public class MockedConfigFactory implements Factory<MockedConfig> {
+
+    private long tableCount;
+    private long recordCount;
+    private Duration refreshInterval;
+    private StartupOptions startupOptions;
+    private int splitSize;
+    private int splitMetaGroupSize;
+    private boolean closeIdleReaders;
+    private boolean skipSnapshotBackfill;
+    private boolean scanNewlyAddedTableEnabled;
+    private boolean assignUnboundedChunkFirst;
+    private boolean multipleStreamSplitsEnabled;
+
+    public MockedConfigFactory setTableCount(long tableCount) {
+        this.tableCount = tableCount;
+        return this;
+    }
+
+    public MockedConfigFactory setRecordCount(long recordCount) {
+        this.recordCount = recordCount;
+        return this;
+    }
+
+    public MockedConfigFactory setRefreshInterval(Duration refreshInterval) {
+        this.refreshInterval = refreshInterval;
+        return this;
+    }
+
+    public MockedConfigFactory setStartupOptions(StartupOptions startupOptions) {
+        this.startupOptions = startupOptions;
+        return this;
+    }
+
+    public MockedConfigFactory setSplitSize(int splitSize) {
+        this.splitSize = splitSize;
+        return this;
+    }
+
+    public MockedConfigFactory setSplitMetaGroupSize(int splitMetaGroupSize) {
+        this.splitMetaGroupSize = splitMetaGroupSize;
+        return this;
+    }
+
+    public MockedConfigFactory setCloseIdleReaders(boolean closeIdleReaders) {
+        this.closeIdleReaders = closeIdleReaders;
+        return this;
+    }
+
+    public MockedConfigFactory setSkipSnapshotBackfill(boolean skipSnapshotBackfill) {
+        this.skipSnapshotBackfill = skipSnapshotBackfill;
+        return this;
+    }
+
+    public MockedConfigFactory setScanNewlyAddedTableEnabled(boolean scanNewlyAddedTableEnabled) {
+        this.scanNewlyAddedTableEnabled = scanNewlyAddedTableEnabled;
+        return this;
+    }
+
+    public MockedConfigFactory setAssignUnboundedChunkFirst(boolean assignUnboundedChunkFirst) {
+        this.assignUnboundedChunkFirst = assignUnboundedChunkFirst;
+        return this;
+    }
+
+    public MockedConfigFactory setMultipleStreamSplitsEnabled(boolean multipleStreamSplitsEnabled) {
+        this.multipleStreamSplitsEnabled = multipleStreamSplitsEnabled;
+        return this;
+    }
+
+    @Override
+    public MockedConfig create(int subtask) {
+        return new MockedConfig(
+                tableCount,
+                recordCount,
+                refreshInterval,
+                startupOptions,
+                splitSize,
+                splitMetaGroupSize,
+                closeIdleReaders,
+                skipSnapshotBackfill,
+                scanNewlyAddedTableEnabled,
+                assignUnboundedChunkFirst,
+                multipleStreamSplitsEnabled);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedDatabase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedDatabase.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.types.RowKind;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit.STREAM_SPLIT_ID;
+import static org.apache.flink.types.RowKind.DELETE;
+import static org.apache.flink.types.RowKind.INSERT;
+import static org.apache.flink.types.RowKind.UPDATE_AFTER;
+import static org.apache.flink.types.RowKind.UPDATE_BEFORE;
+
+/** A dummy database that supports generating snapshot & split data. */
+public class MockedDatabase implements Serializable {
+
+    private final long tableCount;
+    private final long recordCount;
+    private final Duration refreshInterval;
+    private static volatile List<Tuple2<TableId, GenericRowData>> mockedEvents;
+    private static volatile long currentOffset;
+    private @Nullable Thread thread;
+
+    public MockedDatabase(long tableCount, long recordCount, Duration refreshInterval) {
+        this.tableCount = tableCount;
+        this.recordCount = recordCount;
+        this.refreshInterval = refreshInterval;
+    }
+
+    private List<Tuple2<TableId, GenericRowData>> getMockedEvents() {
+        if (mockedEvents == null) {
+            mockedEvents = generateMockedEvents(tableCount, recordCount);
+        }
+        return mockedEvents;
+    }
+
+    public long getCurrentOffset() {
+        synchronized (this) {
+            return currentOffset;
+        }
+    }
+
+    public List<TableId> getTableIds() {
+        return generateTableIds(tableCount);
+    }
+
+    public Map<TableId, TableChanges.TableChange> getTableIdsAndSchema() {
+        return getTableIds().stream()
+                .collect(Collectors.toMap(Function.identity(), this::getSchema));
+    }
+
+    public Map<TableId, TableChanges.TableChange> retrieveSchemas(List<TableId> tableIds) {
+        return tableIds.stream().collect(Collectors.toMap(Function.identity(), this::getSchema));
+    }
+
+    private TableChanges.TableChange getSchema(TableId tableId) {
+        Table table =
+                Table.editor()
+                        .tableId(tableId)
+                        .addColumn(Column.editor().name("id").optional(false).create())
+                        .addColumn(Column.editor().name("desc").optional(true).create())
+                        .setPrimaryKeyNames("id")
+                        .create();
+        return new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
+    }
+
+    public Tuple2<Long, List<RowData>> takeSnapshot(TableId tableId, long minRange, long maxRange) {
+        long currentOffset = getCurrentOffset();
+        Map<Long, GenericRowData> snapshot = new HashMap<>();
+        getMockedEvents().stream()
+                .limit(currentOffset)
+                .filter(rec -> rec.f0.equals(tableId))
+                .map(rec -> rec.f1)
+                .forEach(
+                        rowData -> {
+                            RowKind rowKind = rowData.getRowKind();
+                            long pkValue = rowData.getLong(0);
+                            if (pkValue < minRange || pkValue >= maxRange) {
+                                return;
+                            }
+                            if (rowKind == INSERT || rowKind == UPDATE_AFTER) {
+                                snapshot.put(pkValue, rowData);
+                            } else if (rowKind == UPDATE_BEFORE || rowKind == DELETE) {
+                                snapshot.remove(pkValue);
+                            }
+                        });
+        return Tuple2.of(currentOffset, new ArrayList<>(snapshot.values()));
+    }
+
+    public Tuple2<Long, List<Tuple3<TableId, Long, GenericRowData>>> pollStreamValues(
+            @Nullable TableId tableId,
+            long sinceOffset,
+            long endingOffset,
+            @Nullable Integer splitIndex,
+            int totalSplit) {
+        synchronized (this) {
+            long maxOffset = Math.min(endingOffset, getCurrentOffset());
+
+            List<Tuple2<TableId, GenericRowData>> events = getMockedEvents();
+            List<Tuple3<TableId, Long, GenericRowData>> producedEvents = new ArrayList<>();
+
+            for (long i = sinceOffset; i < Math.min(maxOffset, events.size()); i++) {
+                Tuple2<TableId, GenericRowData> evt = events.get((int) i);
+                if (tableId != null && !tableId.equals(evt.f0)) {
+                    continue;
+                }
+                long primaryKey = evt.f1.getLong(0);
+                if (splitIndex != null && Math.floorMod(primaryKey, totalSplit) != splitIndex) {
+                    continue;
+                }
+                producedEvents.add(Tuple3.of(evt.f0, i, evt.f1));
+            }
+
+            return Tuple2.of(maxOffset, producedEvents);
+        }
+    }
+
+    public long count(TableId tableId) {
+        return takeSnapshot(tableId, Long.MIN_VALUE, Long.MAX_VALUE).f1.size();
+    }
+
+    public void start(long startingOffset) {
+        currentOffset = startingOffset;
+        thread =
+                new Thread(
+                        () -> {
+                            while (true) {
+                                synchronized (this) {
+                                    currentOffset++;
+                                }
+                                try {
+                                    Thread.sleep(refreshInterval.toMillis());
+                                } catch (InterruptedException e) {
+                                    // Gracefully stop
+                                    return;
+                                }
+                            }
+                        });
+        thread.start();
+    }
+
+    public void stop() {
+        if (thread != null) {
+            thread.interrupt();
+        }
+        currentOffset = 0;
+    }
+
+    private List<TableId> generateTableIds(long tableCount) {
+        return LongStream.rangeClosed(1, tableCount)
+                .mapToObj(tableId -> new TableId("mock_ns", "mock_scm", "table_" + tableId))
+                .collect(Collectors.toList());
+    }
+
+    private List<Tuple2<TableId, GenericRowData>> generateMockedEvents(
+            long tableCount, long recordCount) {
+        List<TableId> tableIds = generateTableIds(tableCount);
+        List<Tuple2<TableId, GenericRowData>> generatedRowData = new ArrayList<>();
+        for (long i = 1; i < recordCount + 1; i++) {
+            final long index = i;
+            tableIds.forEach(
+                    tableId ->
+                            generatedRowData.add(
+                                    Tuple2.of(
+                                            tableId,
+                                            GenericRowData.ofKind(
+                                                    INSERT, index, wrap("INITIAL_" + tableId)))));
+        }
+        for (long i = 1; i < recordCount + 1; i++) {
+            final long index = -i;
+            tableIds.forEach(
+                    tableId -> {
+                        generatedRowData.add(
+                                Tuple2.of(
+                                        tableId,
+                                        GenericRowData.ofKind(
+                                                INSERT, index, wrap("INSERT_" + tableId))));
+                        generatedRowData.add(
+                                Tuple2.of(
+                                        tableId,
+                                        GenericRowData.ofKind(
+                                                UPDATE_BEFORE, index, wrap("INSERT_" + tableId))));
+                        generatedRowData.add(
+                                Tuple2.of(
+                                        tableId,
+                                        GenericRowData.ofKind(
+                                                UPDATE_AFTER, index, wrap("UPDATE_" + tableId))));
+                        generatedRowData.add(
+                                Tuple2.of(
+                                        tableId,
+                                        GenericRowData.ofKind(
+                                                DELETE, index, wrap("UPDATE_" + tableId))));
+                    });
+        }
+        return generatedRowData;
+    }
+
+    private static StringData wrap(String str) {
+        return StringData.fromString(str);
+    }
+
+    public static List<SourceSplitBase> createStreamSplits(
+            MockedConfig config,
+            Offset minOffset,
+            Offset stoppingOffset,
+            List<FinishedSnapshotSplitInfo> finishedSnapshotSplitInfos,
+            Map<TableId, TableChanges.TableChange> tableSchemas,
+            int totalFinishedSplitSize,
+            boolean isSuspended,
+            boolean isSnapshotCompleted) {
+        if (stoppingOffset.isAtOrAfter(MockedOffset.MAX)
+                && config.isMultipleStreamSplitsEnabled()) {
+            List<SourceSplitBase> splits = new ArrayList<>();
+
+            for (int i = 0; i < 4; i++) {
+                splits.add(
+                        new StreamSplit(
+                                STREAM_SPLIT_ID + "-" + i,
+                                minOffset,
+                                stoppingOffset,
+                                finishedSnapshotSplitInfos,
+                                tableSchemas,
+                                totalFinishedSplitSize,
+                                isSuspended,
+                                isSnapshotCompleted));
+            }
+
+            return splits;
+        } else {
+            return Collections.singletonList(
+                    new StreamSplit(
+                            STREAM_SPLIT_ID,
+                            minOffset,
+                            stoppingOffset,
+                            finishedSnapshotSplitInfos,
+                            tableSchemas,
+                            totalFinishedSplitSize,
+                            isSuspended,
+                            isSnapshotCompleted));
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedDialect.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.config.SourceConfig;
+import org.apache.flink.cdc.connectors.base.dialect.DataSourceDialect;
+import org.apache.flink.cdc.connectors.base.source.assigner.splitter.ChunkSplitter;
+import org.apache.flink.cdc.connectors.base.source.assigner.state.ChunkSplitterState;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import java.util.List;
+import java.util.Map;
+
+/** {@link DataSourceDialect} for mocked source. */
+public class MockedDialect implements DataSourceDialect<MockedConfig> {
+
+    private final MockedDatabase mockedDatabase;
+
+    public MockedDialect(SourceConfig.Factory<MockedConfig> configFactory) {
+        MockedConfig config = configFactory.create(-1);
+        this.mockedDatabase =
+                new MockedDatabase(
+                        config.getTableCount(),
+                        config.getRecordCount(),
+                        config.getRefreshInterval());
+    }
+
+    @Override
+    public String getName() {
+        return "mocked";
+    }
+
+    public MockedDatabase getMockedDatabase() {
+        return mockedDatabase;
+    }
+
+    @Override
+    public List<TableId> discoverDataCollections(MockedConfig sourceConfig) {
+        return mockedDatabase.getTableIds();
+    }
+
+    @Override
+    public Map<TableId, TableChanges.TableChange> discoverDataCollectionSchemas(
+            MockedConfig sourceConfig) {
+        return mockedDatabase.getTableIdsAndSchema();
+    }
+
+    @Override
+    public Offset displayCurrentOffset(MockedConfig sourceConfig) {
+        return new MockedOffset(mockedDatabase.getCurrentOffset());
+    }
+
+    @Override
+    public boolean isDataCollectionIdCaseSensitive(MockedConfig sourceConfig) {
+        return true;
+    }
+
+    @Override
+    public ChunkSplitter createChunkSplitter(MockedConfig sourceConfig) {
+        return new MockedChunkSplitter(sourceConfig, mockedDatabase);
+    }
+
+    @Override
+    public ChunkSplitter createChunkSplitter(
+            MockedConfig sourceConfig, ChunkSplitterState chunkSplitterState) {
+        return createChunkSplitter(sourceConfig);
+    }
+
+    @Override
+    public FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase) {
+        if (sourceSplitBase.isSnapshotSplit()) {
+            return new MockedSnapshotFetchTask(sourceSplitBase.asSnapshotSplit());
+        } else {
+            return new MockedStreamFetchTask(sourceSplitBase.asStreamSplit());
+        }
+    }
+
+    @Override
+    public FetchTask.Context createFetchTaskContext(MockedConfig sourceConfig) {
+        return new MockedFetchTaskContext(this, sourceConfig);
+    }
+
+    @Override
+    public int getNumberOfStreamSplits(MockedConfig sourceConfig) {
+        return sourceConfig.isMultipleStreamSplitsEnabled() ? 4 : 1;
+    }
+
+    @Override
+    public boolean isIncludeDataCollection(MockedConfig sourceConfig, TableId tableId) {
+        return mockedDatabase.getTableIds().contains(tableId);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedFetchTaskContext.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.config.SourceConfig;
+import org.apache.flink.cdc.connectors.base.dialect.DataSourceDialect;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.util.LoggingContext;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isWatermarkEvent;
+
+/** {@link FetchTask.Context} of mocked source. */
+public class MockedFetchTaskContext implements FetchTask.Context {
+
+    private final MockedDialect dialect;
+    private final MockedConfig sourceConfig;
+
+    private ChangeEventQueue<DataChangeEvent> changeEventQueue;
+
+    public MockedFetchTaskContext(MockedDialect dialect, MockedConfig sourceConfig) {
+        this.dialect = dialect;
+        this.sourceConfig = sourceConfig;
+    }
+
+    @Override
+    public void configure(SourceSplitBase sourceSplitBase) {
+        this.changeEventQueue =
+                new ChangeEventQueue.Builder<DataChangeEvent>()
+                        .pollInterval(Duration.ofMillis(50))
+                        .maxBatchSize(10)
+                        .maxQueueSize(10)
+                        .loggingContextSupplier(
+                                () ->
+                                        LoggingContext.forConnector(
+                                                "mocked",
+                                                "mocked-connector",
+                                                "mocked-connector-task"))
+                        // do not buffer any element, we use signal event
+                        // .buffering()
+                        .build();
+    }
+
+    @Override
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return changeEventQueue;
+    }
+
+    @Override
+    public TableId getTableId(SourceRecord record) {
+        return TableId.parse(record.topic());
+    }
+
+    @Override
+    public Tables.TableFilter getTableFilter() {
+        return Tables.TableFilter.includeAll();
+    }
+
+    @Override
+    public Offset getStreamOffset(SourceRecord record) {
+        return new MockedOffset(((Struct) record.value()).getInt64("timestamp"));
+    }
+
+    @Override
+    public boolean isDataChangeRecord(SourceRecord record) {
+        return !isWatermarkEvent(record);
+    }
+
+    @Override
+    public boolean isRecordBetween(SourceRecord record, Object[] splitStart, Object[] splitEnd) {
+        long splitStartOffset = (long) splitStart[0];
+        long splitEndOffset = (long) splitEnd[0];
+        long currentOffset = ((Struct) record.value()).getInt64("id");
+        return splitStartOffset <= currentOffset && currentOffset < splitEndOffset;
+    }
+
+    @Override
+    public void rewriteOutputBuffer(
+            Map<Struct, SourceRecord> outputBuffer, SourceRecord changeRecord) {}
+
+    @Override
+    public List<SourceRecord> formatMessageTimestamp(Collection<SourceRecord> snapshotRecords) {
+        return new ArrayList<>(snapshotRecords);
+    }
+
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public DataSourceDialect<?> getDataSourceDialect() {
+        return dialect;
+    }
+
+    @Override
+    public SourceConfig getSourceConfig() {
+        return sourceConfig;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedHybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedHybridSplitAssigner.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.cdc.connectors.base.dialect.DataSourceDialect;
+import org.apache.flink.cdc.connectors.base.source.assigner.HybridSplitAssigner;
+import org.apache.flink.cdc.connectors.base.source.assigner.state.HybridPendingSplitsState;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import java.util.List;
+import java.util.Map;
+
+/** A mocked {@link HybridSplitAssigner} that could create multiple stream splits. */
+public class MockedHybridSplitAssigner extends HybridSplitAssigner<MockedConfig> {
+
+    public MockedHybridSplitAssigner(
+            MockedConfig sourceConfig,
+            int currentParallelism,
+            List<TableId> remainingTables,
+            boolean isTableIdCaseSensitive,
+            DataSourceDialect<MockedConfig> dialect,
+            OffsetFactory offsetFactory,
+            SplitEnumeratorContext<? extends SourceSplit> enumeratorContext) {
+        super(
+                sourceConfig,
+                currentParallelism,
+                remainingTables,
+                isTableIdCaseSensitive,
+                dialect,
+                offsetFactory,
+                enumeratorContext);
+    }
+
+    public MockedHybridSplitAssigner(
+            MockedConfig sourceConfig,
+            int currentParallelism,
+            HybridPendingSplitsState checkpoint,
+            DataSourceDialect<MockedConfig> dialect,
+            OffsetFactory offsetFactory,
+            SplitEnumeratorContext<? extends SourceSplit> enumeratorContext) {
+        super(
+                sourceConfig,
+                currentParallelism,
+                checkpoint,
+                dialect,
+                offsetFactory,
+                enumeratorContext);
+    }
+
+    @Override
+    protected List<SourceSplitBase> createStreamSplits(
+            MockedConfig sourceConfig,
+            Offset minOffset,
+            Offset stoppingOffset,
+            List<FinishedSnapshotSplitInfo> finishedSnapshotSplitInfos,
+            Map<TableId, TableChanges.TableChange> tableSchemas,
+            int totalFinishedSplitSize,
+            boolean isSuspended,
+            boolean isSnapshotCompleted) {
+        return MockedDatabase.createStreamSplits(
+                sourceConfig,
+                minOffset,
+                stoppingOffset,
+                finishedSnapshotSplitInfos,
+                tableSchemas,
+                totalFinishedSplitSize,
+                isSuspended,
+                isSnapshotCompleted);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedIncrementalSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedIncrementalSource.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.connectors.base.config.SourceConfig;
+import org.apache.flink.cdc.connectors.base.source.IncrementalSource;
+import org.apache.flink.cdc.connectors.base.source.assigner.SplitAssigner;
+import org.apache.flink.cdc.connectors.base.source.assigner.state.PendingSplitsState;
+import org.apache.flink.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import io.debezium.relational.TableId;
+
+import java.util.List;
+
+/** Mocked {@link IncrementalSource}. */
+public class MockedIncrementalSource extends IncrementalSource<String, MockedConfig> {
+
+    public MockedIncrementalSource(
+            SourceConfig.Factory<MockedConfig> configFactory,
+            DebeziumDeserializationSchema<String> deserializationSchema) {
+        super(
+                configFactory,
+                deserializationSchema,
+                new MockedOffsetFactory(),
+                new MockedDialect(configFactory));
+    }
+
+    @Override
+    public SplitEnumerator<SourceSplitBase, PendingSplitsState> createEnumerator(
+            SplitEnumeratorContext<SourceSplitBase> enumContext) {
+        MockedConfig sourceConfig = configFactory.create(0);
+        final SplitAssigner splitAssigner;
+        if (!sourceConfig.getStartupOptions().isStreamOnly()) {
+            try {
+                final List<TableId> remainingTables =
+                        dataSourceDialect.discoverDataCollections(sourceConfig);
+                boolean isTableIdCaseSensitive =
+                        dataSourceDialect.isDataCollectionIdCaseSensitive(sourceConfig);
+                splitAssigner =
+                        new MockedHybridSplitAssigner(
+                                sourceConfig,
+                                enumContext.currentParallelism(),
+                                remainingTables,
+                                isTableIdCaseSensitive,
+                                dataSourceDialect,
+                                offsetFactory,
+                                enumContext);
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(
+                        "Failed to discover captured tables for enumerator", e);
+            }
+        } else {
+            splitAssigner =
+                    new MockedStreamSplitAssigner(
+                            sourceConfig, dataSourceDialect, offsetFactory, enumContext);
+        }
+
+        return new IncrementalSourceEnumerator(
+                enumContext,
+                sourceConfig,
+                splitAssigner,
+                getBoundedness(),
+                dataSourceDialect.getNumberOfStreamSplits(sourceConfig));
+    }
+
+    @VisibleForTesting
+    public MockedDialect getDialect() {
+        return (MockedDialect) dataSourceDialect;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedOffset.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** An offset for mocked source. */
+public class MockedOffset extends Offset {
+
+    public static final MockedOffset MAX = new MockedOffset(Long.MAX_VALUE);
+    private static final String OFFSET_INDEX_KEY = "offsetIndex";
+
+    public MockedOffset(long offsetIndex) {
+        this.offset = new HashMap<>();
+        offset.put(OFFSET_INDEX_KEY, String.valueOf(offsetIndex));
+    }
+
+    public MockedOffset(Map<String, String> offset) {
+        this.offset = new HashMap<>(offset);
+    }
+
+    public long getOffsetIndex() {
+        return Long.parseLong(this.offset.get(OFFSET_INDEX_KEY));
+    }
+
+    @Override
+    public int compareTo(@NotNull Offset that) {
+        if (offset == null) {
+            return -1;
+        }
+        return Long.compare(getOffsetIndex(), ((MockedOffset) that).getOffsetIndex());
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedOffsetFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedOffsetFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.OffsetFactory;
+
+import java.util.Map;
+
+/** {@link OffsetFactory} for mocked source. */
+public class MockedOffsetFactory extends OffsetFactory {
+    @Override
+    public Offset newOffset(Map<String, String> offset) {
+        return new MockedOffset(offset);
+    }
+
+    @Override
+    public Offset newOffset(String filename, Long position) {
+        throw new UnsupportedOperationException(
+                "Could not create new Offset by filename and position.");
+    }
+
+    @Override
+    public Offset newOffset(Long position) {
+        throw new UnsupportedOperationException("Could not create new Offset by position.");
+    }
+
+    @Override
+    public Offset createTimestampOffset(long timestampMillis) {
+        throw new UnsupportedOperationException("Could not create new Offset by timestamp.");
+    }
+
+    @Override
+    public Offset createInitialOffset() {
+        return new MockedOffset(0);
+    }
+
+    @Override
+    public Offset createNoStoppingOffset() {
+        return new MockedOffset(Long.MAX_VALUE);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedSnapshotFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedSnapshotFetchTask.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkEvent;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
+import org.apache.flink.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
+import org.apache.flink.table.data.RowData;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import org.apache.kafka.connect.source.SourceRecord;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.cdc.connectors.base.mocked.source.MockedUtils.createWatermarkPartitionMap;
+
+/** An {@link AbstractScanFetchTask} for snapshot splits. */
+public class MockedSnapshotFetchTask extends AbstractScanFetchTask {
+
+    public static final String WATERMARK_TOPIC_NAME = "__mocked_watermarks";
+
+    public MockedSnapshotFetchTask(SnapshotSplit snapshotSplit) {
+        super(snapshotSplit);
+    }
+
+    @Override
+    protected void executeBackfillTask(Context context, StreamSplit backfillStreamSplit)
+            throws Exception {
+        MockedStreamFetchTask backfillStreamTask =
+                new MockedStreamFetchTask(backfillStreamSplit, snapshotSplit.getTableId());
+        backfillStreamTask.execute(context);
+    }
+
+    @Override
+    protected void dispatchLowWaterMarkEvent(
+            Context context, SourceSplitBase split, Offset lowWatermark)
+            throws InterruptedException {
+        ChangeEventQueue<DataChangeEvent> changeEventQueue = context.getQueue();
+        changeEventQueue.enqueue(
+                new DataChangeEvent(
+                        WatermarkEvent.create(
+                                createWatermarkPartitionMap(
+                                        snapshotSplit.getTableId().identifier()),
+                                WATERMARK_TOPIC_NAME,
+                                snapshotSplit.splitId(),
+                                WatermarkKind.LOW,
+                                lowWatermark)));
+    }
+
+    @Override
+    protected void dispatchHighWaterMarkEvent(
+            Context context, SourceSplitBase split, Offset highWatermark)
+            throws InterruptedException {
+        ChangeEventQueue<DataChangeEvent> changeEventQueue = context.getQueue();
+        changeEventQueue.enqueue(
+                new DataChangeEvent(
+                        WatermarkEvent.create(
+                                createWatermarkPartitionMap(
+                                        snapshotSplit.getTableId().identifier()),
+                                WATERMARK_TOPIC_NAME,
+                                snapshotSplit.splitId(),
+                                WatermarkKind.HIGH,
+                                highWatermark)));
+    }
+
+    @Override
+    protected void dispatchEndWaterMarkEvent(
+            Context context, SourceSplitBase split, Offset endWatermark)
+            throws InterruptedException {
+        ChangeEventQueue<DataChangeEvent> changeEventQueue = context.getQueue();
+        changeEventQueue.enqueue(
+                new DataChangeEvent(
+                        WatermarkEvent.create(
+                                createWatermarkPartitionMap(
+                                        snapshotSplit.getTableId().identifier()),
+                                WATERMARK_TOPIC_NAME,
+                                snapshotSplit.splitId(),
+                                WatermarkKind.END,
+                                endWatermark)));
+    }
+
+    @Override
+    protected void executeDataSnapshot(Context context) throws InterruptedException {
+        SnapshotSplit split = getSplit();
+        ChangeEventQueue<DataChangeEvent> changeEventQueue = context.getQueue();
+        MockedFetchTaskContext mockedContext = (MockedFetchTaskContext) context;
+        MockedDatabase mockedDatabase =
+                ((MockedDialect) mockedContext.getDataSourceDialect()).getMockedDatabase();
+
+        // Imitating that it costs a long time to finish snapshot reading
+
+        try {
+            Tuple2<Long, List<RowData>> snapshotResult =
+                    mockedDatabase.takeSnapshot(
+                            split.getTableId(),
+                            Optional.ofNullable(split.getSplitStart())
+                                    .map(arr -> arr[0])
+                                    .map(Long.class::cast)
+                                    .orElse(Long.MIN_VALUE),
+                            Optional.ofNullable(split.getSplitEnd())
+                                    .map(arr -> arr[0])
+                                    .map(Long.class::cast)
+                                    .orElse(Long.MAX_VALUE));
+
+            Thread.sleep(1000L);
+
+            snapshotResult.f1.forEach(
+                    rowData -> {
+                        try {
+                            changeEventQueue.enqueue(
+                                    new DataChangeEvent(
+                                            new SourceRecord(
+                                                    createWatermarkPartitionMap(
+                                                            snapshotSplit
+                                                                    .getTableId()
+                                                                    .identifier()),
+                                                    new MockedOffset(snapshotResult.f0).getOffset(),
+                                                    getSplit().getTableId().identifier(),
+                                                    MockedUtils.KEY_SCHEMA,
+                                                    MockedUtils.createKeySchema(rowData.getLong(0)),
+                                                    MockedUtils.VALUE_SCHEMA,
+                                                    MockedUtils.createValueSchema(
+                                                            null,
+                                                            rowData.getRowKind(),
+                                                            rowData.getLong(0),
+                                                            rowData.getString(1)))));
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+        } catch (Exception e) {
+            taskRunning = false;
+            throw e;
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedSourceITCase.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.cdc.debezium.JsonDebeziumDeserializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.api.common.JobStatus.RUNNING;
+import static org.apache.flink.cdc.common.utils.TestCaseUtils.repeatedCheckAndValidate;
+import static org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH;
+
+/** Integrated test cases with {@link MockedIncrementalSource}. */
+public class MockedSourceITCase {
+
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outCaptor = new ByteArrayOutputStream();
+    private StreamExecutionEnvironment env;
+
+    private static final int TABLE_COUNT = 3;
+    private static final int RECORD_COUNT = 5;
+
+    @BeforeEach
+    void before() {
+        System.setOut(new PrintStream(outCaptor));
+        Configuration config = new Configuration();
+        config.set(ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH, true);
+        env = StreamExecutionEnvironment.getExecutionEnvironment(config);
+        env.enableCheckpointing(3000);
+        env.setRestartStrategy(RestartStrategies.noRestart());
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        System.setOut(standardOut);
+        outCaptor.reset();
+        env.close();
+    }
+
+    @ParameterizedTest(name = "multipleStreamSplits: {0}")
+    @ValueSource(booleans = {true, false})
+    void testMockedSource(boolean multipleStreamSplits) throws Exception {
+        MockedIncrementalSource source =
+                new MockedIncrementalSource(
+                        (subTask) ->
+                                new MockedConfigFactory()
+                                        .setTableCount(TABLE_COUNT)
+                                        .setRecordCount(RECORD_COUNT)
+                                        .setSplitSize(2)
+                                        .setSplitMetaGroupSize(10)
+                                        .setStartupOptions(StartupOptions.initial())
+                                        .setRefreshInterval(Duration.ofMillis(100))
+                                        .setMultipleStreamSplitsEnabled(multipleStreamSplits)
+                                        .create(subTask),
+                        new JsonDebeziumDeserializationSchema());
+
+        env.fromSource(source, WatermarkStrategy.noWatermarks(), "Source")
+                .setParallelism(4)
+                .map(s -> s.replaceAll(",\"timestamp\":-?\\d+", ""))
+                .print()
+                .setParallelism(1);
+
+        JobClient client = env.executeAsync("Mocked Source Test");
+        waitUntilJobRunning(client);
+
+        source.getDialect().getMockedDatabase().start(TABLE_COUNT * (RECORD_COUNT - 1));
+
+        try {
+            List<String> expected = new ArrayList<>();
+            IntStream.rangeClosed(1, TABLE_COUNT)
+                    .forEach(
+                            i ->
+                                    IntStream.rangeClosed(1, RECORD_COUNT)
+                                            .forEach(
+                                                    j ->
+                                                            Stream.of(
+                                                                            "{\"op\":\"+I\",\"id\":%d,\"name\":\"INITIAL_mock_ns.mock_scm.table_%d\"}",
+                                                                            "{\"op\":\"+I\",\"id\":-%d,\"name\":\"INSERT_mock_ns.mock_scm.table_%d\"}",
+                                                                            "{\"op\":\"-U\",\"id\":-%d,\"name\":\"INSERT_mock_ns.mock_scm.table_%d\"}",
+                                                                            "{\"op\":\"+U\",\"id\":-%d,\"name\":\"UPDATE_mock_ns.mock_scm.table_%d\"}",
+                                                                            "{\"op\":\"-D\",\"id\":-%d,\"name\":\"UPDATE_mock_ns.mock_scm.table_%d\"}")
+                                                                    .map(
+                                                                            fmtStr ->
+                                                                                    String.format(
+                                                                                            fmtStr,
+                                                                                            j, i))
+                                                                    .forEach(expected::add)));
+            validateStdOut(expected.toArray(new String[0]));
+        } catch (Exception e) {
+            System.err.println("Failed to validate output. Stdout: ");
+            System.err.println(outCaptor);
+            throw e;
+        } finally {
+            source.getDialect().getMockedDatabase().stop();
+            client.cancel().get();
+            env.close();
+        }
+    }
+
+    @Test
+    void testStreamSplitsMoreThanParallelism() {
+        MockedIncrementalSource source =
+                new MockedIncrementalSource(
+                        (subTask) ->
+                                new MockedConfigFactory()
+                                        .setTableCount(TABLE_COUNT)
+                                        .setRecordCount(RECORD_COUNT)
+                                        .setSplitSize(2)
+                                        .setSplitMetaGroupSize(10)
+                                        .setStartupOptions(StartupOptions.initial())
+                                        .setRefreshInterval(Duration.ofMillis(100))
+                                        .setMultipleStreamSplitsEnabled(true)
+                                        .create(subTask),
+                        new JsonDebeziumDeserializationSchema());
+
+        env.fromSource(source, WatermarkStrategy.noWatermarks(), "Source")
+                .setParallelism(2)
+                .map(s -> s.replaceAll(",\"timestamp\":-?\\d+", ""))
+                .print()
+                .setParallelism(1);
+
+        Assertions.assertThatThrownBy(() -> env.execute())
+                .rootCause()
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "4 stream splits generated, which is greater than current parallelism 2. Some splits might never be assigned.");
+    }
+
+    private void validateStdOut(String... lines) {
+        repeatedCheckAndValidate(
+                () -> {
+                    Assertions.assertThat(outCaptor.toString().split("\n"))
+                            .containsExactlyInAnyOrder(lines);
+                    return true;
+                },
+                t -> t,
+                Duration.ofMinutes(1),
+                Duration.ofSeconds(1),
+                singletonList(AssertionError.class));
+    }
+
+    private void waitUntilJobRunning(JobClient jobClient)
+            throws InterruptedException, ExecutionException {
+        do {
+            Thread.sleep(5000L);
+        } while (jobClient.getJobStatus().get() != RUNNING);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedStreamFetchTask.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkEvent;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
+import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
+import org.apache.flink.table.data.GenericRowData;
+
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.relational.TableId;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.testcontainers.shaded.org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.List;
+
+import static org.apache.flink.cdc.connectors.base.mocked.source.MockedSnapshotFetchTask.WATERMARK_TOPIC_NAME;
+import static org.apache.flink.cdc.connectors.base.mocked.source.MockedUtils.createWatermarkPartitionMap;
+import static org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit.STREAM_SPLIT_ID;
+
+/** A {@link FetchTask} for stream splits. */
+public class MockedStreamFetchTask implements FetchTask<SourceSplitBase> {
+
+    private final StreamSplit streamSplit;
+    private final @Nullable TableId tableId;
+    private boolean taskRunning;
+
+    public MockedStreamFetchTask(StreamSplit streamSplit) {
+        this(streamSplit, null);
+    }
+
+    public MockedStreamFetchTask(StreamSplit streamSplit, @Nullable TableId tableId) {
+        this.streamSplit = streamSplit;
+        this.tableId = tableId;
+    }
+
+    @Override
+    public void execute(Context context) throws Exception {
+        try {
+            boolean isPartialStreamSplit = streamSplit.splitId().startsWith(STREAM_SPLIT_ID + "-");
+            Integer readingSplitIndex = null;
+            if (isPartialStreamSplit) {
+                readingSplitIndex = streamSplit.splitId().charAt(13) - '0';
+            }
+
+            ChangeEventQueue<DataChangeEvent> changeEventQueue = context.getQueue();
+            MockedFetchTaskContext taskContext = (MockedFetchTaskContext) context;
+            MockedDialect dialect = (MockedDialect) taskContext.getDataSourceDialect();
+            MockedDatabase database = dialect.getMockedDatabase();
+
+            this.taskRunning = true;
+
+            long currentOffsetIndex =
+                    ((MockedOffset) streamSplit.getStartingOffset()).getOffsetIndex();
+            final long endingOffset =
+                    ((MockedOffset) streamSplit.getEndingOffset()).getOffsetIndex();
+            outer:
+            while (true) {
+                Tuple2<Long, List<Tuple3<TableId, Long, GenericRowData>>> result =
+                        database.pollStreamValues(
+                                tableId, currentOffsetIndex, endingOffset, readingSplitIndex, 4);
+                for (Tuple3<TableId, Long, GenericRowData> rec : result.f1) {
+                    if (rec.f1 > endingOffset) {
+                        break outer;
+                    }
+                    GenericRowData rowData = rec.f2;
+                    long pkValue = rowData.getLong(0);
+                    if (!isPartialStreamSplit || Math.floorMod(pkValue, 4) == readingSplitIndex) {
+                        changeEventQueue.enqueue(
+                                new DataChangeEvent(
+                                        new SourceRecord(
+                                                createWatermarkPartitionMap(rec.f0.identifier()),
+                                                new MockedOffset(rec.f1).getOffset(),
+                                                rec.f0.identifier(),
+                                                MockedUtils.KEY_SCHEMA,
+                                                MockedUtils.createKeySchema(rowData.getLong(0)),
+                                                MockedUtils.VALUE_SCHEMA,
+                                                MockedUtils.createValueSchema(
+                                                        rec.f1,
+                                                        rowData.getRowKind(),
+                                                        rowData.getLong(0),
+                                                        rowData.getString(1)))));
+                    }
+                }
+                currentOffsetIndex = result.f0;
+                Thread.sleep(1000);
+            }
+            SourceRecord endWatermark =
+                    WatermarkEvent.create(
+                            createWatermarkPartitionMap(tableId.identifier()),
+                            WATERMARK_TOPIC_NAME,
+                            streamSplit.splitId(),
+                            WatermarkKind.END,
+                            new MockedOffset(currentOffsetIndex));
+
+            changeEventQueue.enqueue(new DataChangeEvent(endWatermark));
+        } finally {
+            taskRunning = false;
+        }
+    }
+
+    @Override
+    public boolean isRunning() {
+        return taskRunning;
+    }
+
+    @Override
+    public SourceSplitBase getSplit() {
+        return streamSplit;
+    }
+
+    @Override
+    public void close() {
+        taskRunning = false;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedStreamSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedStreamSplitAssigner.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.cdc.connectors.base.dialect.DataSourceDialect;
+import org.apache.flink.cdc.connectors.base.source.assigner.StreamSplitAssigner;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges;
+
+import java.util.List;
+import java.util.Map;
+
+/** A mocked {@link StreamSplitAssigner} that could create multiple stream splits. */
+public class MockedStreamSplitAssigner extends StreamSplitAssigner<MockedConfig> {
+
+    public MockedStreamSplitAssigner(
+            MockedConfig sourceConfig,
+            DataSourceDialect<MockedConfig> dialect,
+            OffsetFactory offsetFactory,
+            SplitEnumeratorContext<? extends SourceSplit> enumeratorContext) {
+        super(sourceConfig, dialect, offsetFactory, enumeratorContext);
+    }
+
+    @Override
+    protected List<SourceSplitBase> createStreamSplits(
+            MockedConfig sourceConfig,
+            Offset minOffset,
+            Offset stoppingOffset,
+            List<FinishedSnapshotSplitInfo> finishedSnapshotSplitInfos,
+            Map<TableId, TableChanges.TableChange> tableSchemas,
+            int totalFinishedSplitSize,
+            boolean isSuspended,
+            boolean isSnapshotCompleted) {
+        return MockedDatabase.createStreamSplits(
+                sourceConfig,
+                minOffset,
+                stoppingOffset,
+                finishedSnapshotSplitInfos,
+                tableSchemas,
+                totalFinishedSplitSize,
+                isSuspended,
+                isSnapshotCompleted);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/mocked/source/MockedUtils.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.mocked.source;
+
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.types.RowKind;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import javax.annotation.Nullable;
+
+import java.util.Map;
+
+import static java.util.Collections.singletonMap;
+
+/** Some utilities for mocked utilities. */
+public class MockedUtils {
+
+    public static final Schema KEY_SCHEMA =
+            SchemaBuilder.struct()
+                    .name("mocked_key_schema")
+                    .field("id", Schema.INT64_SCHEMA)
+                    .build();
+    public static final Schema VALUE_SCHEMA =
+            SchemaBuilder.struct()
+                    .name("mocked_value_schema")
+                    .field("op", Schema.STRING_SCHEMA)
+                    .field("id", Schema.INT64_SCHEMA)
+                    .field("name", Schema.STRING_SCHEMA)
+                    .field("timestamp", Schema.INT64_SCHEMA)
+                    .build();
+
+    public static Struct createKeySchema(long id) {
+        Struct struct = new Struct(KEY_SCHEMA);
+        struct.put("id", id);
+        return struct;
+    }
+
+    public static Struct createValueSchema(
+            @Nullable Long timestamp, RowKind opType, long id, StringData name) {
+        return createValueSchema(timestamp, opType, id, name.toString());
+    }
+
+    public static Struct createValueSchema(
+            @Nullable Long timestamp, RowKind opType, long id, String name) {
+        Struct struct = new Struct(VALUE_SCHEMA);
+        struct.put("op", opType.shortString());
+        struct.put("id", id);
+        struct.put("name", name);
+
+        if (timestamp != null) {
+            struct.put("timestamp", timestamp);
+        } else {
+            struct.put("timestamp", Long.MIN_VALUE);
+        }
+        return struct;
+    }
+
+    public static Map<String, String> createWatermarkPartitionMap(String partition) {
+        return singletonMap("mocked_ns", partition);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/enumerator/PostgresSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/enumerator/PostgresSourceEnumerator.java
@@ -72,7 +72,7 @@ public class PostgresSourceEnumerator extends IncrementalSourceEnumerator {
         // if scan newly added table is enable, can not assign new added table's snapshot splits
         // until source reader doesn't commit offset.
         if (sourceConfig.isScanNewlyAddedTableEnabled()
-                && !streamSplitTaskIds.isEmpty()
+                && !streamSplitAssignedToTaskIdMap.isEmpty()
                 && !receiveOffsetCommitAck
                 && isNewlyAddedAssigning(splitAssigner.getAssignerStatus())) {
             // just return here, the reader has been put into readersAwaitingSplit, will be assigned
@@ -88,7 +88,7 @@ public class PostgresSourceEnumerator extends IncrementalSourceEnumerator {
             this.receiveOffsetCommitAck = false;
         }
         if (sourceEvent instanceof OffsetCommitAckEvent) {
-            if (streamSplitTaskIds.contains(subtaskId)) {
+            if (streamSplitAssignedToTaskIdMap.containsValue(subtaskId)) {
                 this.receiveOffsetCommitAck = true;
             } else {
                 throw new RuntimeException("Receive SyncAssignStatusAck from wrong subtask");
@@ -105,9 +105,9 @@ public class PostgresSourceEnumerator extends IncrementalSourceEnumerator {
         // to tell reader whether to start offset commit.
         if (!receiveOffsetCommitAck
                 && sourceConfig.isScanNewlyAddedTableEnabled()
-                && !streamSplitTaskIds.isEmpty()) {
+                && !streamSplitAssignedToTaskIdMap.isEmpty()) {
             AssignerStatus assignerStatus = splitAssigner.getAssignerStatus();
-            for (int streamSplitTaskId : streamSplitTaskIds) {
+            for (int streamSplitTaskId : streamSplitAssignedToTaskIdMap.values()) {
                 context.sendEventToSourceReader(
                         streamSplitTaskId,
                         new OffsetCommitEvent(


### PR DESCRIPTION
This closes FLINK-37653.

Currently, `HybridSplitAssigner`s and `StreamSplitAssigner`s in incremental snapshot framework implicitly assume that there will be at most one unbounded stream split, which isn't true for some data sources that supports multiple change stream splits, like MongoDB and PolarDB-X.

This change extends assigners' API without changing existing data sources' behavior.