### PR TITLE
[runtime] CDC YAML supports inline Python UDF definition

### DIFF
--- a/.github/workflows/flink_cdc_base.yml
+++ b/.github/workflows/flink_cdc_base.yml
@@ -89,6 +89,16 @@ jobs:
         with:
           maven-version: 3.8.6
 
+      - name: Install Python and Pemja
+        # Required by `flink-cdc-pipeline-udf-python` unit tests.
+        if: ${{ matrix.module == 'core' }}
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip python3-dev
+          python3 -m pip install --upgrade pip
+          python3 -m pip install pemja==0.5.5
+
       - name: Compile and test
         timeout-minutes: 90
         run: |

--- a/.github/workflows/modules.py
+++ b/.github/workflows/modules.py
@@ -13,6 +13,7 @@ MODULES_CORE = [
     "flink-cdc-common",
     "flink-cdc-composer",
     "flink-cdc-runtime",
+    "flink-cdc-pipeline-udf-python",
     "flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base",
     "flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values"
 ]

--- a/docs/content.zh/docs/core-concept/transform.md
+++ b/docs/content.zh/docs/core-concept/transform.md
@@ -472,6 +472,46 @@ transform:
     filter: inc(id) < 100
 ```
 
+### Python UDF
+
+Flink CDC 内置了一个通用 UDF —— `org.apache.flink.cdc.python.PythonUdf`，通过 [Pemja](https://pypi.org/project/pemja/) 在 TaskManager 上嵌入一段内联的 Python 函数。它以可选依赖的方式提供：先下载 `flink-cdc-pipeline-udf-python-{$CDC_VERSION}.jar`，在执行 `flink-cdc.sh` 时通过 `--jar {$PYTHON_UDF_JAR_PATH}` 加上即可；再像声明普通 `user-defined-function` 一样，把每个 Python 函数都指向这个内置类：
+
+```yaml
+source:
+  type: mysql
+  # ...
+
+sink:
+  type: values
+
+transform:
+  - source-table: db.users
+    projection: ID, py_normalize(EMAIL) AS EMAIL_NORM, py_double(AGE) AS DOUBLED
+
+pipeline:
+  parallelism: 4
+  user-defined-function:
+    - name: py_normalize
+      classpath: org.apache.flink.cdc.python.PythonUdf
+      options:
+        python-executable: /usr/bin/python3
+        source: |
+          def eval(s: str) -> str:
+              return s.strip().lower()
+    - name: py_double
+      classpath: org.apache.flink.cdc.python.PythonUdf
+      options:
+        python-executable: /usr/bin/python3
+        source: |
+          def eval(x: int) -> int:
+              return x * 2
+```
+
+**前置条件**
+
+* 每个 TaskManager 都需要在 `options.python-executable` 指向的路径（默认是 `PATH` 上第一个 `python3`）安装好 Python 3 及对应版本的 `pemja`。CLI 端无需安装 Python，只有真正运行 UDF 的 TaskManager 需要。
+* 每个 UDF 条目里只能放一个名为 `eval` 的 Python 函数；如果需要多个 Python UDF，请逐条声明，每个 UDF 函数具有独立的生命周期和上下文。
+
 ## Embedding AI 模型
 
 内置 AI 模型可以在 transform 规则中使用。

--- a/docs/content/docs/core-concept/transform.md
+++ b/docs/content/docs/core-concept/transform.md
@@ -477,6 +477,47 @@ transform:
     filter: inc(id) < 100
 ```
 
