### PR TITLE
[FLINK-39438][MaxCompute] Add support for sink operation types in MaxCompute options

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeDataSinkFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeDataSinkFactory.java
@@ -56,6 +56,8 @@ public class MaxComputeDataSinkFactory implements DataSinkFactory {
         String quotaName = factoryConfiguration.get(MaxComputeDataSinkOptions.QUOTA_NAME);
         String stsToken = factoryConfiguration.get(MaxComputeDataSinkOptions.STS_TOKEN);
         int bucketsNum = factoryConfiguration.get(MaxComputeDataSinkOptions.BUCKETS_NUM);
+        MaxComputeOptions.SinkOperation sinkOperation =
+                factoryConfiguration.get(MaxComputeDataSinkOptions.SINK_OPERATION);
 
         String schemaOperatorUid =
                 pipelineConfiguration.get(PipelineOptions.PIPELINE_SCHEMA_OPERATOR_UID);
@@ -65,6 +67,7 @@ public class MaxComputeDataSinkFactory implements DataSinkFactory {
                 .withStsToken(stsToken)
                 .withBucketsNum(bucketsNum)
                 .withSchemaOperatorUid(schemaOperatorUid)
+                .withSinkOperation(sinkOperation)
                 .build();
     }
 
@@ -124,6 +127,7 @@ public class MaxComputeDataSinkFactory implements DataSinkFactory {
         optionalOptions.add(MaxComputeDataSinkOptions.FLUSH_CONCURRENT_NUM);
         optionalOptions.add(MaxComputeDataSinkOptions.TOTAL_BUFFER_SIZE);
         optionalOptions.add(MaxComputeDataSinkOptions.BUCKET_BUFFER_SIZE);
+        optionalOptions.add(MaxComputeDataSinkOptions.SINK_OPERATION);
 
         return optionalOptions;
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeDataSinkOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.cdc.connectors.maxcompute;
 import org.apache.flink.cdc.common.configuration.ConfigOption;
 import org.apache.flink.cdc.common.configuration.ConfigOptions;
 import org.apache.flink.cdc.connectors.maxcompute.options.CompressAlgorithm;
+import org.apache.flink.cdc.connectors.maxcompute.options.MaxComputeOptions;
 
 /** Options for MaxCompute Data Sink. */
 public class MaxComputeDataSinkOptions {
@@ -107,4 +108,11 @@ public class MaxComputeDataSinkOptions {
                     .intType()
                     .defaultValue(4)
                     .withDescription("The number of concurrent with flush bucket data.");
+
+    public static final ConfigOption<MaxComputeOptions.SinkOperation> SINK_OPERATION =
+            ConfigOptions.key("sink.operation")
+                    .enumType(MaxComputeOptions.SinkOperation.class)
+                    .defaultValue(MaxComputeOptions.SinkOperation.UPSERT)
+                    .withDescription(
+                            "The sink operation type, support 'upsert' and 'append', default is 'upsert'.");
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/options/MaxComputeOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/options/MaxComputeOptions.java
@@ -36,6 +36,7 @@ public class MaxComputeOptions implements Serializable {
     private final String stsToken;
     private final int bucketsNum;
     private final String schemaOperatorUid;
+    private final SinkOperation sinkOperation;
 
     private MaxComputeOptions(Builder builder) {
         this.accessId = builder.accessId;
@@ -48,6 +49,7 @@ public class MaxComputeOptions implements Serializable {
         this.bucketsNum = builder.bucketsNum;
         this.supportSchema = MaxComputeUtils.supportSchema(this);
         this.schemaOperatorUid = builder.schemaOperatorUid;
+        this.sinkOperation = builder.sinkOperation;
     }
 
     public static Builder builder(
@@ -95,6 +97,10 @@ public class MaxComputeOptions implements Serializable {
         return schemaOperatorUid;
     }
 
+    public SinkOperation getSinkOperation() {
+        return sinkOperation;
+    }
+
     /** builder for maxcompute options. */
     public static class Builder {
 
@@ -107,6 +113,7 @@ public class MaxComputeOptions implements Serializable {
         private String stsToken;
         private String schemaOperatorUid;
         private int bucketsNum = 16;
+        private SinkOperation sinkOperation = SinkOperation.UPSERT;
 
         public Builder(String accessId, String accessKey, String endpoint, String project) {
             this.accessId = accessId;
@@ -140,8 +147,46 @@ public class MaxComputeOptions implements Serializable {
             return this;
         }
 
+        public Builder withSinkOperation(SinkOperation sinkOperation) {
+            this.sinkOperation = sinkOperation;
+            return this;
+        }
+
         public MaxComputeOptions build() {
             return new MaxComputeOptions(this);
+        }
+    }
+
+    /** Sink operation mode for MaxCompute: APPEND or UPSERT. */
+    public enum SinkOperation {
+        APPEND("append"),
+        UPSERT("upsert");
+
+        private final String value;
+
+        SinkOperation(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        public static SinkOperation fromValue(String value) {
+            for (SinkOperation op : values()) {
+                if (op.value.equalsIgnoreCase(value)) {
+                    return op;
+                }
+            }
+            throw new IllegalArgumentException(
+                    "Unknown sink operation: '"
+                            + value
+                            + "'. Valid values are: 'upsert', 'append'.");
         }
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/utils/SchemaEvolutionUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/utils/SchemaEvolutionUtils.java
@@ -85,7 +85,8 @@ public class SchemaEvolutionUtils {
                         .withHints(unsupportSchemahints)
                         .ifNotExists()
                         .debug();
-        if (!CollectionUtil.isNullOrEmpty(schema.primaryKeys())) {
+        if (!CollectionUtil.isNullOrEmpty(schema.primaryKeys())
+                && options.getSinkOperation() == MaxComputeOptions.SinkOperation.UPSERT) {
             tableCreator
                     .transactionTable()
                     .withBucketNum(options.getBucketsNum())

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/writer/BatchAppendWriter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/writer/BatchAppendWriter.java
@@ -70,6 +70,10 @@ public class BatchAppendWriter implements MaxComputeWriter {
 
     private void initOrReloadSession(SessionIdentifier identifier) {
         String partitionSpec = identifier.getPartitionName();
+        PartitionSpec partitionSpecObj =
+                partitionSpec != null && !partitionSpec.isEmpty()
+                        ? new PartitionSpec(partitionSpec)
+                        : null;
         String sessionId = identifier.getSessionId();
 
         try {
@@ -79,7 +83,7 @@ public class BatchAppendWriter implements MaxComputeWriter {
                                 identifier.getProject(),
                                 identifier.getSchema(),
                                 identifier.getTable(),
-                                new PartitionSpec(partitionSpec),
+                                partitionSpecObj,
                                 false);
             } else {
                 this.uploadSession =
@@ -87,7 +91,7 @@ public class BatchAppendWriter implements MaxComputeWriter {
                                 identifier.getProject(),
                                 identifier.getSchema(),
                                 identifier.getTable(),
-                                new PartitionSpec(partitionSpec),
+                                partitionSpecObj,
                                 sessionId);
             }
             this.recordWriter =

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/writer/MaxComputeWriter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/writer/MaxComputeWriter.java
@@ -35,7 +35,8 @@ public interface MaxComputeWriter {
             MaxComputeWriteOptions writeOptions,
             SessionIdentifier sessionIdentifier)
             throws IOException {
-        if (MaxComputeUtils.isTransactionalTable(options, sessionIdentifier)) {
+        if (MaxComputeUtils.isTransactionalTable(options, sessionIdentifier)
+                && options.getSinkOperation() == MaxComputeOptions.SinkOperation.UPSERT) {
             return new BatchUpsertWriter(options, writeOptions, sessionIdentifier);
         } else {
             return new BatchAppendWriter(options, writeOptions, sessionIdentifier);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/EmulatorTestBase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/EmulatorTestBase.java
@@ -66,6 +66,11 @@ public class EmulatorTestBase {
     public final MaxComputeOptions testOptions =
             MaxComputeOptions.builder("ak", "sk", getEndpoint(), "mocked_mc").build();
 
+    public final MaxComputeOptions appendOptions =
+            MaxComputeOptions.builder("ak", "sk", getEndpoint(), "mocked_mc")
+                    .withSinkOperation(MaxComputeOptions.SinkOperation.APPEND)
+                    .build();
+
     public final Odps odpsInstance = MaxComputeUtils.getOdps(testOptions);
 
     private String getEndpoint() {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/utils/SchemaEvolutionUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/utils/SchemaEvolutionUtilsTest.java
@@ -128,4 +128,25 @@ class SchemaEvolutionUtilsTest extends EmulatorTestBase {
             fail(e.getMessage());
         }
     }
+
+    @Test
+    void testCreateTableInAppendMode() {
+        try {
+            String appendTable = "SCHEMA_EVOLUTION_APPEND_TABLE";
+            SchemaEvolutionUtils.createTable(
+                    appendOptions,
+                    TableId.tableId(appendTable),
+                    Schema.newBuilder()
+                            .physicalColumn("PK", DataTypes.BIGINT())
+                            .physicalColumn("ID1", DataTypes.BIGINT())
+                            .primaryKey("PK")
+                            .build());
+            // In APPEND mode the table should NOT be created as a transactional table,
+            // so primary key metadata should be absent even though the schema defines one.
+            assertThat(odpsInstance.tables().get(appendTable).getPrimaryKey()).isEmpty();
+            odpsInstance.tables().delete(appendTable, true);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Problem
- Sink operation mode cannot be explicitly configured via pipeline YAML.
- Behavior is tightly coupled with MaxCompute table type.
- Schema evolution auto-creation enforces transactional tables → always upsert.
- No way to override this behavior for append use cases.
## Expected Behavior
- Users can explicitly define sink behavior (append or upsert) via configuration.
- Writer selection logic respects the configured option instead of table type.
## Proposal
Example YAML Configuration:
```yaml
sink:
  type: maxcompute
  name: maxcompute
  access-id: ${secret_values.maxcompute_access_id}
  access-key: ${secret_values.maxcompute_access_key}
  endpoint: ${secret_values.maxcompute_endpoint}
  project: maxcompute_project
  quota.name: res_grp
  sink.operation: append 
```