### PR TITLE
[FLINK-39633][postgres] Fix NPE in incremental snapshot backfill when WAL carries records for other captured tables

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcher.java
@@ -269,14 +269,11 @@ public class IncrementalSourceScanFetcher implements Fetcher<SourceRecords, Sour
         // Skip records of other captured tables; their schema may not be loaded yet
         // and their PKs do not align with this chunk's bounds.
         TableId recordTableId = taskContext.getTableId(record);
-        if (recordTableId == null
-                || !recordTableId.equals(currentSnapshotSplit.getTableId())) {
+        if (recordTableId == null || !recordTableId.equals(currentSnapshotSplit.getTableId())) {
             return false;
         }
         return taskContext.isRecordBetween(
-                record,
-                currentSnapshotSplit.getSplitStart(),
-                currentSnapshotSplit.getSplitEnd());
+                record, currentSnapshotSplit.getSplitStart(), currentSnapshotSplit.getSplitEnd());
     }
 
     @VisibleForTesting

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcher.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcher.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.guava31.com.google.common.util.concurrent.ThreadF
 
 import io.debezium.connector.base.ChangeEventQueue;
 import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.relational.TableId;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -260,13 +261,26 @@ public class IncrementalSourceScanFetcher implements Fetcher<SourceRecords, Sour
                         lowWatermark));
     }
 