+### Python UDFs
+
+Flink CDC ships a built-in generic UDF, `org.apache.flink.cdc.python.PythonUdf`, that embeds an inline Python function via [Pemja](https://pypi.org/project/pemja/). It is packaged as an opt-in dependency: download `flink-cdc-pipeline-udf-python-{$CDC_VERSION}.jar` and add `--jar {$PYTHON_UDF_JAR_PATH}` to your `flink-cdc.sh` invocation, then declare each Python function as a regular `user-defined-function` entry pointing at the built-in class:
+
+```yaml
+source:
+  type: mysql
+  # ...
+
+sink:
+  type: values
+
+transform:
+  - source-table: db.users
+    projection: ID, py_normalize(EMAIL) AS EMAIL_NORM, py_double(AGE) AS DOUBLED
+
+pipeline:
+  parallelism: 4
+  user-defined-function:
+    - name: py_normalize
+      classpath: org.apache.flink.cdc.python.PythonUdf
+      options:
+        python-executable: /usr/bin/python3
+        source: |
+          def eval(s: str) -> str:
+              return s.strip().lower()
+    - name: py_double
+      classpath: org.apache.flink.cdc.python.PythonUdf
+      options:
+        python-executable: /usr/bin/python3
+        source: |
+          def eval(x: int) -> int:
+              return x * 2
+```
+
+**Requirements**
+
+* Every TaskManager must expose a Python 3 interpreter at the path supplied via `options.python-executable` (default: the first `python3` on `PATH`) with a matching `pemja` package installed. The CLI host does not need Python — only the TaskManagers that run the UDF do.
+* Each UDF entry holds one Python callable named `eval`; declare one `user-defined-function` entry per logical UDF. Each of them has individual lifecycle and context.
+
+
 ## Embedding AI Model
 
 Embedding AI Model can be used in transform rules.

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/udf/UserDefinedFunction.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/udf/UserDefinedFunction.java
@@ -26,15 +26,26 @@ import org.apache.flink.cdc.common.types.DataType;
  */
 @PublicEvolving
 public interface UserDefinedFunction {
+
+    /**
+     * Returns the return type of this UDF when it cannot be derived from per-UDF options.
+     *
+     * @deprecated Use {@link #getReturnType(UserDefinedFunctionContext)} instead.
+     */
+    @Deprecated
     default DataType getReturnType() {
         return null;
+    }
+
+    /** Returns the return type of this UDF, given the per-UDF YAML options. */
+    default DataType getReturnType(UserDefinedFunctionContext context) {
+        return getReturnType();
     }
 
     /**
      * This will be invoked every time when a UDF got created.
      *
-     * <p>this method is {@link Deprecated}, please use {@link #open(UserDefinedFunctionContext)}
-     * instead.
+     * @deprecated Use {@link #open(UserDefinedFunctionContext)} instead.
      */
     @Deprecated
     default void open() throws Exception {}

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/pom.xml
@@ -229,6 +229,12 @@ limitations under the License.
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-pipeline-udf-python</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <!-- testcontainers -->
         <dependency>
@@ -783,6 +789,16 @@ limitations under the License.
                             <artifactId>flink-cdc-pipeline-udf-examples</artifactId>
                             <version>${project.version}</version>
                             <destFileName>udf-examples.jar</destFileName>
+                            <type>jar</type>
+                            <outputDirectory>${project.build.directory}/dependencies
+                            </outputDirectory>
+                        </artifactItem>
+
+                        <artifactItem>
+                            <groupId>org.apache.flink</groupId>
+                            <artifactId>flink-cdc-pipeline-udf-python</artifactId>
+                            <version>${project.version}</version>
+                            <destFileName>flink-cdc-pipeline-udf-python.jar</destFileName>
                             <type>jar</type>
                             <outputDirectory>${project.build.directory}/dependencies
                             </outputDirectory>

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/PythonUdfE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/PythonUdfE2eITCase.java
@@ -1,0 +1,475 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.pipeline.tests;
+
+import org.apache.flink.cdc.common.test.utils.TestUtils;
+import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
+import org.apache.flink.cdc.pipeline.tests.utils.PipelineTestEnvironment;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.ExecConfig;
+import org.testcontainers.containers.GenericContainer;
+
+import javax.annotation.Nullable;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/** E2e tests for pipelines that use Python UDFs. */
+class PythonUdfE2eITCase extends PipelineTestEnvironment {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PythonUdfE2eITCase.class);
+
+    private static final String PYTHON_UDF_CLASSPATH = "org.apache.flink.cdc.python.PythonUdf";
+    private static final String CONTAINER_PYTHON_EXECUTABLE = "/usr/bin/python3";
+    private static final String PEMJA_VERSION = "0.5.5";
+    private static final Path pythonUdfJar =
+            TestUtils.getResource("flink-cdc-pipeline-udf-python.jar").toAbsolutePath();
+
+    protected final UniqueDatabase pyUdfTestDatabase =
+            new UniqueDatabase(MYSQL, "python_udf_test", MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+
+    private final Function<String, String> dbNameFormatter =
+            s -> String.format(s, pyUdfTestDatabase.getDatabaseName());
+
+    @BeforeEach
+    public void initializeDatabaseAndPython() throws Exception {
+        pyUdfTestDatabase.createAndInitialize();
+        // Only TM requires Python at runtime. Neither JM nor job submitter requires that.
+        installPythonAndPemja(taskManager);
+    }
+
+    @AfterEach
+    public void destroyDatabase() {
+        pyUdfTestDatabase.dropDatabase();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 4})
+    void testNormalizeEmail(int parallelism) throws Exception {
+        runGenericTest(
+                parallelism,
+                "ID, py_normalize(EMAIL) AS EMAIL_NORM",
+                null,
+                List.of(
+                        udf(
+                                "py_normalize",
+                                "def eval(s: str) -> str:",
+                                "    if s is None:",
+                                "        return None",
+                                "    return s.strip().lower()")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`EMAIL_NORM` STRING}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, alice@example.com], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, bob@test.io], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, carol@example.com], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, dave@example.org], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, null], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testEmailDomain() throws Exception {
+        runGenericTest(
+                1,
+                "ID, py_domain(EMAIL) AS DOMAIN",
+                null,
+                List.of(
+                        udf(
+                                "py_domain",
+                                "def eval(s: str) -> str:",
+                                "    if s is None:",
+                                "        return None",
+                                "    return s.strip().lower().split('@')[-1]")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`DOMAIN` STRING}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, example.com], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, test.io], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, example.com], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, example.org], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testIntDoubling() throws Exception {
+        runGenericTest(
+                1,
+                "ID, py_double(AGE) AS DOUBLED",
+                null,
+                List.of(
+                        udf(
+                                "py_double",
+                                "def eval(x: int) -> int:",
+                                "    if x is None:",
+                                "        return None",
+                                "    return x * 2")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`DOUBLED` BIGINT}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, 56], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, 50], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, 70], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, 84], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, null], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testBytesToHex() throws Exception {
+        runGenericTest(
+                1,
+                "ID, py_to_hex(AVATAR) AS HEX",
+                null,
+                List.of(
+                        udf(
+                                "py_to_hex",
+                                "def eval(b: bytes) -> str:",
+                                "    if b is None:",
+                                "        return None",
+                                "    return b.hex()")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`HEX` STRING}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, 48656c6c6f], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, 576f726c64], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, 00ff7f], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, cafebabe], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testBoolReturnUsedInFilter() throws Exception {
+        runGenericTest(
+                1,
+                "ID, EMAIL",
+                "py_age_ge_30(AGE)",
+                List.of(
+                        udf(
+                                "py_age_ge_30",
+                                "def eval(age: int) -> bool:",
+                                "    return age is not None and age >= 30")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`EMAIL` VARCHAR(128)}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, carol@example.com], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, DAVE@example.org], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testFloatReturnFromScore() throws Exception {
+        runGenericTest(
+                1,
+                "ID, py_twice_score(SCORE) AS TWICE",
+                null,
+                List.of(
+                        udf(
+                                "py_twice_score",
+                                "def eval(x: float) -> float:",
+                                "    if x is None:",
+                                "        return None",
+                                "    return x * 2.0")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`TWICE` DOUBLE}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, 175.0], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, 128.0], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, 185.0], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, 156.0], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, null], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testBytesReturnReversedAvatar() throws Exception {
+        runGenericTest(
+                1,
+                "ID, AVATAR, py_reverse_bytes(AVATAR) AS REV",
+                null,
+                List.of(
+                        udf(
+                                "py_reverse_bytes",
+                                "def eval(b: bytes) -> bytes:",
+                                "    if b is None:",
+                                "        return None",
+                                "    return bytes(reversed(b))")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`AVATAR` VARBINARY(64),`REV` VARBINARY(65536)}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, SGVsbG8=, b2xsZUg=], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, V29ybGQ=, ZGxyb1c=], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, AP9/, f/8A], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, yv66vg==, vrr+yg==], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, null, null], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testStatefulCounter() throws Exception {
+        // Each PythonUdf instance has its own lifecycle.
+        runGenericTest(
+                1,
+                "ID, py_counter(ID) AS SEQ",
+                null,
+                List.of(
+                        udf(
+                                "py_counter",
+                                "_counter = 0",
+                                "def eval(_id: int) -> int:",
+                                "    global _counter",
+                                "    _counter += 7",
+                                "    return _counter")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`SEQ` BIGINT}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, 7], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, 14], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, 21], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, 28], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, 35], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testStatefulRunningTotal() throws Exception {
+        runGenericTest(
+                1,
+                "ID, py_running_sum(AGE) AS TOTAL_AGE",
+                null,
+                List.of(
+                        udf(
+                                "py_running_sum",
+                                "_total = 0",
+                                "def eval(age: int) -> int:",
+                                "    global _total",
+                                "    if age is not None:",
+                                "        _total += age",
+                                "    return _total")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`TOTAL_AGE` BIGINT}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, 28], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, 53], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, 88], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, 130], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, 130], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testMultiplePythonUdfs() throws Exception {
+        runGenericTest(
+                1,
+                "ID, py_normalize(EMAIL) AS EMAIL_NORM, py_double(AGE) AS DOUBLED",
+                null,
+                List.of(
+                        udf(
+                                "py_normalize",
+                                "def eval(s: str) -> str:",
+                                "    if s is None:",
+                                "        return None",
+                                "    return s.strip().lower() if s else s"),
+                        udf(
+                                "py_double",
+                                "def eval(x: int) -> int:",
+                                "    if x is None:",
+                                "        return None",
+                                "    return x * 2 if x else x")),
+                "CreateTableEvent{tableId=%s.USERS, schema=columns={`ID` INT NOT NULL,`EMAIL_NORM` STRING,`DOUBLED` BIGINT}, primaryKeys=ID, options=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[1, alice@example.com, 56], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[2, bob@test.io, 50], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[3, carol@example.com, 70], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[4, dave@example.org, 84], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.USERS, before=[], after=[5, null, null], op=INSERT, meta=()}");
+    }
+
+    @Test
+    void testEvalRaisesAtRuntime() throws Exception {
+        submitPipelineJob(
+                buildJobYaml(
+                        1,
+                        "ID, py_boom(ID) AS X",
+                        null,
+                        List.of(
+                                udf(
+                                        "py_boom",
+                                        "def eval(_id: int) -> int:",
+                                        "    raise ValueError('boom')"))),
+                pythonUdfJar);
+        validateResult(
+                dbNameFormatter,
+                "Failed to evaluate projection expression `PY_BOOM(`TB`.`ID`)` for column `X` in table `%s.USERS`.",
+                "<class 'ValueError'>: boom");
+    }
+
+    @Test
+    void testEvalReturnAnnotationMissing() throws Exception {
+        submitPipelineJob(
+                buildJobYaml(
+                        1,
+                        "ID, py_no_ret(ID) AS X",
+                        null,
+                        List.of(udf("py_no_ret", "def eval(_id: int):", "    return _id"))),
+                pythonUdfJar);
+        waitUntilSpecificEvent("Function 'eval' has no return type annotation.");
+    }
+
+    @Test
+    void testEvalReturnAnnotationUnsupported() throws Exception {
+        submitPipelineJob(
+                buildJobYaml(
+                        1,
+                        "ID, py_unsupported(ID) AS X",
+                        null,
+                        List.of(
+                                udf(
+                                        "py_unsupported",
+                                        "def eval(_id: int) -> bytearray:",
+                                        "    return bytearray(_id)"))),
+                pythonUdfJar);
+        waitUntilSpecificEvent(
+                "Unsupported Python UDF return type 'bytearray'. Supported annotations: [bool, bytes, float, int, str]");
+    }
+
+    @Test
+    void testEvalMissing() throws Exception {
+        submitPipelineJob(
+                buildJobYaml(
+                        1,
+                        "ID, py_no_eval(ID) AS X",
+                        null,
+                        List.of(
+                                udf(
+                                        "py_no_eval",
+                                        "def other(_id: int) -> int:",
+                                        "    return _id"))),
+                pythonUdfJar);
+        waitUntilSpecificEvent("Python UDF source does not define a top-level 'eval' function.");
+    }
+
+    private static UdfEntry udf(String name, String... code) {
+        return new UdfEntry(name, String.join("\n", code));
+    }
+
+    private void runGenericTest(
+            int parallelism,
+            String projection,
+            @Nullable String filter,
+            List<UdfEntry> udfs,
+            String... expectedEvents)
+            throws Exception {
+        submitPipelineJob(buildJobYaml(parallelism, projection, filter, udfs), pythonUdfJar);
+        waitUntilJobRunning(Duration.ofSeconds(60));
+        validateResult(dbNameFormatter, expectedEvents);
+    }
+
+    private String buildJobYaml(
+            int parallelism, String projection, @Nullable String filter, List<UdfEntry> udfs) {
+        StringBuilder transform =
+                new StringBuilder("transform:\n")
+                        .append("  - source-table: ")
+                        .append(pyUdfTestDatabase.getDatabaseName())
+                        .append(".USERS\n")
+                        .append("    projection: ")
+                        .append(projection)
+                        .append('\n');
+        if (filter != null) {
+            transform.append("    filter: ").append(filter).append('\n');
+        }
+
+        StringBuilder udfsYaml = new StringBuilder();
+        for (UdfEntry udf : udfs) {
+            String indentedSource =
+                    Arrays.stream(udf.source.split("\n", -1))
+                            .map(line -> line.isEmpty() ? "" : "          " + line)
+                            .collect(Collectors.joining("\n"));
+            udfsYaml.append("    - name: ").append(udf.name).append('\n');
+            udfsYaml.append("      classpath: ").append(PYTHON_UDF_CLASSPATH).append('\n');
+            udfsYaml.append("      options:\n");
+            udfsYaml.append("        python-executable: ")
+                    .append(CONTAINER_PYTHON_EXECUTABLE)
+                    .append('\n');
+            udfsYaml.append("        source: |\n");
+            udfsYaml.append(indentedSource).append('\n');
+        }
+
+        return String.format(
+                "source:\n"
+                        + "  type: mysql\n"
+                        + "  hostname: %s\n"
+                        + "  port: 3306\n"
+                        + "  username: %s\n"
+                        + "  password: %s\n"
+                        + "  scan.startup.mode: earliest-offset\n"
+                        + "  tables: %s.USERS\n"
+                        + "  server-id: 5400-5404\n"
+                        + "  server-time-zone: UTC\n"
+                        + "\n"
+                        + "sink:\n"
+                        + "  type: values\n"
+                        + "%s"
+                        + "\n"
+                        + "pipeline:\n"
+                        + "  parallelism: %d\n"
+                        + "  user-defined-function:\n"
+                        + "%s",
+                INTER_CONTAINER_MYSQL_ALIAS,
+                MYSQL_TEST_USER,
+                MYSQL_TEST_PASSWORD,
+                pyUdfTestDatabase.getDatabaseName(),
+                transform,
+                parallelism,
+                udfsYaml);
+    }
+
+    private void installPythonAndPemja(GenericContainer<?> container) throws Exception {
+        LOG.info(
+                "Installing Python + Pemja {} into {}",
+                PEMJA_VERSION,
+                container.getDockerImageName());
+        boolean isFlink2 = flinkVersion.startsWith("2");
+        String script =
+                "set -euo pipefail; "
+                        + "apt-get update && "
+                        + "apt-get install -y --no-install-recommends python3 python3-pip python3-dev && "
+                        + "rm -rf /var/lib/apt/lists/* && "
+                        + "pip3 install "
+                        + (isFlink2 ? "--break-system-packages" : "")
+                        + " --no-cache-dir pemja=="
+                        + PEMJA_VERSION
+                        + " && "
+                        + "test -x "
+                        + CONTAINER_PYTHON_EXECUTABLE
+                        + " && "
+                        + CONTAINER_PYTHON_EXECUTABLE
+                        + " -c 'import pemja'";
+        Container.ExecResult result =
+                container.execInContainer(
+                        ExecConfig.builder()
+                                .user("root")
+                                .command(new String[] {"bash", "-c", script})
+                                .build());
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException(
+                    "Failed to install Pemja into "
+                            + container.getDockerImageName()
+                            + " (exit="
+                            + result.getExitCode()
+                            + ").\nstdout:\n"
+                            + result.getStdout()
+                            + "\nstderr:\n"
+                            + result.getStderr());
+        }
+    }
+
+    private static final class UdfEntry {
+        final String name;
+        final String source;
+
+        UdfEntry(String name, String source) {
+            this.name = name;
+            this.source = source;
+        }
+    }
+}

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/ddl/python_udf_test.sql
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/resources/ddl/python_udf_test.sql
@@ -1,0 +1,37 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Fixture for PythonUdfE2eITCase. Rows are intentionally messy (mixed case,
+-- whitespace, varied phone formats) so the Python UDFs have something to do
+-- that built-in transform expressions can't easily match.
+
+DROP TABLE IF EXISTS USERS;
+
+CREATE TABLE USERS (
+    ID INT NOT NULL,
+    EMAIL VARCHAR(128),
+    PHONE VARCHAR(64),
+    AGE INT,
+    SCORE DOUBLE,
+    ACTIVE BOOLEAN,
+    AVATAR VARBINARY(64),
+    PRIMARY KEY (ID)
+);
+
+INSERT INTO USERS VALUES (1, 'Alice@Example.COM',  '+1 (415) 555-0100', 28, 87.5, TRUE,  X'48656C6C6F');
+INSERT INTO USERS VALUES (2, '  bob@TEST.io  ',    '(212)-555-0199',    25, 64.0, FALSE, X'576F726C64');
+INSERT INTO USERS VALUES (3, 'carol@example.com',  '+44 20 7946 0958',  35, 92.5, TRUE,  X'00FF7F');
+INSERT INTO USERS VALUES (4, 'DAVE@example.org',   '+1.617.555.0173',   42, 78.0, TRUE,  X'CAFEBABE');
+INSERT INTO USERS VALUES (5, NULL,                 NULL,                NULL, NULL, NULL,  NULL);

