### PR TITLE
[FLINK-38188][pipeline-connector][postgres]  Fix database name validation logic in PostgresDataSourceFactory

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
@@ -369,23 +369,21 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
                     String.format(
                             "Tables format must db.schema.table, can not 'tables' = %s",
                             TABLES.key()));
-            if (tableNameParts.length == 3) {
-                String currentDbName = tableNameParts[0];
+            String currentDbName = tableNameParts[0];
 
+            checkState(
+                    isValidPostgresDbName(currentDbName),
+                    String.format(
+                            "The value of option %s does not conform to PostgresSQL database name naming conventions",
+                            TABLES.key()));
+            if (dbName == null) {
+                dbName = currentDbName;
+            } else {
                 checkState(
-                        isValidPostgresDbName(currentDbName),
+                        dbName.equals(currentDbName),
                         String.format(
-                                "The value of option %s does not conform to PostgresSQL database name naming conventions",
+                                "The value of option %s all table names must have the same database name",
                                 TABLES.key()));
-                if (dbName == null) {
-                    dbName = currentDbName;
-                } else {
-                    checkState(
-                            !dbName.equals(currentDbName),
-                            String.format(
-                                    "The value of option %s all table names must have the same database name",
-                                    TABLES.key()));
-                }
             }
         }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
@@ -373,17 +373,15 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
 
             checkState(
                     isValidPostgresDbName(currentDbName),
-                    String.format(
-                            "The value of option %s all table names must have the same database name",
-                            TABLES.key()));
+                    String.format("%s is not a valid PostgreSQL database name", currentDbName));
             if (dbName == null) {
                 dbName = currentDbName;
             } else {
                 checkState(
                         dbName.equals(currentDbName),
-                        String.format(
-                                "The value of option %s all table names must have the same database name",
-                                TABLES.key()));
+                        "The value of option `%s` is `%s`, but not all table names have the same database name",
+                        TABLES.key(),
+                        String.join(",", tableNames));
             }
         }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
@@ -374,7 +374,7 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
             checkState(
                     isValidPostgresDbName(currentDbName),
                     String.format(
-                            "The value of option %s does not conform to PostgresSQL database name naming conventions",
+                            "The value of option %s all table names must have the same database name",
                             TABLES.key()));
             if (dbName == null) {
                 dbName = currentDbName;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/test/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/test/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactoryTest.java
@@ -276,7 +276,7 @@ public class PostgresDataSourceFactoryTest extends PostgresTestBase {
         assertThatThrownBy(() -> factory.createDataSource(context))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining(
-                        "The value of option tables all table names must have the same database name");
+                        "The value of option `tables` is `aia_test.public.aia_t_icc_jjdb,different_db.public.aia_t_icc_jjdb_extend`, but not all table names have the same database name");
     }
 
     @Test

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/PostgresE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/PostgresE2eITCase.java
@@ -111,7 +111,7 @@ public class PostgresE2eITCase extends PipelineTestEnvironment {
                                 + "  port: %d\n"
                                 + "  username: %s\n"
                                 + "  password: %s\n"
-                                + "  tables: %s.inventory.\\.*\n"
+                                + "  tables: %s.inventory.products,%s.inventory.customers\n"
                                 + "  slot.name: %s\n"
                                 + "  scan.startup.mode: initial\n"
                                 + "  server-time-zone: UTC\n"
@@ -126,6 +126,7 @@ public class PostgresE2eITCase extends PipelineTestEnvironment {
                         5432,
                         POSTGRES_TEST_USER,
                         POSTGRES_TEST_PASSWORD,
+                        postgresInventoryDatabase.getDatabaseName(),
                         postgresInventoryDatabase.getDatabaseName(),
                         slotName,
                         parallelism);


### PR DESCRIPTION
Fix [FLINK-38188](https://issues.apache.org/jira/browse/FLINK-38188)
## What is the purpose of the change

Fix incorrect validation logic in `getValidateDatabaseName` method that causes validation to fail when all tables have the same database name.

## Brief change log

- Fix the validation condition in `PostgresDataSourceFactory.getValidateDatabaseName()` method
- Change `!dbName.equals(currentDbName)` to `dbName.equals(currentDbName)` to correctly validate that all tables must have the same database name

## Verifying this change

This change is already covered by existing tests, or verify manually by:
- Configure multiple PostgreSQL tables with the same database name
- Verify that validation passes instead of throwing IllegalStateException

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable