### PR TITLE
[FLINK-39696][runtime] Use source partition for distributed flush events

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaOperator.java
@@ -195,11 +195,16 @@ public class SchemaOperator extends AbstractStreamOperatorAdapter<Event>
 
     private void requestSchemaChange(
             TableId sourceTableId, SchemaChangeRequest schemaChangeRequest) {
-        LOG.info("{}> Sent FlushEvent to downstream...", subTaskId);
+        final int sourcePartition = schemaChangeRequest.getSourceSubTaskId();
+
+        LOG.info(
+                "{}> Sent FlushEvent to downstream for source partition {}...",
+                subTaskId,
+                sourcePartition);
         output.collect(
                 new StreamRecord<>(
                         new FlushEvent(
-                                subTaskId,
+                                sourcePartition,
                                 tableIdRouter.route(sourceTableId),
                                 schemaChangeRequest.getSchemaChangeEvent().getType())));
 

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaEvolveTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/distributed/SchemaEvolveTest.java
@@ -382,6 +382,37 @@ public class SchemaEvolveTest extends SchemaTestBase {
                         "Unexpected schema change events occurred in EXCEPTION mode. Job will fail now.");
     }
 
+    @Test
+    void testFlushEventUsesSourcePartitionInsteadOfSchemaOperatorSubtask() throws Exception {
+        CreateTableEvent createTableEvent = new CreateTableEvent(TABLE_ID, INITIAL_SCHEMA);
+
+        Assertions.assertThat(
+                        runInHarness(
+                                () ->
+                                        new SchemaOperator(
+                                                ROUTING_RULES,
+                                                RouteMode.ALL_MATCH,
+                                                Duration.ofMinutes(3),
+                                                SchemaChangeBehavior.LENIENT,
+                                                "UTC"),
+                                (op) ->
+                                        new DistributedEventOperatorTestHarness<>(
+                                                op,
+                                                20,
+                                                1,
+                                                Duration.ofSeconds(3),
+                                                Duration.ofMinutes(3)),
+                                (operator, harness) ->
+                                        operator.processElement(wrap(createTableEvent, 0, 1))))
+                .map(StreamRecord::getValue)
+                .first()
+                .isEqualTo(
+                        new FlushEvent(
+                                0,
+                                Collections.singletonList(TABLE_ID),
+                                createTableEvent.getType()));
+    }
+
     protected static <
                     OP extends AbstractStreamOperatorAdapter<E>,
                     E extends Event,

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/DistributedEventOperatorTestHarness.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/testutils/operators/DistributedEventOperatorTestHarness.java
@@ -81,15 +81,26 @@ public class DistributedEventOperatorTestHarness<
     private final TestingSchemaRegistryGateway schemaRegistryGateway;
     private final LinkedList<StreamRecord<E>> outputRecords = new LinkedList<>();
     private final MockedOperatorCoordinatorContext mockedContext;
+    private final int subtaskIndex;
 
     public DistributedEventOperatorTestHarness(OP operator, int numOutputs) {
-        this(operator, numOutputs, Duration.ofSeconds(3), Duration.ofMinutes(3));
+        this(operator, numOutputs, 0, Duration.ofSeconds(3), Duration.ofMinutes(3));
     }
 
     public DistributedEventOperatorTestHarness(
             OP operator, int numOutputs, Duration applyDuration, Duration rpcTimeout) {
+        this(operator, numOutputs, 0, applyDuration, rpcTimeout);
+    }
+
+    public DistributedEventOperatorTestHarness(
+            OP operator,
+            int numOutputs,
+            int subtaskIndex,
+            Duration applyDuration,
+            Duration rpcTimeout) {
         this.operator = operator;
         this.numOutputs = numOutputs;
+        this.subtaskIndex = subtaskIndex;
         this.mockedContext =
                 new MockedOperatorCoordinatorContext(
                         SCHEMA_OPERATOR_ID, Thread.currentThread().getContextClassLoader());
@@ -160,7 +171,7 @@ public class DistributedEventOperatorTestHarness<
 
     private void initializeOperator() throws Exception {
         operator.setup(
-                new MockStreamTask(schemaRegistryGateway),
+                new MockStreamTask(schemaRegistryGateway, subtaskIndex),
                 new MockStreamConfig(new Configuration(), numOutputs),
                 new EventCollectingOutput<>(outputRecords, schemaRegistryGateway));
         schemaRegistryGateway.sendOperatorEventToCoordinator(
@@ -227,9 +238,10 @@ public class DistributedEventOperatorTestHarness<
     }
 
     private static class MockStreamTask extends StreamTask<Event, AbstractStreamOperator<Event>> {
-        protected MockStreamTask(TestingSchemaRegistryGateway schemaRegistryGateway)
+        protected MockStreamTask(
+                TestingSchemaRegistryGateway schemaRegistryGateway, int subtaskIndex)
                 throws Exception {
-            super(new SchemaRegistryCoordinatingEnvironment(schemaRegistryGateway));
+            super(new SchemaRegistryCoordinatingEnvironment(schemaRegistryGateway, subtaskIndex));
         }
 
         @Override
@@ -240,7 +252,8 @@ public class DistributedEventOperatorTestHarness<
         private final TestingSchemaRegistryGateway schemaRegistryGateway;
 
         public SchemaRegistryCoordinatingEnvironment(
-                TestingSchemaRegistryGateway schemaRegistryGateway) {
+                TestingSchemaRegistryGateway schemaRegistryGateway, int subtaskIndex) {
+            super("test-task", 2, subtaskIndex, 2);
             this.schemaRegistryGateway = schemaRegistryGateway;
         }
 


### PR DESCRIPTION
This closes [FLINK-39696](https://issues.apache.org/jira/browse/FLINK-39696).

# What is the purpose of the change

  This PR fixes inconsistent source identity propagation in the distributed schema evolution flow.

  In distributed mode, `SchemaOperator` forwards schema change requests to the coordinator with the original upstream source partition via `SchemaChangeRequest(sourcePartition, sinkSubTaskId, schemaChangeEvent)`.
  However, when emitting the downstream `FlushEvent`, it previously used the current `SchemaOperator` subtask id instead of the original source partition.

  As a result, the same schema change could be identified by different ids in different parts of the pipeline:

  - `SchemaChangeRequest` / coordinator deduplication use the original source partition
  - `FlushEvent` / downstream flush handling use the `SchemaOperator` subtask id

  This makes the flush lineage inconsistent with the schema-change lineage in distributed topology. In particular, duplicated broadcast branches of the same upstream schema change cannot be consistently aligned
  by the original source partition.

# Brief change log

  - Use `schemaChangeRequest.getSourceSubTaskId()` instead of `SchemaOperator`'s `subTaskId` when constructing distributed `FlushEvent`
  - Add a regression test in `SchemaEvolveTest` to verify that `FlushEvent` keeps the original source partition even when the `SchemaOperator` subtask id is different
  - Extend `DistributedEventOperatorTestHarness` so tests can inject a custom operator subtask index and reliably reproduce this scenario

# Verifying this change

  This change is verified by unit tests:

  - `SchemaEvolveTest#testFlushEventUsesSourcePartitionInsteadOfSchemaOperatorSubtask`

  Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e. is any changed class annotated with `@Public`(`@PublicEvolving`): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no

# Documentation

Does this pull request introduce a new feature? no

If yes, how is the feature documented? not applicable