### PR TITLE
[FLINK-38164][pipeline-connector/mysql] support mysql long and long varchar type

### DIFF
--- a/docs/content.zh/docs/connectors/pipeline-connectors/mysql.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/mysql.md
@@ -596,6 +596,8 @@ source:
         TEXT<br>
         MEDIUMTEXT<br>
         LONGTEXT<br>
+        LONG<br>
+        LONG VARCHAR<br>
       </td>
       <td>STRING</td>
       <td></td>

--- a/docs/content/docs/connectors/pipeline-connectors/mysql.md
+++ b/docs/content/docs/connectors/pipeline-connectors/mysql.md
@@ -609,6 +609,8 @@ Notice:
         TEXT<br>
         MEDIUMTEXT<br>
         LONGTEXT<br>
+        LONG<br>
+        LONG VARCHAR<br>
       </td>
       <td>STRING</td>
       <td></td>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/MySqlTypeUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/utils/MySqlTypeUtils.java
@@ -83,6 +83,8 @@ public class MySqlTypeUtils {
     private static final String MEDIUMTEXT = "MEDIUMTEXT";
     private static final String TEXT = "TEXT";
     private static final String LONGTEXT = "LONGTEXT";
+    private static final String LONG_VARCHAR = "LONG VARCHAR";
+    private static final String LONG = "LONG";
     private static final String DATE = "DATE";
     private static final String TIME = "TIME";
     private static final String DATETIME = "DATETIME";
@@ -217,6 +219,8 @@ public class MySqlTypeUtils {
             case TEXT:
             case MEDIUMTEXT:
             case LONGTEXT:
+            case LONG_VARCHAR:
+            case LONG:
             case JSON:
             case ENUM:
             case GEOMETRY:

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlFullTypesITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlFullTypesITCase.java
@@ -468,7 +468,9 @@ class MySqlFullTypesITCase extends MySqlSourceTestBase {
                     BinaryStringData.fromString(expectMultipointJsonText),
                     BinaryStringData.fromString(expectMultilineJsonText),
                     BinaryStringData.fromString(expectMultipolygonJsonText),
-                    BinaryStringData.fromString(expectGeometryCollectionJsonText)
+                    BinaryStringData.fromString(expectGeometryCollectionJsonText),
+                        BinaryStringData.fromString("long"),
+                        BinaryStringData.fromString("long varchar")
                 };
 
         // skip CreateTableEvent
@@ -670,6 +672,8 @@ class MySqlFullTypesITCase extends MySqlSourceTestBase {
                     DataTypes.BYTES(),
                     DataTypes.BYTES(),
                     DataTypes.INT(),
+                    DataTypes.STRING(),
+                    DataTypes.STRING(),
                     DataTypes.STRING(),
                     DataTypes.STRING(),
                     DataTypes.STRING(),

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlFullTypesITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlFullTypesITCase.java
@@ -469,8 +469,8 @@ class MySqlFullTypesITCase extends MySqlSourceTestBase {
                     BinaryStringData.fromString(expectMultilineJsonText),
                     BinaryStringData.fromString(expectMultipolygonJsonText),
                     BinaryStringData.fromString(expectGeometryCollectionJsonText),
-                        BinaryStringData.fromString("long"),
-                        BinaryStringData.fromString("long varchar")
+                    BinaryStringData.fromString("long"),
+                    BinaryStringData.fromString("long varchar")
                 };
 
         // skip CreateTableEvent

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlMetadataAccessorITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlMetadataAccessorITCase.java
@@ -465,6 +465,8 @@ class MySqlMetadataAccessorITCase extends MySqlSourceTestBase {
                                             DataTypes.STRING(),
                                             DataTypes.STRING(),
                                             DataTypes.STRING(),
+                                            DataTypes.STRING(),
+                                            DataTypes.STRING(),
                                             DataTypes.STRING()
                                         },
                                         new String[] {
@@ -520,7 +522,9 @@ class MySqlMetadataAccessorITCase extends MySqlSourceTestBase {
                                             "multipoint_c",
                                             "multiline_c",
                                             "multipolygon_c",
-                                            "geometrycollection_c"
+                                            "geometrycollection_c",
+                                            "long_c",
+                                            "long_varchar_c",
                                         }))
                         .build();
         assertThat(actualSchema).isEqualTo(expectedSchema);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/ddl/column_type_test.sql
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/ddl/column_type_test.sql
@@ -72,6 +72,8 @@ CREATE TABLE common_types
     multiline_c          MULTILINESTRING,
     multipolygon_c       MULTIPOLYGON,
     geometrycollection_c GEOMETRYCOLLECTION,
+    long_c               LONG,
+    long_varchar_c       LONG VARCHAR,
     PRIMARY KEY (id)
 ) DEFAULT CHARSET=utf8;
 
@@ -94,7 +96,8 @@ VALUES (DEFAULT, 127, 255, 255, 32767, 65535, 65535, 8388607, 16777215, 16777215
         ST_GeomFromText('MULTIPOINT((1 1),(2 2))'),
         ST_GeomFromText('MultiLineString((1 1,2 2,3 3),(4 4,5 5))'),
         ST_GeomFromText('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)), ((5 5, 7 5, 7 7, 5 7, 5 5)))'),
-        ST_GeomFromText('GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))'));
+        ST_GeomFromText('GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))'),
+        'long','long varchar');
 
 CREATE TABLE time_types
 (

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/ddl/column_type_test_mysql8.sql
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/resources/ddl/column_type_test_mysql8.sql
@@ -72,6 +72,8 @@ CREATE TABLE common_types
     multiline_c          MULTILINESTRING,
     multipolygon_c       MULTIPOLYGON,
     geometrycollection_c GEOMETRYCOLLECTION,
+    long_c               LONG,
+    long_varchar_c       LONG VARCHAR,
     PRIMARY KEY (id)
 ) DEFAULT CHARSET=utf8;
 
@@ -94,7 +96,8 @@ VALUES (DEFAULT, 127, 255, 255, 32767, 65535, 65535, 8388607, 16777215, 16777215
         ST_GeomFromText('MULTIPOINT((1 1),(2 2))'),
         ST_GeomFromText('MultiLineString((1 1,2 2,3 3),(4 4,5 5))'),
         ST_GeomFromText('MULTIPOLYGON(((0 0, 10 0, 10 10, 0 10, 0 0)), ((5 5, 7 5, 7 7, 5 7, 5 5)))'),
-        ST_GeomFromText('GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))'));
+        ST_GeomFromText('GEOMETRYCOLLECTION(POINT(10 10), POINT(30 30), LINESTRING(15 15, 20 20))'),
+        'long','long varchar');
 
 CREATE TABLE time_types
 (


### PR DESCRIPTION
In MySQL, LONG and LONG VARCHAR map to the MEDIUMTEXT data type. MySQL-pipeline-connector should support this type. Refer to the official MySQL documentation https://dev.mysql.com/doc/refman/9.0/en/blob.html .
<img width="738" height="54" alt="image" src="https://github.com/user-attachments/assets/eb773070-5d37-4612-b81f-9989d814b592" />
