### PR TITLE
[hotfix] Fix nested-types (array, map, row, variant) coercions

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
@@ -20,9 +20,13 @@ package org.apache.flink.cdc.common.utils;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.common.converter.JavaObjectConverter;
+import org.apache.flink.cdc.common.data.ArrayData;
 import org.apache.flink.cdc.common.data.DateData;
 import org.apache.flink.cdc.common.data.DecimalData;
 import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
+import org.apache.flink.cdc.common.data.MapData;
+import org.apache.flink.cdc.common.data.RecordData;
 import org.apache.flink.cdc.common.data.StringData;
 import org.apache.flink.cdc.common.data.TimeData;
 import org.apache.flink.cdc.common.data.TimestampData;
@@ -61,14 +65,19 @@ import org.apache.flink.cdc.common.types.VarBinaryType;
 import org.apache.flink.cdc.common.types.VarCharType;
 import org.apache.flink.cdc.common.types.VariantType;
 import org.apache.flink.cdc.common.types.ZonedTimestampType;
+import org.apache.flink.cdc.common.types.variant.BinaryVariantInternalBuilder;
 import org.apache.flink.cdc.common.types.variant.Variant;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableList;
 import org.apache.flink.shaded.guava31.com.google.common.collect.Streams;
 import org.apache.flink.shaded.guava31.com.google.common.io.BaseEncoding;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.json.JsonMapper;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -350,6 +359,10 @@ public class SchemaMergingUtils {
             return currentType.copy(nullable);
         }
 
+        if (currentType instanceof VariantType || targetType instanceof VariantType) {
+            return DataTypes.VARIANT().copy(nullable);
+        }
+
         // For TIMESTAMP and EXACT_NUMERIC types, we have fine-grained type merging logic.
         if (currentType.is(DataTypeFamily.TIMESTAMP) && targetType.is(DataTypeFamily.TIMESTAMP)) {
             return mergeTimestampType(currentType, targetType).copy(nullable);
@@ -582,6 +595,10 @@ public class SchemaMergingUtils {
             return coerceToZonedTimestamp(originalField, timezone);
         }
 
+        if (destinationType.is(DataTypeRoot.VARIANT)) {
+            return coerceToVariant(originalField, originalType);
+        }
+
         throw new IllegalArgumentException(
                 String.format(
                         "Column type \"%s\" doesn't support type coercion to \"%s\"",
@@ -609,6 +626,12 @@ public class SchemaMergingUtils {
             return BinaryStringData.fromString(((Variant) originalField).toJson());
         }
 
+        if (originalField instanceof MapData
+                || originalField instanceof ArrayData
+                || originalField instanceof RecordData) {
+            Object javaObject = JavaObjectConverter.convertToJava(originalField, originalType);
+            return BinaryStringData.fromString(javaObject.toString());
+        }
         return BinaryStringData.fromString(originalField.toString());
     }
 
@@ -843,6 +866,24 @@ public class SchemaMergingUtils {
                         ZoneId.of(timezone)));
     }
 
+    private static final JsonMapper jsonMapper =
+            JsonMapper.builder().addModule(new JavaTimeModule()).build();
+
+    private static Variant coerceToVariant(Object object, DataType originalType) {
+        try {
+            // Convert internal object to Plain Java before serializing
+            Object javaObject = JavaObjectConverter.convertToJava(object, originalType);
+            return BinaryVariantInternalBuilder.parseJson(
+                    jsonMapper.writeValueAsString(javaObject), false);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(
+                    "Failed to convert object to JSON for VARIANT type: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(
+                    "IO error while converting object to VARIANT type: " + e.getMessage(), e);
+        }
+    }
+
     private static String hexlify(byte[] bytes) {
         return BaseEncoding.base64().encode(bytes);
     }
