### PR TITLE
[FLINK-39020][pipeline][doris] Fix the bug When synchronizing MySQL to Doris, data of type java.time.LocalTime is serialized or deserialized, but by default, Jackson does not support the handling of Java 8 time types (such as LocalTime, LocalDateTime, etc.)

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisEventSerializer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisEventSerializer.java
@@ -39,6 +39,7 @@ import org.apache.flink.cdc.connectors.doris.utils.DorisSchemaUtils;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import org.apache.doris.flink.sink.writer.serializer.DorisRecord;
 import org.apache.doris.flink.sink.writer.serializer.DorisRecordSerializer;
@@ -143,7 +144,7 @@ public class DorisEventSerializer implements DorisRecordSerializer<Event> {
                                 });
             }
         }
-
+        objectMapper.registerModule(new JavaTimeModule());
         return DorisRecord.of(
                 tableId.getSchemaName(),
                 tableId.getTableName(),


### PR DESCRIPTION
Fix the bug When synchronizing MySQL to Doris, data of type java.time.LocalTime is serialized or deserialized, but by default, Jackson does not support the handling of Java 8 time types (such as LocalTime, LocalDateTime, etc.)

<img width="798" height="341" alt="企业微信截图_17701103798466" src="https://github.com/user-attachments/assets/cbdf89e4-4b92-4b82-94b0-b864d22976a1" />

<img width="2541" height="883" alt="企业微信截图_17700241975833" src="https://github.com/user-attachments/assets/0dd74fa9-ed54-434e-a2e4-31918bb66016" />
