### PR TITLE
[FLINK-38248] The default value of '0000-00-00 00:00:00' for MySQL TIMESTAMP fields is not supported in downstream systems.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -200,7 +200,8 @@ public class DorisMetadataApplier implements MetadataApplier {
                     new FieldSchema(
                             column.getName(),
                             typeString,
-                            column.getDefaultValueExpression(),
+                            convertInvalidTimestampDefaultValue(
+                                    column.getDefaultValueExpression(), column.getType()),
                             column.getComment()));
         }
         return fieldSchemaMap;
@@ -237,7 +238,8 @@ public class DorisMetadataApplier implements MetadataApplier {
                         new FieldSchema(
                                 column.getName(),
                                 buildTypeString(column.getType()),
-                                column.getDefaultValueExpression(),
+                                convertInvalidTimestampDefaultValue(
+                                        column.getDefaultValueExpression(), column.getType()),
                                 column.getComment());
                 schemaChangeManager.addColumn(
                         tableId.getSchemaName(), tableId.getTableName(), addFieldSchema);
@@ -315,5 +317,22 @@ public class DorisMetadataApplier implements MetadataApplier {
         } catch (Exception e) {
             throw new SchemaEvolveException(dropTableEvent, "fail to drop table", e);
         }
+    }
+
+    private String convertInvalidTimestampDefaultValue(String defaultValue, DataType dataType) {
+        if (defaultValue == null) {
+            return null;
+        }
+
+        if (dataType instanceof LocalZonedTimestampType
+                || dataType instanceof TimestampType
+                || dataType instanceof ZonedTimestampType) {
+
+            if (DorisSchemaUtils.MYSQL_INVALID_TIMESTAMP.equals(defaultValue)) {
+                return DorisSchemaUtils.DEFAULT_DATETIME;
+            }
+        }
+
+        return defaultValue;
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/utils/DorisSchemaUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/utils/DorisSchemaUtils.java
@@ -46,6 +46,8 @@ public class DorisSchemaUtils {
     public static final String DEFAULT_DATE = "1970-01-01";
     public static final String DEFAULT_DATETIME = "1970-01-01 00:00:00";
 
+    public static final String MYSQL_INVALID_TIMESTAMP = "0000-00-00 00:00:00";
+    
     /**
      * Get partition info by config. Currently only supports DATE/TIMESTAMP AUTO RANGE PARTITION and
      * doris version should greater than 2.1.6

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/test/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplierTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.doris.sink;
+
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.connectors.doris.utils.DorisSchemaUtils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+/** Unit tests for {@link DorisMetadataApplier}. */
+class DorisMetadataApplierTest {
+
+    @Test
+    public void testMysqlTimestampDefaultValueConversion() throws Exception {
+        Configuration config = new Configuration();
+        DorisMetadataApplier metadataApplier = new DorisMetadataApplier(null, config);
+
+        Method convertMethod =
+                DorisMetadataApplier.class.getDeclaredMethod(
+                        "convertInvalidTimestampDefaultValue", String.class, DataType.class);
+        convertMethod.setAccessible(true);
+
+        String result =
+                (String)
+                        convertMethod.invoke(
+                                metadataApplier,
+                                DorisSchemaUtils.MYSQL_INVALID_TIMESTAMP,
+                                DataTypes.TIMESTAMP());
+        Assertions.assertThat(result).isEqualTo(DorisSchemaUtils.DEFAULT_DATETIME);
+
+        String validResult =
+                (String)
+                        convertMethod.invoke(
+                                metadataApplier, "2023-01-01 00:00:00", DataTypes.TIMESTAMP());
+        Assertions.assertThat(validResult).isEqualTo("2023-01-01 00:00:00");
+    }
+}


### PR DESCRIPTION
issue: https://issues.apache.org/jira/browse/FLINK-38248

description
---
This PR resolves the schema evolution error that occurs when MySQL's default timestamp default value '0000-00-00 00:00:00' is processed by the Doris sink connector.
The fix automatically converts MySQL's invalid timestamp to Doris-compatible default value during table creation and column addition operations. ('0000-00-00 00:00:00' -> '1970-01-01 00:00:00')

Future Work
---
If this is the correct approach, I will proceed with the following.
Similar MySQL timestamp compatibility fixes will be applied to other downstream connectors (Paimon, StarRocks, etc.) in follow-up PRs to ensure consistent behavior across all pipeline connectors.