### PR TITLE
[FLINK-38204]use getLatestEvolvedSchema to get Schema in SessionManageOperator in case of using route.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/coordinator/SessionManageOperator.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/coordinator/SessionManageOperator.java
@@ -194,7 +194,7 @@ public class SessionManageOperator extends AbstractStreamOperator<Event>
     }
 
     private void emitLatestSchema(TableId tableId) throws Exception {
-        Optional<Schema> schema = schemaEvolutionClient.getLatestOriginalSchema(tableId);
+        Optional<Schema> schema = schemaEvolutionClient.getLatestEvolvedSchema(tableId);
         if (schema.isPresent()) {
             Schema latestSchema = schema.get();
             schemaMaps.put(tableId, latestSchema);


### PR DESCRIPTION
changing the method of retrieving the schema from getLatestOriginalSchema to getLatestEvolvedSchema