### PR TITLE
[FLINK-38741][mysql-cdc] Fix MODIFY COLUMN position change events are…

### DIFF
--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashMap;
 import java.util.Set;
 
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ADD_COLUMN;
+import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_POSITION;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_TYPE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.CREATE_TABLE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.DROP_COLUMN;
@@ -54,7 +55,7 @@ import static org.apache.flink.cdc.common.pipeline.PipelineOptions.PIPELINE_LOCA
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-/** Unit test for {@link org.apache.flink.cdc.cli.parser.YamlPipelineDefinitionParser}. */
+/** Unit test for {@link YamlPipelineDefinitionParser}. */
 class YamlPipelineDefinitionParserTest {
 
     @Test
@@ -206,6 +207,7 @@ class YamlPipelineDefinitionParserTest {
                 ImmutableSet.of(
                         ADD_COLUMN,
                         ALTER_COLUMN_TYPE,
+                        ALTER_COLUMN_POSITION,
                         CREATE_TABLE,
                         DROP_COLUMN,
                         DROP_TABLE,
@@ -218,6 +220,7 @@ class YamlPipelineDefinitionParserTest {
                 ImmutableSet.of(
                         ADD_COLUMN,
                         ALTER_COLUMN_TYPE,
+                        ALTER_COLUMN_POSITION,
                         CREATE_TABLE,
                         DROP_COLUMN,
                         DROP_TABLE,
@@ -230,6 +233,7 @@ class YamlPipelineDefinitionParserTest {
                 ImmutableSet.of(
                         ADD_COLUMN,
                         ALTER_COLUMN_TYPE,
+                        ALTER_COLUMN_POSITION,
                         CREATE_TABLE,
                         RENAME_COLUMN,
                         TRUNCATE_TABLE));
@@ -238,7 +242,12 @@ class YamlPipelineDefinitionParserTest {
                 null,
                 null,
                 ImmutableSet.of(
-                        ADD_COLUMN, ALTER_COLUMN_TYPE, CREATE_TABLE, DROP_COLUMN, RENAME_COLUMN));
+                        ADD_COLUMN,
+                        ALTER_COLUMN_TYPE,
+                        ALTER_COLUMN_POSITION,
+                        CREATE_TABLE,
+                        DROP_COLUMN,
+                        RENAME_COLUMN));
         testSchemaEvolutionTypesParsing(
                 "lenient",
                 null,
@@ -246,6 +255,7 @@ class YamlPipelineDefinitionParserTest {
                 ImmutableSet.of(
                         ADD_COLUMN,
                         ALTER_COLUMN_TYPE,
+                        ALTER_COLUMN_POSITION,
                         CREATE_TABLE,
                         DROP_COLUMN,
                         DROP_TABLE,
@@ -532,6 +542,7 @@ class YamlPipelineDefinitionParserTest {
                             ImmutableSet.of(
                                     DROP_COLUMN,
                                     ALTER_COLUMN_TYPE,
+                                    ALTER_COLUMN_POSITION,
                                     ADD_COLUMN,
                                     CREATE_TABLE,
                                     RENAME_COLUMN)),
@@ -558,6 +569,7 @@ class YamlPipelineDefinitionParserTest {
                             ImmutableSet.of(
                                     DROP_COLUMN,
                                     ALTER_COLUMN_TYPE,
+                                    ALTER_COLUMN_POSITION,
                                     ADD_COLUMN,
                                     CREATE_TABLE,
                                     RENAME_COLUMN)),
@@ -644,6 +656,7 @@ class YamlPipelineDefinitionParserTest {
                             ImmutableSet.of(
                                     DROP_COLUMN,
                                     ALTER_COLUMN_TYPE,
+                                    ALTER_COLUMN_POSITION,
                                     ADD_COLUMN,
                                     CREATE_TABLE,
                                     RENAME_COLUMN)),

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/AlterColumnPositionEvent.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/AlterColumnPositionEvent.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.event;
+
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.common.schema.Column;
+import org.apache.flink.cdc.common.schema.Schema;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link SchemaChangeEvent} that represents column position changes in a table, such as {@code
+ * ALTER TABLE ... MODIFY COLUMN ... AFTER/BEFORE} DDL operations.
+ */
+@PublicEvolving
+public class AlterColumnPositionEvent implements SchemaChangeEventWithPreSchema, SchemaChangeEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TableId tableId;
+
+    /** key => column name, value => new position information. */
+    private final Map<String, ColumnPosition> positionMapping;
+
+    /** key => column name, value => old position (0-based). */
+    private final Map<String, Integer> oldPositionMapping;
+
+    public AlterColumnPositionEvent(TableId tableId, Map<String, ColumnPosition> positionMapping) {
+        this.tableId = tableId;
+        this.positionMapping = positionMapping;
+        this.oldPositionMapping = new HashMap<>();
+    }
+
+    public AlterColumnPositionEvent(
+            TableId tableId,
+            Map<String, ColumnPosition> positionMapping,
+            Map<String, Integer> oldPositionMapping) {
+        this.tableId = tableId;
+        this.positionMapping = positionMapping;
+        this.oldPositionMapping = oldPositionMapping;
+    }
+
+    /** Returns the position mapping. */
+    public Map<String, ColumnPosition> getPositionMapping() {
+        return positionMapping;
+    }
+
+    /** Returns the old position mapping. */
+    public Map<String, Integer> getOldPositionMapping() {
+        return oldPositionMapping;
+    }
+
+    @Override
+    public TableId tableId() {
+        return tableId;
+    }
+
+    @Override
+    public SchemaChangeEventType getType() {
+        return SchemaChangeEventType.ALTER_COLUMN_POSITION;
+    }
+
+    @Override
+    public SchemaChangeEvent copy(TableId newTableId) {
+        return new AlterColumnPositionEvent(newTableId, positionMapping, oldPositionMapping);
+    }
+
+    @Override
+    public boolean hasPreSchema() {
+        return !oldPositionMapping.isEmpty();
+    }
+
+    @Override
+    public void fillPreSchema(Schema oldSchema) {
+        oldPositionMapping.clear();
+        List<Column> columns = oldSchema.getColumns();
+        for (int i = 0; i < columns.size(); i++) {
+            String columnName = columns.get(i).getName();
+            if (positionMapping.containsKey(columnName)) {
+                oldPositionMapping.put(columnName, i);
+            }
+        }
+    }
+
+    @Override
+    public boolean trimRedundantChanges() {
+        if (hasPreSchema()) {
+            Set<String> redundantChanges =
+                    positionMapping.entrySet().stream()
+                            .filter(
+                                    entry -> {
+                                        String columnName = entry.getKey();
+                                        ColumnPosition newPos = entry.getValue();
+                                        Integer oldPos = oldPositionMapping.get(columnName);
+                                        return oldPos != null
+                                                && oldPos.equals(newPos.getAbsolutePosition());
+                                    })
+                            .map(Map.Entry::getKey)
+                            .collect(Collectors.toSet());
+
+            positionMapping.keySet().removeAll(redundantChanges);
+            oldPositionMapping.keySet().removeAll(redundantChanges);
+        }
+        return !positionMapping.isEmpty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AlterColumnPositionEvent)) {
+            return false;
+        }
+        AlterColumnPositionEvent that = (AlterColumnPositionEvent) o;
+        return Objects.equals(tableId, that.tableId)
+                && Objects.equals(positionMapping, that.positionMapping)
+                && Objects.equals(oldPositionMapping, that.oldPositionMapping);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableId, positionMapping, oldPositionMapping);
+    }
+
+    @Override
+    public String toString() {
+        if (hasPreSchema()) {
+            return "AlterColumnPositionEvent{"
+                    + "tableId="
+                    + tableId
+                    + ", positionMapping="
+                    + positionMapping
+                    + ", oldPositionMapping="
+                    + oldPositionMapping
+                    + '}';
+        } else {
+            return "AlterColumnPositionEvent{"
+                    + "tableId="
+                    + tableId
+                    + ", positionMapping="
+                    + positionMapping
+                    + '}';
+        }
+    }
+
+    /** Represents the position information for a column. */
+    public static class ColumnPosition implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final int absolutePosition; // 0-based absolute position
+        private final @Nullable String afterColumn; // relative position: after this column
+        private final boolean isFirst; // whether to move to first position
+
+        /** Create position for first column. */
+        public static ColumnPosition first() {
+            return new ColumnPosition(0, null, true);
+        }
+
+        /** Create position after specified column. */
+        public static ColumnPosition after(String columnName) {
+            return new ColumnPosition(-1, columnName, false);
+        }
+
+        /** Create position at absolute index. */
+        public static ColumnPosition at(int position) {
+            return new ColumnPosition(position, null, false);
+        }
+
+        private ColumnPosition(
+                int absolutePosition, @Nullable String afterColumn, boolean isFirst) {
+            this.absolutePosition = absolutePosition;
+            this.afterColumn = afterColumn;
+            this.isFirst = isFirst;
+        }
+
+        public int getAbsolutePosition() {
+            return absolutePosition;
+        }
+
+        @Nullable
+        public String getAfterColumn() {
+            return afterColumn;
+        }
+
+        public boolean isFirst() {
+            return isFirst;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+
+            if (!(o instanceof ColumnPosition)) {
+                return false;
+            }
+
+            ColumnPosition that = (ColumnPosition) o;
+            return absolutePosition == that.absolutePosition
+                    && isFirst == that.isFirst
+                    && Objects.equals(afterColumn, that.afterColumn);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(absolutePosition, afterColumn, isFirst);
+        }
+
+        @Override
+        public String toString() {
+            return "ColumnPosition{"
+                    + "absolutePosition="
+                    + absolutePosition
+                    + ", afterColumn='"
+                    + afterColumn
+                    + '\''
+                    + ", isFirst="
+                    + isFirst
+                    + '}';
+        }
+    }
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/SchemaChangeEventType.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/SchemaChangeEventType.java
@@ -28,7 +28,9 @@ public enum SchemaChangeEventType {
     DROP_COLUMN("drop.column"),
     DROP_TABLE("drop.table"),
     RENAME_COLUMN("rename.column"),
-    TRUNCATE_TABLE("truncate.table");
+    TRUNCATE_TABLE("truncate.table"),
+    ALTER_COLUMN_POSITION("alter.column.position"),
+    ALTER_COLUMN_COMMENT("alter.column.comment");
 
     private final String tag;
 
@@ -55,6 +57,8 @@ public enum SchemaChangeEventType {
             return RENAME_COLUMN;
         } else if (event instanceof TruncateTableEvent) {
             return TRUNCATE_TABLE;
+        } else if (event instanceof AlterColumnPositionEvent) {
+            return ALTER_COLUMN_POSITION;
         } else {
             throw new RuntimeException("Unknown schema change event type: " + event.getClass());
         }
@@ -76,6 +80,10 @@ public enum SchemaChangeEventType {
                 return RENAME_COLUMN;
             case "truncate.table":
                 return TRUNCATE_TABLE;
+            case "alter.column.position":
+                return ALTER_COLUMN_POSITION;
+            case "alter.column.comment":
+                return ALTER_COLUMN_COMMENT;
             default:
                 throw new RuntimeException("Unknown schema change event type: " + tag);
         }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/SchemaChangeEventTypeFamily.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/SchemaChangeEventTypeFamily.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.common.event;
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ADD_COLUMN;
+import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_POSITION;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_TYPE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.CREATE_TABLE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.DROP_COLUMN;
@@ -36,7 +37,7 @@ public class SchemaChangeEventTypeFamily {
 
     public static final SchemaChangeEventType[] ADD = {ADD_COLUMN};
 
-    public static final SchemaChangeEventType[] ALTER = {ALTER_COLUMN_TYPE};
+    public static final SchemaChangeEventType[] ALTER = {ALTER_COLUMN_TYPE, ALTER_COLUMN_POSITION};
 
     public static final SchemaChangeEventType[] CREATE = {CREATE_TABLE};
 
@@ -47,12 +48,13 @@ public class SchemaChangeEventTypeFamily {
     public static final SchemaChangeEventType[] TABLE = {CREATE_TABLE, DROP_TABLE, TRUNCATE_TABLE};
 
     public static final SchemaChangeEventType[] COLUMN = {
-        ADD_COLUMN, ALTER_COLUMN_TYPE, DROP_COLUMN, RENAME_COLUMN
+        ADD_COLUMN, ALTER_COLUMN_TYPE, ALTER_COLUMN_POSITION, DROP_COLUMN, RENAME_COLUMN
     };
 
     public static final SchemaChangeEventType[] ALL = {
         ADD_COLUMN,
         ALTER_COLUMN_TYPE,
+        ALTER_COLUMN_POSITION,
         CREATE_TABLE,
         DROP_COLUMN,
         DROP_TABLE,

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/visitor/AlterColumnPositionEventVisitor.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/visitor/AlterColumnPositionEventVisitor.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.event.visitor;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.event.AlterColumnPositionEvent;
+
+/** Visitor for {@link AlterColumnPositionEvent}. */
+@Internal
+public interface AlterColumnPositionEventVisitor<T, E extends Throwable> {
+    T visit(AlterColumnPositionEvent event) throws E;
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/visitor/SchemaChangeEventVisitor.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/event/visitor/SchemaChangeEventVisitor.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.common.event.visitor;
 
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.AlterColumnPositionEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DropColumnEvent;
@@ -34,6 +35,7 @@ public class SchemaChangeEventVisitor {
             SchemaChangeEvent event,
             AddColumnEventVisitor<T, E> addColumnVisitor,
             AlterColumnTypeEventVisitor<T, E> alterColumnTypeEventVisitor,
+            AlterColumnPositionEventVisitor<T, E> alterColumnPositionEventVisitor,
             CreateTableEventVisitor<T, E> createTableEventVisitor,
             DropColumnEventVisitor<T, E> dropColumnEventVisitor,
             DropTableEventVisitor<T, E> dropTableEventVisitor,
@@ -50,6 +52,11 @@ public class SchemaChangeEventVisitor {
                 return null;
             }
             return alterColumnTypeEventVisitor.visit((AlterColumnTypeEvent) event);
+        } else if (event instanceof AlterColumnPositionEvent) {
+            if (alterColumnPositionEventVisitor == null) {
+                return null;
+            }
+            return alterColumnPositionEventVisitor.visit((AlterColumnPositionEvent) event);
         } else if (event instanceof CreateTableEvent) {
             if (createTableEventVisitor == null) {
                 return null;

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/ChangeEventUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/ChangeEventUtils.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.common.utils;
 
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.AlterColumnPositionEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DataChangeEvent;
@@ -77,6 +78,11 @@ public class ChangeEventUtils {
                                 tableId,
                                 alterColumnEvent.getTypeMapping(),
                                 alterColumnEvent.getOldTypeMapping()),
+                alterColumnPositionEvent ->
+                        new AlterColumnPositionEvent(
+                                tableId,
+                                alterColumnPositionEvent.getPositionMapping(),
+                                alterColumnPositionEvent.getOldPositionMapping()),
                 createTableEvent -> new CreateTableEvent(tableId, createTableEvent.getSchema()),
                 dropColumnEvent ->
                         new DropColumnEvent(tableId, dropColumnEvent.getDroppedColumnNames()),

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/ChangeEventUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/ChangeEventUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ADD_COLUMN;
+import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_POSITION;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_TYPE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.CREATE_TABLE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.DROP_COLUMN;
@@ -37,7 +38,7 @@ import static org.apache.flink.cdc.common.event.SchemaChangeEventType.RENAME_COL
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.TRUNCATE_TABLE;
 import static org.apache.flink.cdc.common.testutils.assertions.EventAssertions.assertThat;
 
-/** A test for the {@link org.apache.flink.cdc.common.utils.ChangeEventUtils}. */
+/** A test for the {@link ChangeEventUtils}. */
 class ChangeEventUtilsTest {
     @Test
     void testResolveSchemaEvolutionOptions() {
@@ -54,6 +55,7 @@ class ChangeEventUtilsTest {
                                 CREATE_TABLE,
                                 DROP_TABLE,
                                 ALTER_COLUMN_TYPE,
+                                ALTER_COLUMN_POSITION,
                                 ADD_COLUMN,
                                 DROP_COLUMN));
 
@@ -64,6 +66,7 @@ class ChangeEventUtilsTest {
                         Sets.set(
                                 ADD_COLUMN,
                                 ALTER_COLUMN_TYPE,
+                                ALTER_COLUMN_POSITION,
                                 RENAME_COLUMN,
                                 CREATE_TABLE,
                                 TRUNCATE_TABLE));
@@ -77,7 +80,12 @@ class ChangeEventUtilsTest {
                         ChangeEventUtils.resolveSchemaEvolutionOptions(
                                 Collections.singletonList("column"),
                                 Collections.singletonList("drop.column")))
-                .isEqualTo(Sets.set(ADD_COLUMN, ALTER_COLUMN_TYPE, RENAME_COLUMN));
+                .isEqualTo(
+                        Sets.set(
+                                ADD_COLUMN,
+                                ALTER_COLUMN_TYPE,
+                                ALTER_COLUMN_POSITION,
+                                RENAME_COLUMN));
 
         assertThat(
                         ChangeEventUtils.resolveSchemaEvolutionOptions(
@@ -89,6 +97,7 @@ class ChangeEventUtilsTest {
                                 TRUNCATE_TABLE,
                                 RENAME_COLUMN,
                                 ALTER_COLUMN_TYPE,
+                                ALTER_COLUMN_POSITION,
                                 CREATE_TABLE));
     }
 
@@ -99,6 +108,7 @@ class ChangeEventUtilsTest {
                         Arrays.asList(
                                 ADD_COLUMN,
                                 ALTER_COLUMN_TYPE,
+                                ALTER_COLUMN_POSITION,
                                 CREATE_TABLE,
                                 DROP_COLUMN,
                                 DROP_TABLE,
@@ -107,7 +117,12 @@ class ChangeEventUtilsTest {
 
         assertThat(ChangeEventUtils.resolveSchemaEvolutionTag("column"))
                 .isEqualTo(
-                        Arrays.asList(ADD_COLUMN, ALTER_COLUMN_TYPE, DROP_COLUMN, RENAME_COLUMN));
+                        Arrays.asList(
+                                ADD_COLUMN,
+                                ALTER_COLUMN_TYPE,
+                                ALTER_COLUMN_POSITION,
+                                DROP_COLUMN,
+                                RENAME_COLUMN));
 
         assertThat(ChangeEventUtils.resolveSchemaEvolutionTag("table"))
                 .isEqualTo(Arrays.asList(CREATE_TABLE, DROP_TABLE, TRUNCATE_TABLE));
@@ -128,7 +143,7 @@ class ChangeEventUtilsTest {
                 .isEqualTo(Collections.singletonList(CREATE_TABLE));
 
         assertThat(ChangeEventUtils.resolveSchemaEvolutionTag("alter"))
-                .isEqualTo(Collections.singletonList(ALTER_COLUMN_TYPE));
+                .isEqualTo(Arrays.asList(ALTER_COLUMN_TYPE, ALTER_COLUMN_POSITION));
 
         assertThat(ChangeEventUtils.resolveSchemaEvolutionTag("alter.column.type"))
                 .isEqualTo(Collections.singletonList(ALTER_COLUMN_TYPE));
@@ -138,5 +153,8 @@ class ChangeEventUtilsTest {
 
         assertThat(ChangeEventUtils.resolveSchemaEvolutionTag("add.column"))
                 .isEqualTo(Collections.singletonList(ADD_COLUMN));
+
+        assertThat(ChangeEventUtils.resolveSchemaEvolutionTag("alter.column.position"))
+                .isEqualTo(Collections.singletonList(ALTER_COLUMN_POSITION));
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -121,6 +121,9 @@ public class DorisMetadataApplier implements MetadataApplier {
                     applyAlterColumnTypeEvent(alterColumnTypeEvent);
                     return null;
                 },
+                alterColumnPositionEvent -> {
+                    return null;
+                },
                 createTableEvent -> {
                     applyCreateTableEvent(createTableEvent);
                     return null;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-iceberg/src/main/java/org/apache/flink/cdc/connectors/iceberg/sink/IcebergMetadataApplier.java
@@ -109,6 +109,9 @@ public class IcebergMetadataApplier implements MetadataApplier {
                     applyAlterColumnType(alterColumnTypeEvent);
                     return null;
                 },
+                alterColumnPositionEvent -> {
+                    return null;
+                },
                 createTableEvent -> {
                     applyCreateTable(createTableEvent);
                     return null;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oceanbase/src/main/java/org/apache/flink/cdc/connectors/oceanbase/sink/OceanBaseMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oceanbase/src/main/java/org/apache/flink/cdc/connectors/oceanbase/sink/OceanBaseMetadataApplier.java
@@ -75,6 +75,9 @@ public class OceanBaseMetadataApplier implements MetadataApplier {
                     applyAlterColumnTypeEvent(alterColumnTypeEvent);
                     return null;
                 },
+                alterColumnPositionEvent -> {
+                    return null;
+                },
                 createTableEvent -> {
                     applyCreateTableEvent(createTableEvent);
                     return null;

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/PaimonMetadataApplier.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.connectors.paimon.sink;
 
 import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.AlterColumnPositionEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DropColumnEvent;
@@ -112,7 +113,8 @@ public class PaimonMetadataApplier implements MetadataApplier {
                 SchemaChangeEventType.ADD_COLUMN,
                 SchemaChangeEventType.DROP_COLUMN,
                 SchemaChangeEventType.RENAME_COLUMN,
-                SchemaChangeEventType.ALTER_COLUMN_TYPE);
+                SchemaChangeEventType.ALTER_COLUMN_TYPE,
+                SchemaChangeEventType.ALTER_COLUMN_POSITION);
     }
 
     @Override
@@ -129,6 +131,10 @@ public class PaimonMetadataApplier implements MetadataApplier {
                 },
                 alterColumnTypeEvent -> {
                     applyAlterColumnType(alterColumnTypeEvent);
+                    return null;
+                },
+                alterColumnPositionEvent -> {
+                    applyAlterColumnPosition(alterColumnPositionEvent);
                     return null;
                 },
                 createTableEvent -> {
@@ -337,6 +343,43 @@ public class PaimonMetadataApplier implements MetadataApplier {
         } catch (Catalog.TableNotExistException
                 | Catalog.ColumnAlreadyExistException
                 | Catalog.ColumnNotExistException e) {
+            throw new SchemaEvolveException(event, e.getMessage(), e);
+        }
+    }
+
+    private void applyAlterColumnPosition(AlterColumnPositionEvent event)
+            throws SchemaEvolveException {
+        try {
+            List<SchemaChange> tableChangeList = new ArrayList<>();
+            Table table = catalog.getTable(tableIdToIdentifier(event));
+            List<String> columnNames = table.rowType().getFieldNames();
+
+            for (Map.Entry<String, AlterColumnPositionEvent.ColumnPosition> entry :
+                    event.getPositionMapping().entrySet()) {
+                String columnName = entry.getKey();
+                AlterColumnPositionEvent.ColumnPosition position = entry.getValue();
+
+                SchemaChange.Move move;
+                if (position.isFirst()) {
+                    move = SchemaChange.Move.first(columnName);
+                } else if (position.getAfterColumn() != null) {
+                    move = SchemaChange.Move.after(columnName, position.getAfterColumn());
+                } else {
+                    int targetIndex =
+                            Math.min(position.getAbsolutePosition(), columnNames.size() - 1);
+                    if (targetIndex == 0) {
+                        move = SchemaChange.Move.first(columnName);
+                    } else {
+                        move =
+                                SchemaChange.Move.after(
+                                        columnName, columnNames.get(targetIndex - 1));
+                    }
+                }
+                tableChangeList.add(SchemaChange.updateColumnPosition(move));
+            }
+
+            catalog.alterTable(tableIdToIdentifier(event), tableChangeList, true);
+        } catch (Exception e) {
             throw new SchemaEvolveException(event, e.getMessage(), e);
         }
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
@@ -111,6 +111,9 @@ public class StarRocksMetadataApplier implements MetadataApplier {
                     applyAlterColumnType(alterColumnTypeEvent);
                     return null;
                 },
+                alterColumnPositionEvent -> {
+                    return null;
+                },
                 createTableEvent -> {
                     applyCreateTable(createTableEvent);
                     return null;

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/event/SchemaChangeEventSerializer.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/serializer/event/SchemaChangeEventSerializer.java
@@ -32,6 +32,7 @@ import org.apache.flink.core.memory.DataOutputView;
 import java.io.IOException;
 
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ADD_COLUMN;
+import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_POSITION;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.ALTER_COLUMN_TYPE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.CREATE_TABLE;
 import static org.apache.flink.cdc.common.event.SchemaChangeEventType.DROP_COLUMN;
@@ -81,6 +82,7 @@ public final class SchemaChangeEventSerializer extends TypeSerializerSingleton<S
                 from,
                 AddColumnEventSerializer.INSTANCE::copy,
                 AlterColumnTypeEventSerializer.INSTANCE::copy,
+                AlterColumnPositionEventSerializer.INSTANCE::copy,
                 CreateTableEventSerializer.INSTANCE::copy,
                 DropColumnEventSerializer.INSTANCE::copy,
                 DropTableEventSerializer.INSTANCE::copy,
@@ -111,6 +113,12 @@ public final class SchemaChangeEventSerializer extends TypeSerializerSingleton<S
                 alterColumnTypeEvent -> {
                     enumSerializer.serialize(ALTER_COLUMN_TYPE, target);
                     AlterColumnTypeEventSerializer.INSTANCE.serialize(alterColumnTypeEvent, target);
+                    return null;
+                },
+                alterColumnPositionEvent -> {
+                    enumSerializer.serialize(ALTER_COLUMN_POSITION, target);
+                    AlterColumnPositionEventSerializer.INSTANCE.serialize(
+                            alterColumnPositionEvent, target);
                     return null;
                 },
                 createTableEvent -> {
@@ -154,6 +162,8 @@ public final class SchemaChangeEventSerializer extends TypeSerializerSingleton<S
                 return RenameColumnEventSerializer.INSTANCE.deserialize(source);
             case ALTER_COLUMN_TYPE:
                 return AlterColumnTypeEventSerializer.INSTANCE.deserialize(source);
+            case ALTER_COLUMN_POSITION:
+                return AlterColumnPositionEventSerializer.INSTANCE.deserialize(source);
             case DROP_TABLE:
                 return DropTableEventSerializer.INSTANCE.deserialize(source);
             case TRUNCATE_TABLE:


### PR DESCRIPTION
When using MySQL CDC Pipeline to synchronize data to Paimon, ALTER TABLE MODIFY COLUMN operations that change column order are ignored and not propagated to the downstream sink, causing schema evolution failure and potential data inconsistency.