### PR TITLE
[FLINK-39573][cdc][docs] Fix Build documentation CI startup_failure by replacing third-party rsync action

### DIFF
--- a/.github/actions/rsync-deployments/LICENSE
+++ b/.github/actions/rsync-deployments/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019-2022 Contention
+Copyright (c) 2019-2026 Burnett01
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/actions/rsync-deployments/action.yml
+++ b/.github/actions/rsync-deployments/action.yml
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Inspired by https://github.com/Burnett01/rsync-deployments/blob/7.1.0/action.yml
+name: Rsync Deploy
+description: Upload a folder to a remote destination via rsync over SSH.
+inputs:
+  switches:
+    description: rsync switches
+    required: false
+    default: "--archive --compress"
+  path:
+    description: Local source directory
+    required: true
+  remote_path:
+    description: Remote destination directory
+    required: true
+  remote_host:
+    description: SSH host
+    required: true
+  remote_port:
+    description: SSH port
+    required: false
+    default: "22"
+  remote_user:
+    description: SSH username
+    required: true
+  remote_key:
+    description: SSH private key (OpenSSH/PEM)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: rsync via ssh-agent
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Start agent and load the key
+        eval "$(ssh-agent -s)"
+        ssh-add - <<< "${{ inputs.remote_key }}"
+
+        # SSH command with host key checking disabled
+        RSH="ssh -o StrictHostKeyChecking=no -p ${{ inputs.remote_port }}"
+
+        # Resolve paths and DSN
+        LOCAL_PATH="$GITHUB_WORKSPACE/${{ inputs.path }}"
+        DSN="${{ inputs.remote_user }}@${{ inputs.remote_host }}"
+
+        # Deploy
+        rsync ${{ inputs.switches }} -e "$RSH" "$LOCAL_PATH" "$DSN:${{ inputs.remote_path }}"
+
+        # Cleanup identities from the agent
+        ssh-add -D || true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -84,7 +84,7 @@ jobs:
           docker run --rm --volume "$PWD:/root/flink-cdc" chesnay/flink-ci:java_8_11_17_21_maven_386 bash -c "cd /root/flink-cdc && chmod +x ./.github/workflows/docs.sh && ./.github/workflows/docs.sh"
 
       - name: Upload documentation
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        uses: ./.github/actions/rsync-deployments
         with:
           switches: --archive --compress --delete
           path: docs/target/
@@ -96,7 +96,7 @@ jobs:
 
       - name: Upload documentation alias
         if: env.flink_alias != ''
-        uses: burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823
+        uses: ./.github/actions/rsync-deployments
         with:
           switches: --archive --compress --delete
           path: docs/target/


### PR DESCRIPTION
## Problem

The `Build documentation` GitHub Actions workflow has been failing with `startup_failure` since April 18, 2026. All scheduled and PR-triggered documentation builds are broken, meaning updated documentation cannot be published to the Apache Nightlies website.

**Error message:**
```
The action burnett01/rsync-deployments@0dc935cdecc5f5e571865e60d2a6cdc673704823 is not allowed in apache/flink-cdc
because all actions must be from a repository owned by your enterprise, created by GitHub,
or match one of the patterns in the allowed list.
```

**CI failure history:** All runs since April 18 show `startup_failure` — [Build documentation workflow runs](https://github.com/apache/flink-cdc/actions/workflows/build_docs.yml)

## Root Cause

The workflow uses `burnett01/rsync-deployments@0dc935cd` which is pinned to **v5.2** (from 2022). This version is **not** in the [Apache Infra approved actions list](https://github.com/apache/infrastructure-actions/blob/main/actions.yml). Apache enforces an allowlist for third-party GitHub Actions, and only the following versions of `burnett01/rsync-deployments` are approved:

- `7659d600d8bdd035bb5cdfba1d4bd0dd4a307ca6` (v8.0.3, expires 2026-05-22)
- `dc0d5d44c4728aad3f02154a87309809e62a960f` (v8.0.4)

## Considered Approaches

### Option 1: Upgrade to an approved version (v8.0.4)

Simply replace the SHA with the approved `dc0d5d44c4728aad3f02154a87309809e62a960f` (v8.0.4).

**Pros:** Minimal change, single-line fix.
**Cons:** Still depends on a third-party action. The approved versions have **expiration dates** (e.g., v8.0.3 expires 2026-05-22). When they expire, the workflow will break again with the same `startup_failure`. This was exactly the experience reported in [FLINK-38448](https://issues.apache.org/jira/browse/FLINK-38448) — upgrading to the latest version did not help at that time.

### Option 2: Replace with a local composite action (Chosen ✅)

Create a local composite action at `.github/actions/rsync-deployments/` that uses native `rsync` + `ssh-agent` (both pre-installed on `ubuntu-latest` runners), eliminating the dependency on any third-party action entirely.

**Pros:**
- No dependency on third-party actions — immune to future allowlist changes or version expirations
- No Docker overhead — the original action runs inside a Docker container, the composite action runs natively
- Same approach already proven in [FLINK-38448](https://issues.apache.org/jira/browse/FLINK-38448) for flink-kubernetes-operator ([commit 3e3cb584](https://github.com/apache/flink-kubernetes-operator/commit/3e3cb584))

**Cons:**
- Slightly more files to maintain
- After merging, the action files need to be backported to `release-3.5` and `release-3.6` branches (the workflow checks out these branches via matrix and requires the local action to be present)

## Changes

- **New:** `.github/actions/rsync-deployments/action.yml` — Local composite action that uses `ssh-agent` + `rsync` to deploy documentation, with the same interface as the original third-party action
- **New:** `.github/actions/rsync-deployments/LICENSE` — MIT License from the original [burnett01/rsync-deployments](https://github.com/Burnett01/rsync-deployments)
- **Modified:** `.github/workflows/build_docs.yml` — Replace `burnett01/rsync-deployments@0dc935cd` with `./.github/actions/rsync-deployments` in both upload steps

## Post-merge Steps

After this PR is merged to `master`, the `.github/actions/rsync-deployments/` directory must be backported to the following branches so that the matrix builds for those versions continue to work:

- `release-3.6`
- `release-3.5`

## References

- JIRA: [FLINK-39573](https://issues.apache.org/jira/browse/FLINK-39573)
- Similar issue: [FLINK-38448](https://issues.apache.org/jira/browse/FLINK-38448) (same fix in flink-kubernetes-operator)
- Apache Actions policy: https://infra.apache.org/github-actions-policy.html
- Apache approved actions list: https://github.com/apache/infrastructure-actions/blob/main/actions.yml