### PR TITLE
[FLINK-38221][pipeline-connector][postgres] Fix critical partition table discovery bug causing CDC data loss

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -6,6 +6,8 @@
 
 package io.debezium.connector.postgresql.connection;
 
+import org.apache.flink.cdc.connectors.postgres.source.utils.TableDiscoveryUtils;
+
 import com.zaxxer.hikari.pool.HikariProxyConnection;
 import io.debezium.DebeziumException;
 import io.debezium.annotation.VisibleForTesting;
@@ -856,7 +858,7 @@ public class PostgresConnection extends JdbcConnection {
      * @throws SQLException if a database exception occurred
      */
     public Set<TableId> getAllTableIds(String catalogName) throws SQLException {
-        return readTableNames(catalogName, null, null, new String[] {"TABLE", "PARTITIONED TABLE"});
+        return TableDiscoveryUtils.listTables(catalogName, this.connect(), null);
     }
 
     @FunctionalInterface

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresDialect.java
@@ -52,6 +52,7 @@ import io.debezium.schema.TopicSelector;
 import javax.annotation.Nullable;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -176,9 +177,12 @@ public class PostgresDialect implements JdbcDataSourceDialect {
     @Override
     public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
         try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
-            return TableDiscoveryUtils.listTables(
-                    // there is always a single database provided
-                    sourceConfig.getDatabaseList().get(0), jdbc, sourceConfig.getTableFilters());
+            return new ArrayList<>(
+                    TableDiscoveryUtils.listTables(
+                            // there is always a single database provided
+                            sourceConfig.getDatabaseList().get(0),
+                            jdbc,
+                            sourceConfig.getTableFilters()));
         } catch (SQLException e) {
             throw new FlinkRuntimeException("Error to discover tables: " + e.getMessage(), e);
         }
@@ -190,8 +194,7 @@ public class PostgresDialect implements JdbcDataSourceDialect {
 
         try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
             // fetch table schemas
-            Map<TableId, TableChange> tableSchemas = queryTableSchema(jdbc, capturedTableIds);
-            return tableSchemas;
+            return queryTableSchema(jdbc, capturedTableIds);
         } catch (Exception e) {
             throw new FlinkRuntimeException(
                     "Error to discover table schemas: " + e.getMessage(), e);


### PR DESCRIPTION
This PR fixes [FLINK-38221](https://issues.apache.org/jira/browse/FLINK-38221) in PostgreSQL partition table discovery that was causing complete CDC data loss when users configured parent partition table names. The core fix adds `"PARTITIONED TABLE"` type support to TableDiscoveryUtils, enabling proper discovery of parent partition tables and eliminating the need for complex regex configurations.

## Critical Problem Statement
**This is a data loss bug affecting production PostgreSQL CDC deployments:**

### The Bug
1. **User configures CDC** with parent partition table name: `"aia_t_icc_jjdb"`
2. **TableDiscoveryUtils fails** to discover parent partition (only looks for "TABLE" type)
3. **Table gets filtered out** - completely ignored by CDC
4. **Result: ZERO CDC data captured** - complete data loss for partition tables

### Current Painful Workarounds
- Users must use complex regex: `"aia_t_icc_jjdb_\\d{6}"` to match child partitions
- This causes **extremely slow initialization** (loads schemas for all individual partitions)
- Requires users to know internal partition naming schemes
- Error-prone and difficult to maintain configurations

## Solution Overview
**Critical Fix**: Enhanced `TableDiscoveryUtils` to include `"PARTITIONED TABLE"` type, enabling proper discovery of parent partition tables.

### Key Improvements
1. **🔧 Data Loss Fix**: Parent partition tables now properly discovered - CDC captures all data
2. **🚀 Performance Fix**: Users configure simple parent names - no more slow regex patterns  
3. **✅ User Experience**: Simple configuration `"aia_t_icc_jjdb"` now works correctly
4. **🏗️ Architecture**: Unified table discovery across all CDC components

### Root Cause & Fix
```sql
-- PROBLEM: Parent partition tables have different relkind
SELECT relname, relkind FROM pg_class WHERE relname = 'aia_t_icc_jjdb';
-- Result: relkind = 'p' (partitioned table) - not discovered by "TABLE" type filter

-- FIX: Include "PARTITIONED TABLE" type in discovery
SELECT * FROM pg_tables WHERE tabletype IN ('TABLE', 'PARTITIONED TABLE');  
-- Now properly discovers parent partition tables
```
