### PR TITLE
[FLINK-38065] Use curly braces in PostgresOffset#toString()

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
@@ -106,7 +106,7 @@ public class PostgresOffset extends Offset {
                 + (getTxid() == null ? "null" : getTxid())
                 + ", lastCommitTs="
                 + (getLastCommitTs() == null ? "null" : getLastCommitTs())
-                + "]";
+                + "}";
     }
 
     @Override
@@ -119,10 +119,5 @@ public class PostgresOffset extends Offset {
         }
         PostgresOffset that = (PostgresOffset) o;
         return offset.equals(that.offset);
-    }
-
-    @Override
-    public Map<String, String> getOffset() {
-        return offset;
     }
 }


### PR DESCRIPTION
Additionally, `PostgresOffset#getOffset()` is being removed since it's identical to the implementation in its super class.