### PR TITLE
[FLINK-39698][docs] Fix incorrect content in SQLServer CDC connector documentation

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/sqlserver-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/sqlserver-cdc.md
@@ -308,6 +308,9 @@ Limitation
 --------
 
 ### Can't perform checkpoint during scanning snapshot of tables
+
+*注意：此限制仅在未启用增量快照框架（即 `scan.incremental.snapshot.enabled` 设置为 `false`）时适用。*
+
 During scanning snapshot of database tables, since there is no recoverable position, we can't perform checkpoints. In order to not perform checkpoints, SqlServer CDC source will keep the checkpoint waiting to timeout. The timeout checkpoint will be recognized as failed checkpoint, by default, this will trigger a failover for the Flink job. So if the database table is large, it is recommended to add following Flink configurations to avoid failover because of the timeout checkpoints:
 
 ```
@@ -530,8 +533,8 @@ Data Type Mapping
       <td>DECIMAL(p, s)</td>
     </tr>
     <tr>
-      <td>numeric</td>
-      <td>NUMERIC</td>
+      <td>numeric(p, s)</td>
+      <td>DECIMAL(p, s)</td>
     </tr>
     <tr>
       <td>

--- a/docs/content/docs/connectors/flink-sources/sqlserver-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/sqlserver-cdc.md
@@ -308,6 +308,9 @@ Limitation
 --------
 
 ### Can't perform checkpoint during scanning snapshot of tables
+
+*Note: This limitation only applies when the incremental snapshot framework is not enabled (i.e., `scan.incremental.snapshot.enabled` is set to `false`).*
+
 During scanning snapshot of database tables, since there is no recoverable position, we can't perform checkpoints. In order to not perform checkpoints, SqlServer CDC source will keep the checkpoint waiting to timeout. The timeout checkpoint will be recognized as failed checkpoint, by default, this will trigger a failover for the Flink job. So if the database table is large, it is recommended to add following Flink configurations to avoid failover because of the timeout checkpoints:
 
 ```
@@ -529,8 +532,8 @@ Data Type Mapping
       <td>DECIMAL(p, s)</td>
     </tr>
     <tr>
-      <td>numeric</td>
-      <td>NUMERIC</td>
+      <td>numeric(p, s)</td>
+      <td>DECIMAL(p, s)</td>
     </tr>
     <tr>
       <td>


### PR DESCRIPTION
## What is the purpose of the change

This Pull Request addresses the documentation issues reported in [FLINK-39698](https://issues.apache.org/jira/browse/FLINK-39698) for the SQLServer CDC connector.

## Brief change log

* **Updated Limitation Section:** Added a note clarifying that the limitation regarding checkpointing during snapshot scanning only applies when the incremental snapshot framework is *not* enabled (`scan.incremental.snapshot.enabled` is `false`).
* **Fixed Data Type Mapping:** Corrected the Flink SQL type mapping for SQL Server's `numeric` type from `NUMERIC` to `DECIMAL(p, s)`.
* Applied these changes to both the English (`content/docs/...`) and Chinese (`content.zh/docs/...`) documentation files to keep them in sync.

## Verifying this change

This change is a documentation update and does not require new tests. 

* Verified locally by checking the markdown format.
* Both English and Chinese documentation files have been updated consistently.