@@ -864,24 +905,27 @@ public class SchemaMergingUtils {
         DataType timestampLtzType = DataTypes.TIMESTAMP_LTZ(LocalZonedTimestampType.MAX_PRECISION);
         DataType timestampType = DataTypes.TIMESTAMP(TimestampType.MAX_PRECISION);
         DataType dateType = DataTypes.DATE();
+        DataType variantType = DataTypes.VARIANT();
 
         Map<Class<? extends DataType>, List<DataType>> mergingTree = new HashMap<>();
 
         // Simple data types
-        mergingTree.put(VarCharType.class, ImmutableList.of(stringType));
-        mergingTree.put(CharType.class, ImmutableList.of(stringType));
-        mergingTree.put(BooleanType.class, ImmutableList.of(stringType));
-        mergingTree.put(BinaryType.class, ImmutableList.of(stringType));
-        mergingTree.put(VarBinaryType.class, ImmutableList.of(stringType));
-        mergingTree.put(DoubleType.class, ImmutableList.of(doubleType, stringType));
-        mergingTree.put(FloatType.class, ImmutableList.of(floatType, doubleType, stringType));
-        mergingTree.put(DecimalType.class, ImmutableList.of(stringType));
+        mergingTree.put(VarCharType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(CharType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(BooleanType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(BinaryType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(VarBinaryType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(DoubleType.class, ImmutableList.of(doubleType, stringType, variantType));
+        mergingTree.put(
+                FloatType.class, ImmutableList.of(floatType, doubleType, stringType, variantType));
+        mergingTree.put(DecimalType.class, ImmutableList.of(stringType, variantType));
         mergingTree.put(
                 BigIntType.class,
-                ImmutableList.of(bigIntType, decimalType, doubleType, stringType));
+                ImmutableList.of(bigIntType, decimalType, doubleType, stringType, variantType));
         mergingTree.put(
                 IntType.class,
-                ImmutableList.of(intType, bigIntType, decimalType, doubleType, stringType));
+                ImmutableList.of(
+                        intType, bigIntType, decimalType, doubleType, stringType, variantType));
         mergingTree.put(
                 SmallIntType.class,
                 ImmutableList.of(
@@ -891,7 +935,8 @@ public class SchemaMergingUtils {
                         decimalType,
                         floatType,
                         doubleType,
-                        stringType));
+                        stringType,
+                        variantType));
         mergingTree.put(
                 TinyIntType.class,
                 ImmutableList.of(
@@ -902,27 +947,36 @@ public class SchemaMergingUtils {
                         decimalType,
                         floatType,
                         doubleType,
-                        stringType));
+                        stringType,
+                        variantType));
 
         // Timestamp series
-        mergingTree.put(ZonedTimestampType.class, ImmutableList.of(timestampTzType, stringType));
+        mergingTree.put(
+                ZonedTimestampType.class,
+                ImmutableList.of(timestampTzType, stringType, variantType));
         mergingTree.put(
                 LocalZonedTimestampType.class,
-                ImmutableList.of(timestampLtzType, timestampTzType, stringType));
+                ImmutableList.of(timestampLtzType, timestampTzType, stringType, variantType));
         mergingTree.put(
                 TimestampType.class,
-                ImmutableList.of(timestampType, timestampLtzType, timestampTzType, stringType));
+                ImmutableList.of(
+                        timestampType, timestampLtzType, timestampTzType, stringType, variantType));
         mergingTree.put(
                 DateType.class,
                 ImmutableList.of(
-                        dateType, timestampType, timestampLtzType, timestampTzType, stringType));
-        mergingTree.put(TimeType.class, ImmutableList.of(stringType));
+                        dateType,
+                        timestampType,
+                        timestampLtzType,
+                        timestampTzType,
+                        stringType,
+                        variantType));
+        mergingTree.put(TimeType.class, ImmutableList.of(stringType, variantType));
 
         // Complex types
-        mergingTree.put(RowType.class, ImmutableList.of(stringType));
-        mergingTree.put(ArrayType.class, ImmutableList.of(stringType));
-        mergingTree.put(MapType.class, ImmutableList.of(stringType));
-        mergingTree.put(VariantType.class, ImmutableList.of(stringType));
+        mergingTree.put(RowType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(ArrayType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(MapType.class, ImmutableList.of(stringType, variantType));
+        mergingTree.put(VariantType.class, ImmutableList.of(stringType, variantType));
         return mergingTree;
     }
 }

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
@@ -21,10 +21,15 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple4;
 import org.apache.flink.cdc.common.data.DateData;
 import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.data.GenericArrayData;
