### PR TITLE
[FLINK-37738][cdc-connector][postgres] Support read changelog as append only mode

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/postgres-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/postgres-cdc.md
@@ -256,6 +256,19 @@ Connector Options
         Experimental option, defaults to false.
       </td>
     </tr>
+    <tr>
+      <td>scan.read-changelog-as-append-only.enabled</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>
+        Whether to convert the changelog stream to an append-only stream.<br>
+        This feature is only used in special scenarios where you need to save upstream table deletion messages. For example, in a logical deletion scenario, users are not allowed to physically delete downstream messages. In this case, this feature is used in conjunction with the row_kind metadata field. Therefore, the downstream can save all detailed data at first, and then use the row_kind field to determine whether to perform logical deletion.<br>
+        The option values are as follows:<br>
+          <li>true: All types of messages (including INSERT, DELETE, UPDATE_BEFORE, and UPDATE_AFTER) will be converted into INSERT messages.</li>
+          <li>false (default): All types of messages are sent as is.</li>
+      </td>
+    </tr>
     </tbody>
     </table>
 </div>

--- a/docs/content/docs/connectors/flink-sources/postgres-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/postgres-cdc.md
@@ -253,6 +253,19 @@ SELECT * FROM shipments;
         Experimental option, defaults to false.
       </td>
     </tr>
+    <tr>
+      <td>scan.read-changelog-as-append-only.enabled</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>
+        是否将 changelog 数据流转换为 append-only 数据流。<br>
+        仅在需要保存上游表删除消息等特殊场景下开启使用，比如在逻辑删除场景下，用户不允许物理删除下游消息，此时使用该特性，并配合 row_kind 元数据字段，下游可以先保存所有明细数据，再通过 row_kind 字段判断是否进行逻辑删除。<br>
+        参数取值如下：<br>
+          <li>true：所有类型的消息（包括INSERT、DELETE、UPDATE_BEFORE、UPDATE_AFTER）都会转换成 INSERT 类型的消息。</li>
+          <li>false（默认）：所有类型的消息都保持原样下发。</li>
+      </td>
+    </tr>
     </tbody>
     </table>
 </div>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/options/SourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/options/SourceOptions.java
@@ -146,4 +146,12 @@ public class SourceOptions {
                             .defaultValue(false)
                             .withDescription(
                                     "Whether to assign the unbounded chunks first during snapshot reading phase. This might help reduce the risk of the TaskManager experiencing an out-of-memory (OOM) error when taking a snapshot of the largest unbounded chunk.  Defaults to false.");
+
+    @Experimental
+    public static final ConfigOption<Boolean> SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED =
+            ConfigOptions.key("scan.read-changelog-as-append-only.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to convert the changelog data stream to an append-only data stream");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -81,6 +81,8 @@ public final class RowDataDebeziumDeserializeSchema
     /** Whether the deserializer needs to handle metadata columns. */
     private final boolean hasMetadata;
 
+    private final boolean appendOnly;
+
     /**
      * A wrapped output collector which is used to append metadata columns after physical columns.
      */
@@ -116,6 +118,7 @@ public final class RowDataDebeziumDeserializeSchema
         this.resultTypeInfo = checkNotNull(resultTypeInfo);
         this.validator = checkNotNull(validator);
         this.changelogMode = checkNotNull(changelogMode);
+        this.appendOnly = appendOnly;
     }
 
     @Override
