### PR TITLE
[FLINK-38141][pipeline-connector/iceberg] Fix iceberg connector incorrect type mapping

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/utils/IcebergTypeUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/utils/IcebergTypeUtils.java
@@ -75,7 +75,6 @@ public class IcebergTypeUtils {
             case DECIMAL:
                 return Types.DecimalType.of(precision, scale);
             case TINYINT:
-                return new Types.BooleanType();
             case SMALLINT:
             case INTEGER:
                 return new Types.IntegerType();
@@ -141,8 +140,6 @@ public class IcebergTypeUtils {
                         };
                 break;
             case TINYINT:
-                fieldGetter = row -> row.getBoolean(fieldPos);
-                break;
             case SMALLINT:
                 fieldGetter = row -> row.getInt(fieldPos);
                 break;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplierTest.java
@@ -136,7 +136,7 @@ public class IcebergMetadataApplierTest {
                                         3,
                                         true,
                                         "tinyIntCol",
-                                        Types.BooleanType.get(),
+                                        Types.IntegerType.get(),
                                         "column for tinyIntCol"),
                                 Types.NestedField.of(
                                         4,
@@ -200,7 +200,7 @@ public class IcebergMetadataApplierTest {
                                         3,
                                         true,
                                         "tinyIntCol",
-                                        Types.BooleanType.get(),
+                                        Types.IntegerType.get(),
                                         "column for tinyIntCol"),
                                 Types.NestedField.of(
                                         4,
@@ -262,7 +262,7 @@ public class IcebergMetadataApplierTest {
                                         3,
                                         true,
                                         "tinyIntCol",
-                                        Types.BooleanType.get(),
+                                        Types.IntegerType.get(),
                                         "column for tinyIntCol"),
                                 Types.NestedField.of(
                                         5,
@@ -318,7 +318,7 @@ public class IcebergMetadataApplierTest {
                                         3,
                                         true,
                                         "tinyIntCol",
-                                        Types.BooleanType.get(),
+                                        Types.IntegerType.get(),
                                         "column for tinyIntCol"),
                                 Types.NestedField.of(
                                         5,
@@ -375,7 +375,7 @@ public class IcebergMetadataApplierTest {
                                         3,
                                         true,
                                         "tinyIntCol",
-                                        Types.BooleanType.get(),
+                                        Types.IntegerType.get(),
                                         "column for tinyIntCol"),
                                 Types.NestedField.of(
                                         5,

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/v2/IcebergWriterTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/v2/IcebergWriterTest.java
@@ -342,7 +342,7 @@ public class IcebergWriterTest {
         List<String> result = fetchTableContent(catalog, tableId);
         Assertions.assertThat(result)
                 .containsExactlyInAnyOrder(
-                        "char, varchar, string, false, [1,2,3,4,5,], [1,2,3,4,5,6,7,8,9,10,], 0.00, true, 2, 12345, 12345, 123.456, 123456.789, 00:00:12.345, 2003-10-20, 1970-01-01T00:00, 1970-01-01T00:00Z, 1970-01-01T08:00Z");
+                        "char, varchar, string, false, [1,2,3,4,5,], [1,2,3,4,5,6,7,8,9,10,], 0.00, 1, 2, 12345, 12345, 123.456, 123456.789, 00:00:12.345, 2003-10-20, 1970-01-01T00:00, 1970-01-01T00:00Z, 1970-01-01T08:00Z");
     }
 
     /** Mock CommitRequestImpl. */


### PR DESCRIPTION
According to the Iceberg documentation https://iceberg.apache.org/docs/nightly/flink/#flink-to-iceberg, the CDC type TINYINT should be mapped to the Iceberg type INTEGER. However, in the code implementation of the Iceberg sink, I noticed that TINYINT is actually mapped to the Iceberg type BOOLEAN.