+import org.apache.flink.cdc.common.data.GenericMapData;
+import org.apache.flink.cdc.common.data.GenericRecordData;
 import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
 import org.apache.flink.cdc.common.data.TimeData;
 import org.apache.flink.cdc.common.data.TimestampData;
 import org.apache.flink.cdc.common.data.ZonedTimestampData;
+import org.apache.flink.cdc.common.data.binary.BinaryArrayData;
+import org.apache.flink.cdc.common.data.binary.BinaryMapData;
 import org.apache.flink.cdc.common.data.binary.BinaryStringData;
 import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.AlterColumnTypeEvent;
@@ -40,6 +45,7 @@ import org.apache.flink.cdc.common.types.DecimalType;
 import org.apache.flink.cdc.common.types.LocalZonedTimestampType;
 import org.apache.flink.cdc.common.types.TimestampType;
 import org.apache.flink.cdc.common.types.ZonedTimestampType;
+import org.apache.flink.cdc.common.types.variant.Variant;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 
@@ -823,13 +829,118 @@ class SchemaMergingUtilsTest {
                                 TIMESTAMP_TZ,
                                 zTsOf("2019", "02", "02"),
                                 STRING,
-                                binStrOf("2019-02-02T00:00:00Z")));
+                                binStrOf("2019-02-02T00:00:00Z")),
+
+                        // From ARRAY
+                        Tuple4.of(
+                                ARRAY,
+                                new GenericArrayData(
+                                        new Object[] {binStrOf("hello"), binStrOf("world")}),
+                                STRING,
+                                binStrOf("[hello, world]")),
+
+                        // From MAP
+                        Tuple4.of(
+                                MAP,
+                                new GenericMapData(Collections.singletonMap(42, binStrOf("value"))),
+                                STRING,
+                                binStrOf("{42=value}")),
+
+                        // From ROW
+                        Tuple4.of(
+                                ROW,
+                                GenericRecordData.of(42, binStrOf("Alice")),
+                                STRING,
+                                binStrOf("[42, Alice]")));
 
         conversionExpects.forEach(
                 rule ->
                         Assertions.assertThat(coerceObject("UTC", rule.f1, rule.f0, rule.f2))
                                 .as("Try coercing %s (%s) to %s type", rule.f1, rule.f0, rule.f2)
                                 .isEqualTo(rule.f3));