@@ -161,7 +164,7 @@ public final class RowDataDebeziumDeserializeSchema
     }
 
     private void emit(SourceRecord inRecord, RowData physicalRow, Collector<RowData> collector) {
-        if (!hasMetadata) {
+        if (!hasMetadata && !appendOnly) {
             collector.collect(physicalRow);
             return;
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -26,7 +26,6 @@ import org.apache.flink.cdc.connectors.mysql.utils.OptionUtils;
 import org.apache.flink.cdc.debezium.table.DebeziumOptions;
 import org.apache.flink.cdc.debezium.utils.JdbcUrlUtils;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.config.TableConfigOptions;
@@ -125,7 +124,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                     MySqlSourceOptions.CONNECT_TIMEOUT, connectTimeout, Duration.ofMillis(250));
         }
 
-        OptionUtils.printOptions(IDENTIFIER, ((Configuration) config).toMap());
+        OptionUtils.printOptions(IDENTIFIER, config.toMap());
 
         return new MySqlTableSource(
                 physicalSchema,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableFactory.java
@@ -23,7 +23,6 @@ import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.postgres.utils.OptionUtils;
 import org.apache.flink.cdc.debezium.table.DebeziumChangelogMode;
 import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -46,6 +45,7 @@ import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_IN
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED;
+import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED;
 import static org.apache.flink.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
 import static org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceOptions.CHANGELOG_MODE;
 import static org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceOptions.CHUNK_META_GROUP_SIZE;
@@ -119,6 +119,7 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
         int lsnCommitCheckpointsDelay = config.get(SCAN_LSN_COMMIT_CHECKPOINTS_DELAY);
         boolean assignUnboundedChunkFirst =
                 config.get(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        boolean appendOnly = config.get(SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED);
 
         if (enableParallelRead) {
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
@@ -134,7 +135,7 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
                     "The Postgres CDC connector does not support 'latest-offset' startup mode when 'scan.incremental.snapshot.enabled' is disabled, you can enable 'scan.incremental.snapshot.enabled' to use this startup mode.");
         }
 
-        OptionUtils.printOptions(IDENTIFIER, ((Configuration) config).toMap());
+        OptionUtils.printOptions(IDENTIFIER, config.toMap());
 
         return new PostgreSQLTableSource(
                 physicalSchema,
@@ -165,7 +166,8 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
                 skipSnapshotBackfill,
                 isScanNewlyAddedTableEnabled,
                 lsnCommitCheckpointsDelay,
-                assignUnboundedChunkFirst);
+                assignUnboundedChunkFirst,
+                appendOnly);
     }
 
     @Override
@@ -209,6 +211,7 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
         options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         options.add(SCAN_LSN_COMMIT_CHECKPOINTS_DELAY);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        options.add(SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableSource.java
@@ -86,6 +86,7 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
     private final boolean scanNewlyAddedTableEnabled;
     private final int lsnCommitCheckpointsDelay;
     private final boolean assignUnboundedChunkFirst;
+    private final boolean appendOnly;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -126,7 +127,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
             boolean skipSnapshotBackfill,
             boolean isScanNewlyAddedTableEnabled,
             int lsnCommitCheckpointsDelay,
-            boolean assignUnboundedChunkFirst) {
+            boolean assignUnboundedChunkFirst,
+            boolean appendOnly) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -159,10 +161,15 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
         this.scanNewlyAddedTableEnabled = isScanNewlyAddedTableEnabled;
         this.lsnCommitCheckpointsDelay = lsnCommitCheckpointsDelay;
         this.assignUnboundedChunkFirst = assignUnboundedChunkFirst;
