### PR TITLE
[minor][improvement] Add subdirectory scrapping to add all .jar in classpath

### DIFF
--- a/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
+++ b/flink-cdc-dist/src/main/flink-cdc-bin/bin/flink-cdc.sh
@@ -64,11 +64,11 @@ FLINK_CDC_LOG="$FLINK_CDC_HOME"/log
 # Build Java classpath
 CLASSPATH=""
 # Add Flink libraries to the classpath
-for jar in "$FLINK_HOME"/lib/*.jar; do
+for jar in $(find "$FLINK_HOME"/lib -name "*.jar" -type f); do
   CLASSPATH=$CLASSPATH:$jar
 done
 # Add Flink CDC libraries to classpath
-for jar in "$FLINK_CDC_LIB"/*.jar; do
+for jar in $(find "$FLINK_CDC_LIB" -name "*.jar" -type f); do
   CLASSPATH=$CLASSPATH:$jar
 done
 # Add Hadoop classpath, which is defined in config.sh


### PR DESCRIPTION
## Rationale

I was stuck with this issue for a while when deploying CDC pipelines on my cluster. It seems that it is not convenient to get .jar files only at the first level of depth, so I want to fix it and add a more convenient search for files.

## Solution

Add all-depth search for .jar files