### PR TITLE
[FLINK-39315][mysql] Unregister listeners of BinaryLogClient to prevent snapshot reader hang during backfill

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -1106,23 +1106,30 @@ public class MySqlStreamingChangeEventSource
                     (event) -> handleRowsQuery(effectiveOffsetContext, event));
         }
 
-        BinaryLogClient.EventListener listener;
+        BinaryLogClient.EventListener eventListener;
         if (connectorConfig.bufferSizeForStreamingChangeEventSource() == 0) {
-            listener = (event) -> handleEvent(partition, effectiveOffsetContext, event);
+            eventListener = (event) -> handleEvent(partition, effectiveOffsetContext, event);
         } else {
             EventBuffer buffer =
                     new EventBuffer(
                             connectorConfig.bufferSizeForStreamingChangeEventSource(),
                             this,
                             context);
-            listener = (event) -> buffer.add(partition, effectiveOffsetContext, event);
+            eventListener = (event) -> buffer.add(partition, effectiveOffsetContext, event);
         }
-        client.registerEventListener(listener);
 
-        client.registerLifecycleListener(new ReaderThreadLifecycleListener(effectiveOffsetContext));
-        client.registerEventListener((event) -> onEvent(effectiveOffsetContext, event));
-        if (LOGGER.isDebugEnabled()) {
-            client.registerEventListener((event) -> logEvent(effectiveOffsetContext, event));
+        ReaderThreadLifecycleListener lifecycleListener =
+                new ReaderThreadLifecycleListener(effectiveOffsetContext);
+        BinaryLogClient.EventListener metricsEventListener =
+                (event) -> onEvent(effectiveOffsetContext, event);
+        BinaryLogClient.EventListener logEventListener =
+                LOGGER.isDebugEnabled() ? (event) -> logEvent(effectiveOffsetContext, event) : null;
+
+        client.registerEventListener(eventListener);
+        client.registerLifecycleListener(lifecycleListener);
+        client.registerEventListener(metricsEventListener);
+        if (logEventListener != null) {
+            client.registerEventListener(logEventListener);
         }
 
         final boolean isGtidModeEnabled = connection.isGtidModeEnabled();
@@ -1179,6 +1186,7 @@ public class MySqlStreamingChangeEventSource
         // Only when we reach the first BEGIN event will we start to skip events ...
         skipEvent = false;
 
+        Throwable executionError = null;
         try {
             // Start the log reader, which starts background threads ...
             if (context.isRunning()) {
@@ -1263,6 +1271,13 @@ public class MySqlStreamingChangeEventSource
                 client.disconnect();
             } catch (Exception e) {
                 LOGGER.info("Exception while stopping binary log client", e);
+            }
+
+            client.unregisterEventListener(eventListener);
+            client.unregisterEventListener(metricsEventListener);
+            client.unregisterLifecycleListener(lifecycleListener);
+            if (logEventListener != null) {
+                client.unregisterEventListener(logEventListener);
             }
         }
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -1186,7 +1186,6 @@ public class MySqlStreamingChangeEventSource
         // Only when we reach the first BEGIN event will we start to skip events ...
         skipEvent = false;
 
-        Throwable executionError = null;
         try {
             // Start the log reader, which starts background threads ...
             if (context.isRunning()) {
@@ -1266,18 +1265,19 @@ public class MySqlStreamingChangeEventSource
             while (context.isRunning()) {
                 Thread.sleep(100);
             }
-        } finally {
-            try {
-                client.disconnect();
-            } catch (Exception e) {
-                LOGGER.info("Exception while stopping binary log client", e);
-            }
 
+            // Unregister listeners to avoid client reuse interference (FLINK-39315)
             client.unregisterEventListener(eventListener);
             client.unregisterEventListener(metricsEventListener);
             client.unregisterLifecycleListener(lifecycleListener);
             if (logEventListener != null) {
                 client.unregisterEventListener(logEventListener);
+            }
+        } finally {
+            try {
+                client.disconnect();
+            } catch (Exception e) {
+                LOGGER.info("Exception while stopping binary log client", e);
             }
         }
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -87,18 +87,20 @@ import static io.debezium.util.Strings.isNullOrEmpty;
  * Copied from Debezium project(1.9.8.Final) to fix
  * https://github.com/ververica/flink-cdc-connectors/issues/1944.
  *
- * <p>Line 1432-1443 : Adjust GTID merging logic to support recovering from job which previously
+ * <p>Line 1449-1461 : Adjust GTID merging logic to support recovering from job which previously
  * specifying starting offset on start. Uses {@link GtidUtils#fixOldChannelsGtidSet} for shared
  * EARLIEST/LATEST logic.
  *
- * <p>Line 1444-1452 : Fix LATEST mode GTID merging to avoid replaying pre-checkpoint transactions
+ * <p>Line 1463-1469 : Fix LATEST mode GTID merging to avoid replaying pre-checkpoint transactions
  * when checkpoint GTID has non-contiguous ranges. Delegates to {@link
  * GtidUtils#computeLatestModeGtidSet}. See FLINK-39149.
  *
- * <p>Line 1490 : Add more error details for some exceptions.
+ * <p>Line 1507 : Add more error details for some exceptions.
  *
- * <p>Line 951-963 : Use iterator instead of index-based loop to avoid O(n²) complexity when
+ * <p>Line 954-966 : Use iterator instead of index-based loop to avoid O(n²) complexity when
  * processing LinkedList rows in handleChange method. See FLINK-38846.
+ *
+ * <p>Line 1271-1277 : Unregister listeners to avoid client reuse interference. See FLINK-39315.
  */
 public class MySqlStreamingChangeEventSource
         implements StreamingChangeEventSource<MySqlPartition, MySqlOffsetContext> {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -586,6 +586,21 @@ class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                                 "UPDATE " + tableId + " SET address = 'Beijing' WHERE id = 103");
                         mySqlConnection.commit();
                     } else if (split.splitId().equals(tableId + ":1")) {
+                        // To verify that FLINK-39315 is fixed, generate sufficient binlog events,
+                        // so that the MySqlBinlogSplitReadTask runs long enough to exercise the
+                        // context-running checks in binlog reading backfill phase.
+                        for (int i = 0; i < 1000; i++) {
+                            mySqlConnection.execute(
+                                    "UPDATE "
+                                            + tableId
+                                            + " SET address = 'Beijing' WHERE id = 106");
+                            mySqlConnection.commit();
+                            mySqlConnection.execute(
+                                    "UPDATE "
+                                            + tableId
+                                            + " SET address = 'Shanghai' WHERE id = 106");
+                            mySqlConnection.commit();
+                        }
                         mySqlConnection.execute(
                                 "UPDATE " + tableId + " SET address = 'Beijing' WHERE id = 106");
                         mySqlConnection.commit();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/SnapshotSplitReaderTest.java
@@ -589,7 +589,7 @@ class SnapshotSplitReaderTest extends MySqlSourceTestBase {
                         // To verify that FLINK-39315 is fixed, generate sufficient binlog events,
                         // so that the MySqlBinlogSplitReadTask runs long enough to exercise the
                         // context-running checks in binlog reading backfill phase.
-                        for (int i = 0; i < 1000; i++) {
+                        for (int i = 0; i < 100; i++) {
                             mySqlConnection.execute(
                                     "UPDATE "
                                             + tableId


### PR DESCRIPTION
This closes [FLINK-39315](https://issues.apache.org/jira/browse/FLINK-39315).

### What is the purpose of the change

This PR fixes a MySQL CDC source hang in the snapshot backfill phase when processing multiple snapshot splits sequentially while reusing the same `BinaryLogClient`.

`SnapshotSplitReader.pollWithBuffer()` waits for the `BINLOG_END` watermark to finish a split. However, `BinaryLogClient` was reused across split executions and `MySqlStreamingChangeEventSource.execute()` registered multiple event/lifecycle listeners on each execution without unregistering them. As a result, listeners from previous splits could still receive binlog events during later splits and:

- stop the shared `ChangeEventSourceContext` prematurely (causing the current split’s backfill to exit early), and/or
- dispatch `BINLOG_END` via a stale `SignalEventDispatcher` into a stale queue (so the current `pollWithBuffer()` never sees `BINLOG_END`).

This could leave the queue empty while the backfill thread has already stopped, causing the reader to hang indefinitely.

### Brief change log

- Unregister `BinaryLogClient` event and lifecycle listeners in `MySqlStreamingChangeEventSource.execute()` after each execution to avoid listener accumulation and cross-split interference.
- Ensure the unregister/cleanup logic is executed deterministically in the cleanup path (fail-fast behavior if cleanup fails).
- Add/extend unit test coverage in `SnapshotSplitReaderTest` (based on `testMultipleSplitsWithBackfill`) to validate multiple snapshot splits with a forced backfill phase can finish and produce the expected output.

### Verifying this change

This change is verified by unit tests:
- `SnapshotSplitReaderTest#testMultipleSplitsWithBackfill`

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no

### Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable