### PR TITLE
[FLINK-38045] Build createTableEventCache using TableSchemas from split and Make transform operator stateless

### DIFF
--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.composer.flink;
 
 import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.pipeline.PipelineOptions;
@@ -186,9 +187,7 @@ public class FlinkPipelineComposer implements PipelineComposer {
                         pipelineDef.getTransforms(),
                         pipelineDef.getUdfs(),
                         pipelineDef.getModels(),
-                        dataSource.supportedMetadataColumns(),
-                        !isParallelMetadataSource && !isBatchMode,
-                        operatorUidGenerator);
+                        dataSource.supportedMetadataColumns());
 
         // PreTransform ---> PostTransform
         stream =
@@ -289,5 +288,10 @@ public class FlinkPipelineComposer implements PipelineComposer {
             return Optional.empty();
         }
         return Optional.of(container);
+    }
+
+    @VisibleForTesting
+    public StreamExecutionEnvironment getEnv() {
+        return env;
     }
 }

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/TransformTranslator.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/translator/TransformTranslator.java
@@ -50,30 +50,21 @@ public class TransformTranslator {
             List<TransformDef> transforms,
             List<UdfDef> udfFunctions,
             List<ModelDef> models,
-            SupportedMetadataColumn[] supportedMetadataColumns,
-            boolean shouldStoreSchemasInState,
-            OperatorUidGenerator operatorUidGenerator) {
+            SupportedMetadataColumn[] supportedMetadataColumns) {
         if (transforms.isEmpty()) {
             return input;
         }
         return input.transform(
-                        "Transform:Schema",
-                        new EventTypeInfo(),
-                        generatePreTransform(
-                                transforms,
-                                udfFunctions,
-                                models,
-                                supportedMetadataColumns,
-                                shouldStoreSchemasInState))
-                .uid(operatorUidGenerator.generateUid("pre-transform"));
+                "Transform:Schema",
+                new EventTypeInfo(),
+                generatePreTransform(transforms, udfFunctions, models, supportedMetadataColumns));
     }
 
     private PreTransformOperator generatePreTransform(
             List<TransformDef> transforms,
             List<UdfDef> udfFunctions,
             List<ModelDef> models,
-            SupportedMetadataColumn[] supportedMetadataColumns,
-            boolean shouldStoreSchemasInState) {
+            SupportedMetadataColumn[] supportedMetadataColumns) {
 
         PreTransformOperatorBuilder preTransformFunctionBuilder = PreTransformOperator.newBuilder();
         for (TransformDef transform : transforms) {
@@ -94,8 +85,7 @@ public class TransformTranslator {
                                 .map(this::udfDefToUDFTuple)
                                 .collect(Collectors.toList()))
                 .addUdfFunctions(
-                        models.stream().map(this::modelToUDFTuple).collect(Collectors.toList()))
-                .shouldStoreSchemasInState(shouldStoreSchemasInState);
+                        models.stream().map(this::modelToUDFTuple).collect(Collectors.toList()));
 
         return preTransformFunctionBuilder.build();
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/MySqlTypeUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/MySqlTypeUtils.java
@@ -127,7 +127,8 @@ public class MySqlTypeUtils {
         String typeName = column.typeName();
         switch (typeName) {
             case BIT:
-                return column.length() == 1
+                // column.length() might be -1
+                return column.length() <= 1
                         ? DataTypes.BOOLEAN()
                         : DataTypes.BINARY((column.length() + 7) / 8);
             case BOOL:

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/ValuesDatabase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/ValuesDatabase.java
@@ -81,8 +81,15 @@ public class ValuesDatabase {
 
         private Set<SchemaChangeEventType> enabledSchemaEvolutionTypes;
 
+        private final boolean materializedInMemory;
+
         public ValuesMetadataApplier() {
+            this(true);
+        }
+
+        public ValuesMetadataApplier(boolean materializedInMemory) {
             this.enabledSchemaEvolutionTypes = getSupportedSchemaEvolutionTypes();
+            this.materializedInMemory = materializedInMemory;
         }
 
         @Override
@@ -109,7 +116,9 @@ public class ValuesDatabase {
 
         @Override
         public void applySchemaChange(SchemaChangeEvent schemaChangeEvent) {
-            applySchemaChangeEvent(schemaChangeEvent);
+            if (materializedInMemory) {
+                applySchemaChangeEvent(schemaChangeEvent);
+            }
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
@@ -80,7 +80,7 @@ public class ValuesDataSink implements DataSink, Serializable {
         if (errorOnSchemaChange) {
             return new ValuesDatabase.ErrorOnChangeMetadataApplier();
         } else {
-            return new ValuesDatabase.ValuesMetadataApplier();
+            return new ValuesDatabase.ValuesMetadataApplier(materializedInMemory);
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
@@ -28,7 +28,7 @@ public class ValuesDataSinkOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "True if the DataChangeEvent need to be materialized in memory.");
+                            "True if the SchemaChangeEvent and DataChangeEvent need to be materialized in memory.");
 
     public static final ConfigOption<Boolean> PRINT_ENABLED =
             ConfigOptions.key("print.enabled")

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
@@ -48,7 +48,6 @@ import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReaderCont
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSplitReader;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitSerializer;
-import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitState;
 import org.apache.flink.cdc.connectors.mysql.source.split.SourceRecords;
 import org.apache.flink.cdc.connectors.mysql.source.utils.hooks.SnapshotPhaseHooks;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
@@ -289,7 +288,6 @@ public class MySqlSource<T>
     @FunctionalInterface
     interface RecordEmitterSupplier<T> extends Serializable {
 
-        RecordEmitter<SourceRecords, T, MySqlSplitState> get(
-                MySqlSourceReaderMetrics metrics, MySqlSourceConfig sourceConfig);
+        MySqlRecordEmitter<T> get(MySqlSourceReaderMetrics metrics, MySqlSourceConfig sourceConfig);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.connectors.mysql.source.reader;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
 import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
+import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitState;
 import org.apache.flink.cdc.connectors.mysql.source.split.SourceRecords;
 import org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils;
@@ -119,6 +120,8 @@ public class MySqlRecordEmitter<T> implements RecordEmitter<SourceRecords, T, My
         outputCollector.currentMessageTimestamp = RecordUtils.getMessageTimestamp(element);
         debeziumDeserializationSchema.deserialize(element, outputCollector);
     }
+
+    public void applySplit(MySqlSplit split) {}
 
     private void reportMetrics(SourceRecord element) {
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperatorBuilder.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/PreTransformOperatorBuilder.java
@@ -29,7 +29,6 @@ import java.util.Map;
 /** Builder of {@link PreTransformOperator}. */
 public class PreTransformOperatorBuilder {
     private final List<TransformRule> transformRules = new ArrayList<>();
-    private boolean shouldStoreSchemasInState;
 
     private final List<Tuple3<String, String, Map<String, String>>> udfFunctions =
             new ArrayList<>();
@@ -77,13 +76,7 @@ public class PreTransformOperatorBuilder {
         return this;
     }
 
-    public PreTransformOperatorBuilder shouldStoreSchemasInState(
-            boolean shouldStoreSchemasInState) {
-        this.shouldStoreSchemasInState = shouldStoreSchemasInState;
-        return this;
-    }
-
     public PreTransformOperator build() {
-        return new PreTransformOperator(transformRules, udfFunctions, shouldStoreSchemasInState);
+        return new PreTransformOperator(transformRules, udfFunctions);
     }
 }


### PR DESCRIPTION
For historical reasons, the current implementation does not utilize the Source to build a schema cache. This requires the TransformOperator to maintain its own complex state.

An optimization is proposed: to build a reusable schema cache at the Source (or in an operator immediately following it).

The primary benefit of this approach is that the transform operator can be made completely stateless. This simplifies its design, improves architectural modularity, and makes the entire pipeline more robust and maintainable.

