### PR TITLE
[hotfix][doc] Update uses of Upload documentation in build_docs.yml.

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -84,7 +84,7 @@ jobs:
           docker run --rm --volume "$PWD:/root/flink-cdc" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink-cdc && chmod +x ./.github/workflows/docs.sh && ./.github/workflows/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@7.0.2
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         with:
           switches: --archive --compress --delete
           path: docs/target/
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@7.0.2
+        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
         with:
           switches: --archive --compress --delete
           path: docs/target/

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -84,7 +84,7 @@ jobs:
           docker run --rm --volume "$PWD:/root/flink-cdc" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink-cdc && chmod +x ./.github/workflows/docs.sh && ./.github/workflows/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@7.0.2
         with:
           switches: --archive --compress --delete
           path: docs/target/
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@5.2
+        uses: burnett01/rsync-deployments@7.0.2
         with:
           switches: --archive --compress --delete
           path: docs/target/


### PR DESCRIPTION
Fix error in https://github.com/apache/flink-cdc/actions/runs/16954053615, refer to https://github.com/apache/incubator-gluten/pull/10373/files.
Error message:
```
The action burnett01/rsync-deployments@5.2 is not allowed in apache/flink-cdc because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: 1Password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0, AdoptOpenJDK/install-jdk@*, BobAnkh/auto-generate-changelog@*, DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e, DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8, EnricoMi/publish-unit-test-result-action@*, JamesIves/github-pages-deploy-action@6c2d9db40f9296374acc17b90404b6e8864128c8, JamesIves/github-pages-deploy-action@881db5376404c5c8d621010bcbec0310b58d5e29, JustinBeckwith/linkinator-action@3d5ba091319fa7b0ac14703761eebb7d100e6f6d, Kesin11/actions-timeline@427ee2cf860166e404d0d69b4f2b24012bb7af4f, Kesin11/actions-timeline@a7eaabf426cdae26c3582c3fa674b897170dec8f, PyO3/maturin-action@*, TobKed/label-when-approved-action@*, ...
```