### PR TITLE
[FLINK-37905] Fix transform failure with non-ascii string literals

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -34,6 +34,7 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.commons.compiler.Location;
 import org.codehaus.janino.ExpressionEvaluator;
@@ -158,10 +159,10 @@ public class JaninoCompiler {
         if (sqlLiteral.getValue() == null) {
             return new Java.NullLiteral(Location.NOWHERE);
         }
-        String value = sqlLiteral.getValue().toString();
+        Object value = sqlLiteral.getValue();
         if (sqlLiteral instanceof SqlCharStringLiteral) {
             // Double quotation marks represent strings in Janino.
-            value = "\"" + value.substring(1, value.length() - 1) + "\"";
+            value = "\"" + ((NlsString) value).getValue() + "\"";
         } else if (sqlLiteral instanceof SqlNumericLiteral) {
             if (((SqlNumericLiteral) sqlLiteral).isInteger()) {
                 long longValue = sqlLiteral.longValue(true);
@@ -173,7 +174,7 @@ public class JaninoCompiler {
         if (SQL_TYPE_NAME_IGNORE.contains(sqlLiteral.getTypeName())) {
             value = "\"" + value + "\"";
         }
-        return new Java.AmbiguousName(Location.NOWHERE, new String[] {value});
+        return new Java.AmbiguousName(Location.NOWHERE, new String[] {value.toString()});
     }
 
     private static Java.Rvalue translateSqlBasicCall(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -162,7 +162,7 @@ public class JaninoCompiler {
         Object value = sqlLiteral.getValue();
         if (sqlLiteral instanceof SqlCharStringLiteral) {
             // Double quotation marks represent strings in Janino.
-            value = "\"" + ((NlsString) value).getValue() + "\"";
+            value = "\"" + sqlLiteral.getValueAs(NlsString.class).getValue() + "\"";
         } else if (sqlLiteral instanceof SqlNumericLiteral) {
             if (((SqlNumericLiteral) sqlLiteral).isInteger()) {
                 long longValue = sqlLiteral.longValue(true);

--- a/flink-cdc-runtime/src/main/resources/saffron.properties
+++ b/flink-cdc-runtime/src/main/resources/saffron.properties
@@ -1,0 +1,16 @@
+################################################################################
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+calcite.default.charset = utf8


### PR DESCRIPTION
This closes FLINK-37905.

As reported by @ruanhang1993, any non-ascii string literals in transform expressions will be encoded into something like `"&'\xxxx"`, which is unexpected since Unicodes are fully supported in Flink SQL expressions.

+@aiwenmo