### PR TITLE
[FLINK-38184] one time of GetCopyOfBuffer is enough When serializing split.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/FinishedSnapshotSplitInfo.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/meta/split/FinishedSnapshotSplitInfo.java
@@ -129,7 +129,8 @@ public class FinishedSnapshotSplitInfo implements OffsetDeserializerSerializer {
     public byte[] serialize() {
         try {
             final DataOutputSerializer out = SERIALIZER_CACHE.get();
-            final byte[] result = serialize(out);
+            serialize(out);
+            final byte[] result = out.getCopyOfBuffer();
             out.clear();
             return result;
         } catch (IOException e) {
@@ -137,7 +138,7 @@ public class FinishedSnapshotSplitInfo implements OffsetDeserializerSerializer {
         }
     }
 
-    public byte[] serialize(final DataOutputSerializer out) throws IOException {
+    public void serialize(final DataOutputSerializer out) throws IOException {
         out.writeUTF(this.getTableId().toString());
         out.writeUTF(this.getSplitId());
         out.writeUTF(SerializerUtils.rowToSerializedString(this.getSplitStart()));
@@ -147,7 +148,6 @@ public class FinishedSnapshotSplitInfo implements OffsetDeserializerSerializer {
         boolean useCatalogBeforeSchema =
                 SerializerUtils.shouldUseCatalogBeforeSchema(this.getTableId());
         out.writeBoolean(useCatalogBeforeSchema);
-        return out.getCopyOfBuffer();
     }
 
     @Override


### PR DESCRIPTION
Fix [FLINK-38184](https://issues.apache.org/jira/browse/FLINK-38184)

When I have a big Postgres source table(1 billion data), then the checkpoint will cost multiple minutes which will block the whole reading. The main cost is org.apache.flink.core.memory.DataOutputSerializer#getCopyOfBuffer.

In cdc framework, SplitSerializer will invoke DataOutputSerializer#getCopyOfBuffer for each finished split info
```java
// org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitSerializer#writeFinishedSplitsInfo
private void writeFinishedSplitsInfo(
        List<FinishedSnapshotSplitInfo> finishedSplitsInfo, DataOutputSerializer out)
        throws IOException {
    final int size = finishedSplitsInfo.size();
    out.writeInt(size);
    for (FinishedSnapshotSplitInfo splitInfo : finishedSplitsInfo) {
        splitInfo.serialize(out);
    }
}

//org.apache.flink.cdc.connectors.base.source.meta.split.FinishedSnapshotSplitInfo#serialize(org.apache.flink.core.memory.DataOutputSerializer)
public byte[] serialize(final DataOutputSerializer out) throws IOException {
    out.writeUTF(this.getTableId().toString());
    out.writeUTF(this.getSplitId());
    out.writeUTF(SerializerUtils.rowToSerializedString(this.getSplitStart()));
    out.writeUTF(SerializerUtils.rowToSerializedString(this.getSplitEnd()));
    out.writeUTF(SerializerUtils.rowToSerializedString(this.offsetFactory));
    writeOffsetPosition(this.getHighWatermark(), out);
    boolean useCatalogBeforeSchema =
            SerializerUtils.shouldUseCatalogBeforeSchema(this.getTableId());
    out.writeBoolean(useCatalogBeforeSchema);
    return out.getCopyOfBuffer();
} 
```

However, it's different in mysql cdc

```java
// org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitSerializer#writeFinishedSplitsInfo
private static void writeFinishedSplitsInfo(
        List<FinishedSnapshotSplitInfo> finishedSplitsInfo, DataOutputSerializer out)
        throws IOException {
    final int size = finishedSplitsInfo.size();
    out.writeInt(size);
    for (FinishedSnapshotSplitInfo splitInfo : finishedSplitsInfo) {
        out.writeUTF(splitInfo.getTableId().toString());
        out.writeUTF(splitInfo.getSplitId());
        out.writeUTF(rowToSerializedString(splitInfo.getSplitStart()));
        out.writeUTF(rowToSerializedString(splitInfo.getSplitEnd()));
        writeBinlogPosition(splitInfo.getHighWatermark(), out);
    }
} 
```


To be honest, it's a redundant operation. For one split, it only need  one time of out.getCopyOfBuffer rather than multiple times.