### PR TITLE
[FLINK-38934][cdc connector mysql] honour ssl protocol setting configured in debeziumProps

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
@@ -379,7 +379,14 @@ Flink SQL> SELECT * FROM orders;
       <td>String</td>
       <td>将 Debezium 的属性传递给 Debezium 嵌入式引擎，该引擎用于从 MySQL 服务器捕获数据更改。
           For example: <code>'debezium.snapshot.mode' = 'never'</code>.
-          查看更多关于 <a href="https://debezium.io/documentation/reference/1.9/connectors/mysql.html#mysql-connector-properties"> Debezium 的  MySQL 连接器属性</a></td> 
+          查看更多关于 <a href="https://debezium.io/documentation/reference/1.9/connectors/mysql.html#mysql-connector-properties"> Debezium 的  MySQL 连接器属性</a></td>
+    </tr>
+    <tr>
+      <td>debezium.binlog.ssl.protocol</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>覆盖自动检测的 binlog SSL 连接 TLS 协议。例如：<code>'debezium.binlog.ssl.protocol' = 'TLSv1.2'</code>。</td>
     </tr>
     <tr>
       <td>scan.incremental.close-idle-reader.enabled</td>

--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -391,6 +391,13 @@ Only valid for cdc 1.x version. During a snapshot operation, the connector will 
       </td>
     </tr>
     <tr>
+      <td>debezium.binlog.ssl.protocol</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>Override the auto-detected TLS protocol for binlog SSL connections. Example: <code>'debezium.binlog.ssl.protocol' = 'TLSv1.2'</code>.</td>
+    </tr>
+    <tr>
       <td>debezium.binary.handling.mode</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -99,6 +99,21 @@ public class MySqlStreamingChangeEventSource
             LoggerFactory.getLogger(MySqlStreamingChangeEventSource.class);
 
     private static final String KEEPALIVE_THREAD_NAME = "blc-keepalive";
+    static final String BINLOG_SSL_PROTOCOL = "binlog.ssl.protocol";
+
+    /**
+     * Resolves the TLS protocol to use for the binlog connection.
+     *
+     * @param configuredProtocol the user-configured protocol (may be null or empty)
+     * @param detectedProtocol the protocol detected from the MySQL server
+     * @return the configured protocol if set, otherwise the detected protocol
+     */
+    static String resolveBinlogSslProtocol(String configuredProtocol, String detectedProtocol) {
+        if (configuredProtocol == null || configuredProtocol.isEmpty()) {
+            return detectedProtocol;
+        }
+        return configuredProtocol;
+    }
 
     private final EnumMap<EventType, BlockingConsumer<Event>> eventHandlers =
             new EnumMap<>(EventType.class);
@@ -1322,8 +1337,18 @@ public class MySqlStreamingChangeEventSource
             }
             // DBZ-1208 Resembles the logic from the upstream BinaryLogClient, only that
             // the accepted TLS version is passed to the constructed factory
+            // FLINK-38934 Honour the configured ssl protocol where provided.
+            String configuredProtocol = connectorConfig.getConfig().getString(BINLOG_SSL_PROTOCOL);
+            String protocolToUse = resolveBinlogSslProtocol(configuredProtocol, acceptedTlsVersion);
+            LOGGER.debug(
+                    "Using TLS protocol {} for binlog connection{}",
+                    protocolToUse,
+                    configuredProtocol == null || configuredProtocol.isEmpty()
+                            ? " (auto-detected)"
+                            : " (configured)");
+
             final KeyManager[] finalKMS = keyManagers;
