### PR TITLE
Paimon connector - support table specific table.properties config

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSink.java
@@ -44,6 +44,9 @@ public class PaimonDataSink implements DataSink, Serializable {
     // options for creating Paimon table.
     private final Map<String, String> tableOptions;
 
+    // options that apply to a specific table
+    private final Map<String, String> tableSpecificOptions;
+
     private final String commitUser;
 
     private final Map<TableId, List<String>> partitionMaps;
@@ -57,6 +60,7 @@ public class PaimonDataSink implements DataSink, Serializable {
     public PaimonDataSink(
             Options options,
             Map<String, String> tableOptions,
+            Map<String, String> tableSpecificOptions,
             String commitUser,
             Map<TableId, List<String>> partitionMaps,
             PaimonRecordSerializer<Event> serializer,
@@ -64,6 +68,7 @@ public class PaimonDataSink implements DataSink, Serializable {
             String schemaOperatorUid) {
         this.options = options;
         this.tableOptions = tableOptions;
+        this.tableSpecificOptions = tableSpecificOptions;
         this.commitUser = commitUser;
         this.partitionMaps = partitionMaps;
         this.serializer = serializer;
@@ -79,7 +84,8 @@ public class PaimonDataSink implements DataSink, Serializable {
 
     @Override
     public MetadataApplier getMetadataApplier() {
-        return new PaimonMetadataApplier(options, tableOptions, partitionMaps);
+        return new PaimonMetadataApplier(
+                options, tableOptions, tableSpecificOptions, partitionMaps);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonDataSinkOptions.java
@@ -29,6 +29,9 @@ public class PaimonDataSinkOptions {
     // prefix for passing properties for table creation.
     public static final String PREFIX_TABLE_PROPERTIES = "table.properties.";
 
+    // prefix for passing table-specific properties.
+    public static final String PREFIX_SPECIFIC_TABLE_PROPERTIES = "specific.table.properties.";
+
     // prefix for passing properties for catalog creation.
     public static final String PREFIX_CATALOG_PROPERTIES = "catalog.properties.";
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunctionTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/test/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonHashFunctionTest.java
@@ -76,7 +76,8 @@ class PaimonHashFunctionTest {
         TableId tableId = TableId.tableId(TEST_DATABASE, "test_table");
         Map<String, String> tableOptions = new HashMap<>();
         MetadataApplier metadataApplier =
-                new PaimonMetadataApplier(catalogOptions, tableOptions, new HashMap<>());
+                new PaimonMetadataApplier(
+                        catalogOptions, tableOptions, new HashMap<>(), new HashMap<>());
         Schema schema =
                 Schema.newBuilder()
                         .physicalColumn("col1", DataTypes.STRING().notNull())
@@ -132,7 +133,8 @@ class PaimonHashFunctionTest {
         Map<String, String> tableOptions = new HashMap<>();
         tableOptions.put("bucket", "10");
         MetadataApplier metadataApplier =
-                new PaimonMetadataApplier(catalogOptions, tableOptions, new HashMap<>());
+                new PaimonMetadataApplier(
+                        catalogOptions, tableOptions, new HashMap<>(), new HashMap<>());
         Schema schema =
                 Schema.newBuilder()
                         .physicalColumn("col1", DataTypes.STRING().notNull())


### PR DESCRIPTION
This PR adds a new format for defining table properties as `specific.table.properties.<database_name>.<table_name>.<property>`. This allows defining properties that are specific to a table. The table specific property takes precedence.

Paimon sink supports [defining table properties](https://nightlies.apache.org/flink/flink-cdc-docs-master/docs/connectors/pipeline-connectors/paimon/#pipeline-connector-options) as `table.properties.*`. They apply to ALL tables. In some cases it is warranted to set table properties based on the table use case. Some examples are compaction settings, Iceberg compatibility settings, etc. This PR allows this.