+    }
+
+    @Test
+    void testCoerceObjectBinaryTypes() {
+        DataType intArrayType = DataTypes.ARRAY(DataTypes.INT());
+        DataType intIntMapType = DataTypes.MAP(DataTypes.INT(), DataTypes.INT());
+
+        // BinaryArrayData to STRING
+        BinaryArrayData binaryArray = BinaryArrayData.fromPrimitiveArray(new int[] {1, 2, 3});
+        Assertions.assertThat(coerceObject("UTC", binaryArray, intArrayType, STRING))
+                .as("Try coercing BinaryArrayData to STRING")
+                .isEqualTo(binStrOf("[1, 2, 3]"));
+
+        // BinaryMapData to STRING
+        BinaryArrayData keys = BinaryArrayData.fromPrimitiveArray(new int[] {10});
+        BinaryArrayData values = BinaryArrayData.fromPrimitiveArray(new int[] {100});
+        BinaryMapData binaryMap = BinaryMapData.valueOf(keys, values);
+        Assertions.assertThat(coerceObject("UTC", binaryMap, intIntMapType, STRING))
+                .as("Try coercing BinaryMapData to STRING")
+                .isEqualTo(binStrOf("{10=100}"));
+    }
+
+    @Test
+    void testCoerceComplexTypesToVariant() {
+        DataType intArrayType = DataTypes.ARRAY(DataTypes.INT());
+        DataType intStrMapType = DataTypes.MAP(DataTypes.INT(), DataTypes.STRING());
+        DataType intIntMapType = DataTypes.MAP(DataTypes.INT(), DataTypes.INT());
+
+        Variant fromArray =
+                (Variant)
+                        coerceObject(
+                                "UTC",
+                                new GenericArrayData(new int[] {7, 8}),
+                                intArrayType,
+                                VARIANT);
+        Assertions.assertThat(fromArray.toJson()).isEqualTo("[7,8]");
+
+        Variant fromMap =
+                (Variant)
+                        coerceObject(
+                                "UTC",
+                                new GenericMapData(Collections.singletonMap(99, binStrOf("yy"))),
+                                intStrMapType,
+                                VARIANT);
+        Assertions.assertThat(fromMap.toJson()).isEqualTo("{\"99\":\"yy\"}");
+
+        Variant fromRow =
+                (Variant)
+                        coerceObject(
+                                "UTC",
+                                GenericRecordData.of(42, BinaryStringData.fromString("hi")),
+                                ROW,
+                                VARIANT);
+        Assertions.assertThat(fromRow.toJson()).isEqualTo("[42,\"hi\"]");
+
+        Variant fromBinaryArray =
+                (Variant)
+                        coerceObject(
+                                "UTC",
+                                BinaryArrayData.fromPrimitiveArray(new int[] {1, 2, 3}),
+                                intArrayType,
+                                VARIANT);
+        Assertions.assertThat(fromBinaryArray.toJson()).isEqualTo("[1,2,3]");
+
+        BinaryArrayData mapKeys = BinaryArrayData.fromPrimitiveArray(new int[] {10});
+        BinaryArrayData mapValues = BinaryArrayData.fromPrimitiveArray(new int[] {-1});
+        Variant fromBinaryMap =
+                (Variant)
+                        coerceObject(
+                                "UTC",
+                                BinaryMapData.valueOf(mapKeys, mapValues),
+                                intIntMapType,
+                                VARIANT);
+        Assertions.assertThat(fromBinaryMap.toJson()).isEqualTo("{\"10\":-1}");
+
+        Object[] coercedRow =
+                coerceRow(
+                        "UTC",
+                        of("c", VARIANT),
+                        of("c", ROW),
+                        Collections.singletonList(GenericRecordData.of(1, binStrOf("r"))));
+        Assertions.assertThat(coercedRow).singleElement().isInstanceOf(Variant.class);
+        Assertions.assertThat(((Variant) coercedRow[0]).toJson()).isEqualTo("[1,\"r\"]");
     }
 
     @Test
