### PR TITLE
[FLINK-38249] Add support for skipping specific Debezium operations in MySQL CDC source.

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -300,4 +300,9 @@ public class MySqlSourceBuilder<T> {
     public MySqlSource<T> build() {
         return new MySqlSource<>(configFactory, checkNotNull(deserializer));
     }
+
+    public MySqlSourceBuilder<T> setDebeziumSkippedOperations(String skippedOperation) {
+        this.configFactory.skippedOperations(skippedOperation);
+        return this;
+    }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -51,6 +51,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private List<String> tableList;
     private String excludeTableList;
     private String serverTimeZone = ZoneId.systemDefault().getId();
+    private String debeziumSkippedOperations;
     private StartupOptions startupOptions = StartupOptions.initial();
     private int splitSize = MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue();
     private int splitMetaGroupSize = MySqlSourceOptions.CHUNK_META_GROUP_SIZE.defaultValue();
@@ -109,6 +110,11 @@ public class MySqlSourceConfigFactory implements Serializable {
 
     public MySqlSourceConfigFactory excludeTableList(String tableInclusions) {
         this.excludeTableList = tableInclusions;
+        return this;
+    }
+
+    public MySqlSourceConfigFactory skippedOperations(String debeziumSkippedOperations) {
+        this.debeziumSkippedOperations = debeziumSkippedOperations;
         return this;
     }
 
@@ -381,6 +387,9 @@ public class MySqlSourceConfigFactory implements Serializable {
         }
         if (serverTimeZone != null) {
             props.setProperty("database.serverTimezone", serverTimeZone);
+        }
+        if (debeziumSkippedOperations != null) {
+            props.put("skipped.operations", debeziumSkippedOperations);
         }
 
         // override the user-defined debezium properties

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -107,6 +107,15 @@ public class MySqlSourceOptions {
                     .withDescription(
                             "The chunk size (number of rows) of table snapshot, captured tables are split into multiple chunks when read the snapshot of table.");
 
+    public static final ConfigOption<String> DEBEZIUM_SKIPPED_OPERATIONS =
+            ConfigOptions.key("debezium.skipped.operations")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The comma-separated list of operations to skip during streaming, "
+                                    + "defined as: 'c' for inserts/create; 'u' for updates; 'd' for deletes, "
+                                    + "'t' for truncates, By default, no operations will be skipped.");
+
     public static final ConfigOption<Integer> SCAN_SNAPSHOT_FETCH_SIZE =
             ConfigOptions.key("scan.snapshot.fetch.size")
                     .intType()


### PR DESCRIPTION
issues: https://issues.apache.org/jira/browse/FLINK-38249

# Describe 
In some scenarios, users may want to filter out certain delete operations. This configuration allows Debezium to filter these operations, helping meet user requirements while reducing serialization overhead.So Flink CDC can meet user requirements by setting this parameter.Debezium can set 'skipped.operations' to filter some operations.

