### PR TITLE
 Implement comma-separated parsing for chunk key columns

### DIFF
--- a/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
@@ -31,7 +31,7 @@ Postgres CDC Pipeline 连接器允许从 Postgres 数据库读取快照数据和
 
 ## 示例
 
-从 Postgres 读取数据同步到 Doris 的 Pipeline 可以定义如下：
+从 Postgres 读取数据同步到 Fluss 的 Pipeline 可以定义如下：
 
 ```yaml
 source:
@@ -41,19 +41,23 @@ source:
    port: 5432
    username: admin
    password: pass
-   tables: adb.\.*.\.*, bdb.user_schema_[0-9].user_table_[0-9]+, [app|web].schema_\.*.order_\.*
+   # 需要确保所有的表来自同一个database
+   tables: adb.\.*.\.*
    decoding.plugin.name:  pgoutput
    slot.name: pgtest
 
 sink:
-  type: doris
-  name: Doris Sink
-  fenodes: 127.0.0.1:8030
-  username: root
-  password: pass
+  type: fluss
+  name: Fluss Sink
+  bootstrap.servers: localhost:9123
+  # Security-related properties for the Fluss client
+  properties.client.security.protocol: sasl
+  properties.client.security.sasl.mechanism: PLAIN
+  properties.client.security.sasl.username: developer
+  properties.client.security.sasl.password: developer-pass
 
 pipeline:
-   name: Postgres to Doris Pipeline
+   name: Postgres to Fluss Pipeline
    parallelism: 4
 ```
 
@@ -105,8 +109,9 @@ pipeline:
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>需要监视的 Postgres 数据库的表名。表名支持正则表达式，以监视满足正则表达式的多个表。<br>
-          需要注意的是，点号（.）被视为数据库和表名的分隔符。 如果需要在正则表达式中使用点（.）来匹配任何字符，必须使用反斜杠对点进行转义。<br>
-          例如，adb.\.*.\.*, bdb.user_schema_[0-9].user_table_[0-9]+, [app|web].schema_\.*.order_\.*</td>
+          需要确保所有的表来自同一个数据库。<br>
+          需要注意的是，点号（.）被视为数据库、模式和表名的分隔符。 如果需要在正则表达式中使用点（.）来匹配任何字符，必须使用反斜杠对点进行转义。<br>
+          例如，bdb.user_schema_[0-9].user_table_[0-9]+, bdb.schema_\.*.order_\.*</td>
     </tr>
     <tr>
       <td>slot.name</td>

--- a/docs/content/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content/docs/connectors/pipeline-connectors/postgres.md
@@ -32,29 +32,33 @@ Note: Since the Postgres WAL log cannot parse table structure change records, Po
 
 ## Example
 
-An example of the pipeline for reading data from Postgres and sink to Doris can be defined as follows:
+An example of the pipeline for reading data from Postgres and sink to Fluss can be defined as follows:
 
 ```yaml
 source:
-   type: posgtres
+   type: postgres
    name: Postgres Source
    hostname: 127.0.0.1
    port: 5432
    username: admin
    password: pass
-   tables: adb.\.*.\.*, bdb.user_schema_[0-9].user_table_[0-9]+, [app|web].schema_\.*.order_\.*
+   # make sure all the tables share same database.
+   tables: adb.\.*.\.*
    decoding.plugin.name:  pgoutput
    slot.name: pgtest
 
 sink:
-  type: doris
-  name: Doris Sink
-  fenodes: 127.0.0.1:8030
-  username: root
-  password: pass
+  type: fluss
+  name: Fluss Sink
+  bootstrap.servers: localhost:9123
+  # Security-related properties for the Fluss client
+  properties.client.security.protocol: sasl
+  properties.client.security.sasl.mechanism: PLAIN
+  properties.client.security.sasl.username: developer
+  properties.client.security.sasl.password: developer-pass
 
 pipeline:
-   name: Postgres to Doris Pipeline
+   name: Postgres to Fluss Pipeline
    parallelism: 4
 ```
 
@@ -106,9 +110,10 @@ pipeline:
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>Table name of the Postgres database to monitor. The table-name also supports regular expressions to monitor multiple tables that satisfy the regular expressions. <br>
-          It is important to note that the dot (.) is treated as a delimiter for database and table names. 
+          All the tables are required to share same database.  <br>
+          It is important to note that the dot (.) is treated as a delimiter for database, schema and table names.
           If there is a need to use a dot (.) in a regular expression to match any character, it is necessary to escape the dot with a backslash.<br>
