### PR TITLE
[FLINK-38194][pipeline-connector/iceberg] Iceberg connector supports auto-creating namespace

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/pom.xml
@@ -59,6 +59,24 @@ limitations under the License.
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils-junit</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- hadoop dependency -->
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
@@ -171,8 +171,8 @@ public class IcebergMetadataApplier implements MetadataApplier {
             if (!catalog.tableExists(tableIdentifier)) {
                 catalog.createTable(tableIdentifier, icebergSchema, partitionSpec, tableOptions);
                 LOG.info(
-                        "Spend {} ms to create iceberg table",
-                        System.currentTimeMillis() - startTimestamp);
+                        "Spend {} ms to create iceberg table {}",
+                        System.currentTimeMillis() - startTimestamp, tableIdentifier);
             }
         } catch (Exception e) {
             throw new SchemaEvolveException(event, e.getMessage(), e);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
@@ -172,7 +172,8 @@ public class IcebergMetadataApplier implements MetadataApplier {
                 catalog.createTable(tableIdentifier, icebergSchema, partitionSpec, tableOptions);
                 LOG.info(
                         "Spend {} ms to create iceberg table {}",
-                        System.currentTimeMillis() - startTimestamp, tableIdentifier);
+                        System.currentTimeMillis() - startTimestamp,
+                        tableIdentifier);
             }
         } catch (Exception e) {
             throw new SchemaEvolveException(event, e.getMessage(), e);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
@@ -43,6 +43,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.types.Type;
@@ -129,7 +131,16 @@ public class IcebergMetadataApplier implements MetadataApplier {
 
     private void applyCreateTable(CreateTableEvent event) {
         try {
+            long startTimestamp = System.currentTimeMillis();
             TableIdentifier tableIdentifier = TableIdentifier.parse(event.tableId().identifier());
+            // Step 0: Create namespace if not exists.
+            if (catalog instanceof SupportsNamespaces) {
+                SupportsNamespaces namespaceCatalog = (SupportsNamespaces) catalog;
+                Namespace namespace = Namespace.of(tableIdentifier.namespace().levels());
+                if (!namespaceCatalog.namespaceExists(namespace)) {
+                    namespaceCatalog.createNamespace(namespace);
+                }
+            }
 
             // Step1: Build Schema.
             org.apache.flink.cdc.common.schema.Schema cdcSchema = event.getSchema();
@@ -159,6 +170,9 @@ public class IcebergMetadataApplier implements MetadataApplier {
             PartitionSpec partitionSpec = builder.build();
             if (!catalog.tableExists(tableIdentifier)) {
                 catalog.createTable(tableIdentifier, icebergSchema, partitionSpec, tableOptions);
+                LOG.info(
+                        "Spend {} ms to create iceberg table",
+                        System.currentTimeMillis() - startTimestamp);
             }
         } catch (Exception e) {
             throw new SchemaEvolveException(event, e.getMessage(), e);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/utils/HiveContainer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/utils/HiveContainer.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.cdc.connectors.iceberg.sink.utils;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+/** Docker container for Apache Hive 4.0.0. */
+public class HiveContainer extends GenericContainer<HiveContainer> {
+    private static final String DOCKER_IMAGE_NAME = "apache/hive:4.0.0";
+    public static final int METASTORE_PORT = 9083;
+    public static final int HIVESERVER2_PORT = 10000;
+    public static final Network NETWORK = Network.newNetwork();
+    public HiveContainer(String hostWarehouseDir) {
+        this(NETWORK, hostWarehouseDir);
+    }
+    public HiveContainer(Network network, String hostWarehouseDir) {
+        super(DockerImageName.parse(DOCKER_IMAGE_NAME));
+        setExposedPorts(Arrays.asList(METASTORE_PORT, HIVESERVER2_PORT));
+        setNetwork(network);
+        withEnv("SERVICE_NAME", "metastore")
+                .withEnv(
+                        "SERVICE_OPTS",
+                        "-Dhive.metastore.disallow.incompatible.col.type.changes=false")
+                .withFileSystemBind(hostWarehouseDir, "/opt/hive/warehouse")
+                .setWaitStrategy(
+                        new LogMessageWaitStrategy()
+                                .withRegEx(".*Actual binding is of type.*")
+                                .withStartupTimeout(Duration.of(20, ChronoUnit.SECONDS)));
+    }
+    public String getMetastoreUri() {
+        return String.format("thrift://%s:%d", getHost(), getMappedPort(METASTORE_PORT));
+    }
+    public String getHiveJdbcUrl() {
+        return String.format("jdbc:hive2://%s:%d/", getHost(), getMappedPort(HIVESERVER2_PORT));
+    }
+}


### PR DESCRIPTION
Currently, Icerberg connector does not support auto-creating namaspace. When using hive matastore, it will throw a exception if a user tries write data to iceberg which does not have a namespace.
In the Iceberg sink, when a createTableEvent is encountered, we can first create the namespace and then create the table.