### PR TITLE
[FLINK-39492][starrocks] Fix microsecond precision loss for TIMESTAMP types in StarRocks sink

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -137,6 +137,31 @@ public class StarRocksUtils {
     private static final DateTimeFormatter DATETIME_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
+    private static final DateTimeFormatter[] DATETIME_FORMATTERS = new DateTimeFormatter[10];
+
+    private static DateTimeFormatter datetimeFormatter(int precision) {
+        if (precision <= 0) {
+            return DATETIME_FORMATTER;
+        }
+        if (precision < DATETIME_FORMATTERS.length) {
+            DateTimeFormatter formatter = DATETIME_FORMATTERS[precision];
+            if (formatter == null) {
+                formatter =
+                        new DateTimeFormatterBuilder()
+                                .appendPattern("yyyy-MM-dd HH:mm:ss")
+                                .appendFraction(
+                                        ChronoField.NANO_OF_SECOND, precision, precision, true)
+                                .toFormatter();
+                DATETIME_FORMATTERS[precision] = formatter;
+            }
+            return formatter;
+        }
+        return new DateTimeFormatterBuilder()
+                .appendPattern("yyyy-MM-dd HH:mm:ss")
+                .appendFraction(ChronoField.NANO_OF_SECOND, precision, precision, true)
+                .toFormatter();
+    }
+
     /** Format TIME type data. */
     private static final DateTimeFormatter TIME_FORMATTER =
             new DateTimeFormatterBuilder().appendPattern("HH:mm:ss").toFormatter();
@@ -229,22 +254,24 @@ public class StarRocksUtils {
                                         .format(timeFormatter(getPrecision(fieldType)));
                 break;
             case TIMESTAMP_WITHOUT_TIME_ZONE:
+                final int tsPrecision = getPrecision(fieldType);
                 fieldGetter =
                         record ->
-                                record.getTimestamp(fieldPos, getPrecision(fieldType))
+                                record.getTimestamp(fieldPos, tsPrecision)
                                         .toLocalDateTime()
-                                        .format(DATETIME_FORMATTER);
+                                        .format(datetimeFormatter(tsPrecision));
                 break;
             case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                final int ltzPrecision = getPrecision(fieldType);
                 fieldGetter =
                         record ->
                                 ZonedDateTime.ofInstant(
                                                 record.getLocalZonedTimestampData(
-                                                                fieldPos, getPrecision(fieldType))
+                                                                fieldPos, ltzPrecision)
                                                         .toInstant(),
                                                 zoneId)
                                         .toLocalDateTime()
-                                        .format(DATETIME_FORMATTER);
+                                        .format(datetimeFormatter(ltzPrecision));
                 break;
             default:
                 throw new UnsupportedOperationException(

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -40,6 +40,8 @@ import org.apache.flink.cdc.common.types.TinyIntType;
 import org.apache.flink.cdc.common.types.VarBinaryType;
 import org.apache.flink.cdc.common.types.VarCharType;
 
+import org.apache.flink.cdc.common.utils.Preconditions;
+
 import com.starrocks.connector.flink.catalog.StarRocksColumn;
 import com.starrocks.connector.flink.catalog.StarRocksTable;
 
@@ -140,26 +142,25 @@ public class StarRocksUtils {
     private static final DateTimeFormatter[] DATETIME_FORMATTERS = new DateTimeFormatter[10];
 
     private static DateTimeFormatter datetimeFormatter(int precision) {
+        Preconditions.checkArgument(
+                precision < DATETIME_FORMATTERS.length,
+                "Temporal precision %d exceeds the maximum of %d.",
+                precision,
+                DATETIME_FORMATTERS.length - 1);
         if (precision <= 0) {
             return DATETIME_FORMATTER;
         }
-        if (precision < DATETIME_FORMATTERS.length) {
-            DateTimeFormatter formatter = DATETIME_FORMATTERS[precision];
-            if (formatter == null) {
-                formatter =
-                        new DateTimeFormatterBuilder()
-                                .appendPattern("yyyy-MM-dd HH:mm:ss")
-                                .appendFraction(
-                                        ChronoField.NANO_OF_SECOND, precision, precision, true)
-                                .toFormatter();
-                DATETIME_FORMATTERS[precision] = formatter;
-            }
-            return formatter;
+        DateTimeFormatter formatter = DATETIME_FORMATTERS[precision];
+        if (formatter == null) {
+            formatter =
+                    new DateTimeFormatterBuilder()
+                            .appendPattern("yyyy-MM-dd HH:mm:ss")
+                            .appendFraction(
+                                    ChronoField.NANO_OF_SECOND, precision, precision, true)
+                            .toFormatter();
+            DATETIME_FORMATTERS[precision] = formatter;
         }
-        return new DateTimeFormatterBuilder()
-                .appendPattern("yyyy-MM-dd HH:mm:ss")
-                .appendFraction(ChronoField.NANO_OF_SECOND, precision, precision, true)
-                .toFormatter();
+        return formatter;
     }
 
     /** Format TIME type data. */
@@ -169,26 +170,25 @@ public class StarRocksUtils {
     private static final DateTimeFormatter[] TIME_FORMATTERS = new DateTimeFormatter[10];
 
     private static DateTimeFormatter timeFormatter(int precision) {
+        Preconditions.checkArgument(
+                precision < TIME_FORMATTERS.length,
+                "Temporal precision %d exceeds the maximum of %d.",
+                precision,
+                TIME_FORMATTERS.length - 1);
         if (precision <= 0) {
             return TIME_FORMATTER;
         }
-        if (precision < TIME_FORMATTERS.length) {
-            DateTimeFormatter formatter = TIME_FORMATTERS[precision];
-            if (formatter == null) {
-                formatter =
-                        new DateTimeFormatterBuilder()
-                                .appendPattern("HH:mm:ss")
-                                .appendFraction(
-                                        ChronoField.NANO_OF_SECOND, precision, precision, true)
-                                .toFormatter();
-                TIME_FORMATTERS[precision] = formatter;
-            }
-            return formatter;
+        DateTimeFormatter formatter = TIME_FORMATTERS[precision];
+        if (formatter == null) {
+            formatter =
+                    new DateTimeFormatterBuilder()
+                            .appendPattern("HH:mm:ss")
+                            .appendFraction(
+                                    ChronoField.NANO_OF_SECOND, precision, precision, true)
+                            .toFormatter();
+            TIME_FORMATTERS[precision] = formatter;
         }
-        return new DateTimeFormatterBuilder()
-                .appendPattern("HH:mm:ss")
-                .appendFraction(ChronoField.NANO_OF_SECOND, precision, precision, true)
-                .toFormatter();
+        return formatter;
     }
 
     /**

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/EventRecordSerializationSchemaTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/EventRecordSerializationSchemaTest.java
@@ -139,7 +139,7 @@ class EventRecordSerializationSchemaTest {
                                 }));
         verifySerializeResult(
                 table1,
-                "{\"col1\":1,\"col2\":true,\"col3\":\"2023-11-27 18:00:00\",\"__op\":0}",
+                "{\"col1\":1,\"col2\":true,\"col3\":\"2023-11-27 18:00:00.000000\",\"__op\":0}",
                 serializer.serialize(insertEvent1));
 
         DataChangeEvent deleteEvent1 =
@@ -154,7 +154,7 @@ class EventRecordSerializationSchemaTest {
                                 }));
         verifySerializeResult(
                 table1,
-                "{\"col1\":2,\"col2\":false,\"col3\":\"2023-11-27 19:00:00\",\"__op\":1}",
+                "{\"col1\":2,\"col2\":false,\"col3\":\"2023-11-27 19:00:00.000000\",\"__op\":1}",
                 serializer.serialize(deleteEvent1));
 
         DataChangeEvent updateEvent1 =
@@ -176,7 +176,7 @@ class EventRecordSerializationSchemaTest {
                                 }));
         verifySerializeResult(
                 table1,
-                "{\"col1\":3,\"col2\":true,\"col3\":\"2023-11-27 21:00:00\",\"__op\":0}",
+                "{\"col1\":3,\"col2\":true,\"col3\":\"2023-11-27 21:00:00.000000\",\"__op\":0}",
                 serializer.serialize(updateEvent1));
 
         // 2. create table2, and insert data
@@ -243,7 +243,7 @@ class EventRecordSerializationSchemaTest {
                                 }));
         verifySerializeResult(
                 table1,
-                "{\"col1\":4,\"col2\":true,\"col3\":\"2023-11-27 21:00:00\",\"col4\":83.23,\"col5\":9,\"col6\":\"2023-11-27 19:00:00\",\"__op\":1}",
+                "{\"col1\":4,\"col2\":true,\"col3\":\"2023-11-27 21:00:00.000000\",\"col4\":83.23,\"col5\":9,\"col6\":\"2023-11-27 19:00:00.000000\",\"__op\":1}",
                 Objects.requireNonNull(serializer.serialize(deleteEvent2)));
 
         // 4. drop columns from table2, and insert data

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksPipelineITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksPipelineITCase.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.data.LocalZonedTimestampData;
+import org.apache.flink.cdc.common.data.TimestampData;
 import org.apache.flink.cdc.common.data.binary.BinaryStringData;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DataChangeEvent;
@@ -44,7 +45,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.cdc.connectors.starrocks.sink.StarRocksDataSinkOptions.JDBC_URL;
@@ -217,5 +221,142 @@ class StarRocksPipelineITCase extends StarRocksSinkTestBase {
                         "21 | 1.732 | Disenchanted | 2023-01-01 00:00:00.0");
 
         assertEqualsInAnyOrder(expected, actual);
+    }
+
+    @Test
+    void testTimestampPrecisionToStarRocks() throws Exception {
+        String precisionTable = "timestamp_precision_table";
+        TableId tableId =
+                TableId.tableId(StarRocksContainer.STARROCKS_DATABASE_NAME, precisionTable);
+
+        executeSql(
+                String.format(
+                        "CREATE TABLE `%s`.`%s` ("
+                                + "id INT NOT NULL, "
+                                + "ts3 DATETIME, "
+                                + "ts6 DATETIME"
+                                + ") PRIMARY KEY (`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 1"
+                                + " PROPERTIES (\"replication_num\" = \"1\");",
+                        StarRocksContainer.STARROCKS_DATABASE_NAME, precisionTable));
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT(), null))
+                        .column(new PhysicalColumn("ts3", DataTypes.TIMESTAMP(3), null))
+                        .column(new PhysicalColumn("ts6", DataTypes.TIMESTAMP(6), null))
+                        .primaryKey("id")
+                        .build();
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(
+                        RowType.of(
+                                DataTypes.INT(), DataTypes.TIMESTAMP(3), DataTypes.TIMESTAMP(6)));
+
+        LocalDateTime dt3 = LocalDateTime.of(2026, 3, 27, 15, 20, 29, 123_000_000);
+        LocalDateTime dt6 = LocalDateTime.of(2026, 3, 27, 15, 20, 29, 921_550_000);
+
+        List<Event> events =
+                Arrays.asList(
+                        new CreateTableEvent(tableId, schema),
+                        DataChangeEvent.insertEvent(
+                                tableId,
+                                generator.generate(
+                                        new Object[] {
+                                            1,
+                                            TimestampData.fromLocalDateTime(dt3),
+                                            TimestampData.fromLocalDateTime(dt6)
+                                        })));
+
+        DataStream<Event> stream =
+                env.fromCollection(events, TypeInformation.of(Event.class));
+
+        Configuration config =
+                new Configuration()
+                        .set(LOAD_URL, STARROCKS_CONTAINER.getLoadUrl())
+                        .set(JDBC_URL, STARROCKS_CONTAINER.getJdbcUrl())
+                        .set(USERNAME, StarRocksContainer.STARROCKS_USERNAME)
+                        .set(PASSWORD, StarRocksContainer.STARROCKS_PASSWORD);
+
+        Sink<Event> starRocksSink =
+                ((FlinkSinkProvider) createStarRocksDataSink(config).getEventSinkProvider())
+                        .getSink();
+        stream.sinkTo(starRocksSink);
+
+        env.execute("Timestamp Precision to StarRocks Sink");
+
+        List<String> actual = fetchTableContent(tableId, 3);
+        assertEqualsInAnyOrder(
+                Collections.singletonList("1 | 2026-03-27 15:20:29.123 | 2026-03-27 15:20:29.92155"),
+                actual);
+
+        executeSql(
+                String.format(
+                        "DROP TABLE `%s`.`%s`;",
+                        StarRocksContainer.STARROCKS_DATABASE_NAME, precisionTable));
+    }
+
+    @Test
+    void testLocalZonedTimestampPrecisionToStarRocks() throws Exception {
+        String precisionTable = "ltz_precision_table";
+        TableId tableId =
+                TableId.tableId(StarRocksContainer.STARROCKS_DATABASE_NAME, precisionTable);
+
+        executeSql(
+                String.format(
+                        "CREATE TABLE `%s`.`%s` ("
+                                + "id INT NOT NULL, "
+                                + "ts6 DATETIME"
+                                + ") PRIMARY KEY (`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 1"
+                                + " PROPERTIES (\"replication_num\" = \"1\");",
+                        StarRocksContainer.STARROCKS_DATABASE_NAME, precisionTable));
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT(), null))
+                        .column(new PhysicalColumn("ts6", DataTypes.TIMESTAMP_LTZ(6), null))
+                        .primaryKey("id")
+                        .build();
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(
+                        RowType.of(DataTypes.INT(), DataTypes.TIMESTAMP_LTZ(6)));
+
+        // UTC 07:20:29.921550 -> stored as-is (pipeline local-time-zone is UTC in MockContext)
+        Instant instant =
+                LocalDateTime.of(2026, 3, 27, 7, 20, 29, 921_550_000).toInstant(ZoneOffset.UTC);
+
+        List<Event> events =
+                Arrays.asList(
+                        new CreateTableEvent(tableId, schema),
+                        DataChangeEvent.insertEvent(
+                                tableId,
+                                generator.generate(
+                                        new Object[] {
+                                            1, LocalZonedTimestampData.fromInstant(instant)
+                                        })));
+
+        DataStream<Event> stream =
+                env.fromCollection(events, TypeInformation.of(Event.class));
+
+        Configuration config =
+                new Configuration()
+                        .set(LOAD_URL, STARROCKS_CONTAINER.getLoadUrl())
+                        .set(JDBC_URL, STARROCKS_CONTAINER.getJdbcUrl())
+                        .set(USERNAME, StarRocksContainer.STARROCKS_USERNAME)
+                        .set(PASSWORD, StarRocksContainer.STARROCKS_PASSWORD);
+
+        Sink<Event> starRocksSink =
+                ((FlinkSinkProvider) createStarRocksDataSink(config).getEventSinkProvider())
+                        .getSink();
+        stream.sinkTo(starRocksSink);
+
+        env.execute("LocalZonedTimestamp Precision to StarRocks Sink");
+
+        List<String> actual = fetchTableContent(tableId, 2);
+        assertEqualsInAnyOrder(
+                Collections.singletonList("1 | 2026-03-27 07:20:29.92155"), actual);
+
+        executeSql(
+                String.format(
+                        "DROP TABLE `%s`.`%s`;",
+                        StarRocksContainer.STARROCKS_DATABASE_NAME, precisionTable));
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtilsTest.java
@@ -395,12 +395,12 @@ class StarRocksUtilsTest {
 
     @Test
     void testCreateFieldGetterTimestamp() {
-        // Timestamp field getter should format output as "yyyy-MM-dd HH:mm:ss"
+        // Timestamp with precision 0 should format as "yyyy-MM-dd HH:mm:ss"
         RecordData.FieldGetter getter =
-                StarRocksUtils.createFieldGetter(new TimestampType(3), 0, ZoneId.of("UTC"));
+                StarRocksUtils.createFieldGetter(new TimestampType(0), 0, ZoneId.of("UTC"));
 
         BinaryRecordDataGenerator generator =
-                new BinaryRecordDataGenerator(new DataType[] {new TimestampType(3)});
+                new BinaryRecordDataGenerator(new DataType[] {new TimestampType(0)});
         BinaryRecordData record =
                 generator.generate(
                         new Object[] {
@@ -411,8 +411,58 @@ class StarRocksUtilsTest {
     }
 
     @Test
+    void testCreateFieldGetterTimestampWithPrecision() {
+        // Timestamp with precision 6 should preserve microseconds
+        RecordData.FieldGetter getter =
+                StarRocksUtils.createFieldGetter(new TimestampType(6), 0, ZoneId.of("UTC"));
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(new DataType[] {new TimestampType(6)});
+        LocalDateTime dateTime = LocalDateTime.of(2026, 3, 27, 15, 20, 29, 921550000);
+        BinaryRecordData record =
+                generator.generate(
+                        new Object[] {TimestampData.fromLocalDateTime(dateTime)});
+        assertThat(getter.getFieldOrNull(record)).isEqualTo("2026-03-27 15:20:29.921550");
+    }
+
+    @Test
+    void testCreateFieldGetterTimestampWithPrecision3() {
+        // Timestamp with precision 3 should preserve milliseconds
+        RecordData.FieldGetter getter =
+                StarRocksUtils.createFieldGetter(new TimestampType(3), 0, ZoneId.of("UTC"));
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(new DataType[] {new TimestampType(3)});
+        LocalDateTime dateTime = LocalDateTime.of(2024, 1, 15, 10, 30, 0, 123000000);
+        BinaryRecordData record =
+                generator.generate(
+                        new Object[] {TimestampData.fromLocalDateTime(dateTime)});
+        assertThat(getter.getFieldOrNull(record)).isEqualTo("2024-01-15 10:30:00.123");
+    }
+
+    @Test
     void testCreateFieldGetterLocalZonedTimestamp() {
-        // LocalZonedTimestamp field getter should convert to the specified zone
+        // LocalZonedTimestamp with precision 0 should convert to the specified zone
+        ZoneId zoneId = ZoneId.of("Asia/Shanghai");
+        RecordData.FieldGetter getter =
+                StarRocksUtils.createFieldGetter(new LocalZonedTimestampType(0), 0, zoneId);
+
+        BinaryRecordDataGenerator generator =
+                new BinaryRecordDataGenerator(new DataType[] {new LocalZonedTimestampType(0)});
+        BinaryRecordData record =
+                generator.generate(
+                        new Object[] {
+                            LocalZonedTimestampData.fromInstant(
+                                    LocalDateTime.of(2024, 1, 15, 10, 30, 0)
+                                            .toInstant(ZoneOffset.UTC))
+                        });
+        // UTC 10:30 -> Asia/Shanghai 18:30
+        assertThat(getter.getFieldOrNull(record)).isEqualTo("2024-01-15 18:30:00");
+    }
+
+    @Test
+    void testCreateFieldGetterLocalZonedTimestampWithPrecision() {
+        // LocalZonedTimestamp with precision 6 should preserve microseconds
         ZoneId zoneId = ZoneId.of("Asia/Shanghai");
         RecordData.FieldGetter getter =
                 StarRocksUtils.createFieldGetter(new LocalZonedTimestampType(6), 0, zoneId);
@@ -423,11 +473,11 @@ class StarRocksUtilsTest {
                 generator.generate(
                         new Object[] {
                             LocalZonedTimestampData.fromInstant(
-                                    LocalDateTime.of(2024, 1, 15, 10, 30, 0)
+                                    LocalDateTime.of(2026, 3, 27, 7, 20, 29, 921550000)
                                             .toInstant(ZoneOffset.UTC))
                         });
-        // UTC 10:30 -> Asia/Shanghai 18:30
-        assertThat(getter.getFieldOrNull(record)).isEqualTo("2024-01-15 18:30:00");
+        // UTC 07:20:29.921550 -> Asia/Shanghai 15:20:29.921550
+        assertThat(getter.getFieldOrNull(record)).isEqualTo("2026-03-27 15:20:29.921550");
     }
 
     @Test


### PR DESCRIPTION
  TIMESTAMP_WITHOUT_TIME_ZONE and TIMESTAMP_WITH_LOCAL_TIME_ZONE fields were
  serialized using a hardcoded "yyyy-MM-dd HH:mm:ss" formatter, silently
  dropping sub-second precision regardless of the declared column precision.

  Add datetimeFormatter(int precision), mirroring the existing timeFormatter,
  which appends fractional seconds only when precision > 0. The formatter
  instances are cached per precision to avoid repeated allocation.

  For StarRocks < 3.1, the fractional part is truncated by the server on
  ingestion — no behavioral regression. For StarRocks >= 3.1 (which supports
  microsecond DATETIME storage), full precision is now preserved end-to-end.