--- a/flink-cdc-pipeline-udf-python/pom.xml
+++ b/flink-cdc-pipeline-udf-python/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-cdc-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>flink-cdc-pipeline-udf-python</artifactId>
+    <name>Flink CDC : Pipeline UDF : Python</name>
+
+    <properties>
+        <pemja.version>0.5.5</pemja.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-cdc-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>pemja</artifactId>
+            <version>${pemja.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.shade.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadeTestJar>false</shadeTestJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.alibaba:pemja</include>
+                                </includes>
+                            </artifactSet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flink-cdc-pipeline-udf-python/src/main/java/org/apache/flink/cdc/python/PythonUdf.java
+++ b/flink-cdc-pipeline-udf-python/src/main/java/org/apache/flink/cdc/python/PythonUdf.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.python;
+
+import org.apache.flink.cdc.common.annotation.Experimental;
+import org.apache.flink.cdc.common.configuration.ConfigOption;
+import org.apache.flink.cdc.common.configuration.ConfigOptions;
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+import org.apache.flink.cdc.common.udf.UserDefinedFunctionContext;
+import org.apache.flink.cdc.python.utils.PythonUdfSignature;
+
+import pemja.core.PythonInterpreter;
+import pemja.core.PythonInterpreterConfig;
+
+/** Generic UDF that delegates to a Python function defined inline in YAML. */
+@Experimental
+public final class PythonUdf implements UserDefinedFunction {
+
+    public static final ConfigOption<String> OPTION_SOURCE =
+            ConfigOptions.key("source")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Inline Python source containing a `def eval(...)`.");
+
+    public static final ConfigOption<String> OPTION_PYTHON_EXECUTABLE =
+            ConfigOptions.key("python-executable")
+                    .stringType()
+                    .defaultValue("python3")
+                    .withDescription(
+                            "Path to the Python interpreter Pemja embeds on every TaskManager."
+                                    + " The interpreter must have a matching `pemja` package"
+                                    + " installed; defaults to the first `python3` on PATH.");
+
+    private static final String PYTHON_FUNCTION_NAME = "eval";
+
+    private transient PythonInterpreter interpreter;
+
+    @Override
+    public void open(UserDefinedFunctionContext context) {
+        Configuration config = context.configuration();
+        String source = requireSource(config);
+        String pythonExec = config.get(OPTION_PYTHON_EXECUTABLE);
+
+        PythonInterpreterConfig pemjaConfig =
+                PythonInterpreterConfig.newBuilder().setPythonExec(pythonExec).build();
+        this.interpreter = new PythonInterpreter(pemjaConfig);
+        this.interpreter.exec(source);
+    }
+
+    @Override
+    public void close() {
+        if (interpreter != null) {
+            try {
+                interpreter.close();
+            } finally {
+                interpreter = null;
+            }
+        }
+    }
+
+    @Override
+    public DataType getReturnType(UserDefinedFunctionContext context) {
+        Configuration config = context.configuration();
+        String source = requireSource(config);
+        return PythonUdfSignature.parseReturnType(source, config.get(OPTION_PYTHON_EXECUTABLE));
+    }
+
+    public Object eval(Object... args) {
+        if (interpreter == null) {
+            throw new IllegalStateException("PythonUdf invoked before open() was called.");
+        }
+        return interpreter.invoke(PYTHON_FUNCTION_NAME, args);
+    }
+
+    private static String requireSource(Configuration config) {
+        return config.getOptional(OPTION_SOURCE)
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        "Python UDF is missing required option '"
+                                                + OPTION_SOURCE.key()
+                                                + "'."));
+    }
+}