@@ -961,42 +1072,42 @@ class SchemaMergingUtilsTest {
         // To-be-merged types are:
         // STRING, CHAR, VARCHAR, BINARY, VARBINARY, TINYINT, SMALLINT, INT, BIGINT,
         // DECIMAL, FLOAT, DOUBLE, TIMESTAMP, TIMESTAMP_LTZ, TIMESTAMP_TZ, TIME, ROW, ARRAY,
-        // MAP
+        // MAP, VARIANT
 
         assertTypeMergingVector(
                 STRING,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 CHAR,
                 Arrays.asList(
                         STRING, CHAR, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 VARCHAR,
                 Arrays.asList(
                         STRING, STRING, VARCHAR, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 BINARY,
                 Arrays.asList(
                         STRING, STRING, STRING, BINARY, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 VARBINARY,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, VARBINARY, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         // 8-bit TINYINT could fit into FLOAT (24 sig bits) or DOUBLE (53 sig bits)
         assertTypeMergingVector(
@@ -1004,7 +1115,7 @@ class SchemaMergingUtilsTest {
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, TINYINT, SMALLINT, INT, BIGINT,
                         DECIMAL, FLOAT, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         // 16-bit SMALLINT could fit into FLOAT (24 sig bits) or DOUBLE (53 sig bits)
         assertTypeMergingVector(
@@ -1012,7 +1123,7 @@ class SchemaMergingUtilsTest {
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, SMALLINT, SMALLINT, INT, BIGINT,
                         DECIMAL, FLOAT, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         // 32-bit INT could fit into DOUBLE (53 sig bits)
         assertTypeMergingVector(
@@ -1020,35 +1131,35 @@ class SchemaMergingUtilsTest {
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, INT, INT, INT, BIGINT, DECIMAL,
                         DOUBLE, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING));
+                        VARIANT));
 
         assertTypeMergingVector(
                 BIGINT,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, BIGINT, BIGINT, BIGINT, BIGINT,
                         DECIMAL, DOUBLE, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 DECIMAL,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, DECIMAL, DECIMAL, DECIMAL, DECIMAL,
                         DECIMAL, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 FLOAT,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, FLOAT, FLOAT, DOUBLE, DOUBLE,
                         STRING, FLOAT, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 DOUBLE,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, DOUBLE, DOUBLE, DOUBLE, DOUBLE,
                         STRING, DOUBLE, DOUBLE, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 TIMESTAMP,
@@ -1072,7 +1183,7 @@ class SchemaMergingUtilsTest {
                         STRING,
                         STRING,
                         STRING,
-                        STRING));
+                        VARIANT));
 
         assertTypeMergingVector(
                 TIMESTAMP_LTZ,
@@ -1096,7 +1207,7 @@ class SchemaMergingUtilsTest {
                         STRING,
                         STRING,
                         STRING,
-                        STRING));
+                        VARIANT));
 
         assertTypeMergingVector(
                 TIMESTAMP_TZ,
@@ -1120,42 +1231,42 @@ class SchemaMergingUtilsTest {
                         STRING,
                         STRING,
                         STRING,
-                        STRING));
+                        VARIANT));
 
         assertTypeMergingVector(
                 TIME,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, TIME, STRING, STRING,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 ROW,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, ROW, STRING, STRING,
-                        STRING));
+                        VARIANT));
 
         assertTypeMergingVector(
                 ARRAY,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, ARRAY,
-                        STRING, STRING));
+                        STRING, VARIANT));
 
         assertTypeMergingVector(
                 MAP,
                 Arrays.asList(
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
                         STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, MAP,
-                        STRING));
+                        VARIANT));
 
         assertTypeMergingVector(
                 VARIANT,
                 Arrays.asList(
-                        STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING, STRING,
-                        STRING, VARIANT));
+                        VARIANT, VARIANT, VARIANT, VARIANT, VARIANT, VARIANT, VARIANT, VARIANT,
+                        VARIANT, VARIANT, VARIANT, VARIANT, VARIANT, VARIANT, VARIANT, VARIANT,
+                        VARIANT, VARIANT, VARIANT, VARIANT));
     }
 
     private static void assertTypeMergingVector(DataType incomingType, List<DataType> resultTypes) {

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineBatchComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineBatchComposerITCase.java
@@ -19,6 +19,9 @@ package org.apache.flink.cdc.composer.flink;
 
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.data.DecimalData;
+import org.apache.flink.cdc.common.data.GenericArrayData;
+import org.apache.flink.cdc.common.data.GenericMapData;
+import org.apache.flink.cdc.common.data.GenericRecordData;
 import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
 import org.apache.flink.cdc.common.data.TimestampData;
 import org.apache.flink.cdc.common.data.ZonedTimestampData;
@@ -884,6 +887,116 @@ public class FlinkPipelineBatchComposerITCase {
                         "DataChangeEvent{tableId=default_namespace.default_schema.merged, before=[], after=[2, Bob, 20, null], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.merged, before=[], after=[3, Charlie, 15, student], op=INSERT, meta=()}",
                         "DataChangeEvent{tableId=default_namespace.default_schema.merged, before=[], after=[4, Donald, 25, student], op=INSERT, meta=()}");
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void testMergingComplexTypesWithRouteInBatchMode(ValuesDataSink.SinkApi sinkApi)
+            throws Exception {
+        FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
+
+        Configuration sourceConfig = new Configuration();
+        sourceConfig.set(
+                ValuesDataSourceOptions.EVENT_SET_ID,
+                ValuesDataSourceHelper.EventSetId.CUSTOM_SOURCE_EVENTS);
+        sourceConfig.set(ValuesDataSourceOptions.BATCH_MODE_ENABLED, true);
+
+        TableId myTable1 = TableId.tableId("default_namespace", "default_schema", "mytable1");
+        TableId myTable2 = TableId.tableId("default_namespace", "default_schema", "mytable2");
+
+        Schema table1Schema =
+                Schema.newBuilder()
+                        .physicalColumn("id", DataTypes.INT())
+                        .physicalColumn("arr", DataTypes.ARRAY(DataTypes.INT()))
+                        .physicalColumn("mp", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT()))
+                        .physicalColumn("rw", DataTypes.ROW(DataTypes.INT(), DataTypes.STRING()))
+                        .primaryKey("id")
+                        .build();
+
+        Schema table2Schema =
+                Schema.newBuilder()
+                        .physicalColumn("id", DataTypes.INT())
+                        .physicalColumn("arr", DataTypes.STRING())
+                        .physicalColumn("mp", DataTypes.STRING())
+                        .physicalColumn("rw", DataTypes.STRING())
+                        .primaryKey("id")
+                        .build();
+
+        BinaryRecordDataGenerator table1dataGenerator =
+                new BinaryRecordDataGenerator(
+                        table1Schema.getColumnDataTypes().toArray(new DataType[0]));
+        BinaryRecordDataGenerator table2dataGenerator =
+                new BinaryRecordDataGenerator(
+                        table2Schema.getColumnDataTypes().toArray(new DataType[0]));
+
+        List<Event> events = new ArrayList<>();
+        events.add(new CreateTableEvent(myTable1, table1Schema));
+        events.add(new CreateTableEvent(myTable2, table2Schema));
+
+        events.add(
+                DataChangeEvent.insertEvent(
+                        myTable1,
+                        table1dataGenerator.generate(
+                                new Object[] {
+                                    1,
+                                    new GenericArrayData(new int[] {10, 20, 30}),
+                                    new GenericMapData(
+                                            Collections.singletonMap(
+                                                    BinaryStringData.fromString("key"), 42)),
+                                    GenericRecordData.of(7, BinaryStringData.fromString("hello"))
+                                })));
+
+        events.add(
+                DataChangeEvent.insertEvent(
+                        myTable2,
+                        table2dataGenerator.generate(
+                                new Object[] {
+                                    2,
+                                    BinaryStringData.fromString("plain_arr"),
+                                    BinaryStringData.fromString("plain_mp"),
+                                    BinaryStringData.fromString("plain_rw")
+                                })));
+
+        ValuesDataSourceHelper.setSourceEvents(Collections.singletonList(events));
+
+        SourceDef sourceDef =
+                new SourceDef(ValuesDataFactory.IDENTIFIER, "Value Source", sourceConfig);
+
+        Configuration sinkConfig = new Configuration();
+        sinkConfig.set(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY, true);
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
+        SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
+
+        TableId mergedTable = TableId.tableId("default_namespace", "default_schema", "merged");
+        List<RouteDef> routeDef =
+                Collections.singletonList(
+                        new RouteDef(
+                                "default_namespace.default_schema.mytable[0-9]",
+                                mergedTable.toString(),
+                                null,
+                                null));
+
+        Configuration pipelineConfig = new Configuration();
+        pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, 1);
+        pipelineConfig.set(
+                PipelineOptions.PIPELINE_EXECUTION_RUNTIME_MODE, RuntimeExecutionMode.BATCH);
+        PipelineDef pipelineDef =
+                new PipelineDef(
+                        sourceDef,
+                        sinkDef,
+                        routeDef,
+                        Collections.emptyList(),
+                        Collections.emptyList(),
+                        pipelineConfig);
+
+        PipelineExecution execution = composer.compose(pipelineDef);
+        execution.execute();
+        String[] outputEvents = outCaptor.toString().trim().split("\n");
+        assertThat(outputEvents)
+                .containsExactly(
+                        "CreateTableEvent{tableId=default_namespace.default_schema.merged, schema=columns={`id` INT,`arr` STRING,`mp` STRING,`rw` STRING}, primaryKeys=id, options=()}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.merged, before=[], after=[1, [10, 20, 30], {key=42}, [7, hello]], op=INSERT, meta=()}",
+                        "DataChangeEvent{tableId=default_namespace.default_schema.merged, before=[], after=[2, plain_arr, plain_mp, plain_rw], op=INSERT, meta=()}");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This fixes the behavior of nested types (including Array, Map, Row, and Variant) implicitly coerced into String. Array, Map, Row could be merged into String, and any other types could fit into Variant.