### PR TITLE
[FLINK-38398][pipeline-connector][postgresql] Improve PostgresSQL temporal field type supported with debezium.time.precision.mode=connect config(#4129)

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-baseURL = '//nightlies.apache.org/flink/flink-cdc-docs-master'
+baseURL = '//nightlies.apache.org/flink/flink-cdc-docs-release-3.5'
 languageCode = 'en-us'
 title = 'Apache Flink CDC'
 enableGitInfo = false
@@ -24,7 +24,7 @@ pygmentsUseClasses = true
 [params]
   # Flag whether this is a stable version or not.
   # Used for the quickstart page.
-  IsStable = false
+  IsStable = true
 
   # Flag to indicate whether an outdated warning should be shown.
   ShowOutDatedWarning = false
@@ -34,14 +34,14 @@ pygmentsUseClasses = true
   # where we change the version for the complete docs when forking of a release
   # branch etc.
   # The full version string as referenced in Maven (e.g. 1.2.1)
-  Version = "3.5-SNAPSHOT"
+  Version = "3.5.0"
 
   # For stable releases, leave the bugfix version out (e.g. 1.2). For snapshot
   # release this should be the same as the regular version
-  VersionTitle = "3.5-SNAPSHOT"
+  VersionTitle = "3.5"
 
   # The branch for this version of Apache Flink CDC
-  Branch = "master"
+  Branch = "release-3.5"
 
   # The GitHub repository for Apache Flink CDC
   Repo = "//github.com/apache/flink-cdc"
@@ -54,7 +54,7 @@ pygmentsUseClasses = true
   # of the menu
   MenuLinks = [
     ["Project Homepage", "//flink.apache.org"],
-    ["JavaDocs", "//nightlies.apache.org/flink/flink-cdc-docs-master/api/java/"],
+    ["JavaDocs", "//nightlies.apache.org/flink/flink-cdc-docs-release-3.5/api/java/"],
   ]
 
   PreviousDocs = [

--- a/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
@@ -417,11 +417,11 @@ pipeline:
 - debezium.time.precision.mode=adaptive_time_microseconds
 - debezium.time.precision.mode=connect
 
-注意： 受限当前CDC对时间类型的支持，<code>debezium.time.precision.mode</code>为adaptive或adaptive_time_microseconds或connect Time类型都转化为Integer类型，并精度为3，后续将进行完善。
+注意： 受限当前CDC对时间类型Time的精度为3，<code>debezium.time.precision.mode</code>为adaptive或adaptive_time_microseconds或connect Time类型都转化为Time(3)类型。
 
 <u>debezium.time.precision.mode=adaptive</u>
 
-当<code>debezium.time.precision.mode</code>属性设置为默认的 adaptive（自适应）时，连接器会根据列的数据类型定义来确定字面类型和语义类型。这可以确保事件能够精确地表示数据库中的值。
+当<code>debezium.time.precision.mode</code>属性设置为默认的 adaptive（自适应）时，TIME的精度为3，TIMESTAMP的精度为6。
 <div class="wy-table-responsive">
 <table class="colwidths-auto docutils">
     <thead>
@@ -440,13 +440,79 @@ pipeline:
         <td>
           TIME([P])
         </td>
-        <td>INTEGER</td>
+        <td>TIME(3)</td>
       </tr>
       <tr>
         <td>
           TIMESTAMP([P])
         </td>
         <td>TIMESTAMP([P])</td>
+      </tr>
+    </tbody>
+</table>
+</div>
+
+<u>debezium.time.precision.mode=adaptive_time_microseconds</u>
+
+当<code>debezium.time.precision.mode</code>属性设置为默认的 adaptive_time_microseconds时，TIME的精度为3，TIMESTAMP的精度为6。
+<div class="wy-table-responsive">
+<table class="colwidths-auto docutils">
+    <thead>
+      <tr>
+        <th class="text-left">PostgreSQL type<a href="https://www.postgresql.org/docs/12/datatype.html"></a></th>
+        <th class="text-left">CDC type<a href="{% link dev/table/types.md %}"></a></th>
+      </tr>
+    </thead>
+    <tbody>
+       <tr>
+        <td>
+          DATE
+        <td>DATE</td>
+      </tr>
+      <tr>
+        <td>
+          TIME([P])
+        </td>
+        <td>TIME(3)</td>
+      </tr>
+      <tr>
+        <td>
+          TIMESTAMP([P])
+        </td>
+        <td>TIMESTAMP([P])</td>
+      </tr>
+    </tbody>
+</table>
+</div>
+
+<u>debezium.time.precision.mode=connect</u>
+
+当<code>debezium.time.precision.mode</code>属性设置为默认的 connect时，TIME和TIMESTAMP的精度都为3。
+<div class="wy-table-responsive">
+<table class="colwidths-auto docutils">
+    <thead>
+      <tr>
+        <th class="text-left">PostgreSQL type<a href="https://www.postgresql.org/docs/12/datatype.html"></a></th>
+        <th class="text-left">CDC type<a href="{% link dev/table/types.md %}"></a></th>
+      </tr>
+    </thead>
+    <tbody>
+       <tr>
+        <td>
+          DATE
+        <td>DATE</td>
+      </tr>
+      <tr>
+        <td>
+          TIME([P])
+        </td>
+        <td>TIME(3)</td>
+      </tr>
+      <tr>
+        <td>
+          TIMESTAMP([P])
+        </td>
+        <td>TIMESTAMP(3)</td>
       </tr>
     </tbody>
 </table>

--- a/docs/content/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content/docs/connectors/pipeline-connectors/postgres.md
@@ -412,11 +412,11 @@ Other than PostgreSQL’s TIMESTAMPTZ data types, which contain time zone inform
 - debezium.time.precision.mode=adaptive_time_microseconds
 - debezium.time.precision.mode=connect 
 
-Note: Due to current CDC limitations in supporting time types, when <code>debezium.time.precision.mode</code> is set to "adaptive", "adaptive_time_microseconds", or when using Connect time types, all time values are converted to the Integer type with a precision of 3. This will be improved in future updates.
+Note: Due to the current CDC limitation, the precision for the TIME type is fixed at 3. Regardless of whether <code>debezium.time.precision.mode<code> is set to adaptive, adaptive_time_microseconds, or connect, the TIME type will be converted to TIME(3).
 
 <u>debezium.time.precision.mode=adaptive</u>
 
-When the <code>debezium.time.precision.mode</code> property is set to adaptive, the default, the connector determines the literal type and semantic type based on the column’s data type definition. This ensures that events exactly represent the values in the database.
+When the <code>debezium.time.precision.mode</code> property is set to the default value `adaptive_time_microseconds`, the precision of `TIME` is 3, and the precision of `TIMESTAMP` is 6.
 <div class="wy-table-responsive">
 <table class="colwidths-auto docutils">
     <thead>
@@ -435,13 +435,79 @@ When the <code>debezium.time.precision.mode</code> property is set to adaptive, 
         <td>
           TIME([P])
         </td>
-        <td>INTEGER</td>
+        <td>TIME(3)</td>
       </tr>
       <tr>
         <td>
           TIMESTAMP([P])
         </td>
         <td>TIMESTAMP([P])</td>
+      </tr>
+    </tbody>
+</table>
+</div>
+
+<u>debezium.time.precision.mode=adaptive_time_microseconds</u>
+
+When the `debezium.time.precision.mode` property is set to the value `adaptive_time_microseconds`, the precision of `TIME` is 3, and the precision of `TIMESTAMP` is 6.
+<div class="wy-table-responsive">
+<table class="colwidths-auto docutils">
+    <thead>
+      <tr>
+        <th class="text-left">PostgreSQL type<a href="https://www.postgresql.org/docs/12/datatype.html"></a></th>
+        <th class="text-left">CDC type<a href="{% link dev/table/types.md %}"></a></th>
+      </tr>
+    </thead>
+    <tbody>
+       <tr>
+        <td>
+          DATE
+        <td>DATE</td>
+      </tr>
+      <tr>
+        <td>
+          TIME([P])
+        </td>
+        <td>TIME(3)</td>
+      </tr>
+      <tr>
+        <td>
+          TIMESTAMP([P])
+        </td>
+        <td>TIMESTAMP([P])</td>
+      </tr>
+    </tbody>
+</table>
+</div>
+
+<u>debezium.time.precision.mode=connect</u>
+
+When the <code>debezium.time.precision.mode</code> property is set to the default value connect, both TIME and TIMESTAMP have a precision of 3.
+<div class="wy-table-responsive">
+<table class="colwidths-auto docutils">
+    <thead>
+      <tr>
+        <th class="text-left">PostgreSQL type<a href="https://www.postgresql.org/docs/12/datatype.html"></a></th>
+        <th class="text-left">CDC type<a href="{% link dev/table/types.md %}"></a></th>
+      </tr>
+    </thead>
+    <tbody>
+       <tr>
+        <td>
+          DATE
+        <td>DATE</td>
+      </tr>
+      <tr>
+        <td>
+          TIME([P])
+        </td>
+        <td>TIME(3)</td>
+      </tr>
+      <tr>
+        <td>
+          TIMESTAMP([P])
+        </td>
+        <td>TIMESTAMP(3)</td>
       </tr>
     </tbody>
 </table>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/utils/PostgresTypeUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/utils/PostgresTypeUtils.java
@@ -277,7 +277,7 @@ public class PostgresTypeUtils {
             case ADAPTIVE:
             case ADAPTIVE_TIME_MICROSECONDS:
             case CONNECT:
-                return DataTypes.INT();
+                return DataTypes.TIME(scale);
             default:
                 throw new IllegalArgumentException("Unknown temporal precision mode: " + mode);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/event/DebeziumEventDeserializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/event/DebeziumEventDeserializationSchema.java
@@ -66,6 +66,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -326,6 +327,9 @@ public abstract class DebeziumEventDeserializationSchema extends SourceRecordEve
             }
         } else if (dbzObj instanceof Integer) {
             return TimeData.fromMillisOfDay((int) dbzObj);
+        } else if (dbzObj instanceof Date) {
+            long millisOfDay = ((Date) dbzObj).getTime() % (24 * 60 * 60 * 1000);
+            return TimeData.fromMillisOfDay((int) millisOfDay);
         }
         // get number of milliseconds of the day
         return TimeData.fromLocalTime(TemporalConversions.toLocalTime(dbzObj));
@@ -344,6 +348,12 @@ public abstract class DebeziumEventDeserializationSchema extends SourceRecordEve
                     long nano = (long) dbzObj;
                     return TimestampData.fromMillis(
                             Math.floorDiv(nano, 1000_000), (int) (Math.floorMod(nano, 1000_000)));
+            }
+        }
+        if (dbzObj instanceof Date) {
+            if (schema.name().equals(org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME)) {
+                Instant instant = ((Date) dbzObj).toInstant();
+                return TimestampData.fromMillis(instant.toEpochMilli());
             }
         }
         throw new IllegalArgumentException(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/event/DebeziumSchemaDataTypeInference.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/event/DebeziumSchemaDataTypeInference.java
@@ -104,10 +104,14 @@ public class DebeziumSchemaDataTypeInference implements SchemaDataTypeInference,
     }
 
     protected DataType inferInt32(Object value, Schema schema) {
-        if (Date.SCHEMA_NAME.equals(schema.name())) {
+        if (Date.SCHEMA_NAME.equals(schema.name())
+                || org.apache.kafka.connect.data.Date.LOGICAL_NAME.equals(schema.name())) {
             return DataTypes.DATE();
         }
         if (Time.SCHEMA_NAME.equals(schema.name())) {
+            return DataTypes.TIME(3);
+        }
+        if (org.apache.kafka.connect.data.Time.LOGICAL_NAME.equals(schema.name())) {
             return DataTypes.TIME(3);
         }
         return DataTypes.INT();
@@ -120,7 +124,8 @@ public class DebeziumSchemaDataTypeInference implements SchemaDataTypeInference,
         if (NanoTime.SCHEMA_NAME.equals(schema.name())) {
             return DataTypes.TIME(9);
         }
-        if (Timestamp.SCHEMA_NAME.equals(schema.name())) {
+        if (Timestamp.SCHEMA_NAME.equals(schema.name())
+                || org.apache.kafka.connect.data.Timestamp.LOGICAL_NAME.equals(schema.name())) {
             return DataTypes.TIMESTAMP(3);
         }
         if (MicroTimestamp.SCHEMA_NAME.equals(schema.name())) {


### PR DESCRIPTION
After support timetype, serialization of time type, PostgresTypeUtils# handleTimeWithTemporalMode is type int, leads to the downstream processing field in the process of conflict.

At present time field support debezium. Time. Precision. The mode = connect will handle exceptions, repair it.

relation: https://github.com/apache/flink-cdc/commit/272d99e9e9552eb2c73840259dc1ba5b7672d582