--- a/flink-cdc-pipeline-udf-python/src/main/java/org/apache/flink/cdc/python/utils/PythonUdfSignature.java
+++ b/flink-cdc-pipeline-udf-python/src/main/java/org/apache/flink/cdc/python/utils/PythonUdfSignature.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.python.utils;
+
+import org.apache.flink.cdc.common.types.DataType;
+import org.apache.flink.cdc.common.types.DataTypes;
+
+import pemja.core.PythonInterpreter;
+import pemja.core.PythonInterpreterConfig;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Resolves the return type of a {@code PythonUdf} from its inline Python source. */
+public final class PythonUdfSignature {
+
+    private static final String SIGNATURE_PARSER_RESOURCE =
+            "/org/apache/flink/cdc/python/signature.py";
+
+    private static final Map<String, DataType> SUPPORTED_ANNOTATIONS =
+            Map.of(
+                    "bool", DataTypes.BOOLEAN(),
+                    "int", DataTypes.BIGINT(),
+                    "float", DataTypes.DOUBLE(),
+                    "str", DataTypes.STRING(),
+                    "bytes", DataTypes.BYTES());
+
+    private PythonUdfSignature() {}
+
+    public static DataType parseReturnType(String source, String pythonExec) {
+        String annotation = parseReturnAnnotation(source, pythonExec).trim();
+        DataType type = SUPPORTED_ANNOTATIONS.get(annotation);
+        if (type == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported Python UDF return type '"
+                            + annotation
+                            + "'. Supported annotations: "
+                            + SUPPORTED_ANNOTATIONS.keySet().stream()
+                                    .sorted()
+                                    .collect(Collectors.toList()));
+        }
+        return type;
+    }
+
+    private static String parseReturnAnnotation(String source, String pythonExec) {
+        PythonInterpreterConfig pemjaConfig =
+                PythonInterpreterConfig.newBuilder().setPythonExec(pythonExec).build();
+        try (PythonInterpreter parser = new PythonInterpreter(pemjaConfig)) {
+            parser.exec(loadSignatureScript());
+            return (String) parser.invoke("eval_return_type", source);
+        }
+    }
+
+    private static String loadSignatureScript() {
+        try (InputStream in =
+                PythonUdfSignature.class.getResourceAsStream(SIGNATURE_PARSER_RESOURCE)) {
+            if (in == null) {
+                throw new IllegalStateException(
+                        "Bundled signature parser resource not found: "
+                                + SIGNATURE_PARSER_RESOURCE);
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to parse Python UDF signature", e);
+        }
+    }
+}

