### PR TITLE
[FLINK-38440][pipeline-connector][iceberg] fixed iceberg write SMALLINT/TINYINT data wrong

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/utils/IcebergTypeUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/utils/IcebergTypeUtils.java
@@ -140,8 +140,10 @@ public class IcebergTypeUtils {
                         };
                 break;
             case TINYINT:
+                fieldGetter = row -> (int) row.getByte(fieldPos);
+                break;
             case SMALLINT:
-                fieldGetter = row -> row.getInt(fieldPos);
+                fieldGetter = row -> ((Short) row.getShort(fieldPos)).intValue();
                 break;
             case BIGINT:
                 fieldGetter = row -> row.getLong(fieldPos);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/v2/IcebergWriterTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/test/java/org/apache/flink/cdc/connectors/iceberg/sink/v2/IcebergWriterTest.java
@@ -291,7 +291,9 @@ public class IcebergWriterTest {
                                 .physicalColumn("varbinary(10)", DataTypes.BINARY(10))
                                 .physicalColumn("decimal(10, 2)", DataTypes.DECIMAL(10, 2))
                                 .physicalColumn("tinyint", DataTypes.TINYINT())
+                                .physicalColumn("negative_tinyint", DataTypes.TINYINT())
                                 .physicalColumn("smallint", DataTypes.SMALLINT())
+                                .physicalColumn("negative_smallint", DataTypes.SMALLINT())
                                 .physicalColumn("int", DataTypes.INT())
                                 .physicalColumn("bigint", DataTypes.BIGINT())
                                 .physicalColumn("float", DataTypes.FLOAT())
@@ -319,7 +321,9 @@ public class IcebergWriterTest {
                             new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
                             DecimalData.zero(10, 2),
                             (byte) 1,
+                            (byte) -1,
                             (short) 2,
+                            (short) -2,
                             12345,
                             12345L,
                             123.456f,
@@ -342,7 +346,7 @@ public class IcebergWriterTest {
         List<String> result = fetchTableContent(catalog, tableId);
         Assertions.assertThat(result)
                 .containsExactlyInAnyOrder(
-                        "char, varchar, string, false, [1,2,3,4,5,], [1,2,3,4,5,6,7,8,9,10,], 0.00, 1, 2, 12345, 12345, 123.456, 123456.789, 00:00:12.345, 2003-10-20, 1970-01-01T00:00, 1970-01-01T00:00Z, 1970-01-01T00:00Z");
+                        "char, varchar, string, false, [1,2,3,4,5,], [1,2,3,4,5,6,7,8,9,10,], 0.00, 1, -1, 2, -2, 12345, 12345, 123.456, 123456.789, 00:00:12.345, 2003-10-20, 1970-01-01T00:00, 1970-01-01T00:00Z, 1970-01-01T00:00Z");
     }
 
     /** Mock CommitRequestImpl. */


### PR DESCRIPTION
flink-cdc run with mysql -> iceberg, column type in mysql is TINYINT and the value is
negative( like -1), write to iceberg table the value change to 65535.
 
Because -1 pack to "\xff\xff" (short, 2bytes). But in code uppack by int, is get "\xff\xff\x00\x00" (int, 4bytes, got more \x00\x00 from data binary), then get 65535.