### PR TITLE
[FLINK-37909-][cdc-connector-mongodb] Update MongoDBStreamFetchTask to renew heartbeatManager

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/reader/fetch/MongoDBStreamFetchTask.java
@@ -121,6 +121,7 @@ public class MongoDBStreamFetchTask implements FetchTask<SourceSplitBase> {
                                     "Resume token has expired, fallback to timestamp restart mode");
                         }
                         changeStreamCursor = openChangeStreamCursor(descriptor, resumeTokenExpires);
+                        heartbeatManager = openHeartbeatManagerIfNeeded(changeStreamCursor);
                         next = Optional.ofNullable(changeStreamCursor.tryNext());
                     } else {
                         throw e;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-37909

Update `heartbeatManager` so it has latest `changeStreamCursor`, when it changes in the running while loop.
Right now `heartbeatManager` is created with orginal  `changeStreamCursor` and not renewed whenever `changeStreamCursor` is updated upon Change stream cursor expiry.