--- a/flink-cdc-pipeline-udf-python/src/main/resources/org/apache/flink/cdc/python/signature.py
+++ b/flink-cdc-pipeline-udf-python/src/main/resources/org/apache/flink/cdc/python/signature.py
@@ -1,0 +1,54 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+################################################################################
+"""Resolve the Calcite return type of a Python UDF from its inline source."""
+
+import ast
+
+
+def eval_return_type(source):
+    """Return the raw return-type annotation string of the top-level ``eval``
+    function. Raises ``ValueError`` if it can't be determined.
+    """
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.FunctionDef) and node.name == 'eval':
+            if node.returns is None:
+                raise ValueError(
+                    "Function 'eval' has no return type annotation."
+                )
+            annotation = _annotation_string(node.returns)
+            if annotation is None:
+                raise ValueError(
+                    "Return type annotation of 'eval' could not be rendered "
+                    "(needs Python 3.9+ for non-trivial annotations)."
+                )
+            return annotation
+    raise ValueError(
+        "Python UDF source does not define a top-level 'eval' function."
+    )
+
+
+def _annotation_string(annotation):
+    if isinstance(annotation, ast.Name):
+        return annotation.id
+    unparse = getattr(ast, 'unparse', None)
+    if unparse is None:
+        return None
+    try:
+        return unparse(annotation)
+    except (AttributeError, TypeError):
+        return None

