### PR TITLE
[FLINK-38358][pipeline-connector][mysql] Ignore trailing spaces in table capturing rules.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -538,7 +538,8 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
 
         // In CDC-style table matching, table names could be separated by `,` character.
         // Convert it to `|` as it's standard RegEx syntax.
-        tables = tables.replace(",", "|");
+        tables =
+                Arrays.stream(tables.split(",")).map(String::trim).collect(Collectors.joining("|"));
         LOG.info("Expression after replacing comma with vert separator: {}", tables);
 
         // Essentially, we're just trying to swap escaped `\\.` and unescaped `.`.

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlTablePatternMatchingTest.java
@@ -312,12 +312,12 @@ class MySqlTablePatternMatchingTest extends MySqlSourceTestBase {
         Assertions.assertThat(
                         getRealWorldMatchedTables(
                                 "db.tbl1 , db2.tbl\\.* , db3.tbl3", null, false, expected.length))
-                .containsExactly(expected);
+                .containsExactlyInAnyOrder(expected);
 
         Assertions.assertThat(
                         getRealWorldMatchedTables(
                                 "db.tbl1 , db2.tbl\\.* , db3.tbl3", null, true, expected.length))
-                .containsExactly(expected);
+                .containsExactlyInAnyOrder(expected);
     }
 
     private static void initializeMySqlTables(List<Tuple2<String, String>> tableNames) {


### PR DESCRIPTION
Ignore trailing spaces in table capturing rules like `tables:  foo.bar , foo.baz `.
This is not actually completely forward compatible, but we believe that using spaces in table names is very dangerous(could not guarantee that all downstream systems support this configuration).

For those who want to capture a table with space in table name, they can use `\s` to replace the ` `. 