### PR TITLE
[FLINK-38276][cdc-common] PaimonWriter does not invalidate cache when…

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonWriter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonWriter.java
@@ -133,6 +133,7 @@ public class PaimonWriter<InputT>
             // remove the table temporarily, then add the table with latest schema when received
             // DataChangeEvent.
             tables.remove(tableId);
+            catalog.invalidateTable(tableId);
             try {
                 if (writes.containsKey(tableId)) {
                     writes.get(tableId).replace(getTable(tableId));


### PR DESCRIPTION
invalidateTable when receiving SchemaChangeEvent to prevent retrieving outdated schema