-    private boolean isChangeRecordInChunkRange(SourceRecord record) {
-        if (taskContext.isDataChangeRecord(record)) {
-            return taskContext.isRecordBetween(
-                    record,
-                    currentSnapshotSplit.getSplitStart(),
-                    currentSnapshotSplit.getSplitEnd());
+    @VisibleForTesting
+    boolean isChangeRecordInChunkRange(SourceRecord record) {
+        if (!taskContext.isDataChangeRecord(record)) {
+            return false;
         }
-        return false;
+        // Skip records of other captured tables; their schema may not be loaded yet
+        // and their PKs do not align with this chunk's bounds.
+        TableId recordTableId = taskContext.getTableId(record);
+        if (recordTableId == null
+                || !recordTableId.equals(currentSnapshotSplit.getTableId())) {
+            return false;
+        }
+        return taskContext.isRecordBetween(
+                record,
+                currentSnapshotSplit.getSplitStart(),
+                currentSnapshotSplit.getSplitEnd());
+    }
+
+    @VisibleForTesting
+    void setCurrentSnapshotSplit(SnapshotSplit currentSnapshotSplit) {
+        this.currentSnapshotSplit = currentSnapshotSplit;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcherTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcherTest.java
@@ -41,12 +41,11 @@ class IncrementalSourceScanFetcherTest {
     private static final TableId OTHER_TABLE = TableId.parse("test_db.table_b");
 
     /**
-     * Reproduces the NPE seen in PostgreSQL backfill when the WAL stream carries change records
-     * for a captured table other than the one currently being snapshotted. Before the fix, the
-     * fetcher passed the foreign-table record to {@code isRecordBetween}, which dereferenced a
-     * null Debezium {@code Table} from the schema cache and threw NPE. After the fix, the
-     * foreign-table record is filtered out by tableId and {@code isRecordBetween} is never
-     * invoked.
+     * Reproduces the NPE seen in PostgreSQL backfill when the WAL stream carries change records for
+     * a captured table other than the one currently being snapshotted. Before the fix, the fetcher
+     * passed the foreign-table record to {@code isRecordBetween}, which dereferenced a null
+     * Debezium {@code Table} from the schema cache and threw NPE. After the fix, the foreign-table
+     * record is filtered out by tableId and {@code isRecordBetween} is never invoked.
      */
     @Test
     void testIsChangeRecordInChunkRangeFiltersOutForeignTableRecord() {
@@ -105,9 +104,7 @@ class IncrementalSourceScanFetcherTest {
 
     private static SnapshotSplit newSnapshotSplit(TableId tableId) {
         RowType splitKeyType =
-                (RowType)
-                        DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT()))
-                                .getLogicalType();
+                (RowType) DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT())).getLogicalType();
         return new SnapshotSplit(
                 tableId,
                 0,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcherTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcherTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.base.source.reader.external;
+
+import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.logical.RowType;
+
+import io.debezium.relational.TableId;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link IncrementalSourceScanFetcher}. */
+class IncrementalSourceScanFetcherTest {
+
+    private static final TableId CURRENT_SPLIT_TABLE = TableId.parse("test_db.table_a");
+    private static final TableId OTHER_TABLE = TableId.parse("test_db.table_b");
+
+    /**
+     * Reproduces the NPE seen in PostgreSQL backfill when the WAL stream carries change records
+     * for a captured table other than the one currently being snapshotted. Before the fix, the
+     * fetcher passed the foreign-table record to {@code isRecordBetween}, which dereferenced a
+     * null Debezium {@code Table} from the schema cache and threw NPE. After the fix, the
+     * foreign-table record is filtered out by tableId and {@code isRecordBetween} is never
+     * invoked.
+     */
+    @Test
+    void testIsChangeRecordInChunkRangeFiltersOutForeignTableRecord() {
+        FetchTask.Context taskContext = mock(FetchTask.Context.class);
+        SourceRecord foreignTableRecord = mock(SourceRecord.class);
+
+        when(taskContext.isDataChangeRecord(foreignTableRecord)).thenReturn(true);
+        when(taskContext.getTableId(foreignTableRecord)).thenReturn(OTHER_TABLE);
+        // Mirrors the production failure mode: the record is for a table whose schema is not in
+        // the cache, so any downstream lookup explodes with NPE. The test asserts we never get
+        // here.
+        when(taskContext.isRecordBetween(any(), any(), any()))
+                .thenThrow(
+                        new NullPointerException(
+                                "Cannot invoke \"io.debezium.relational.Table.primaryKeyColumns()\" because \"table\" is null"));
+
+        IncrementalSourceScanFetcher fetcher = new IncrementalSourceScanFetcher(taskContext, 0);
+        fetcher.setCurrentSnapshotSplit(newSnapshotSplit(CURRENT_SPLIT_TABLE));
+
+        Assertions.assertThatCode(() -> fetcher.isChangeRecordInChunkRange(foreignTableRecord))
+                .doesNotThrowAnyException();
+        Assertions.assertThat(fetcher.isChangeRecordInChunkRange(foreignTableRecord)).isFalse();
+        verify(taskContext, never()).isRecordBetween(any(), any(), any());
+    }
+
+    @Test
+    void testIsChangeRecordInChunkRangeDelegatesForCurrentTableRecord() {
+        FetchTask.Context taskContext = mock(FetchTask.Context.class);
+        SourceRecord currentTableRecord = mock(SourceRecord.class);
+
+        when(taskContext.isDataChangeRecord(currentTableRecord)).thenReturn(true);
+        when(taskContext.getTableId(currentTableRecord)).thenReturn(CURRENT_SPLIT_TABLE);
+        when(taskContext.isRecordBetween(any(), any(), any())).thenReturn(true);
+
+        IncrementalSourceScanFetcher fetcher = new IncrementalSourceScanFetcher(taskContext, 0);
+        fetcher.setCurrentSnapshotSplit(newSnapshotSplit(CURRENT_SPLIT_TABLE));
+
+        Assertions.assertThat(fetcher.isChangeRecordInChunkRange(currentTableRecord)).isTrue();
+        verify(taskContext).isRecordBetween(any(), any(), any());
+    }
+
+    @Test
+    void testIsChangeRecordInChunkRangeIgnoresNonDataChangeRecord() {
+        FetchTask.Context taskContext = mock(FetchTask.Context.class);
+        SourceRecord watermarkRecord = mock(SourceRecord.class);
+
+        when(taskContext.isDataChangeRecord(watermarkRecord)).thenReturn(false);
+
+        IncrementalSourceScanFetcher fetcher = new IncrementalSourceScanFetcher(taskContext, 0);
+        fetcher.setCurrentSnapshotSplit(newSnapshotSplit(CURRENT_SPLIT_TABLE));
+
+        Assertions.assertThat(fetcher.isChangeRecordInChunkRange(watermarkRecord)).isFalse();
+        verify(taskContext, never()).getTableId(any());
+        verify(taskContext, never()).isRecordBetween(any(), any(), any());
+    }
+
+    private static SnapshotSplit newSnapshotSplit(TableId tableId) {
+        RowType splitKeyType =
+                (RowType)
+                        DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT()))
+                                .getLogicalType();
+        return new SnapshotSplit(
+                tableId,
+                0,
+                splitKeyType,
+                new Object[] {0L},
+                new Object[] {1024L},
+                null,
+                Collections.emptyMap());
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcherTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/test/java/org/apache/flink/cdc/connectors/base/source/reader/external/IncrementalSourceScanFetcherTest.java
@@ -65,9 +65,8 @@ class IncrementalSourceScanFetcherTest {
         IncrementalSourceScanFetcher fetcher = new IncrementalSourceScanFetcher(taskContext, 0);
         fetcher.setCurrentSnapshotSplit(newSnapshotSplit(CURRENT_SPLIT_TABLE));
 
-        Assertions.assertThatCode(() -> fetcher.isChangeRecordInChunkRange(foreignTableRecord))
-                .doesNotThrowAnyException();
-        Assertions.assertThat(fetcher.isChangeRecordInChunkRange(foreignTableRecord)).isFalse();
+        boolean result = fetcher.isChangeRecordInChunkRange(foreignTableRecord);
+        Assertions.assertThat(result).isFalse();
         verify(taskContext, never()).isRecordBetween(any(), any(), any());
     }
 


### PR DESCRIPTION
This closes https://issues.apache.org/jira/browse/FLINK-39633.

## Problem

During the snapshot backfill phase of PostgreSQL CDC (incremental snapshot), the WAL stream from the logical replication slot may carry change records for captured tables other than the one whose chunk is currently being snapshotted. `IncrementalSourceScanFetcher#isChangeRecordInChunkRange` does not filter records by tableId before delegating to `JdbcSourceFetchTaskContext#isRecordBetween`, which calls `getDatabaseSchema().tableFor(record.tableId)`. If the foreign table's schema is not yet present in `RelationAwarePostgresSchema`'s lazy cache, the lookup returns null and `ChunkUtils.getSplitColumn` throws NPE on `null.primaryKeyColumns()`:

```
java.lang.NullPointerException: Cannot invoke "io.debezium.relational.Table.primaryKeyColumns()" because "table" is null
    at org.apache.flink.cdc.connectors.postgres.source.utils.ChunkUtils.getSplitColumn(ChunkUtils.java:45)
    at org.apache.flink.cdc.connectors.postgres.source.fetch.PostgresSourceFetchTaskContext.getSplitType(PostgresSourceFetchTaskContext.java:291)
    at org.apache.flink.cdc.connectors.base.source.reader.external.JdbcSourceFetchTaskContext.isRecordBetween(JdbcSourceFetchTaskContext.java:76)
    at org.apache.flink.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher.isChangeRecordInChunkRange(IncrementalSourceScanFetcher.java:265)
```

The streaming reader (`IncrementalSourceStreamFetcher#shouldEmit`) already guards against this case via `finishedSplitsInfo.containsKey(tableId)` before invoking `isRecordBetween`. The scan fetcher was missing the symmetric guard.

## Fix

Filter change records by tableId in `IncrementalSourceScanFetcher#isChangeRecordInChunkRange` before delegating to `isRecordBetween`. Records whose tableId does not equal `currentSnapshotSplit.getTableId()` are skipped.

## Test plan

- [x] Added `IncrementalSourceScanFetcherTest` with three cases:
  - foreign-table change record is filtered out (no NPE, `isRecordBetween` is never invoked)
  - same-table change record is still delegated to `isRecordBetween`
  - non-data change records (watermark / signal) short-circuit without calling `getTableId`
- [x] All existing `flink-cdc-base` unit tests still pass (16/16)