-            return new DefaultSSLSocketFactory(acceptedTlsVersion) {
+            return new DefaultSSLSocketFactory(protocolToUse) {
 
                 @Override
                 protected void initSSLContext(SSLContext sc) throws GeneralSecurityException {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSourceTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.mysql;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.net.ssl.SSLContext;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.stream.Stream;
+
+import static io.debezium.connector.mysql.MySqlStreamingChangeEventSource.resolveBinlogSslProtocol;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link MySqlStreamingChangeEventSource}. */
+class MySqlStreamingChangeEventSourceTest {
+
+    @ParameterizedTest(name = "configured={0}, detected={1}, expected={2}")
+    @MethodSource("protocolResolutionProvider")
+    void testResolveBinlogSslProtocol(
+            String configuredProtocol, String detectedProtocol, String expectedProtocol) {
+        String result = resolveBinlogSslProtocol(configuredProtocol, detectedProtocol);
+        assertThat(result).isEqualTo(expectedProtocol);
+    }
+
+    private static Stream<Arguments> protocolResolutionProvider() {
+        return Stream.of(
+                // When configured protocol is set, it should be used
+                Arguments.of("TLSv1.2", "TLSv1.3", "TLSv1.2"),
+                Arguments.of("TLSv1.3", "TLSv1.2", "TLSv1.3"),
+                Arguments.of("TLSv1.1", "TLSv1.3", "TLSv1.1"),
+                // When configured protocol is empty, detected should be used
+                Arguments.of("", "TLSv1.3", "TLSv1.3"),
+                Arguments.of("", "TLSv1.2", "TLSv1.2"),
+                // When configured protocol is null, detected should be used
+                Arguments.of(null, "TLSv1.3", "TLSv1.3"),
+                Arguments.of(null, "TLSv1.2", "TLSv1.2"));
+    }
+
+    @ParameterizedTest(name = "protocol={0}")
+    @ValueSource(strings = {"TLSv1.2", "TLSv1.3"})
+    void testValidProtocolsAreAcceptedBySSLContext(String protocol)
+            throws NoSuchAlgorithmException {
+        // Verify that valid protocols can be used to create an SSLContext
+        SSLContext context = SSLContext.getInstance(protocol);
+        assertThat(context).isNotNull();
+        assertThat(context.getProtocol()).isEqualTo(protocol);
+    }
+
+    @ParameterizedTest(name = "invalidProtocol={0}")
+    @ValueSource(strings = {"InvalidProtocol", "TLSv99", "SSLv2"})
+    void testInvalidProtocolsAreRejectedBySSLContext(String invalidProtocol) {
+        // Verify that invalid protocols cause SSLContext.getInstance() to fail
+        assertThatThrownBy(() -> SSLContext.getInstance(invalidProtocol))
+                .isInstanceOf(NoSuchAlgorithmException.class);
+    }
+
+    @Test
+    void testBinlogSslProtocolConstant() {
+        // Verify the constant value matches what users would configure
+        assertThat(MySqlStreamingChangeEventSource.BINLOG_SSL_PROTOCOL)
+                .isEqualTo("binlog.ssl.protocol");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oceanbase-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -101,6 +101,21 @@ public class MySqlStreamingChangeEventSource
             LoggerFactory.getLogger(MySqlStreamingChangeEventSource.class);
 
     private static final String KEEPALIVE_THREAD_NAME = "blc-keepalive";
+    static final String BINLOG_SSL_PROTOCOL = "binlog.ssl.protocol";
+
+    /**
+     * Resolves the TLS protocol to use for the binlog connection.
+     *
+     * @param configuredProtocol the user-configured protocol (may be null or empty)
+     * @param detectedProtocol the protocol detected from the MySQL server
+     * @return the configured protocol if set, otherwise the detected protocol
+     */
+    static String resolveBinlogSslProtocol(String configuredProtocol, String detectedProtocol) {
+        if (configuredProtocol == null || configuredProtocol.isEmpty()) {
+            return detectedProtocol;
+        }
+        return configuredProtocol;
+    }
 
     private final EnumMap<EventType, BlockingConsumer<Event>> eventHandlers =
             new EnumMap<>(EventType.class);
@@ -1327,8 +1342,18 @@ public class MySqlStreamingChangeEventSource
             }
             // DBZ-1208 Resembles the logic from the upstream BinaryLogClient, only that
             // the accepted TLS version is passed to the constructed factory
+            // FLINK-38934 Honour the configured ssl protocol where provided.
+            String configuredProtocol = connectorConfig.getConfig().getString(BINLOG_SSL_PROTOCOL);
+            String protocolToUse = resolveBinlogSslProtocol(configuredProtocol, acceptedTlsVersion);
+            LOGGER.debug(
+                    "Using TLS protocol {} for binlog connection{}",
+                    protocolToUse,
+                    configuredProtocol == null || configuredProtocol.isEmpty()
+                            ? " (auto-detected)"
+                            : " (configured)");
+
             final KeyManager[] finalKMS = keyManagers;
-            return new DefaultSSLSocketFactory(acceptedTlsVersion) {
+            return new DefaultSSLSocketFactory(protocolToUse) {
 
                 @Override
                 protected void initSSLContext(SSLContext sc) throws GeneralSecurityException {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-38934

## What is the purpose of the change
Add support for configuring the TLS protocol used by the binlog client via `debezium.binlog.ssl.protocol`

Use case:  Allow users to specify the tls version used by the binlog client.
One example use caseWorkaround for FLINK-38904 (TLS 1.3 KeyUpdate deadlock) by allowing users to force TLSv1.2 for the binlog connection. 

Example:
 'debezium.binlog.ssl.protocol' = 'TLSv1.2'

## Changes
Use the protocol provided in `debezium.binlog.ssl.protocol` for binlog client connection.