-          例如，adb.\.*.\.*, bdb.user_schema_[0-9].user_table_[0-9]+, [app|web].schema_\.*.order_\.*</td>
+          for example:  bdb.user_schema_[0-9].user_table_[0-9]+, bdb.schema_\.*.order_\.*</td>
     </tr>
     <tr>
       <td>slot.name</td>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/config/JdbcSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/config/JdbcSourceConfig.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.base.config;
 
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.base.source.IncrementalSource;
+import org.apache.flink.table.catalog.ObjectPath;
 
 import io.debezium.config.Configuration;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
@@ -26,6 +27,7 @@ import io.debezium.relational.RelationalTableFilters;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -46,7 +48,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
     protected final Duration connectTimeout;
     protected final int connectMaxRetries;
     protected final int connectionPoolSize;
-    protected final String chunkKeyColumn;
+    protected final Map<ObjectPath, String> chunkKeyColumns;
 
     public JdbcSourceConfig(
             StartupOptions startupOptions,
@@ -71,7 +73,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
-            String chunkKeyColumn,
+            Map<ObjectPath, String> chunkKeyColumns,
             boolean skipSnapshotBackfill,
             boolean isScanNewlyAddedTableEnabled,
             boolean assignUnboundedChunkFirst) {
@@ -101,7 +103,7 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
         this.connectTimeout = connectTimeout;
         this.connectMaxRetries = connectMaxRetries;
         this.connectionPoolSize = connectionPoolSize;
-        this.chunkKeyColumn = chunkKeyColumn;
+        this.chunkKeyColumns = chunkKeyColumns;
     }
 
     public abstract RelationalDatabaseConnectorConfig getDbzConnectorConfig();
@@ -154,8 +156,8 @@ public abstract class JdbcSourceConfig extends BaseSourceConfig {
         return connectionPoolSize;
     }
 