+        this.appendOnly = appendOnly;
     }
 
     @Override
     public ChangelogMode getChangelogMode() {
+        if (appendOnly) {
+            return ChangelogMode.insertOnly();
+        }
+
         switch (changelogMode) {
             case UPSERT:
                 return org.apache.flink.table.connector.ChangelogMode.upsert();
@@ -190,6 +197,7 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                                 PostgreSQLDeserializationConverterFactory.instance())
                         .setValueValidator(new PostgresValueValidator(schemaName, tableName))
                         .setChangelogMode(changelogMode)
+                        .setAppendOnly(appendOnly)
                         .build();
 
         if (enableParallelRead) {
@@ -291,7 +299,8 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                         skipSnapshotBackfill,
                         scanNewlyAddedTableEnabled,
                         lsnCommitCheckpointsDelay,
-                        assignUnboundedChunkFirst);
+                        assignUnboundedChunkFirst,
+                        appendOnly);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresSourceITCase.java
@@ -314,67 +314,18 @@ class PostgresSourceITCase extends PostgresTestBase {
     @ParameterizedTest
     @ValueSource(strings = {"initial", "latest-offset"})
     void testDebeziumSlotDropOnStop(String scanStartupMode) throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
-
-        env.setParallelism(2);
-        env.enableCheckpointing(200L);
-        env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
-        String sourceDDL =
-                format(
-                        "CREATE TABLE customers ("
-                                + " Id BIGINT NOT NULL,"
-                                + " Name STRING,"
-                                + " address STRING,"
-                                + " phone_number STRING,"
-                                + " primary key (Id) not enforced"
-                                + ") WITH ("
-                                + " 'connector' = 'postgres-cdc',"
-                                + " 'scan.incremental.snapshot.enabled' = 'true',"
-                                + " 'hostname' = '%s',"
-                                + " 'port' = '%s',"
-                                + " 'username' = '%s',"
-                                + " 'password' = '%s',"
-                                + " 'database-name' = '%s',"
-                                + " 'schema-name' = '%s',"
-                                + " 'table-name' = '%s',"
-                                + " 'scan.startup.mode' = '%s',"
-                                + " 'scan.incremental.snapshot.chunk.size' = '100',"
-                                + " 'decoding.plugin.name' = 'pgoutput', "
-                                + " 'slot.name' = '%s', "
-                                + " 'debezium.slot.drop.on.stop' = 'true'"
-                                + ")",
-                        customDatabase.getHost(),
-                        customDatabase.getDatabasePort(),
-                        customDatabase.getUsername(),
-                        customDatabase.getPassword(),
-                        customDatabase.getDatabaseName(),
-                        SCHEMA_NAME,
-                        "Customers",
-                        scanStartupMode,
-                        slotName);
-        tEnv.executeSql(sourceDDL);
-        TableResult tableResult = tEnv.executeSql("select * from customers");
-
-        // first step: check the snapshot data
-        if (DEFAULT_SCAN_STARTUP_MODE.equals(scanStartupMode)) {
-            checkSnapshotData(
-                    tableResult,
-                    PostgresTestUtils.FailoverType.JM,
-                    PostgresTestUtils.FailoverPhase.STREAM,
-                    new String[] {"Customers"});
-        }
-
-        // second step: check the stream data
-        checkStreamDataWithDDLDuringFailover(
-                tableResult,
+        Map<String, String> options = new HashMap<>();
+        options.put("debezium.snapshot.fetch.size", "2");
+        options.put("debezium.max.batch.size", "3");
+        testPostgresParallelSource(
+                2,
+                scanStartupMode,
                 PostgresTestUtils.FailoverType.JM,
                 PostgresTestUtils.FailoverPhase.STREAM,
-                new String[] {"Customers"});
-
-        Optional<JobClient> optionalJobClient = tableResult.getJobClient();
-        assertThat(optionalJobClient).isPresent();
-        optionalJobClient.get().cancel().get();
+                new String[] {"Customers"},
+                RestartStrategies.fixedDelayRestart(1, 0),
+                options,
+                this::checkStreamDataWithDDLDuringFailover);
     }
 
     @Test
