### PR TITLE
[FLINK-39403][cdc-connector] Fix transaction leak during snapshot split read for DB2, Oracle, PostgreSQL, and SQL Server connectors

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/fetch/Db2ScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-db2-cdc/src/main/java/org/apache/flink/cdc/connectors/db2/source/fetch/Db2ScanFetchTask.java
@@ -305,6 +305,12 @@ public class Db2ScanFetchTask extends AbstractScanFetchTask {
                         Strings.duration(clock.currentTimeInMillis() - exportStart));
             } catch (SQLException e) {
                 throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);
+            } finally {
+                try {
+                    jdbcConnection.connection().setAutoCommit(true);
+                } catch (SQLException e) {
+                    LOG.warn("Failed to set autoCommit after snapshot split read", e);
+                }
             }
         }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -319,6 +319,12 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                         Strings.duration(clock.currentTimeInMillis() - exportStart));
             } catch (SQLException e) {
                 throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);
+            } finally {
+                try {
+                    jdbcConnection.connection().setAutoCommit(true);
+                } catch (SQLException e) {
+                    LOG.warn("Failed to set autoCommit after snapshot split read", e);
+                }
             }
         }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
@@ -353,6 +353,12 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
             } catch (SQLException e) {
                 throw new FlinkRuntimeException(
                         "Snapshotting of table " + table.id() + " failed", e);
+            } finally {
+                try {
+                    jdbcConnection.connection().setAutoCommit(true);
+                } catch (SQLException e) {
+                    LOG.warn("Failed to set autoCommit after snapshot split read", e);
+                }
             }
         }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/reader/fetch/SqlServerScanFetchTask.java
@@ -309,6 +309,12 @@ public class SqlServerScanFetchTask extends AbstractScanFetchTask {
                         Strings.duration(clock.currentTimeInMillis() - exportStart));
             } catch (SQLException e) {
                 throw new ConnectException("Snapshotting of table " + table.id() + " failed", e);
+            } finally {
+                try {
+                    jdbcConnection.connection().setAutoCommit(true);
+                } catch (SQLException e) {
+                    LOG.warn("Failed to set autoCommit after snapshot split read", e);
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose

During the snapshot split reading phase, `initStatement()` sets `autoCommit` to `false` on the JDBC
connection to enable cursor-based result set fetching. However, after the split read completes, the transaction is never committed and `autoCommit` is never restored to `true`. This may lead to idle transactions leak.

## Change

Added a `finally` block in `createDataEventsForTable()` of `Db2ScanFetchTask`, `OracleScanFetchTask`, `PostgresScanFetchTask`, and `SqlServerScanFetchTask` to restore `autoCommit` to `true` after each snapshot split read.