### PR TITLE
[FLINK-38236][mongodb] Add metadata support for full document in MongoDB CDC connector

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/mongodb-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/mongodb-cdc.md
@@ -384,6 +384,11 @@ MongoDB 的更改事件记录在消息之前没有更新。因此，我们只能
       <td>它指示在数据库中进行更改的时间。 <br>如果记录是从表的快照而不是改变流中读取的，该值将始终为0。</td>
     </tr>
     <tr>
+      <td>full_document</td>
+      <td>STRING</td>
+      <td>变更事件的完整文档 JSON 字符串原始数据。对于 insert 事件，这是新文档。对于 update 事件，这是更新后的完整文档。对于 delete 事件，该值为 null。</td>
+    </tr>
+    <tr>
       <td>row_kind</td>
       <td>STRING NOT NULL</td>
       <td>当前记录对应的 changelog 类型。注意：当 Source 算子选择为每条记录输出 row_kind 字段后，下游 SQL 算子在处理消息撤回时会因为这个字段不同而比对失败，
@@ -398,6 +403,7 @@ CREATE TABLE products (
     db_name         STRING METADATA FROM 'database_name' VIRTUAL,
     collection_name STRING METADATA  FROM 'collection_name' VIRTUAL,
     operation_ts    TIMESTAMP_LTZ(3) METADATA FROM 'op_ts' VIRTUAL,
+    raw_data        STRING METADATA FROM 'full_document' VIRTUAL,
     operation       STRING METADATA FROM 'row_kind' VIRTUAL,
     _id             STRING, // 必须声明
     name            STRING,

--- a/docs/content/docs/connectors/flink-sources/mongodb-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mongodb-cdc.md
@@ -409,6 +409,11 @@ The following format metadata can be exposed as read-only (VIRTUAL) columns in a
       <td>It indicates the time that the change was made in the database. <br>If the record is read from snapshot of the table instead of the change stream, the value is always 0.</td>
     </tr>
     <tr>
+      <td>full_document</td>
+      <td>STRING</td>
+      <td>The full document of the change event as a JSON string raw data. For insert events, this is the new document. For update events, this is the full document after the update. For delete events, this is null.</td>
+    </tr>
+    <tr>
       <td>row_kind</td>
       <td>STRING NOT NULL</td>
       <td>It indicates the row kind of the changelog,Note: The downstream SQL operator may fail to compare due to this new added column when processing the row retraction if 
@@ -424,6 +429,7 @@ CREATE TABLE products (
     db_name         STRING METADATA FROM 'database_name' VIRTUAL,
     collection_name STRING METADATA  FROM 'collection_name' VIRTUAL,
     operation_ts    TIMESTAMP_LTZ(3) METADATA FROM 'op_ts' VIRTUAL,
+    raw_data        STRING METADATA FROM 'full_document' VIRTUAL,
     operation       STRING METADATA FROM 'row_kind' VIRTUAL,
     _id             STRING, // must be declared
     name            STRING,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBReadableMetadata.java
@@ -85,6 +85,21 @@ public enum MongoDBReadableMetadata {
                 }
             }),
 
+    /** It indicates the full document as string raw data. */
+    FULL_DOCUMENT(
+            "full_document",
+            DataTypes.STRING().nullable(),
+            new MetadataConverter() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct value = (Struct) record.value();
+                    String fullDocString = value.getString(MongoDBEnvelope.FULL_DOCUMENT_FIELD);
+                    return fullDocString != null ? StringData.fromString(fullDocString) : null;
+                }
+            }),
+
     /**
      * It indicates the row kind of the changelog. '+I' means INSERT message, '-D' means DELETE
      * message, '-U' means UPDATE_BEFORE message and '+U' means UPDATE_AFTER message

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/table/MongoDBTableFactoryTest.java
@@ -89,6 +89,8 @@ class MongoDBTableFactoryTest {
                             Column.metadata("time", DataTypes.TIMESTAMP_LTZ(3), "op_ts", true),
                             Column.metadata(
                                     "_database_name", DataTypes.STRING(), "database_name", true),
+                            Column.metadata(
+                                    "_full_document", DataTypes.STRING(), "full_document", true),
                             Column.metadata("_row_kind", DataTypes.STRING(), "row_kind", true)),
                     Collections.emptyList(),
                     UniqueConstraint.primaryKey("pk", Collections.singletonList("_id")));
@@ -227,7 +229,7 @@ class MongoDBTableFactoryTest {
         DynamicTableSource actualSource = createTableSource(SCHEMA_WITH_METADATA, properties);
         MongoDBTableSource mongoDBSource = (MongoDBTableSource) actualSource;
         mongoDBSource.applyReadableMetadata(
-                Arrays.asList("op_ts", "database_name", "row_kind"),
+                Arrays.asList("op_ts", "database_name", "full_document", "row_kind"),
                 SCHEMA_WITH_METADATA.toSourceRowDataType());
         actualSource = mongoDBSource.copy();
 
@@ -262,7 +264,8 @@ class MongoDBTableFactoryTest {
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED.defaultValue());
 
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
-        expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name", "row_kind");
+        expectedSource.metadataKeys =
+                Arrays.asList("op_ts", "database_name", "full_document", "row_kind");
 
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
 


### PR DESCRIPTION
This close https://issues.apache.org/jira/browse/FLINK-38236

This pull request adds support for exposing the full document of MongoDB change events as a metadata column in the Flink MongoDB CDC connector.