### PR TITLE
[FLINK-37462] Fix consecutive schema change requests might be overwritten

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -419,15 +419,17 @@ public class SchemaCoordinator extends SchemaRegistry {
                     tableId, schemaManager.getLatestEvolvedSchema(tableId).orElse(null));
         }
 
-        // And returns all successfully applied schema change events to SchemaOperator.
-        responseFuture.complete(
-                wrap(new SchemaChangeResponse(appliedSchemaChangeEvents, refreshedEvolvedSchemas)));
-
         pendingRequests.remove(sourceSubTaskId);
+
         LOG.info(
                 "Finished handling schema change request from {}. Pending requests: {}",
                 sourceSubTaskId,
                 pendingRequests);
+
+        // We release the response future at last to avoid leaking internal states to SchemaOperator
+        // client accidentally.
+        responseFuture.complete(
+                wrap(new SchemaChangeResponse(appliedSchemaChangeEvents, refreshedEvolvedSchemas)));
     }
 
     private boolean applyAndUpdateEvolvedSchemaChange(SchemaChangeEvent schemaChangeEvent) {

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaOperator.java
@@ -167,10 +167,11 @@ public class SchemaOperator extends AbstractStreamOperator<Event>
         output.collect(
                 new StreamRecord<>(new FlushEvent(subTaskId, sinkTables, originalEvent.getType())));
 
+        LOG.info("{}> Going to request schema change...", subTaskId);
+
         // Then, queue to request schema change to SchemaCoordinator.
         SchemaChangeResponse response = requestSchemaChange(tableId, originalEvent);
 
-        LOG.info("{}> Successfully requested schema change.", subTaskId);
         LOG.info(
                 "{}> Finished schema change events: {}",
                 subTaskId,


### PR DESCRIPTION
This closes FLINK-37462.

As reported previously, FlinkParallelizedPipelineITCase.testRegularTablesSourceInMultipleParallelism test case fails frequently on GitHub Actions, but could not be reliably reproduced locally (perhaps because GHA runners are much more powerful).

By enabling verbose logging, the reason might be: we released responseFuture from SchemaOperator before clearing it from `pendingRequests` set. So if client proposes another request immediately after being responded, the request coming later might be removed accidentally.

`SchemaOperator`'s logging sequence has been modified to indicate current stage of schema change requests.

I've ran this test case repeatedly (17 times) in my forked repo (https://github.com/yuxiqian/flink-cdc/pull/121) to verify this change.