### PR TITLE
[hotfix][cdc-base] Fix split not serialize isSnapshotCompleted

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializer.java
@@ -464,7 +464,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         for (TableId tableId : tableIds) {
             boolean useCatalogBeforeSchema = SerializerUtils.shouldUseCatalogBeforeSchema(tableId);
             out.writeBoolean(useCatalogBeforeSchema);
-            out.writeUTF(tableId.toString());
+            out.writeUTF(tableId.toDoubleQuotedString());
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
@@ -207,7 +207,7 @@ public abstract class SourceSplitSerializer
             boolean useCatalogBeforeSchema =
                     SerializerUtils.shouldUseCatalogBeforeSchema(entry.getKey());
             out.writeBoolean(useCatalogBeforeSchema);
-            out.writeUTF(entry.getKey().toString());
+            out.writeUTF(entry.getKey().toDoubleQuotedString());
             final String tableChangeStr =
                     documentWriter.write(jsonSerializer.toDocument(entry.getValue()));
             final byte[] tableChangeBytes = tableChangeStr.getBytes(StandardCharsets.UTF_8);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/SourceSplitSerializer.java
@@ -109,6 +109,7 @@ public abstract class SourceSplitSerializer
             writeTableSchemas(streamSplit.getTableSchemas(), out);
             out.writeInt(streamSplit.getTotalFinishedSplitSize());
             out.writeBoolean(streamSplit.isSuspended());
+            out.writeBoolean(streamSplit.isSnapshotCompleted());
             final byte[] result = out.getCopyOfBuffer();
             out.clear();
             // optimization: cache the serialized from, so we avoid the byte work during repeated
@@ -173,7 +174,7 @@ public abstract class SourceSplitSerializer
             }
 
             boolean isSuspended = false;
-            if (version == 5) {
+            if (version >= 5) {
                 isSuspended = in.readBoolean();
             }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializerTest.java
@@ -19,19 +19,51 @@ package org.apache.flink.cdc.connectors.base.source.assigner.state;
 
 import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
 import org.apache.flink.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitSerializer;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
 
+import io.debezium.relational.Table;
 import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.history.TableChanges;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link PendingSplitsStateSerializer}. */
 class PendingSplitsStateSerializerTest {
+    @Test
+    void testSourceSplitSerializeAndDeserialize() throws IOException {
+        SnapshotSplit snapshotSplitBefore = constuctSnapshotSplit();
+        SourceSplitSerializer sourceSplitSerializer = constructSourceSplitSerializer();
+        SnapshotSplit snapshotSplitAfter =
+                (SnapshotSplit)
+                        sourceSplitSerializer.deserialize(
+                                sourceSplitSerializer.getVersion(),
+                                sourceSplitSerializer.serialize(snapshotSplitBefore));
 
-    private final TableId tableId = TableId.parse("catalog.schema.table1");
+        assertThat(snapshotSplitAfter).isEqualTo(snapshotSplitBefore);
+        assertThat(snapshotSplitAfter.getTableSchemas())
+                .isEqualTo(snapshotSplitBefore.getTableSchemas());
+        StreamSplit streamSplitBefore = constuctStreamSplit();
+        StreamSplit streamSplitAfter =
+                (StreamSplit)
+                        sourceSplitSerializer.deserialize(
+                                sourceSplitSerializer.getVersion(),
+                                sourceSplitSerializer.serialize(streamSplitBefore));
+
+        assertThat(streamSplitAfter).isEqualTo(streamSplitBefore);
+    }
 
     @Test
     void testOutputIsFinallyCleared() throws Exception {
@@ -48,7 +80,7 @@ class PendingSplitsStateSerializerTest {
                 .isExactlyInstanceOf(IOException.class);
 
         final byte[] ser2 = serializer.serialize(state);
-        Assertions.assertThat(ser1).isEqualTo(ser2);
+        assertThat(ser1).isEqualTo(ser2);
     }
 
     private SourceSplitSerializer constructSourceSplitSerializer() {
@@ -88,6 +120,42 @@ class PendingSplitsStateSerializerTest {
                 };
             }
         };
+    }
+
+    private SnapshotSplit constuctSnapshotSplit() {
+        TableId tableId = new TableId("cata`log\"", "s\"che`ma", "ta\"ble.1`");
+        return new SnapshotSplit(
+                tableId,
+                "test",
+                new RowType(
+                        Collections.singletonList(new RowType.RowField("id", new BigIntType()))),
+                new Object[] {1},
+                new Object[] {100},
+                null,
+                constructTableSchema());
+    }
+
+    private StreamSplit constuctStreamSplit() {
+        return new StreamSplit(
+                "database1.schema1.table1",
+                null,
+                null,
+                new ArrayList<>(),
+                constructTableSchema(),
+                0,
+                false,
+                true);
+    }
+
+    private HashMap<TableId, TableChanges.TableChange> constructTableSchema() {
+        TableId tableId = new TableId("cata`log\"", "s\"che`ma", "ta\"ble.1`");
+        HashMap<TableId, TableChanges.TableChange> tableSchema = new HashMap<>();
+        Tables tables = new Tables();
+        Table table = tables.editOrCreateTable(tableId).create();
+        TableChanges.TableChange tableChange =
+                new TableChanges.TableChange(TableChanges.TableChangeType.CREATE, table);
+        tableSchema.put(tableId, tableChange);
+        return tableSchema;
     }
 
     /** An implementation for {@link PendingSplitsState} which will cause a serialization error. */


### PR DESCRIPTION
This Pr do two things:
1. [hotfix][cdc-base] Fix split not serialize isSnapshotCompleted
2. Cp https://github.com/apache/flink-cdc/pull/2705.