### PR TITLE
[FLINK-37835] Fix NoPointException when start with latest-offset.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffset.java
@@ -238,7 +238,9 @@ public class BinlogOffset implements Comparable<BinlogOffset>, Serializable {
         }
 
         // First compare the MySQL binlog filenames
-        if (this.getFilename().compareToIgnoreCase(that.getFilename()) != 0) {
+        if (this.getFilename() != null
+                && that.getFilename() != null
+                && this.getFilename().compareToIgnoreCase(that.getFilename()) != 0) {
             return this.getFilename().compareToIgnoreCase(that.getFilename());
         }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -120,6 +120,9 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
         LOG.info("Starting MySql8 containers...");
         Startables.deepStart(Stream.of(MYSQL8_CONTAINER)).join();
         LOG.info("Container MySql8 is started.");
+        LOG.info("Starting MySqlNoGtid containers...");
+        Startables.deepStart(Stream.of(MYSQL_CONTAINER_NOGTID)).join();
+        LOG.info("Container MySqlNoGtid is started.");
     }
 
     @AfterAll
@@ -127,6 +130,9 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
         LOG.info("Stopping MySql8 containers...");
         MYSQL8_CONTAINER.stop();
         LOG.info("Container MySql8 is stopped.");
+        LOG.info("Stopping MySqlNoGtid containers...");
+        MYSQL_CONTAINER_NOGTID.stop();
+        LOG.info("Container MySqlNoGtid is stopped.");
     }
 
     @AfterEach

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -66,8 +66,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.lifecycle.Startables;
 
 import java.sql.Connection;
@@ -509,17 +507,17 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         DataTypes.FIELD("phone_number", DataTypes.STRING()));
         String[] expected =
                 new String[] {
-                        "-U[103, user_3, Shanghai, 123567891234]",
-                        "+U[103, user_3, Hangzhou, 123567891234]",
-                        "-D[102, user_2, Shanghai, 123567891234]",
-                        "+I[102, user_2, Shanghai, 123567891234]",
-                        "-U[103, user_3, Hangzhou, 123567891234]",
-                        "+U[103, user_3, Shanghai, 123567891234]",
-                        "-U[1010, user_11, Shanghai, 123567891234]",
-                        "+U[1010, Hangzhou, Shanghai, 123567891234]",
-                        "+I[2001, user_22, Shanghai, 123567891234]",
-                        "+I[2002, user_23, Shanghai, 123567891234]",
-                        "+I[2003, user_24, Shanghai, 123567891234]"
+                    "-U[103, user_3, Shanghai, 123567891234]",
+                    "+U[103, user_3, Hangzhou, 123567891234]",
+                    "-D[102, user_2, Shanghai, 123567891234]",
+                    "+I[102, user_2, Shanghai, 123567891234]",
+                    "-U[103, user_3, Hangzhou, 123567891234]",
+                    "+U[103, user_3, Shanghai, 123567891234]",
+                    "-U[1010, user_11, Shanghai, 123567891234]",
+                    "+U[1010, Hangzhou, Shanghai, 123567891234]",
+                    "+I[2001, user_22, Shanghai, 123567891234]",
+                    "+I[2002, user_23, Shanghai, 123567891234]",
+                    "+I[2003, user_24, Shanghai, 123567891234]"
                 };
         List<String> actual = readBinlogSplits(dataType, reader, expected.length);
         assertEqualsInOrder(Arrays.asList(expected), actual);


### PR DESCRIPTION
The `compareTo` method in `BinlogOffset` would throw a NullPointerException if the filename field was null. This could happen in scenarios like reading from the latest offset where the initial offset might not have a filename.

This commit updates the comparison logic to safely handle null filenames.A new test, `testReadBinlogWithoutGtidFromLatestOffset`, is also introduced to cover this specific case and verify the solution.