### PR TITLE
[BP-3.4.0] Fix environment variable check for FLINK_CDC_HOME in YarnApplicationDeploymentExecutor. 

### DIFF
--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/deployment/YarnApplicationDeploymentExecutor.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/deployment/YarnApplicationDeploymentExecutor.java
@@ -127,7 +127,7 @@ public class YarnApplicationDeploymentExecutor implements PipelineDeploymentExec
         Preconditions.checkNotNull(
                 flinkCDCHomeFromEnvVar,
                 "FLINK_CDC_HOME is not correctly set in environment variable, current FLINK_CDC_HOME is: "
-                        + FLINK_CDC_HOME_ENV_VAR);
+                        + flinkCDCHomeFromEnvVar);
         Path flinkCDCLibPath = new Path(flinkCDCHomeFromEnvVar, "lib");
         if (!flinkCDCLibPath.getFileSystem().exists(flinkCDCLibPath)
                 || !flinkCDCLibPath.getFileSystem().getFileStatus(flinkCDCLibPath).isDir()) {


### PR DESCRIPTION
Fix environment variable check for FLINK_CDC_HOME in YarnApplicationDeploymentExecutor.  (#4012)

(cherry picked from commit ceffbc0ea1a223bb2a81bd63c507be5978dee7f3)