-    public String getChunkKeyColumn() {
-        return chunkKeyColumn;
+    public Map<ObjectPath, String> getChunkKeyColumns() {
+        return chunkKeyColumns;
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/config/JdbcSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/config/JdbcSourceConfigFactory.java
@@ -22,10 +22,13 @@ import org.apache.flink.cdc.connectors.base.config.SourceConfig.Factory;
 import org.apache.flink.cdc.connectors.base.options.JdbcSourceOptions;
 import org.apache.flink.cdc.connectors.base.options.SourceOptions;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.table.catalog.ObjectPath;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 /** A {@link Factory} to provide {@link SourceConfig} of JDBC data source. */
@@ -55,7 +58,7 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
     protected int connectMaxRetries = JdbcSourceOptions.CONNECT_MAX_RETRIES.defaultValue();
     protected int connectionPoolSize = JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue();
     protected Properties dbzProperties;
-    protected String chunkKeyColumn;
+    protected Map<ObjectPath, String> chunkKeyColumns = new HashMap<>();
     protected boolean skipSnapshotBackfill =
             JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue();
     protected boolean scanNewlyAddedTableEnabled =
@@ -198,8 +201,17 @@ public abstract class JdbcSourceConfigFactory implements Factory<JdbcSourceConfi
      * The chunk key of table snapshot, captured tables are split into multiple chunks by the chunk
      * key column when read the snapshot of table.
      */
-    public JdbcSourceConfigFactory chunkKeyColumn(String chunkKeyColumn) {
-        this.chunkKeyColumn = chunkKeyColumn;
+    public JdbcSourceConfigFactory chunkKeyColumn(ObjectPath objectPath, String chunkKeyColumn) {
+        this.chunkKeyColumns.put(objectPath, chunkKeyColumn);
+        return this;
+    }
+
+    /**
+     * The chunk key of table snapshot, captured tables are split into multiple chunks by the chunk
+     * key column when read the snapshot of table.
+     */
+    public JdbcSourceConfigFactory chunkKeyColumn(Map<ObjectPath, String> chunkKeyColumns) {
+        this.chunkKeyColumns.putAll(chunkKeyColumns);
         return this;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/splitter/JdbcSourceChunkSplitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/splitter/JdbcSourceChunkSplitter.java
@@ -24,6 +24,7 @@ import org.apache.flink.cdc.connectors.base.source.assigner.state.ChunkSplitterS
 import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.utils.JdbcChunkUtils;
 import org.apache.flink.cdc.connectors.base.utils.ObjectUtils;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
@@ -253,11 +254,13 @@ public abstract class JdbcSourceChunkSplitter implements ChunkSplitter {
      * Get the column which is seen as chunk key.
      *
      * @param table table identity.
-     * @param chunkKeyColumn column name which is seen as chunk key, if chunkKeyColumn is null, use
-     *     primary key instead. @Column the column which is seen as chunk key.
+     * @param chunkKeyColumns column name which is seen as chunk key, if chunkKeyColumns is null,
+     *     use primary key instead.
+     * @return the column which is seen as chunk key.
      */
-    protected Column getSplitColumn(Table table, @Nullable String chunkKeyColumn) {
-        return JdbcChunkUtils.getSplitColumn(table, chunkKeyColumn);
+    protected Column getSplitColumn(
+            Table table, @Nullable Map<ObjectPath, String> chunkKeyColumns) {
+        return JdbcChunkUtils.getSplitColumn(table, chunkKeyColumns);
     }
 
     /** ChunkEnd less than or equal to max. */
@@ -360,7 +363,7 @@ public abstract class JdbcSourceChunkSplitter implements ChunkSplitter {
         try {
             currentSchema = dialect.queryTableSchema(jdbcConnection, tableId);
             currentSplittingTable = Objects.requireNonNull(currentSchema).getTable();
-            splitColumn = getSplitColumn(currentSplittingTable, sourceConfig.getChunkKeyColumn());
+            splitColumn = getSplitColumn(currentSplittingTable, sourceConfig.getChunkKeyColumns());
             splitType = getSplitType(splitColumn);
             minMaxOfSplitColumn = queryMinMax(jdbcConnection, tableId, splitColumn);
             approximateRowCnt = queryApproximateRowCnt(jdbcConnection, tableId);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
@@ -37,6 +37,8 @@ import io.debezium.relational.TableId;
 import io.debezium.util.SchemaNameAdjuster;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.util.Collection;
@@ -47,7 +49,7 @@ import java.util.stream.Collectors;
 /** The context for fetch task that fetching data of snapshot split from JDBC data source. */
 @Internal
 public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
-
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceFetchTaskContext.class);
     protected final JdbcSourceConfig sourceConfig;
     protected final JdbcDataSourceDialect dataSourceDialect;
     protected CommonConnectorConfig dbzConnectorConfig;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/utils/SourceRecordUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/utils/SourceRecordUtils.java
@@ -141,7 +141,7 @@ public class SourceRecordUtils {
         if (keyStruct != null && keyStruct.schema().field(splitFieldName) != null) {
             return new Object[] {keyStruct.get(splitFieldName)};
         }
-        LOG.info("Get Split Key From Value {} {}",dataRecord, splitFieldName);
+        LOG.info("Get Split Key From Value {} {}", dataRecord, splitFieldName);
         // For non-primary key chunk keys, use value-based approach
         return getSplitKeyFromValue(dataRecord, splitFieldName);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/utils/SourceRecordUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/utils/SourceRecordUtils.java
@@ -141,7 +141,7 @@ public class SourceRecordUtils {
         if (keyStruct != null && keyStruct.schema().field(splitFieldName) != null) {
             return new Object[] {keyStruct.get(splitFieldName)};
         }
-
+        LOG.info("Get Split Key From Value {} {}",dataRecord, splitFieldName);
         // For non-primary key chunk keys, use value-based approach
         return getSplitKeyFromValue(dataRecord, splitFieldName);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -127,7 +127,7 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
         return chunkKeyColumns;
     }
 
-  /**
+    /**
      * Returns {@code includePartitionedTables} value.
      *
      * @return include partitioned table

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.postgres.source.config;
 
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.table.catalog.ObjectPath;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
@@ -27,6 +28,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static io.debezium.connector.postgresql.PostgresConnectorConfig.SLOT_NAME;
@@ -64,7 +66,7 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
             Duration connectTimeout,
             int connectMaxRetries,
             int connectionPoolSize,
-            @Nullable String chunkKeyColumn,
+            @Nullable Map<ObjectPath, String> chunkKeyColumns,
             boolean skipSnapshotBackfill,
             boolean isScanNewlyAddedTableEnabled,
             int lsnCommitCheckpointsDelay,
@@ -93,10 +95,11 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn,
+                chunkKeyColumns,
                 skipSnapshotBackfill,
                 isScanNewlyAddedTableEnabled,
                 assignUnboundedChunkFirst);
+
         this.subtaskId = subtaskId;
         this.lsnCommitCheckpointsDelay = lsnCommitCheckpointsDelay;
         this.includePartitionedTables = includePartitionedTables;
@@ -120,6 +123,18 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
         return this.lsnCommitCheckpointsDelay;
     }
 
+    public Map<ObjectPath, String> getChunkKeyColumns() {
+        return chunkKeyColumns;
+    }
+
+  /**
+     * Returns {@code includePartitionedTables} value.
+     *
+     * @return include partitioned table
+     */
+    public boolean includePartitionedTables() {
+        return includePartitionedTables;
+    }
     /**
      * Returns {@code includePartitionedTables} value.
      *

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.postgres.source.config;
 
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfigFactory;
 import org.apache.flink.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
+import org.apache.flink.table.catalog.ObjectPath;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnector;
@@ -26,7 +27,9 @@ import io.debezium.connector.postgresql.PostgresConnector;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -51,6 +54,9 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
     private List<String> schemaList;
 
     private int lsnCommitCheckpointsDelay;
+
+    private Map<ObjectPath, String> chunkKeyColumns = new HashMap<>();
+
 
     private boolean includePartitionedTables;
 
@@ -107,6 +113,7 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
         props.setProperty("snapshot.mode", "never");
 
         Configuration dbzConfiguration = Configuration.from(props);
+
         return new PostgresSourceConfig(
                 subtaskId,
                 startupOptions,
@@ -131,7 +138,7 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
                 connectTimeout,
                 connectMaxRetries,
                 connectionPoolSize,
-                chunkKeyColumn,
+                chunkKeyColumns,
                 skipSnapshotBackfill,
                 scanNewlyAddedTableEnabled,
                 lsnCommitCheckpointsDelay,
@@ -183,6 +190,21 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
     /** The lsn commit checkpoints delay for Postgres. */
     public void setLsnCommitCheckpointsDelay(int lsnCommitCheckpointsDelay) {
         this.lsnCommitCheckpointsDelay = lsnCommitCheckpointsDelay;
+    }
+
+    /**
+     * The chunk key of table snapshot, captured tables are split into multiple chunks by the chunk
+     * key column when read the snapshot of table.
+     */
+    public PostgresSourceConfigFactory chunkKeyColumn(
+            ObjectPath objectPath, String chunkKeyColumn) {
+        this.chunkKeyColumns.put(objectPath, chunkKeyColumn);
+        return this;
+    }
+
+    public PostgresSourceConfigFactory chunkKeyColumn(Map<ObjectPath, String> chunkKeyColumns) {
+        this.chunkKeyColumns.putAll(chunkKeyColumns);
+        return this;
     }
 
     /** Enable include partitioned table. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigFactory.java
@@ -57,7 +57,6 @@ public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
 
     private Map<ObjectPath, String> chunkKeyColumns = new HashMap<>();
 
-
     private boolean includePartitionedTables;
 
     /** Creates a new {@link PostgresSourceConfig} for the given subtask {@code subtaskId}. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -25,6 +25,7 @@ import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.base.source.reader.external.JdbcSourceFetchTaskContext;
+import org.apache.flink.cdc.connectors.base.source.utils.JdbcChunkUtils;
 import org.apache.flink.cdc.connectors.postgres.source.PostgresDialect;
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfig;
 import org.apache.flink.cdc.connectors.postgres.source.offset.PostgresOffset;
@@ -288,7 +289,8 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
 
     @Override
     public RowType getSplitType(Table table) {
-        Column splitColumn = ChunkUtils.getSplitColumn(table, sourceConfig.getChunkKeyColumn());
+        Column splitColumn =
+                JdbcChunkUtils.getSplitColumn(table, sourceConfig.getChunkKeyColumns());
         return ChunkUtils.getSplitType(splitColumn);
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/table/PostgreSQLTableSource.java
@@ -27,6 +27,7 @@ import org.apache.flink.cdc.debezium.DebeziumSourceFunction;
 import org.apache.flink.cdc.debezium.table.DebeziumChangelogMode;
 import org.apache.flink.cdc.debezium.table.MetadataConverter;
 import org.apache.flink.cdc.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -226,7 +227,7 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                             .connectMaxRetries(connectMaxRetries)
                             .connectionPoolSize(connectionPoolSize)
                             .startupOptions(startupOptions)
-                            .chunkKeyColumn(chunkKeyColumn)
+                            .chunkKeyColumn(new ObjectPath(schemaName, tableName), chunkKeyColumn)
                             .heartbeatInterval(heartbeatInterval)
                             .closeIdleReaders(closeIdleReaders)
                             .skipSnapshotBackfill(skipSnapshotBackfill)

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresChunkyColumnsConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/PostgresChunkyColumnsConfigTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source;
+
+import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfigFactory;
+import org.apache.flink.table.catalog.ObjectPath;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for chunky columns configuration functionality. */
+public class PostgresChunkyColumnsConfigTest {
+
+    @Test
+    public void testChunkKeyColumnConfiguration() {
+        // Create a config factory to test chunk key column functionality
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Test basic configuration
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Test chunk key column configuration
+        ObjectPath tablePath = new ObjectPath("public", "customers");
+        configFactory.chunkKeyColumn(tablePath, "customer_id");
+
+        // Verify the factory is properly configured
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testMultipleChunkKeyColumns() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Configure multiple chunk key columns for different tables
+        configFactory.chunkKeyColumn(new ObjectPath("public", "customers"), "customer_id");
+        configFactory.chunkKeyColumn(new ObjectPath("public", "orders"), "order_id");
+        configFactory.chunkKeyColumn(new ObjectPath("public", "products"), "product_id");
+
+        // Verify the factory accepts multiple chunk key columns
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithDifferentSchemas() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Configure chunk key columns for tables in different schemas
+        configFactory.chunkKeyColumn(new ObjectPath("public", "customers"), "customer_id");
+        configFactory.chunkKeyColumn(new ObjectPath("inventory", "products"), "product_id");
+        configFactory.chunkKeyColumn(new ObjectPath("sales", "orders"), "order_id");
+
+        // Verify the factory handles different schemas
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithSpecialCharacters() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Configure chunk key columns with special characters
+        configFactory.chunkKeyColumn(new ObjectPath("public", "user_profiles"), "user_profile_id");
+        configFactory.chunkKeyColumn(new ObjectPath("public", "order_items"), "order_item_id");
+
+        // Verify the factory handles special characters
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithSplitSizeConfiguration() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Configure split size along with chunk key column
+        configFactory.splitSize(1000);
+        configFactory.chunkKeyColumn(new ObjectPath("public", "large_table"), "id");
+
+        // Verify the factory handles both split size and chunk key column
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithEmptyTableName() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Test with empty table name (should handle gracefully)
+        try {
+            ObjectPath emptyTablePath = new ObjectPath("public", "");
+            configFactory.chunkKeyColumn(emptyTablePath, "id");
+        } catch (Exception e) {
+            // Expected to handle empty table names gracefully
+            assertThat(e).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        // Verify the factory still exists
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithEmptyColumnName() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Test with empty column name (should handle gracefully)
+        ObjectPath tablePath = new ObjectPath("public", "customers");
+        configFactory.chunkKeyColumn(tablePath, "");
+
+        // Verify the factory handles empty column names
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithNullValues() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Test with null values (should handle gracefully)
+        try {
+            configFactory.chunkKeyColumn(null, "id");
+        } catch (Exception e) {
+            // Expected to handle null values gracefully
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+
+        try {
+            configFactory.chunkKeyColumn(new ObjectPath("public", "customers"), null);
+        } catch (Exception e) {
+            // Expected to handle null values gracefully
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithLongTableName() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Test with very long table name
+        String longTableName =
+                "a_very_long_table_name_that_exceeds_normal_length_limits_for_testing_purposes";
+        configFactory.chunkKeyColumn(new ObjectPath("public", longTableName), "id");
+
+        // Verify the factory handles long table names
+        assertThat(configFactory).isNotNull();
+    }
+
+    @Test
+    public void testChunkKeyColumnWithLongColumnName() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+
+        // Configure basic settings
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("testdb");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        // Test with very long column name
+        String longColumnName =
+                "a_very_long_column_name_that_exceeds_normal_length_limits_for_testing_purposes";
+        configFactory.chunkKeyColumn(new ObjectPath("public", "customers"), longColumnName);
+
+        // Verify the factory handles long column names
+        assertThat(configFactory).isNotNull();
+    }
+}


### PR DESCRIPTION
 This PR adds support for per-table chunk key column configuration in the PostgreSQL CDC connector, enabling fine-grained control over incremental snapshot
  chunking. Previously, all tables shared the same chunk key column, which was inefficient for heterogeneous table schemas.

  Key Changes

  - ✨ Added chunk key column parsing logic to PostgreSQL DataSourceFactory
  - 🔧 Implemented comma-separated configuration format support

  Example Usage

  sourceConf:
    scan.incremental.snapshot.chunk.key-column: public.action_logs:created_at,public.service_logs:created_at
