### PR TITLE
[FLINK-37713][runtime] Fix SchemaManager was recreated in SchemaRegistry after job failover.

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaRegistry.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaRegistry.java
@@ -123,7 +123,9 @@ public abstract class SchemaRegistry implements OperatorCoordinator, Coordinatio
         this.currentParallelism = context.currentParallelism();
         this.activeSinkWriters = ConcurrentHashMap.newKeySet();
         this.failedReasons = new ConcurrentHashMap<>();
-        this.schemaManager = new SchemaManager();
+        if (this.schemaManager == null) {
+            this.schemaManager = new SchemaManager();
+        }
         this.router = new TableIdRouter(routingRules);
     }
 


### PR DESCRIPTION
OperatorCoordinator#resetToCheckpoint() is called even before OperatorCoordinator#start(). So we should check SchemaManager is null before we create a new one.