### PR TITLE
[FLINK-39265][postgres] PostgreSQL CDC intermittently drops INSERT records after checkpoint recovery due to WalPositionLocator filtering

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
@@ -45,27 +45,29 @@ public class PostgresOffset extends Offset {
     // used by PostgresOffsetFactory
     PostgresOffset(Map<String, String> offset) {
         Map<String, String> filtered = new HashMap<>(offset);
-        // When lsn == lsn_proc, WalPositionLocator is constructed with
-        // (lastCommitStoredLsn=Y, lastEventStoredLsn=Y). In pgoutput non-streaming mode,
-        // BEGIN and DML of the first new transaction after recovery share the same
-        // data_start as the previous COMMIT LSN (Y). WalPositionLocator puts Y into
-        // lsnSeen but sets startStreamingLsn to the new COMMIT LSN (Z), causing those
-        // DML records to be silently dropped in the actual streaming phase
-        // (Y in lsnSeen, Y != Z -> filtered).
+        // When a checkpoint is taken right after a COMMIT (state-3a), all three LSN fields
+        // converge to the same value: lsn == lsn_proc == lsn_commit.
+        // Recovering from such a checkpoint constructs WalPositionLocator(C0, C0), which
+        // causes the first new transaction's DML records (data_start=C0 in pgoutput) to be
+        // silently dropped: they are added to lsnSeen during the find phase, but
+        // startStreamingLsn is set to the next COMMIT (C1), so they are filtered in the
+        // stream phase.
         //
-        // Fix: when lsn == lsn_proc, remove lsn_proc and lsn_commit so that
-        // WalPositionLocator is constructed with lastCommitStoredLsn=null, which
-        // triggers the fast path: startStreamingLsn=firstLsnReceived=Y, switch-off
-        // happens immediately and all messages pass through.
+        // Fix: when lsn == lsn_proc == lsn_commit, remove lsn_proc and lsn_commit so that
+        // WalPositionLocator is constructed with lastCommitStoredLsn=null, which triggers
+        // the fast path: startStreamingLsn=firstLsnReceived=C0, all messages pass through.
         //
-        // This is fixed upstream in Debezium via DBZ-6204 (adding Operation.COMMIT to
-        // the lastProcessedMessageType check in WalPositionLocator.resumeFromLsn):
-        // https://github.com/debezium/debezium/commit/3b5740f1a836c8b438888f2458ebb1554320bac7
+        // The triple-equality condition is safe: mid-transaction checkpoints (state-3b) have
+        // lsn_commit pointing to the previous commit, so lsn_commit != lsn, and this branch
+        // is not taken.
+        //
         // This workaround can be removed once Debezium is upgraded to a version that
-        // includes DBZ-6204.
+        // includes DBZ-6204:
+        // https://github.com/debezium/debezium/commit/3b5740f1a836c8b438888f2458ebb1554320bac7
         String lsnVal = filtered.get(SourceInfo.LSN_KEY);
         String lsnProc = filtered.get(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY);
-        if (lsnVal != null && lsnVal.equals(lsnProc)) {
+        String lsnCommit = filtered.get(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
+        if (lsnVal != null && lsnVal.equals(lsnProc) && lsnVal.equals(lsnCommit)) {
             filtered.remove(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY);
             filtered.remove(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
         }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
@@ -19,6 +19,7 @@ package org.apache.flink.cdc.connectors.postgres.source.offset;
 
 import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
 
+import io.debezium.connector.postgresql.PostgresOffsetContext;
 import io.debezium.connector.postgresql.SourceInfo;
 import io.debezium.connector.postgresql.connection.Lsn;
 import io.debezium.time.Conversions;
@@ -43,7 +44,10 @@ public class PostgresOffset extends Offset {
 
     // used by PostgresOffsetFactory
     PostgresOffset(Map<String, String> offset) {
-        this.offset = offset;
+        Map<String, String> filtered = new HashMap<>(offset);
+        filtered.remove(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY); // lsn_proc
+        filtered.remove(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);               // lsn_commit
+        this.offset = filtered;
     }
 
     PostgresOffset(Long lsn, Long txId, Instant lastCommitTs) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
@@ -46,7 +46,7 @@ public class PostgresOffset extends Offset {
     PostgresOffset(Map<String, String> offset) {
         Map<String, String> filtered = new HashMap<>(offset);
         filtered.remove(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY); // lsn_proc
-        filtered.remove(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);               // lsn_commit
+        filtered.remove(PostgresOffsetContext.LAST_COMMIT_LSN_KEY); // lsn_commit
         this.offset = filtered;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/offset/PostgresOffset.java
@@ -45,8 +45,30 @@ public class PostgresOffset extends Offset {
     // used by PostgresOffsetFactory
     PostgresOffset(Map<String, String> offset) {
         Map<String, String> filtered = new HashMap<>(offset);
-        filtered.remove(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY); // lsn_proc
-        filtered.remove(PostgresOffsetContext.LAST_COMMIT_LSN_KEY); // lsn_commit
+        // When lsn == lsn_proc, WalPositionLocator is constructed with
+        // (lastCommitStoredLsn=Y, lastEventStoredLsn=Y). In pgoutput non-streaming mode,
+        // BEGIN and DML of the first new transaction after recovery share the same
+        // data_start as the previous COMMIT LSN (Y). WalPositionLocator puts Y into
+        // lsnSeen but sets startStreamingLsn to the new COMMIT LSN (Z), causing those
+        // DML records to be silently dropped in the actual streaming phase
+        // (Y in lsnSeen, Y != Z -> filtered).
+        //
+        // Fix: when lsn == lsn_proc, remove lsn_proc and lsn_commit so that
+        // WalPositionLocator is constructed with lastCommitStoredLsn=null, which
+        // triggers the fast path: startStreamingLsn=firstLsnReceived=Y, switch-off
+        // happens immediately and all messages pass through.
+        //
+        // This is fixed upstream in Debezium via DBZ-6204 (adding Operation.COMMIT to
+        // the lastProcessedMessageType check in WalPositionLocator.resumeFromLsn):
+        // https://github.com/debezium/debezium/commit/3b5740f1a836c8b438888f2458ebb1554320bac7
+        // This workaround can be removed once Debezium is upgraded to a version that
+        // includes DBZ-6204.
+        String lsnVal = filtered.get(SourceInfo.LSN_KEY);
+        String lsnProc = filtered.get(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY);
+        if (lsnVal != null && lsnVal.equals(lsnProc)) {
+            filtered.remove(PostgresOffsetContext.LAST_COMPLETELY_PROCESSED_LSN_KEY);
+            filtered.remove(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
+        }
         this.offset = filtered;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-39265

Fix data loss in PostgreSQL CDC source where INSERT/UPDATE/DELETE records                                                             
  are silently dropped after checkpoint recovery.                                                                                       
                                                                                                                                        
  ## Root Cause   
                                                                                                                                        
  When recovering from a checkpoint, the stored offset contains `lsn_proc`                                                              
  and `lsn_commit` (both equal to the last commit LSN `Y`). These are used
  to construct `WalPositionLocator(lastCommitLsn=Y, lastEventStoredLsn=Y)`.                                                             
                                                                                                                                        
  In pgoutput non-streaming mode, BEGIN and DML messages of the first new                                                               
  transaction after `Y` share the same `data_start=Y` as the previous                                                                   
  COMMIT. The find phase puts `Y` into `lsnSeen` but sets                                                                               
  `startStreamingLsn` to the subsequent COMMIT LSN `Z`. In the actual                                                                   
  streaming phase, DML messages with `data_start=Y` satisfy                                                                             
  `Y ∈ lsnSeen && Y ≠ Z` and are permanently filtered out.                                                                              
                                                                                                                                        
  ## Fix                                                                                                                                
                                                                                                                                        
  Remove `lsn_proc` and `lsn_commit` from `PostgresOffset` when                                                                         
  constructed from a Debezium source offset. With `lastCommitStoredLsn=null`,
  `WalPositionLocator` immediately sets `startStreamingLsn` to the first                                                                
  received LSN and switch-off happens before any DML is filtered.                                                                       
                                                                                                                                        
  ## Changes                                                                                                                            
                                                                                                                                        
  - `PostgresOffset.java`: filter out `lsn_proc` and `lsn_commit` in the                                                                
    `Map` constructor