### PR TITLE
[minor] Fix potential sql connection statement issue

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlEventDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlEventDeserializer.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.debezium.connector.AbstractSourceInfo.DATABASE_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;
 import static org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils.getHistoryRecord;
 
 /** Event deserializer for {@link MySqlDataSource}. */
@@ -146,8 +148,11 @@ public class MySqlEventDeserializer extends DebeziumEventDeserializationSchema {
 
     @Override
     protected TableId getTableId(SourceRecord record) {
-        String[] parts = record.topic().split("\\.");
-        return TableId.tableId(parts[1], parts[2]);
+        Struct value = (Struct) record.value();
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        String dbName = source.getString(DATABASE_NAME_KEY);
+        String tableName = source.getString(TABLE_NAME_KEY);
+        return TableId.tableId(dbName, tableName);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -27,6 +27,7 @@ import org.apache.flink.cdc.connectors.mysql.schema.MySqlTableDefinition;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import org.apache.flink.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitState;
+import org.apache.flink.cdc.connectors.mysql.source.utils.StatementUtils;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
 import org.apache.flink.cdc.connectors.mysql.utils.MySqlTypeUtils;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
@@ -155,7 +156,7 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
 
     private String showCreateTable(JdbcConnection jdbc, TableId tableId) {
         final String showCreateTableQuery =
-                String.format("SHOW CREATE TABLE `%s`.`%s`", tableId.catalog(), tableId.table());
+                String.format("SHOW CREATE TABLE %s", StatementUtils.quote(tableId));
         try {
             return jdbc.queryAndMap(
                     showCreateTableQuery,
@@ -177,7 +178,7 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
         List<String> primaryKeys = new ArrayList<>();
         try {
             return jdbc.queryAndMap(
-                    String.format("DESC `%s`.`%s`", tableId.catalog(), tableId.table()),
+                    String.format("DESC %s", StatementUtils.quote(tableId)),
                     rs -> {
                         while (rs.next()) {
                             MySqlFieldDefinition meta = new MySqlFieldDefinition();

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlPipelineITCase.java
@@ -255,6 +255,148 @@ class MySqlPipelineITCase extends MySqlSourceTestBase {
     }
 
     @Test
+    void testSqlInjection() throws Exception {
+        inventoryDatabase.createAndInitialize();
+        env.setParallelism(1);
+        String sqlInjectionTable = "sqlInjection; DROP TABLE important_data;";
+        try (Connection connection = inventoryDatabase.getJdbcConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute(
+                    String.format(
+                            "CREATE TABLE `%s`.`%s` (  "
+                                    + "id INTEGER NOT NULL AUTO_INCREMENT PRIMARY KEY,\n"
+                                    + "  name VARCHAR(255) NOT NULL DEFAULT 'flink',\n"
+                                    + "  description VARCHAR(512),\n"
+                                    + "  weight FLOAT(6)"
+                                    + ");\n",
+                            inventoryDatabase.getDatabaseName(), sqlInjectionTable));
+            statement.execute(
+                    String.format(
+                            "ALTER TABLE `%s`.`%s` AUTO_INCREMENT = 101;",
+                            inventoryDatabase.getDatabaseName(), sqlInjectionTable));
+            statement.execute(
+                    String.format(
+                            "INSERT INTO `%s`.`%s`\n"
+                                    + "VALUES (default,\"scooter\",\"Small 2-wheel scooter\",3.14),\n"
+                                    + "       (default,\"car battery\",\"12V car battery\",8.1),\n"
+                                    + "       (default,\"12-pack drill bits\",\"12-pack of drill bits with sizes ranging from #40 to #3\",0.8),\n"
+                                    + "       (default,\"hammer\",\"12oz carpenter's hammer\",0.75),\n"
+                                    + "       (default,\"hammer\",\"14oz carpenter's hammer\",0.875),\n"
+                                    + "       (default,\"hammer\",\"16oz carpenter's hammer\",1.0),\n"
+                                    + "       (default,\"rocks\",\"box of assorted rocks\",5.3),\n"
+                                    + "       (default,\"jacket\",\"water resistent black wind breaker\",0.1),\n"
+                                    + "       (default,\"spare tire\",\"24 inch spare tire\",22.2);",
+                            inventoryDatabase.getDatabaseName(), sqlInjectionTable));
+        }
+        MySqlSourceConfigFactory configFactory =
+                new MySqlSourceConfigFactory()
+                        .hostname(MYSQL8_CONTAINER.getHost())
+                        .port(MYSQL8_CONTAINER.getDatabasePort())
+                        .username(TEST_USER)
+                        .password(TEST_PASSWORD)
+                        .databaseList(inventoryDatabase.getDatabaseName())
+                        .tableList(inventoryDatabase.getDatabaseName() + "\\.sql.*")
+                        .startupOptions(StartupOptions.initial())
+                        .serverId(getServerId(env.getParallelism()))
+                        .serverTimeZone("UTC")
+                        .includeSchemaChanges(SCHEMA_CHANGE_ENABLED.defaultValue());
+
+        FlinkSourceProvider sourceProvider =
+                (FlinkSourceProvider) new MySqlDataSource(configFactory).getEventSourceProvider();
+        CloseableIterator<Event> events =
+                env.fromSource(
+                                sourceProvider.getSource(),
+                                WatermarkStrategy.noWatermarks(),
+                                MySqlDataSourceFactory.IDENTIFIER,
+                                new EventTypeInfo())
+                        .executeAndCollect();
+        Thread.sleep(10_000);
+
+        TableId tableId =
+                TableId.tableId(
+                        inventoryDatabase.getDatabaseName(),
+                        "sqlInjection; DROP TABLE important_data;");
+        CreateTableEvent createTableEvent =
+                new CreateTableEvent(
+                        tableId,
+                        Schema.newBuilder()
+                                .physicalColumn("id", DataTypes.INT().notNull())
+                                .physicalColumn(
+                                        "name", DataTypes.VARCHAR(255).notNull(), null, "flink")
+                                .physicalColumn("description", DataTypes.VARCHAR(512))
+                                .physicalColumn("weight", DataTypes.FLOAT())
+                                .primaryKey(Collections.singletonList("id"))
+                                .build());
+
+        // generate snapshot data
+        List<Event> expectedSnapshot = getSnapshotExpected(tableId);
+
+        List<Event> expectedBinlog = new ArrayList<>();
+        try (Connection connection = inventoryDatabase.getJdbcConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute(
+                    String.format(
+                            "ALTER TABLE `%s`.`%s` ADD COLUMN `desc1` VARCHAR(45) NULL AFTER `weight`;",
+                            inventoryDatabase.getDatabaseName(), sqlInjectionTable));
+            expectedBinlog.add(
+                    new AddColumnEvent(
+                            tableId,
+                            Collections.singletonList(
+                                    new AddColumnEvent.ColumnWithPosition(
+                                            Column.physicalColumn("desc1", DataTypes.VARCHAR(45)),
+                                            AddColumnEvent.ColumnPosition.AFTER,
+                                            "weight"))));
+            statement.execute(
+                    String.format(
+                            "INSERT INTO `%s`.`%s`\n"
+                                    + "VALUES (default,\"scooter\",\"Small 2-wheel scooter\",3.14, 1.1),\n"
+                                    + "       (default,\"car battery\",\"12V car battery\",8.1, 1.1);",
+                            inventoryDatabase.getDatabaseName(), sqlInjectionTable));
+            RowType rowType =
+                    RowType.of(
+                            DataTypes.INT().notNull(),
+                            DataTypes.VARCHAR(255).notNull(),
+                            DataTypes.VARCHAR(512),
+                            DataTypes.FLOAT(),
+                            DataTypes.VARCHAR(45));
+            BinaryRecordDataGenerator generator = new BinaryRecordDataGenerator(rowType);
+            expectedBinlog.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generator.generate(
+                                    new Object[] {
+                                        110,
+                                        BinaryStringData.fromString("scooter"),
+                                        BinaryStringData.fromString("Small 2-wheel scooter"),
+                                        3.14f,
+                                        BinaryStringData.fromString("1.1")
+                                    })));
+            expectedBinlog.add(
+                    DataChangeEvent.insertEvent(
+                            tableId,
+                            generator.generate(
+                                    new Object[] {
+                                        111,
+                                        BinaryStringData.fromString("car battery"),
+                                        BinaryStringData.fromString("12V car battery"),
+                                        8.1f,
+                                        BinaryStringData.fromString("1.1")
+                                    })));
+        }
+
+        // In this configuration, several subtasks might emit their corresponding CreateTableEvent
+        // to downstream. Since it is not possible to predict how many CreateTableEvents should we
+        // expect, we simply filter them out from expected sets, and assert there's at least one.
+        List<Event> actual =
+                fetchResultsExcept(
+                        events, expectedSnapshot.size() + expectedBinlog.size(), createTableEvent);
+        assertThat(actual.subList(0, expectedSnapshot.size()))
+                .containsExactlyInAnyOrder(expectedSnapshot.toArray(new Event[0]));
+        assertThat(actual.subList(expectedSnapshot.size(), actual.size()))
+                .isEqualTo(expectedBinlog);
+    }
+
+    @Test
     void testExcludeTables() throws Exception {
         inventoryDatabase.createAndInitialize();
         String databaseName = inventoryDatabase.getDatabaseName();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/utils/Db2Utils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/utils/Db2Utils.java
@@ -357,7 +357,7 @@ public class Db2Utils {
     }
 
     public static String quote(String dbOrTableName) {
-        return "\"" + dbOrTableName + "\"";
+        return "\"" + dbOrTableName.replace("\"", "\"\"") + "\"";
     }
 
     public static String quote(TableId tableId) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/StatementUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/StatementUtils.java
@@ -225,7 +225,7 @@ public class StatementUtils {
     }
 
     public static String quote(String dbOrTableName) {
-        return "`" + dbOrTableName + "`";
+        return "`" + dbOrTableName.replace("`", "``") + "`";
     }
 
     public static String quote(TableId tableId) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleUtils.java
@@ -231,7 +231,7 @@ public class OracleUtils {
     }
 
     public static String quote(String dbOrTableName) {
-        return "\"" + dbOrTableName + "\"";
+        return "\"" + dbOrTableName.replace("\"", "\"\"") + "\"";
     }
 
     public static String quoteSchemaAndTable(TableId tableId) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
@@ -366,7 +366,7 @@ public class SqlServerUtils {
      *     href="https://learn.microsoft.com/en-us/sql/t-sql/functions/quotename-transact-sql">QUOTENAME</a>
      */
     public static String quote(String name) {
-        return "[" + name + "]";
+        return "[" + name.replace("]", "]]") + "]";
     }
 
     public static String quote(TableId tableId) {


### PR DESCRIPTION
The vulnerability exists in the `quote()` function implementations that fail to properly escape special characters:

**Vulnerable Implementations:**

1. **MySQL** (Line 226):
```java
public static String quote(String dbOrTableName) {
    return "`" + dbOrTableName + "`";  // No backtick escaping
}
```

2. **SQL Server** (Line 367):
```java
public static String quote(String name) {
    return "[" + name + "]";  // No bracket escaping
}
```

3. **Oracle** (Line 232):
```java
public static String quote(String dbOrTableName) {
    return "\"" + dbOrTableName + "\"";  // No quote escaping
}
```

4. **DB2** (Line 358):
```java
public static String quote(String dbOrTableName) {
    return "\"" + dbOrTableName + "\"";  // No quote escaping
}
```

**Correct Implementation (PostgreSQL only):**
```java
public static String quote(String name) {
    return "\"" + name.replace("\"", "\"\"") + "\"";  // Proper escaping
}
```

However, this issue should not occur in FlinkCDC, as FlinkCDC will first retrieve the table names of all tables and then use regular expressions for matching.
