### PR TITLE
[FLINK-38279] Add SnapshotPendingSplitsState to MySQL checkpoint stat…

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
@@ -36,6 +36,7 @@ import org.apache.flink.cdc.connectors.mysql.source.assigners.MySqlSnapshotSplit
 import org.apache.flink.cdc.connectors.mysql.source.assigners.MySqlSplitAssigner;
 import org.apache.flink.cdc.connectors.mysql.source.assigners.state.BinlogPendingSplitsState;
 import org.apache.flink.cdc.connectors.mysql.source.assigners.state.HybridPendingSplitsState;
+import org.apache.flink.cdc.connectors.mysql.source.assigners.state.SnapshotPendingSplitsState;
 import org.apache.flink.cdc.connectors.mysql.source.assigners.state.PendingSplitsState;
 import org.apache.flink.cdc.connectors.mysql.source.assigners.state.PendingSplitsStateSerializer;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
@@ -251,6 +252,13 @@ public class MySqlSource<T>
                             enumContext.currentParallelism(),
                             (HybridPendingSplitsState) checkpoint,
                             enumContext);
+        } else if (checkpoint instanceof SnapshotPendingSplitsState) {
+            splitAssigner =
+                    new MySqlSnapshotSplitAssigner(
+                            sourceConfig,
+                            enumContext.currentParallelism(),
+                            (SnapshotPendingSplitsState) checkpoint,
+                            enumContext);                
         } else if (checkpoint instanceof BinlogPendingSplitsState) {
             splitAssigner =
                     new MySqlBinlogSplitAssigner(


### PR DESCRIPTION
…e restoration

[FLINK-38279]

This issue currently prevents restoring snapshot jobs from being restart-able from save points/checkpoints which means that large table and database replication must be done in one shot. Any thing that crashes the snapshotting process creates an entirely non-recoverable situation which is highly inconvenient and un-workable in many set ups.