@@ -626,71 +577,18 @@ class PostgresSourceITCase extends PostgresTestBase {
     @ParameterizedTest
     @ValueSource(strings = {"initial", "latest-offset"})
     void testNewLsnCommittedWhenCheckpoint(String scanStartupMode) throws Exception {
-        int parallelism = 1;
-        PostgresTestUtils.FailoverType failoverType = PostgresTestUtils.FailoverType.JM;
-        PostgresTestUtils.FailoverPhase failoverPhase = PostgresTestUtils.FailoverPhase.STREAM;
-        String[] captureCustomerTables = new String[] {"Customers"};
-        RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration =
-                RestartStrategies.fixedDelayRestart(1, 0);
-        boolean skipSnapshotBackfill = false;
-
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
-
-        env.setParallelism(parallelism);
-        env.enableCheckpointing(200L);
-        env.setRestartStrategy(restartStrategyConfiguration);
-        String sourceDDL =
-                format(
-                        "CREATE TABLE customers ("
-                                + " Id BIGINT NOT NULL,"
-                                + " Name STRING,"
-                                + " address STRING,"
-                                + " phone_number STRING,"
-                                + " primary key (Id) not enforced"
-                                + ") WITH ("
-                                + " 'connector' = 'postgres-cdc-mock',"
-                                + " 'scan.incremental.snapshot.enabled' = 'true',"
-                                + " 'hostname' = '%s',"
-                                + " 'port' = '%s',"
-                                + " 'username' = '%s',"
-                                + " 'password' = '%s',"
-                                + " 'database-name' = '%s',"
-                                + " 'schema-name' = '%s',"
-                                + " 'table-name' = '%s',"
-                                + " 'scan.startup.mode' = '%s',"
-                                + " 'scan.incremental.snapshot.chunk.size' = '100',"
-                                + " 'decoding.plugin.name' = 'pgoutput', "
-                                + " 'slot.name' = '%s',"
-                                + " 'scan.incremental.snapshot.backfill.skip' = '%s'"
-                                + ")",
-                        customDatabase.getHost(),
-                        customDatabase.getDatabasePort(),
-                        customDatabase.getUsername(),
-                        customDatabase.getPassword(),
-                        customDatabase.getDatabaseName(),
-                        SCHEMA_NAME,
-                        getTableNameRegex(captureCustomerTables),
-                        scanStartupMode,
-                        slotName,
-                        skipSnapshotBackfill);
-        tEnv.executeSql(sourceDDL);
-        TableResult tableResult = tEnv.executeSql("select * from customers");
-
-        // first step: check the snapshot data
-        if (DEFAULT_SCAN_STARTUP_MODE.equals(scanStartupMode)) {
-            checkSnapshotData(tableResult, failoverType, failoverPhase, captureCustomerTables);
-        }
-
-        // second step: check the stream data
-        checkStreamDataWithHook(tableResult, failoverType, failoverPhase, captureCustomerTables);
-
-        Optional<JobClient> optionalJobClient = tableResult.getJobClient();
-        assertThat(optionalJobClient).isPresent();
-        optionalJobClient.get().cancel().get();
-
-        // sleep 1000ms to wait until connections are closed.
-        Thread.sleep(1000L);
+        Map<String, String> options = new HashMap<>();
+        options.put("scan.incremental.snapshot.backfill.skip", "false");
+        options.put("connector", "postgres-cdc-mock");
+        testPostgresParallelSource(
+                1,
+                scanStartupMode,
+                PostgresTestUtils.FailoverType.JM,
+                PostgresTestUtils.FailoverPhase.STREAM,
+                new String[] {"Customers"},
+                RestartStrategies.fixedDelayRestart(1, 0),
+                options,
+                this::checkStreamDataWithHook);
     }
 
     @ParameterizedTest
@@ -743,73 +641,19 @@ class PostgresSourceITCase extends PostgresTestBase {
     @ParameterizedTest
     @ValueSource(strings = {"initial", "latest-offset"})
     void testCommitLsnWhenTaskManagerFailover(String scanStartupMode) throws Exception {
-        int parallelism = 1;
-        PostgresTestUtils.FailoverType failoverType = PostgresTestUtils.FailoverType.TM;
-        PostgresTestUtils.FailoverPhase failoverPhase = PostgresTestUtils.FailoverPhase.STREAM;
-        String[] captureCustomerTables = new String[] {"Customers"};
-        RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration =
-                RestartStrategies.fixedDelayRestart(1, 0);
-        boolean skipSnapshotBackfill = false;
-
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
-
-        env.setParallelism(parallelism);
-        env.enableCheckpointing(1000L);
-        env.setRestartStrategy(restartStrategyConfiguration);
-        String sourceDDL =
-                format(
-                        "CREATE TABLE customers ("
-                                + " Id BIGINT NOT NULL,"
-                                + " Name STRING,"
-                                + " address STRING,"
-                                + " phone_number STRING,"
-                                + " primary key (Id) not enforced"
-                                + ") WITH ("
-                                + " 'connector' = 'postgres-cdc',"
-                                + " 'scan.incremental.snapshot.enabled' = 'true',"
-                                + " 'hostname' = '%s',"
-                                + " 'port' = '%s',"
-                                + " 'username' = '%s',"
-                                + " 'password' = '%s',"
-                                + " 'database-name' = '%s',"
-                                + " 'schema-name' = '%s',"
-                                + " 'table-name' = '%s',"
-                                + " 'scan.startup.mode' = '%s',"
-                                + " 'scan.incremental.snapshot.chunk.size' = '100',"
-                                + " 'decoding.plugin.name' = 'pgoutput', "
-                                + " 'slot.name' = '%s',"
-                                + " 'scan.incremental.snapshot.backfill.skip' = '%s',"
-                                + " 'scan.newly-added-table.enabled' = 'true',"
-                                + " 'scan.lsn-commit.checkpoints-num-delay' = '0'"
-                                + ")",
-                        customDatabase.getHost(),
-                        customDatabase.getDatabasePort(),
-                        customDatabase.getUsername(),
-                        customDatabase.getPassword(),
-                        customDatabase.getDatabaseName(),
-                        SCHEMA_NAME,
-                        getTableNameRegex(captureCustomerTables),
-                        scanStartupMode,
-                        slotName,
-                        skipSnapshotBackfill);
-        tEnv.executeSql(sourceDDL);
-        TableResult tableResult = tEnv.executeSql("select * from customers");
-
-        // first step: check the snapshot data
-        if (DEFAULT_SCAN_STARTUP_MODE.equals(scanStartupMode)) {
-            checkSnapshotData(tableResult, failoverType, failoverPhase, captureCustomerTables);
-        }
-
-        // second step: check the stream data
-        checkStreamDataWithTestLsn(tableResult, failoverType, failoverPhase, captureCustomerTables);
-
-        Optional<JobClient> optionalJobClient = tableResult.getJobClient();
-        assertThat(optionalJobClient).isPresent();
-        optionalJobClient.get().cancel().get();
-
-        // sleep 1000ms to wait until connections are closed.
-        Thread.sleep(1000L);
+        Map<String, String> options = new HashMap<>();
+        options.put("scan.incremental.snapshot.backfill.skip", "false");
+        options.put("scan.newly-added-table.enabled", "true");
+        options.put("scan.lsn-commit.checkpoints-num-delay", "0");
+        testPostgresParallelSource(
+                1,
+                scanStartupMode,
+                PostgresTestUtils.FailoverType.TM,
+                PostgresTestUtils.FailoverPhase.STREAM,
+                new String[] {"Customers"},
+                RestartStrategies.fixedDelayRestart(1, 0),
+                options,
+                this::checkStreamDataWithTestLsn);
     }
 
     private List<String> testBackfillWhenWritingEvents(
@@ -924,8 +768,7 @@ class PostgresSourceITCase extends PostgresTestBase {
                 failoverType,
                 failoverPhase,
                 captureCustomerTables,
-                RestartStrategies.fixedDelayRestart(1, 0),
-                new HashMap<>());
+                RestartStrategies.fixedDelayRestart(1, 0));
     }
 
     private void testPostgresParallelSource(
@@ -955,57 +798,35 @@ class PostgresSourceITCase extends PostgresTestBase {
             RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration,
             Map<String, String> otherOptions)
             throws Exception {
+        testPostgresParallelSource(
+                parallelism,
+                scanStartupMode,
+                failoverType,
+                failoverPhase,
+                captureCustomerTables,
+                restartStrategyConfiguration,
+                otherOptions,
+                this::checkStreamData);
+    }
+
+    private void testPostgresParallelSource(
+            int parallelism,
+            String scanStartupMode,
+            PostgresTestUtils.FailoverType failoverType,
+            PostgresTestUtils.FailoverPhase failoverPhase,
+            String[] captureCustomerTables,
+            RestartStrategies.RestartStrategyConfiguration restartStrategyConfiguration,
+            Map<String, String> otherOptions,
+            StreamDataChecker streamDataChecker)
+            throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
 
         env.setParallelism(parallelism);
         env.enableCheckpointing(200L);
         env.setRestartStrategy(restartStrategyConfiguration);
-        String sourceDDL =
-                format(
-                        "CREATE TABLE customers ("
-                                + " Id BIGINT NOT NULL,"
-                                + " Name STRING,"
-                                + " address STRING,"
-                                + " phone_number STRING,"
-                                + " primary key (Id) not enforced"
-                                + ") WITH ("
-                                + " 'connector' = 'postgres-cdc',"
-                                + " 'scan.incremental.snapshot.enabled' = 'true',"
-                                + " 'hostname' = '%s',"
-                                + " 'port' = '%s',"
-                                + " 'username' = '%s',"
-                                + " 'password' = '%s',"
-                                + " 'database-name' = '%s',"
-                                + " 'schema-name' = '%s',"
-                                + " 'table-name' = '%s',"
-                                + " 'scan.startup.mode' = '%s',"
-                                + " 'scan.incremental.snapshot.chunk.size' = '100',"
-                                + " 'decoding.plugin.name' = 'pgoutput', "
-                                + " 'slot.name' = '%s',"
-                                + " 'scan.lsn-commit.checkpoints-num-delay' = '1'"
-                                + " %s"
-                                + ")",
-                        customDatabase.getHost(),
-                        customDatabase.getDatabasePort(),
-                        customDatabase.getUsername(),
-                        customDatabase.getPassword(),
-                        customDatabase.getDatabaseName(),
-                        SCHEMA_NAME,
-                        getTableNameRegex(captureCustomerTables),
-                        scanStartupMode,
-                        slotName,
-                        otherOptions.isEmpty()
-                                ? ""
-                                : ","
-                                        + otherOptions.entrySet().stream()
-                                                .map(
-                                                        e ->
-                                                                String.format(
-                                                                        "'%s'='%s'",
-                                                                        e.getKey(), e.getValue()))
-                                                .collect(Collectors.joining(",")));
-        tEnv.executeSql(sourceDDL);
+
+        tEnv.executeSql(getSourceDDL(scanStartupMode, captureCustomerTables, otherOptions));
         TableResult tableResult = tEnv.executeSql("select * from customers");
 
         // first step: check the snapshot data
@@ -1014,7 +835,7 @@ class PostgresSourceITCase extends PostgresTestBase {
         }
 
         // second step: check the stream data
-        checkStreamData(tableResult, failoverType, failoverPhase, captureCustomerTables);
+        streamDataChecker.check(tableResult, failoverType, failoverPhase, captureCustomerTables);
 
         Optional<JobClient> optionalJobClient = tableResult.getJobClient();
         assertThat(optionalJobClient).isPresent();
@@ -1022,6 +843,56 @@ class PostgresSourceITCase extends PostgresTestBase {
 
         // sleep 1000ms to wait until connections are closed.
         Thread.sleep(1000L);
+    }
+
+    private String getSourceDDL(
+            String scanStartupMode,
+            String[] captureCustomerTables,
+            Map<String, String> otherOptions) {
+        return format(
+                "CREATE TABLE customers ("
+                        + " Id BIGINT NOT NULL,"
+                        + " Name STRING,"
+                        + " address STRING,"
+                        + " phone_number STRING,"
+                        + " primary key (Id) not enforced"
+                        + ") WITH ("
+                        + " 'connector' = '%s',"
+                        + " 'scan.incremental.snapshot.enabled' = 'true',"
+                        + " 'hostname' = '%s',"
+                        + " 'port' = '%s',"
+                        + " 'username' = '%s',"
+                        + " 'password' = '%s',"
+                        + " 'database-name' = '%s',"
+                        + " 'schema-name' = '%s',"
+                        + " 'table-name' = '%s',"
+                        + " 'scan.startup.mode' = '%s',"
+                        + " 'scan.incremental.snapshot.chunk.size' = '100',"
+                        + " 'decoding.plugin.name' = 'pgoutput', "
+                        + " 'slot.name' = '%s',"
+                        + " 'scan.lsn-commit.checkpoints-num-delay' = '1'"
+                        + " %s"
+                        + ")",
+                otherOptions.getOrDefault("connector", "postgres-cdc"),
+                customDatabase.getHost(),
+                customDatabase.getDatabasePort(),
+                customDatabase.getUsername(),
+                customDatabase.getPassword(),
+                customDatabase.getDatabaseName(),
+                SCHEMA_NAME,
+                getTableNameRegex(captureCustomerTables),
+                scanStartupMode,
+                slotName,
+                otherOptions.isEmpty()
+                        ? ""
+                        : ","
+                                + otherOptions.entrySet().stream()
+                                        .map(
+                                                e ->
+                                                        String.format(
+                                                                "'%s'='%s'",
+                                                                e.getKey(), e.getValue()))
+                                        .collect(Collectors.joining(",")));
     }
 
     private void checkSnapshotData(
@@ -1415,5 +1286,14 @@ class PostgresSourceITCase extends PostgresTestBase {
                     }
                     return rs.getString(1);
                 });
+    }
+
+    private interface StreamDataChecker {
+        void check(
+                TableResult tableResult,
+                PostgresTestUtils.FailoverType failoverType,
+                PostgresTestUtils.FailoverPhase failoverPhase,
+                String[] captureCustomerTables)
+                throws Exception;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/MockPostgreSQLTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/MockPostgreSQLTableSource.java
@@ -66,7 +66,8 @@ public class MockPostgreSQLTableSource extends PostgreSQLTableSource {
                 (boolean) get(postgreSQLTableSource, "skipSnapshotBackfill"),
                 (boolean) get(postgreSQLTableSource, "scanNewlyAddedTableEnabled"),
                 (int) get(postgreSQLTableSource, "lsnCommitCheckpointsDelay"),
-                (boolean) get(postgreSQLTableSource, "assignUnboundedChunkFirst"));
+                (boolean) get(postgreSQLTableSource, "assignUnboundedChunkFirst"),
+                (boolean) get(postgreSQLTableSource, "appendOnly"));
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLConnectorITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.util.CloseableIterator;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -306,10 +307,9 @@ class PostgreSQLConnectorITCase extends PostgresTestBase {
         result.getJobClient().get().cancel().get();
     }
 
