### PR TITLE
[FLINK-39412][cdc-common] Skip duplicate columns in AddColumnEvent to ensure idempotency

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
@@ -121,7 +121,16 @@ public class SchemaUtils {
 
     private static Schema applyAddColumnEvent(AddColumnEvent event, Schema oldSchema) {
         LinkedList<Column> columns = new LinkedList<>(oldSchema.getColumns());
+        Set<String> existingColumnNames =
+                columns.stream()
+                        .map(Column::getName)
+                        .collect(Collectors.toCollection(HashSet::new));
         for (AddColumnEvent.ColumnWithPosition columnWithPosition : event.getAddedColumns()) {
+            // Skip adding the column if it already exists in the schema to ensure idempotency.
+            // This can happen when schema change events are replayed after a failover recovery.
+            if (existingColumnNames.contains(columnWithPosition.getAddColumn().getName())) {
+                continue;
+            }
             switch (columnWithPosition.getPosition()) {
                 case FIRST:
                     {
@@ -170,6 +179,7 @@ public class SchemaUtils {
                         break;
                     }
             }
+            existingColumnNames.add(columnWithPosition.getAddColumn().getName());
         }
         return oldSchema.copy(columns);
     }

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -160,6 +160,46 @@ class SchemaUtilsTest {
                                 "AFTER type AddColumnEvent error: Column %s does not exist in table %s",
                                 "col10", tableId));
 
+        // add duplicate column should be ignored (idempotency)
+        addedColumns = new ArrayList<>();
+        addedColumns.add(
+                new AddColumnEvent.ColumnWithPosition(
+                        Column.physicalColumn("col3", DataTypes.STRING()),
+                        AddColumnEvent.ColumnPosition.LAST,
+                        null));
+        addColumnEvent = new AddColumnEvent(tableId, addedColumns);
+        schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
+        Assertions.assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col0", DataTypes.STRING())
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col4", DataTypes.STRING())
+                                .physicalColumn("col5", DataTypes.STRING())
+                                .physicalColumn("col3", DataTypes.STRING())
+                                .build());
+
+        // add duplicate column in FIRST position should be ignored
+        addedColumns = new ArrayList<>();
+        addedColumns.add(
+                new AddColumnEvent.ColumnWithPosition(
+                        Column.physicalColumn("col0", DataTypes.STRING()),
+                        AddColumnEvent.ColumnPosition.FIRST,
+                        null));
+        addColumnEvent = new AddColumnEvent(tableId, addedColumns);
+        schema = SchemaUtils.applySchemaChangeEvent(schema, addColumnEvent);
+        Assertions.assertThat(schema)
+                .isEqualTo(
+                        Schema.newBuilder()
+                                .physicalColumn("col0", DataTypes.STRING())
+                                .physicalColumn("col1", DataTypes.STRING())
+                                .physicalColumn("col2", DataTypes.STRING())
+                                .physicalColumn("col4", DataTypes.STRING())
+                                .physicalColumn("col5", DataTypes.STRING())
+                                .physicalColumn("col3", DataTypes.STRING())
+                                .build());
+
         // drop columns
         DropColumnEvent dropColumnEvent =
                 new DropColumnEvent(tableId, Arrays.asList("col3", "col5"));


### PR DESCRIPTION
## Summary

When recovering from a checkpoint/savepoint, binlog events may be replayed, causing `AddColumnEvent` to be applied for columns that already exist in the cached schema. This leads to duplicate field names in `RowType`, which throws:

```
java.lang.IllegalArgumentException: Field names must be unique. Found duplicates: [valid_date]
    at org.apache.flink.cdc.common.types.RowType.validateFields(RowType.java:158)
    at org.apache.flink.cdc.runtime.operators.transform.PreTransformOperator.processElement(...)
```

### Root Cause

`SchemaUtils.applyAddColumnEvent()` blindly adds columns without checking if a column with the same name already exists. While `isSchemaChangeEventRedundant()` exists as a utility, `PreTransformOperator.cacheChangeSchema()` does not call it before applying schema changes.

### Fix

- Added an idempotency check in `SchemaUtils.applyAddColumnEvent()` to skip columns that already exist in the schema
- This is the most defensive fix location since it protects **all** callers of `applySchemaChangeEvent()`, not just `PreTransformOperator`
- Also maintains `existingColumnNames` set across iterations for correctness when a single event adds multiple columns

### Changes

- `SchemaUtils.java`: Added duplicate column name check before adding columns
- `SchemaUtilsTest.java`: Added test cases for duplicate `AddColumnEvent` in both `LAST` and `FIRST` positions

## Test plan

- [x] Added unit tests for duplicate `AddColumnEvent` with `LAST` position
- [x] Added unit tests for duplicate `AddColumnEvent` with `FIRST` position
- [x] All existing `SchemaUtilsTest` tests pass (5/5)