--- a/flink-cdc-pipeline-udf-python/src/test/java/org/apache/flink/cdc/python/PythonUdfTest.java
+++ b/flink-cdc-pipeline-udf-python/src/test/java/org/apache/flink/cdc/python/PythonUdfTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.python;
+
+import org.apache.flink.cdc.common.configuration.Configuration;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.cdc.common.udf.UserDefinedFunctionContext;
+import org.apache.flink.cdc.python.utils.PemjaTestSupport;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PythonUdf}. */
+class PythonUdfTest {
+
+    @BeforeAll
+    static void requirePemja() {
+        PemjaTestSupport.requirePemja();
+    }
+
+    @Test
+    void evalBeforeOpenThrows() {
+        PythonUdf udf = new PythonUdf();
+        assertThatThrownBy(() -> udf.eval(1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("before open()");
+    }
+
+    @Test
+    void closeIsIdempotent() {
+        PythonUdf udf = new PythonUdf();
+        udf.close();
+        udf.close();
+        try {
+            udf.open(contextFor("def eval(x: int) -> int:\n    return x\n"));
+            udf.close();
+            udf.close();
+        } finally {
+            udf.close();
+        }
+    }
+
+    @Test
+    void openRequiresSourceOption() {
+        PythonUdf udf = new PythonUdf();
+        Map<String, String> opts = new HashMap<>();
+        opts.put(PythonUdf.OPTION_PYTHON_EXECUTABLE.key(), PemjaTestSupport.PYTHON_EXEC);
+        assertThatThrownBy(() -> udf.open(() -> Configuration.fromMap(opts)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(PythonUdf.OPTION_SOURCE.key());
+    }
+
+    @Test
+    void getReturnTypeReadsFromSource() {
+        PythonUdf udf = new PythonUdf();
+        assertThat(udf.getReturnType(contextFor("def eval(x: int) -> int:\n    return x * 2\n")))
+                .isEqualTo(DataTypes.BIGINT());
+    }
+
+    @Test
+    void evalRoundTripsInt() {
+        PythonUdf udf = new PythonUdf();
+        udf.open(contextFor("def eval(x: int) -> int:\n    return x * 2\n"));
+        try {
+            assertThat(udf.eval(21L)).isEqualTo(42L);
+        } finally {
+            udf.close();
+        }
+    }
+
+    @Test
+    void evalRoundTripsString() {
+        PythonUdf udf = new PythonUdf();
+        udf.open(contextFor("def eval(s: str) -> str:\n    return s.upper()\n"));
+        try {
+            assertThat(udf.eval("abc")).isEqualTo("ABC");
+        } finally {
+            udf.close();
+        }
+    }
+
+    @Test
+    void evalForwardsNullToPython() {
+        // Pemja maps Java null -> Python None; a guard-clause UDF should see it and may handle it.
+        PythonUdf udf = new PythonUdf();
+        udf.open(
+                contextFor(
+                        "def eval(s) -> str:\n" + "    return 'null' if s is None else str(s)\n"));
+        try {
+            assertThat(udf.eval(new Object[] {null})).isEqualTo("null");
+        } finally {
+            udf.close();
+        }
+    }
+
+    private static UserDefinedFunctionContext contextFor(String source) {
+        Map<String, String> opts = new HashMap<>();
+        opts.put(PythonUdf.OPTION_SOURCE.key(), source);
+        opts.put(PythonUdf.OPTION_PYTHON_EXECUTABLE.key(), PemjaTestSupport.PYTHON_EXEC);
+        return () -> Configuration.fromMap(opts);
+    }
+}

--- a/flink-cdc-pipeline-udf-python/src/test/java/org/apache/flink/cdc/python/utils/PemjaTestSupport.java
+++ b/flink-cdc-pipeline-udf-python/src/test/java/org/apache/flink/cdc/python/utils/PemjaTestSupport.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.python.utils;
+
+import pemja.core.PythonInterpreter;
+import pemja.core.PythonInterpreterConfig;
+
+/**
+ * Fails fast with an actionable message if Pemja or its Python sidecar isn't reachable. The
+ * interpreter is resolved from {@code pemja.python.executable} (system property) or {@code
+ * PEMJA_PYTHON_EXECUTABLE} (env var), falling back to {@code python3} on PATH.
+ */
+public final class PemjaTestSupport {
+
+    public static final String PYTHON_EXEC =
+            System.getProperty(
+                    "pemja.python.executable",
+                    System.getenv().getOrDefault("PEMJA_PYTHON_EXECUTABLE", "python3"));
+
+    private PemjaTestSupport() {}
+
+    public static void requirePemja() {
+        try (PythonInterpreter ignored =
+                new PythonInterpreter(
+                        PythonInterpreterConfig.newBuilder().setPythonExec(PYTHON_EXEC).build())) {
+            // Smoke-test: starting the interpreter loads libpython + the pemja package.
+        } catch (Throwable t) {
+            throw new IllegalStateException(
+                    "Pemja could not be initialized using '"
+                            + PYTHON_EXEC
+                            + "'. Install Python 3.9+ and `pip install pemja==0.5.5`, or point"
+                            + " the tests at a usable interpreter via"
+                            + " -Dpemja.python.executable=/path/to/python3"
+                            + " (or PEMJA_PYTHON_EXECUTABLE env var).",
+                    t);
+        }
+    }
+}

--- a/flink-cdc-pipeline-udf-python/src/test/java/org/apache/flink/cdc/python/utils/PythonUdfSignatureTest.java
+++ b/flink-cdc-pipeline-udf-python/src/test/java/org/apache/flink/cdc/python/utils/PythonUdfSignatureTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.python.utils;
+
+import org.apache.flink.cdc.common.types.DataTypes;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link PythonUdfSignature}. */
+class PythonUdfSignatureTest {
+
+    @BeforeAll
+    static void requirePemja() {
+        PemjaTestSupport.requirePemja();
+    }
+
+    @Test
+    void resolvesEvenWhenOtherFunctionsArePresent() {
+        String source =
+                "def helper(x: int) -> int:\n"
+                        + "    return x\n"
+                        + "def eval(x: str) -> str:\n"
+                        + "    return helper(len(x)) and x\n";
+        assertThat(PythonUdfSignature.parseReturnType(source, PemjaTestSupport.PYTHON_EXEC))
+                .isEqualTo(DataTypes.STRING());
+    }
+
+    @Test
+    void throwsWhenNoEvalFunction() {
+        String source = "def other(x: int) -> int:\n    return x\n";
+        assertThatThrownBy(
+                        () ->
+                                PythonUdfSignature.parseReturnType(
+                                        source, PemjaTestSupport.PYTHON_EXEC))
+                .hasMessageContaining(
+                        "Python UDF source does not define a top-level 'eval' function.");
+    }
+
+    @Test
+    void throwsWhenEvalHasNoReturnAnnotation() {
+        String source = "def eval(x: int):\n    return x\n";
+        assertThatThrownBy(
+                        () ->
+                                PythonUdfSignature.parseReturnType(
+                                        source, PemjaTestSupport.PYTHON_EXEC))
+                .hasMessageContaining("Function 'eval' has no return type annotation.");
+    }
+
+    @Test
+    void throwsWhenAnnotationUnsupported() {
+        String source = "def eval(x: int) -> bytearray:\n    return bytearray(x)\n";
+        assertThatThrownBy(
+                        () ->
+                                PythonUdfSignature.parseReturnType(
+                                        source, PemjaTestSupport.PYTHON_EXEC))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported Python UDF return type 'bytearray'.")
+                .hasMessageContaining("Supported annotations: [bool, bytes, float, int, str]");
+    }
+
+    @Test
+    void throwsOnInvalidPythonSource() {
+        // Not "no eval" — outright syntax error so ast.parse blows up inside the parser.
+        String source = "def eval(x ->\n";
+        assertThatThrownBy(
+                        () ->
+                                PythonUdfSignature.parseReturnType(
+                                        source, PemjaTestSupport.PYTHON_EXEC))
+                .hasMessageContaining("invalid syntax");
+    }
+}

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/TransformExpressionCompiler.java
@@ -64,7 +64,7 @@ public class TransformExpressionCompiler {
                         List<Class<?>> argumentClasses = new ArrayList<>(key.getArgumentClasses());
 
                         for (UserDefinedFunctionDescriptor udfFunction : udfDescriptors) {
-                            argumentNames.add("__instanceOf" + udfFunction.getClassName());
+                            argumentNames.add("__udf_" + udfFunction.getName());
                             argumentClasses.add(Class.forName(udfFunction.getClasspath()));
                         }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/UserDefinedFunctionDescriptor.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/UserDefinedFunctionDescriptor.java
@@ -19,8 +19,10 @@ package org.apache.flink.cdc.runtime.operators.transform;
 
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.udf.UserDefinedFunction;
+import org.apache.flink.cdc.common.udf.UserDefinedFunctionContext;
 
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
@@ -62,13 +64,10 @@ public class UserDefinedFunctionDescriptor implements Serializable {
             Class<?> clazz = Class.forName(classpath);
             isCdcPipelineUdf = isCdcPipelineUdf(clazz);
             if (isCdcPipelineUdf) {
-                // We use reflection to invoke UDF methods since we may add more methods
-                // into UserDefinedFunction interface, thus the provided UDF classes
-                // might not be compatible with the interface definition in CDC common.
+                UserDefinedFunctionContext context = () -> Configuration.fromMap(parameters);
                 returnTypeHint =
-                        (DataType)
-                                clazz.getMethod("getReturnType")
-                                        .invoke(clazz.getConstructor().newInstance());
+                        ((UserDefinedFunction) clazz.getConstructor().newInstance())
+                                .getReturnType(context);
             } else {
                 returnTypeHint = null;
             }

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -654,12 +654,12 @@ public class JaninoCompiler {
     private static String generateInvokeExpression(UserDefinedFunctionDescriptor udfFunction) {
         if (udfFunction.getReturnTypeHint() != null) {
             return String.format(
-                    "(%s) __instanceOf%s.eval",
+                    "(%s) __udf_%s.eval",
                     JavaClassConverter.toJavaClass(udfFunction.getReturnTypeHint())
                             .getCanonicalName(),
-                    udfFunction.getClassName());
+                    udfFunction.getName());
         } else {
-            return String.format("__instanceOf%s.eval", udfFunction.getClassName());
+            return String.format("__udf_%s.eval", udfFunction.getName());
         }
     }
 

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -643,46 +643,30 @@ class TransformParserTest {
 
     @Test
     void testTranslateUdfFilterToJaninoExpression() {
+        testFilterExpressionWithUdf("format(upper(id))", "__udf_format.eval(upper(id))");
+        testFilterExpressionWithUdf("format(lower(id))", "__udf_format.eval(lower(id))");
+        testFilterExpressionWithUdf("format(concat(a,b))", "__udf_format.eval(concat(a, b))");
+        testFilterExpressionWithUdf("format(SUBSTR(a,1))", "__udf_format.eval(substr(a, 1))");
         testFilterExpressionWithUdf(
-                "format(upper(id))", "__instanceOfFormatFunctionClass.eval(upper(id))");
+                "typeof(id like '^[a-zA-Z]')", "__udf_typeof.eval(like(id, \"^[a-zA-Z]\"))");
         testFilterExpressionWithUdf(
-                "format(lower(id))", "__instanceOfFormatFunctionClass.eval(lower(id))");
-        testFilterExpressionWithUdf(
-                "format(concat(a,b))", "__instanceOfFormatFunctionClass.eval(concat(a, b))");
-        testFilterExpressionWithUdf(
-                "format(SUBSTR(a,1))", "__instanceOfFormatFunctionClass.eval(substr(a, 1))");
-        testFilterExpressionWithUdf(
-                "typeof(id like '^[a-zA-Z]')",
-                "__instanceOfTypeOfFunctionClass.eval(like(id, \"^[a-zA-Z]\"))");
-        testFilterExpressionWithUdf(
-                "typeof(id not like '^[a-zA-Z]')",
-                "__instanceOfTypeOfFunctionClass.eval(notLike(id, \"^[a-zA-Z]\"))");
-        testFilterExpressionWithUdf(
-                "typeof(abs(2))", "__instanceOfTypeOfFunctionClass.eval(abs(2))");
-        testFilterExpressionWithUdf(
-                "typeof(ceil(2))", "__instanceOfTypeOfFunctionClass.eval(ceil(2))");
-        testFilterExpressionWithUdf(
-                "typeof(ceiling(2))", "__instanceOfTypeOfFunctionClass.eval(ceil(2))");
-        testFilterExpressionWithUdf(
-                "typeof(floor(2))", "__instanceOfTypeOfFunctionClass.eval(floor(2))");
-        testFilterExpressionWithUdf(
-                "typeof(round(2,2))", "__instanceOfTypeOfFunctionClass.eval(round(2, 2))");
-        testFilterExpressionWithUdf(
-                "typeof(id + 2)", "__instanceOfTypeOfFunctionClass.eval(id + 2)");
-        testFilterExpressionWithUdf(
-                "typeof(id - 2)", "__instanceOfTypeOfFunctionClass.eval(id - 2)");
-        testFilterExpressionWithUdf(
-                "typeof(id * 2)", "__instanceOfTypeOfFunctionClass.eval(id * 2)");
-        testFilterExpressionWithUdf(
-                "typeof(id / 2)", "__instanceOfTypeOfFunctionClass.eval(id / 2)");
-        testFilterExpressionWithUdf(
-                "typeof(id % 2)", "__instanceOfTypeOfFunctionClass.eval(id % 2)");
+                "typeof(id not like '^[a-zA-Z]')", "__udf_typeof.eval(notLike(id, \"^[a-zA-Z]\"))");
+        testFilterExpressionWithUdf("typeof(abs(2))", "__udf_typeof.eval(abs(2))");
+        testFilterExpressionWithUdf("typeof(ceil(2))", "__udf_typeof.eval(ceil(2))");
+        testFilterExpressionWithUdf("typeof(ceiling(2))", "__udf_typeof.eval(ceil(2))");
+        testFilterExpressionWithUdf("typeof(floor(2))", "__udf_typeof.eval(floor(2))");
+        testFilterExpressionWithUdf("typeof(round(2,2))", "__udf_typeof.eval(round(2, 2))");
+        testFilterExpressionWithUdf("typeof(id + 2)", "__udf_typeof.eval(id + 2)");
+        testFilterExpressionWithUdf("typeof(id - 2)", "__udf_typeof.eval(id - 2)");
+        testFilterExpressionWithUdf("typeof(id * 2)", "__udf_typeof.eval(id * 2)");
+        testFilterExpressionWithUdf("typeof(id / 2)", "__udf_typeof.eval(id / 2)");
+        testFilterExpressionWithUdf("typeof(id % 2)", "__udf_typeof.eval(id % 2)");
         testFilterExpressionWithUdf(
                 "addone(addone(id)) > 4 OR typeof(id) <> 'bool' AND format('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "greaterThan(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
+                "greaterThan(__udf_addone.eval(__udf_addone.eval(id)), 4) || !valueEquals(__udf_typeof.eval(id), \"bool\") && !valueEquals(__udf_format.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
         testFilterExpressionWithUdf(
                 "ADDONE(ADDONE(id)) > 4 OR TYPEOF(id) <> 'bool' AND FORMAT('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "greaterThan(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval(id)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval(id), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
+                "greaterThan(__udf_addone.eval(__udf_addone.eval(id)), 4) || !valueEquals(__udf_typeof.eval(id), \"bool\") && !valueEquals(__udf_format.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")");
     }
 
     @Test
@@ -699,53 +683,38 @@ class TransformParserTest {
         columnNameMap.put("a-b", "$2");
 
         testFilterExpressionWithUdf(
-                "format(upper(a))",
-                "__instanceOfFormatFunctionClass.eval(upper($0))",
-                columns,
-                columnNameMap);
+                "format(upper(a))", "__udf_format.eval(upper($0))", columns, columnNameMap);
         testFilterExpressionWithUdf(
-                "format(lower(b))",
-                "__instanceOfFormatFunctionClass.eval(lower($1))",
-                columns,
-                columnNameMap);
+                "format(lower(b))", "__udf_format.eval(lower($1))", columns, columnNameMap);
         testFilterExpressionWithUdf(
-                "format(concat(a,b))",
-                "__instanceOfFormatFunctionClass.eval(concat($0, $1))",
-                columns,
-                columnNameMap);
+                "format(concat(a,b))", "__udf_format.eval(concat($0, $1))", columns, columnNameMap);
         testFilterExpressionWithUdf(
                 "format(SUBSTR(`a-b`,1))",
-                "__instanceOfFormatFunctionClass.eval(substr($2, 1))",
+                "__udf_format.eval(substr($2, 1))",
                 columns,
                 columnNameMap);
         testFilterExpressionWithUdf(
                 "typeof(`a-b` like '^[a-zA-Z]')",
-                "__instanceOfTypeOfFunctionClass.eval(like($2, \"^[a-zA-Z]\"))",
+                "__udf_typeof.eval(like($2, \"^[a-zA-Z]\"))",
                 columns,
                 columnNameMap);
         testFilterExpressionWithUdf(
                 "typeof(`a-b` not like '^[a-zA-Z]')",
-                "__instanceOfTypeOfFunctionClass.eval(notLike($2, \"^[a-zA-Z]\"))",
+                "__udf_typeof.eval(notLike($2, \"^[a-zA-Z]\"))",
                 columns,
                 columnNameMap);
         testFilterExpressionWithUdf(
-                "typeof(a-b-`a-b`)",
-                "__instanceOfTypeOfFunctionClass.eval($0 - $1 - $2)",
-                columns,
-                columnNameMap);
+                "typeof(a-b-`a-b`)", "__udf_typeof.eval($0 - $1 - $2)", columns, columnNameMap);
         testFilterExpressionWithUdf(
-                "typeof(a-b-2)",
-                "__instanceOfTypeOfFunctionClass.eval($0 - $1 - 2)",
-                columns,
-                columnNameMap);
+                "typeof(a-b-2)", "__udf_typeof.eval($0 - $1 - 2)", columns, columnNameMap);
         testFilterExpressionWithUdf(
                 "addone(addone(`a-b`)) > 4 OR typeof(a-b) <> 'bool' AND format('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "greaterThan(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval($2)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval($0 - $1), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")",
+                "greaterThan(__udf_addone.eval(__udf_addone.eval($2)), 4) || !valueEquals(__udf_typeof.eval($0 - $1), \"bool\") && !valueEquals(__udf_format.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")",
                 columns,
                 columnNameMap);
         testFilterExpressionWithUdf(
                 "ADDONE(ADDONE(`a-b`)) > 4 OR TYPEOF(a-b) <> 'bool' AND FORMAT('from %s to %s is %s', 'a', 'z', 'lie') <> ''",
-                "greaterThan(__instanceOfAddOneFunctionClass.eval(__instanceOfAddOneFunctionClass.eval($2)), 4) || !valueEquals(__instanceOfTypeOfFunctionClass.eval($0 - $1), \"bool\") && !valueEquals(__instanceOfFormatFunctionClass.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")",
+                "greaterThan(__udf_addone.eval(__udf_addone.eval($2)), 4) || !valueEquals(__udf_typeof.eval($0 - $1), \"bool\") && !valueEquals(__udf_format.eval(\"from %s to %s is %s\", \"a\", \"z\", \"lie\"), \"\")",
                 columns,
                 columnNameMap);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@ limitations under the License.
         <module>flink-cdc-runtime</module>
         <module>flink-cdc-e2e-tests</module>
         <module>flink-cdc-pipeline-udf-examples</module>
+        <module>flink-cdc-pipeline-udf-python</module>
         <module>flink-cdc-pipeline-model</module>
     </modules>
 


### PR DESCRIPTION
This PR provides the ability to write inline Python UDFs with YAML pipeline jobs. It could be used like this:

```yaml
transform:
  - source-table: db.users
    projection: ID, py_normalize(EMAIL) AS EMAIL_NORM, py_accumulate(AGE) AS acc

pipeline:
  user-defined-function:
    - name: py_normalize
      classpath: org.apache.flink.cdc.python.PythonUdf
      options:
        python-executable: /usr/bin/python3
        source: |
          def eval(s: str) -> str:
            return s.strip().lower()
    - name: py_accumulate
      classpath: org.apache.flink.cdc.python.PythonUdf
      options:
        python-executable: /usr/bin/python3
        source: |
          total = 0
          def eval(x: int) -> int:
            global total
            total += x
            return total
```

The wrapper itself is implemented as a Java UDF as well. No changes are made in the existing framework except the following:

* Runtime UDF binding names are slightly changed to allow defining multiple UDFs with the same class.
* Added an overload function for `UserDefinedFunction#getReturnType` to pass extra context info.
