### PR TITLE
FLINK-37774: SQL Server CDC connector incorrectly handles special characters in database and table names

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/state/PendingSplitsStateSerializer.java
@@ -187,7 +187,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         out.writeBoolean(hasTableIsSplitting);
         if (hasTableIsSplitting) {
             ChunkSplitterState chunkSplitterState = state.getChunkSplitterState();
-            out.writeUTF(chunkSplitterState.getCurrentSplittingTableId().toString());
+            out.writeUTF(chunkSplitterState.getCurrentSplittingTableId().toDoubleQuotedString());
             out.writeUTF(
                     SerializerUtils.rowToSerializedString(
                             new Object[] {chunkSplitterState.getNextChunkStart().getValue()}));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
@@ -169,7 +169,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         out.writeBoolean(hasTableIsSplitting);
         if (hasTableIsSplitting) {
             ChunkSplitterState chunkSplitterState = state.getChunkSplitterState();
-            out.writeUTF(chunkSplitterState.getCurrentSplittingTableId().toString());
+            out.writeUTF(chunkSplitterState.getCurrentSplittingTableId().toDoubleQuotedString());
             out.writeUTF(
                     SerializerUtils.rowToSerializedString(
                             new Object[] {chunkSplitterState.getNextChunkStart().getValue()}));
@@ -415,7 +415,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
         final int size = tableIds.size();
         out.writeInt(size);
         for (TableId tableId : tableIds) {
-            out.writeUTF(tableId.toString());
+            out.writeUTF(tableId.toDoubleQuotedString());
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/split/MySqlSplitSerializer.java
@@ -192,7 +192,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
         final int size = tableSchemas.size();
         out.writeInt(size);
         for (Map.Entry<TableId, TableChange> entry : tableSchemas.entrySet()) {
-            out.writeUTF(entry.getKey().toString());
+            out.writeUTF(entry.getKey().toDoubleQuotedString());
             final String tableChangeStr =
                     documentWriter.write(jsonSerializer.toDocument(entry.getValue()));
             final byte[] tableChangeBytes = tableChangeStr.getBytes(StandardCharsets.UTF_8);
@@ -237,7 +237,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
         final int size = finishedSplitsInfo.size();
         out.writeInt(size);
         for (FinishedSnapshotSplitInfo splitInfo : finishedSplitsInfo) {
-            out.writeUTF(splitInfo.getTableId().toString());
+            out.writeUTF(splitInfo.getTableId().toDoubleQuotedString());
             out.writeUTF(splitInfo.getSplitId());
             out.writeUTF(rowToSerializedString(splitInfo.getSplitStart()));
             out.writeUTF(rowToSerializedString(splitInfo.getSplitEnd()));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializerTest.java
@@ -52,8 +52,8 @@ import static org.apache.flink.cdc.connectors.mysql.source.split.MySqlSnapshotSp
 class PendingSplitsStateSerializerTest {
 
     private static final TableId tableId0 = TableId.parse("test_db.test_table");
-    private static final TableId tableId1 = TableId.parse("test_db.test_table1");
-    private static final TableId tableId2 = TableId.parse("test_db.test_table2");
+    private static final TableId tableId1 = TableId.parse("test_db.\"test_table 1\"");
+    private static final TableId tableId2 = TableId.parse("test_db.\"test_table 2\"");
 
     public static Stream<Arguments> params() {
         return Stream.of(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerConnectionUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerConnectionUtils.java
@@ -92,7 +92,7 @@ public class SqlServerConnectionUtils {
             try {
                 jdbc.query(
                         "SELECT * FROM "
-                                + dbName
+                                + SqlServerUtils.quote(dbName)
                                 + ".INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';",
                         rs -> {
                             while (rs.next()) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
@@ -361,12 +361,16 @@ public class SqlServerUtils {
         return quoted.toString();
     }
 
-    public static String quote(String dbOrTableName) {
-        return "[" + dbOrTableName + "]";
+    /**
+     * @link <a
+     *     href="https://learn.microsoft.com/en-us/sql/t-sql/functions/quotename-transact-sql">QUOTENAME</a>
+     */
+    public static String quote(String name) {
+        return "[" + name.replace("]", "]]") + "]";
     }
 
     public static String quote(TableId tableId) {
-        return "[" + tableId.schema() + "].[" + tableId.table() + "]";
+        return String.format("%s.%s", quote(tableId.schema()), quote(tableId.table()));
     }
 
     private static void addPrimaryKeyColumnsToCondition(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
@@ -366,7 +366,7 @@ public class SqlServerUtils {
      *     href="https://learn.microsoft.com/en-us/sql/t-sql/functions/quotename-transact-sql">QUOTENAME</a>
      */
     public static String quote(String name) {
-        return "[" + name.replace("]", "]]") + "]";
+        return "[" + name + "]";
     }
 
     public static String quote(TableId tableId) {


### PR DESCRIPTION
There are two problems:
1. Invalid SQL query for listing tables.
2. Invalid serialization of `TableId`s.

The latter is similar to #4000, which wasn't fixed consistently across the codebase.

Besides making the database name quoted in SQL, I modified the implementation of `SqlServerUtils#quote()` – it should not only enclose the name in square brackets but also escape the closing square bracket.