### PR TITLE
[hotfix][ci] Run MongoDB tests with supported 7.0.x and 8.0.x images

### DIFF
--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -214,10 +214,10 @@ jobs:
               ("oracle")
                modules=${{ env.MODULES_ORACLE }}
               ;;
-              ("mongodb6")
+              ("mongodb7")
                modules=${{ env.MODULES_MONGODB }}
               ;;
-              ("mongodb7")
+              ("mongodb8")
                modules=${{ env.MODULES_MONGODB }}
               ;;
               ("sqlserver")
@@ -278,10 +278,10 @@ jobs:
           
           build_maven_parameter=""
 
-          if [ ${{ matrix.module }} == "mongodb6" ]; then
-            build_maven_parameter="-DspecifiedMongoVersion=6.0.16"
-          elif [ ${{ matrix.module }} == "mongodb7" ]; then
-            build_maven_parameter="-DspecifiedMongoVersion=7.0.12"
+          if [ ${{ matrix.module }} == "mongodb7" ]; then
+            build_maven_parameter="-DspecifiedMongoVersion=7.0.24"
+          elif [ ${{ matrix.module }} == "mongodb8" ]; then
+            build_maven_parameter="-DspecifiedMongoVersion=8.0.14"
           fi
           
           if [ ! -z "${{ matrix.flink-version }}" ]; then

--- a/.github/workflows/flink_cdc_ci.yml
+++ b/.github/workflows/flink_cdc_ci.yml
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/flink_cdc_base.yml
     with:
       java-versions: "[8]"
-      modules: "['mysql-source', 'postgres-source', 'oracle', 'mongodb6', 'mongodb7', 'sqlserver', 'tidb', 'oceanbase-source', 'db2', 'vitess']"
+      modules: "['mysql-source', 'postgres-source', 'oracle', 'mongodb7', 'mongodb8', 'sqlserver', 'tidb', 'oceanbase-source', 'db2', 'vitess']"
   pipeline_e2e:
     strategy:
       fail-fast: false

--- a/.github/workflows/flink_cdc_ci_nightly.yml
+++ b/.github/workflows/flink_cdc_ci_nightly.yml
@@ -67,7 +67,7 @@ jobs:
     uses: ./.github/workflows/flink_cdc_base.yml
     with:
       java-versions: "[11]"
-      modules: "['mysql-source', 'postgres-source', 'oracle', 'mongodb6', 'mongodb7', 'sqlserver', 'tidb', 'oceanbase-source', 'db2', 'vitess']"
+      modules: "['mysql-source', 'postgres-source', 'oracle', 'mongodb7', 'mongodb8', 'sqlserver', 'tidb', 'oceanbase-source', 'db2', 'vitess']"
   pipeline_e2e:
     if: github.repository == 'apache/flink-cdc'
     strategy:

--- a/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/org/apache/flink/cdc/connectors/tests/MongoE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-source-e2e-tests/src/test/java/org/apache/flink/cdc/connectors/tests/MongoE2eITCase.java
@@ -112,14 +112,14 @@ class MongoE2eITCase extends FlinkContainerTestEnvironment {
     @ParameterizedTest(
             name = "MongoDB Version: {0}, boolean parallelismSnapshot: {1}, scanFullChangelog: {2}")
     @CsvSource({
-        "6.0.16, true, true",
-        "6.0.16, true, false",
-        "6.0.16, false, true",
-        "6.0.16, false, false",
-        "7.0.12, true, true",
-        "7.0.12, true, false",
-        "7.0.12, false, true",
-        "7.0.12, false, false"
+        "7.0.24, true, true",
+        "7.0.24, true, false",
+        "7.0.24, false, true",
+        "7.0.24, false, false",
+        "8.0.14, true, true",
+        "8.0.14, true, false",
+        "8.0.14, false, true",
+        "8.0.14, false, false"
     })
     void testMongoDbCDC(String mongoVersion, boolean parallelismSnapshot, boolean scanFullChangelog)
             throws Exception {


### PR DESCRIPTION
MongoDB 6.0.x reached its EOL in this July [1], so this PR updates MongoDB testing pipelines to 7.0.24 and 8.0.14. According to the MongoDB compatibility table [2], our current MongoDB driver version should work with the latest MongoDB 8.x servers.

[1] https://www.mongodb.com/legal/support-policy/lifecycles
[2] https://www.mongodb.com/zh-cn/docs/drivers/java/sync/current/reference/compatibility/