-    @ParameterizedTest
-    @ValueSource(booleans = {true})
-    public void testStartupFromCommittedOffset(boolean parallelismSnapshot) throws Exception {
-        setup(parallelismSnapshot);
+    @Test
+    public void testStartupFromCommittedOffset() throws Exception {
+        setup(true);
         initializePostgresTable(POSTGRES_CONTAINER, "inventory");
         try (Connection connection = getJdbcConnection(POSTGRES_CONTAINER);
                 Statement statement = connection.createStatement()) {
@@ -325,7 +325,9 @@ class PostgreSQLConnectorITCase extends PostgresTestBase {
         String publicName = "dbz_publication_" + new Random().nextInt(1000);
         try (Connection connection = getJdbcConnection(POSTGRES_CONTAINER);
                 Statement statement = connection.createStatement()) {
-            // TODO: Remove it after adding publication to an existing replication slot.
+            // For pgoutput specifically, the publication must be created before the slot.
+            // postgres community is still working on it:
+            // https://www.postgresql.org/message-id/CALDaNm0-n8FGAorM%2BbTxkzn%2BAOUyx5%3DL_XmnvOP6T24%2B-NcBKg%40mail.gmail.com
             statement.execute(
                     String.format(
                             "CREATE PUBLICATION %s FOR TABLE inventory.products", publicName));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableFactoryTest.java
@@ -59,6 +59,7 @@ import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_IN
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED;
+import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND;
@@ -153,7 +154,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
                         SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
-                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
+                        SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue());
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 
@@ -166,6 +168,7 @@ class PostgreSQLTableFactoryTest {
         options.put("changelog-mode", "upsert");
         options.put("scan.incremental.snapshot.backfill.skip", "true");
         options.put("scan.newly-added-table.enabled", "true");
+        options.put("scan.read-changelog-as-append-only.enabled", "true");
 
         DynamicTableSource actualSource = createTableSource(options);
         Properties dbzProperties = new Properties();
@@ -200,7 +203,8 @@ class PostgreSQLTableFactoryTest {
                         true,
                         true,
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
-                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
+                        true);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 
@@ -245,7 +249,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
                         SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
-                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
+                        SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue());
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys =
                 Arrays.asList("row_kind", "op_ts", "database_name", "schema_name", "table_name");
@@ -300,7 +305,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
                         SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
-                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
+                        SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue());
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 
@@ -345,7 +351,8 @@ class PostgreSQLTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
                         SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
                         SCAN_LSN_COMMIT_CHECKPOINTS_DELAY.defaultValue(),
-                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue());
+                        SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue(),
+                        SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED.defaultValue());
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
 


### PR DESCRIPTION
As shown in https://issues.apache.org/jira/browse/FLINK-37738, support reading changelog as append only mode in postgres cdc connector