### PR TITLE
[FLINK-37696][test][cdc-connector][postgres] replace postgres image to official pg 14 and adjust test to use pgoutput plugin

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/NewlyAddedTableITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/NewlyAddedTableITCase.java
@@ -942,6 +942,7 @@ class NewlyAddedTableITCase extends PostgresTestBase {
                         + " 'username' = '%s',"
                         + " 'password' = '%s',"
                         + " 'database-name' = '%s',"
+                        + " 'decoding.plugin.name' = 'pgoutput', "
                         + " 'schema-name' = '%s',"
                         + " 'table-name' = '%s',"
                         + " 'slot.name' = '%s', "

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceExampleTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceExampleTest.java
@@ -68,7 +68,7 @@ class PostgresSourceExampleTest extends PostgresTestBase {
     private static final String TABLE_ID = SCHEMA_NAME + ".products";
 
     private static final String SLOT_NAME = "flink";
-    private static final String PLUGIN_NAME = "decoderbufs";
+    private static final String PLUGIN_NAME = "pgoutput";
     private static final long CHECKPOINT_INTERVAL_MS = 3000;
 
     private static final int DEFAULT_PARALLELISM = 2;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
@@ -348,6 +348,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.startup.mode' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '100',"
+                                + " 'decoding.plugin.name' = 'pgoutput', "
                                 + " 'slot.name' = '%s', "
                                 + " 'debezium.slot.drop.on.stop' = 'true'"
                                 + ")",
@@ -652,6 +653,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.startup.mode' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '100',"
+                                + " 'decoding.plugin.name' = 'pgoutput', "
                                 + " 'slot.name' = '%s',"
                                 + " 'scan.incremental.snapshot.backfill.skip' = '%s'"
                                 + ")",
@@ -774,6 +776,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.startup.mode' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '100',"
+                                + " 'decoding.plugin.name' = 'pgoutput', "
                                 + " 'slot.name' = '%s',"
                                 + " 'scan.incremental.snapshot.backfill.skip' = '%s',"
                                 + " 'scan.newly-added-table.enabled' = 'true',"
@@ -837,6 +840,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                         .username(customDatabase.getUsername())
                         .password(customDatabase.getPassword())
                         .database(customDatabase.getDatabaseName())
+                        .decodingPluginName("pgoutput")
                         .slotName(slotName)
                         .tableList(tableId.toString())
                         .startupOptions(startupOptions)
@@ -976,6 +980,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.startup.mode' = '%s',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '100',"
+                                + " 'decoding.plugin.name' = 'pgoutput', "
                                 + " 'slot.name' = '%s',"
                                 + " 'scan.lsn-commit.checkpoints-num-delay' = '1'"
                                 + " %s"

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresSourceReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresSourceReaderTest.java
@@ -77,6 +77,7 @@ class PostgresSourceReaderTest {
         configFactory.database("pgdb");
         configFactory.username("username");
         configFactory.password("password");
+        configFactory.decodingPluginName("pgoutput");
         configFactory.setLsnCommitCheckpointsDelay(lsnCommitCheckpointsDelay);
         final TestTable customerTable =
                 new TestTable(ResolvedSchema.of(Column.physical("id", BIGINT())));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLSavepointITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLSavepointITCase.java
@@ -88,6 +88,7 @@ class PostgreSQLSavepointITCase extends PostgresTestBase {
                                 + " 'table-name' = '%s',"
                                 + " 'scan.incremental.snapshot.enabled' = 'true',"
                                 + " 'scan.incremental.snapshot.chunk.size' = '2',"
+                                + " 'decoding.plugin.name' = 'pgoutput', "
                                 + " 'slot.name' = '%s'"
                                 + ")",
                         POSTGRES_CONTAINER.getHost(),

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/column_type_test.sql
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/column_type_test.sql
@@ -19,8 +19,9 @@
 -- Generate a number of tables to cover as many of the PG types as possible
 DROP SCHEMA IF EXISTS inventory CASCADE;
 CREATE SCHEMA inventory;
-SET search_path TO inventory;
-CREATE EXTENSION postgis;
+-- postgis is installed into public schema
+SET search_path TO inventory, public;
+
 
 CREATE TABLE full_types
 (
@@ -48,10 +49,10 @@ CREATE TABLE full_types
     PRIMARY KEY (id)
 );
 
-ALTER TABLE full_types
+ALTER TABLE inventory.full_types
     REPLICA IDENTITY FULL;
 
-INSERT INTO full_types
+INSERT INTO inventory.full_types
 VALUES (1, '2', 32767, 65535, 2147483647, 5.5, 6.6, 123.12345, 404.4443, true,
         'Hello World', 'a', 'abc', 'abcd..xyz', '2020-07-17 18:00:22.123', '2020-07-17 18:00:22.123456',
         '2020-07-17', '18:00:22', 500, 'SRID=3187;POINT(174.9479 -36.7208)'::geometry,


### PR DESCRIPTION
As discussed in http://issues.apache.org/jira/browse/FLINK-37696, the postgres 14 is most used version of postgres, thus this Jira will replace test image and use pgoutput.