### PR TITLE
[FLINK-39354]  Fix case-insensitive existing-column lookup in SchemaUtils.applyAddColumnEvent

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
@@ -138,9 +138,8 @@ public class SchemaUtils {
                         Preconditions.checkNotNull(
                                 columnWithPosition.getExistedColumnName(),
                                 "existedColumnName could not be null in BEFORE type AddColumnEvent");
-                        List<String> columnNames =
-                                columns.stream().map(Column::getName).collect(Collectors.toList());
-                        int index = columnNames.indexOf(columnWithPosition.getExistedColumnName());
+                        int index =
+                                findColumnIndex(columns, columnWithPosition.getExistedColumnName());
                         if (index < 0) {
                             throw new IllegalArgumentException(
                                     String.format(
@@ -156,9 +155,8 @@ public class SchemaUtils {
                         Preconditions.checkNotNull(
                                 columnWithPosition.getExistedColumnName(),
                                 "existedColumnName could not be null in AFTER type AddColumnEvent");
-                        List<String> columnNames =
-                                columns.stream().map(Column::getName).collect(Collectors.toList());
-                        int index = columnNames.indexOf(columnWithPosition.getExistedColumnName());
+                        int index =
+                                findColumnIndex(columns, columnWithPosition.getExistedColumnName());
                         if (index < 0) {
                             throw new IllegalArgumentException(
                                     String.format(
@@ -172,6 +170,20 @@ public class SchemaUtils {
             }
         }
         return oldSchema.copy(columns);
+    }
+
+    private static int findColumnIndex(List<Column> columns, String existedColumnName) {
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).getName().equals(existedColumnName)) {
+                return i;
+            }
+        }
+        for (int i = 0; i < columns.size(); i++) {
+            if (columns.get(i).getName().equalsIgnoreCase(existedColumnName)) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private static Schema applyDropColumnEvent(DropColumnEvent event, Schema oldSchema) {

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -205,6 +205,29 @@ class SchemaUtilsTest {
     }
 
     @Test
+    void testApplyAddColumnEventWithCaseInsensitiveExistingColumnName() {
+        TableId tableId = TableId.parse("gc_fps_receivable.billstat");
+        Schema schema =
+                Schema.newBuilder().physicalColumn("changetype", DataTypes.STRING()).build();
+
+        List<AddColumnEvent.ColumnWithPosition> addedColumns = new ArrayList<>();
+        addedColumns.add(
+                new AddColumnEvent.ColumnWithPosition(
+                        Column.physicalColumn("origintypecode", DataTypes.STRING()),
+                        AddColumnEvent.ColumnPosition.AFTER,
+                        "ChangeType"));
+        AddColumnEvent addColumnEvent = new AddColumnEvent(tableId, addedColumns);
+
+        schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
+        Assertions.assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("changetype", DataTypes.STRING())
+                                .physicalColumn("origintypecode", DataTypes.STRING())
+                                .build());
+    }
+
+    @Test
     void testGetNumericPrecision() {
         Assertions.assertThat(SchemaUtils.getNumericPrecision(DataTypes.TINYINT())).isEqualTo(3);
         Assertions.assertThat(SchemaUtils.getNumericPrecision(DataTypes.SMALLINT())).isEqualTo(5);


### PR DESCRIPTION
* Fixes a bug in SchemaUtils.applyAddColumnEvent where AddColumnEvent column positioning fails if the referenced existing column name differs only by case.
* Implementation:
* * SchemaUtils.applyAddColumnEvent now finds the referenced column by:
* * 1. exact name match
* * 2. fallback to case-insensitive match
* Added regression coverage in SchemaUtilsTest
* No other behavior changes for exact matching
* Testing
* * mvn -pl flink-cdc-common -Dtest=SchemaUtilsTest test
