### PR TITLE
[FLINK-37677][cdc-common][cdc-runtime] Handle Exclusion of `create.table` Events in Flink CDC Schema Evolution

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/MetadataApplier.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/MetadataApplier.java
@@ -41,7 +41,7 @@ public interface MetadataApplier extends Serializable, AutoCloseable {
         return this;
     }
 
-    /** Checks if this metadata applier should this event type. */
+    /** Checks if this metadata applier should accept this event type. */
     default boolean acceptsSchemaEvolutionType(SchemaChangeEventType schemaChangeEventType) {
         return true;
     }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaDerivator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaDerivator.java
@@ -25,6 +25,7 @@ import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.DropColumnEvent;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.event.SchemaChangeEventWithPreSchema;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
@@ -171,7 +172,9 @@ public class SchemaDerivator {
 
         List<SchemaChangeEvent> finalSchemaChangeEvents = new ArrayList<>();
         for (SchemaChangeEvent schemaChangeEvent : rewrittenSchemaChangeEvents) {
-            if (metadataApplier.acceptsSchemaEvolutionType(schemaChangeEvent.getType())) {
+            // always accept create.table event
+            if (metadataApplier.acceptsSchemaEvolutionType(schemaChangeEvent.getType())
+                    || schemaChangeEvent.getType().equals(SchemaChangeEventType.CREATE_TABLE)) {
                 finalSchemaChangeEvents.add(schemaChangeEvent);
             } else {
                 LOG.info("Ignored schema change {}.", schemaChangeEvent);

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaCoordinator.java
@@ -462,11 +462,18 @@ public class SchemaCoordinator extends SchemaRegistry {
 
     private boolean applyAndUpdateEvolvedSchemaChange(SchemaChangeEvent schemaChangeEvent) {
         try {
-            metadataApplier.applySchemaChange(schemaChangeEvent);
+            // filter create.table schema change event
+            if (metadataApplier.acceptsSchemaEvolutionType(schemaChangeEvent.getType())) {
+                metadataApplier.applySchemaChange(schemaChangeEvent);
+                LOG.info(
+                        "Successfully applied schema change event {} to external system.",
+                        schemaChangeEvent);
+            } else {
+                LOG.info(
+                        "Skip apply schema change event {} to external system.",
+                        schemaChangeEvent);
+            }
             schemaManager.applyEvolvedSchemaChange(schemaChangeEvent);
-            LOG.info(
-                    "Successfully applied schema change event {} to external system.",
-                    schemaChangeEvent);
             return true;
         } catch (Throwable t) {
             handleUnrecoverableError(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaCoordinator.java
@@ -434,7 +434,12 @@ public class SchemaCoordinator extends SchemaRegistry {
 
     private boolean applyAndUpdateEvolvedSchemaChange(SchemaChangeEvent schemaChangeEvent) {
         try {
-            metadataApplier.applySchemaChange(schemaChangeEvent);
+            // filter create.table schema change event
+            if (metadataApplier.acceptsSchemaEvolutionType(schemaChangeEvent.getType())) {
+                metadataApplier.applySchemaChange(schemaChangeEvent);
+            } else {
+                LOG.info("Skip apply schema change {}.", schemaChangeEvent);
+            }
             schemaManager.applyEvolvedSchemaChange(schemaChangeEvent);
             LOG.info(
                     "Successfully applied schema change event {} to external system.",

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/RegularEventOperatorTestHarness.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/RegularEventOperatorTestHarness.java
@@ -168,6 +168,22 @@ public class RegularEventOperatorTestHarness<OP extends AbstractStreamOperator<E
     }
 
     public static <OP extends AbstractStreamOperator<E>, E extends Event>
+            RegularEventOperatorTestHarness<OP, E> withDurationAndExcludeCreateTableBehavior(
+                    OP operator,
+                    int numOutputs,
+                    Duration evolveDuration,
+                    SchemaChangeBehavior behavior) {
+        return new RegularEventOperatorTestHarness<>(
+                operator,
+                numOutputs,
+                evolveDuration,
+                DEFAULT_RPC_TIMEOUT,
+                behavior,
+                Arrays.stream(SchemaChangeEventTypeFamily.COLUMN).collect(Collectors.toSet()),
+                Arrays.stream(SchemaChangeEventTypeFamily.TABLE).collect(Collectors.toSet()));
+    }
+
+    public static <OP extends AbstractStreamOperator<E>, E extends Event>
             RegularEventOperatorTestHarness<OP, E> withDurationAndFineGrainedBehavior(
                     OP operator,
                     int numOutputs,


### PR DESCRIPTION
**Description:**

This PR addresses the issue identified in FLINK-37677, where setting `exclude.schema.changes: [create.table]` in the YAML configuration causes Flink CDC to throw an `IllegalStateException`. 

```
java.lang.IllegalStateException: Unable to coerce data record from my_company.my_branch.customers (schema: columns={`id` INT,`name` STRING NOT NULL,`age` SMALLINT}, primaryKeys=id, options=()) to my_company.my_branch.customers (schema: null)

	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.lambda$handleDataChangeEvent$1(SchemaOperator.java:215)
	at java.util.Optional.orElseThrow(Optional.java:290)
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.handleDataChangeEvent(SchemaOperator.java:212)
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.processElement(SchemaOperator.java:150)
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaEvolveTest.processEvent(SchemaEvolveTest.java:2643)
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaEvolveTest.testLenientSchemaEvolvesExcludeCreate(SchemaEvolveTest.java:2600)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
```

**Solution:**

- Always accept create.table event
- Skip apply create.table schema change event {} to external system

**Testing:**

Added unit tests.
