### PR TITLE
[FLINK-39383][Docs] Improve scan.incremental.snapshot.chunk.key-column documentation for MySQL/PostgreSQL/Oracle/DB2/SQLServer connectors

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/db2-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/db2-cdc.md
@@ -240,8 +240,13 @@ for more detailed information.</td>
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.</td>
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
+            <br>
+            <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
+          </td>
     </tr>
     <tr>
       <td>debezium.*</td>

--- a/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
@@ -273,9 +273,6 @@ Flink SQL> SELECT * FROM orders;
               对于<b>无主键表</b>，此选项为<b>必填项</b>，且指定列必须为 <code>NOT NULL</code>。
               可以使用非主键列作为分片键，但这可能会导致查询性能下降。
               <br>
-              在 Pipeline 连接器中，可使用 <code>&lt;table-pattern&gt;:&lt;column&gt;</code> 格式为多张表分别指定分片键，多个配置之间用分号（<code>;</code>）分隔。
-              例如：<code>db1.table_[0-9]+:col1;db2.orders:col2</code>。
-              <br>
               <b>警告：</b> 使用非主键列作为分片键可能会导致数据不一致。请参阅 <a href="#警告">警告</a> 了解详细信息。
           </td>
     </tr>

--- a/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
@@ -268,10 +268,15 @@ Flink SQL> SELECT * FROM orders;
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>表快照的分片键，在读取表的快照时，被捕获的表会按分片键拆分为多个分片。  
-              默认情况下，分片键是主键的第一列。可以使用非主键列作为分片键，但这可能会导致查询性能下降。  
-              <br>  
-              <b>警告：</b> 使用非主键列作为分片键可能会导致数据不一致。请参阅 <a href="#警告">警告</a> 了解详细信息。  
+          <td>表快照的分片键列，用于将表快照拆分为多个分片。
+              默认情况下，分片键是主键的第一列。
+              对于<b>无主键表</b>，此选项为<b>必填项</b>，且指定列必须为 <code>NOT NULL</code>。
+              可以使用非主键列作为分片键，但这可能会导致查询性能下降。
+              <br>
+              在 Pipeline 连接器中，可使用 <code>&lt;table-pattern&gt;:&lt;column&gt;</code> 格式为多张表分别指定分片键，多个配置之间用分号（<code>;</code>）分隔。
+              例如：<code>db1.table_[0-9]+:col1;db2.orders:col2</code>。
+              <br>
+              <b>警告：</b> 使用非主键列作为分片键可能会导致数据不一致。请参阅 <a href="#警告">警告</a> 了解详细信息。
           </td>
     </tr>
     <tr>

--- a/docs/content.zh/docs/connectors/flink-sources/oracle-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/oracle-cdc.md
@@ -427,8 +427,9 @@ Connector Options
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
           <td>The chunk key column used to split table snapshots into chunks.
-            By default, the chunk key is <code>ROWID</code>. A non-primary-key column can be used, but this may lead to slower query performance.
+            By default, the chunk key is <code>ROWID</code>.
             For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content.zh/docs/connectors/flink-sources/oracle-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/oracle-cdc.md
@@ -426,8 +426,9 @@ Connector Options
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is 'ROWID'. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is <code>ROWID</code>. A non-primary-key column can be used, but this may lead to slower query performance.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content.zh/docs/connectors/flink-sources/postgres-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/postgres-cdc.md
@@ -378,8 +378,10 @@ The following options is available only when `scan.incremental.snapshot.enabled=
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content.zh/docs/connectors/flink-sources/sqlserver-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/sqlserver-cdc.md
@@ -235,8 +235,10 @@ Connector Options
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content.zh/docs/connectors/pipeline-connectors/mysql.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/mysql.md
@@ -167,6 +167,20 @@ pipeline:
       <td>表快照的块大小（行数），读取表的快照时，捕获的表被拆分为多个块。</td>
     </tr>
     <tr>
+      <td>scan.incremental.snapshot.chunk.key-column</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>用于将表快照拆分为多个分片的分片键列。
+        默认情况下，分片键是主键的第一列。
+        对于<b>无主键表</b>，此选项为<b>必填项</b>，且指定列必须为 <code>NOT NULL</code>。
+        可以使用非主键列作为分片键，但这可能会导致查询性能下降。
+        <br>
+        可使用 <code>&lt;table-pattern&gt;:&lt;column&gt;</code> 格式为多张表分别指定分片键，多个配置之间用分号（<code>;</code>）分隔。
+        例如：<code>db1.table_[0-9]+:col1;db2.orders:col2</code>。
+      </td>
+    </tr>
+    <tr>
       <td>scan.snapshot.fetch.size</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">1024</td>

--- a/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
@@ -166,6 +166,8 @@ pipeline:
         可以使用非主键列作为分片键，但这可能会导致查询性能下降。
       </td>
     </tr>
+    <tr>
+      <td>scan.snapshot.fetch.size</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">1024</td>
       <td>Integer</td>

--- a/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/postgres.md
@@ -156,7 +156,16 @@ pipeline:
       <td>表快照的块大小（行数），读取表的快照时，捕获的表被拆分为多个块。</td>
     </tr>
     <tr>
-      <td>scan.snapshot.fetch.size</td>
+      <td>scan.incremental.snapshot.chunk.key-column</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>用于将表快照拆分为多个分片的分片键列。
+        默认情况下，分片键是主键的第一列。
+        对于<b>无主键表</b>，此选项为<b>必填项</b>，且指定列必须为 <code>NOT NULL</code>。
+        可以使用非主键列作为分片键，但这可能会导致查询性能下降。
+      </td>
+    </tr>
       <td>optional</td>
       <td style="word-wrap: break-word;">1024</td>
       <td>Integer</td>

--- a/docs/content/docs/connectors/flink-sources/db2-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/db2-cdc.md
@@ -240,8 +240,13 @@ for more detailed information.</td>
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.</td>
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
+            <br>
+            <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
+          </td>
     </tr>
     <tr>
       <td>debezium.*</td>

--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -267,14 +267,10 @@ Connector Options
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key column(s) used to split table snapshots into chunks.
+          <td>The chunk key column used to split table snapshots into chunks.
             By default, the chunk key is the first column of the primary key.
             For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
             A non-primary-key column can be used, but this may lead to slower query performance.
-            <br>
-            For the pipeline connector, multiple tables can be assigned different chunk keys using the format
-            <code>&lt;table-pattern&gt;:&lt;column&gt;</code>, with entries separated by semicolons (<code>;</code>).
-            For example: <code>db1.table_[0-9]+:col1;db2.orders:col2</code>.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -267,8 +267,14 @@ Connector Options
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
+          <td>The chunk key column(s) used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
+            <br>
+            For the pipeline connector, multiple tables can be assigned different chunk keys using the format
+            <code>&lt;table-pattern&gt;:&lt;column&gt;</code>, with entries separated by semicolons (<code>;</code>).
+            For example: <code>db1.table_[0-9]+:col1;db2.orders:col2</code>.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content/docs/connectors/flink-sources/oracle-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/oracle-cdc.md
@@ -428,8 +428,9 @@ Connector Options
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
           <td>The chunk key column used to split table snapshots into chunks.
-            By default, the chunk key is <code>ROWID</code>. A non-primary-key column can be used, but this may lead to slower query performance.
+            By default, the chunk key is <code>ROWID</code>.
             For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content/docs/connectors/flink-sources/oracle-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/oracle-cdc.md
@@ -427,8 +427,9 @@ Connector Options
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is 'ROWID'. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is <code>ROWID</code>. A non-primary-key column can be used, but this may lead to slower query performance.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content/docs/connectors/flink-sources/postgres-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/postgres-cdc.md
@@ -375,9 +375,11 @@ The following options is available only when `scan.incremental.snapshot.enabled=
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
-          <br>
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
+            <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>
     </tr>

--- a/docs/content/docs/connectors/flink-sources/sqlserver-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/sqlserver-cdc.md
@@ -235,8 +235,10 @@ Connector Options
           <td>optional</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>String</td>
-          <td>The chunk key of table snapshot, captured tables are split into multiple chunks by a chunk key when read the snapshot of table.
-            By default, the chunk key is the first column of the primary key. A column that is not part of the primary key can be used as a chunk key, but this may lead to slower query performance.
+          <td>The chunk key column used to split table snapshots into chunks.
+            By default, the chunk key is the first column of the primary key.
+            For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+            A non-primary-key column can be used, but this may lead to slower query performance.
             <br>
             <b>Warning:</b> Using a non-primary key column as a chunk key may lead to data inconsistencies. Please see <a href="#warning">Warning</a> for details.
           </td>

--- a/docs/content/docs/connectors/pipeline-connectors/mysql.md
+++ b/docs/content/docs/connectors/pipeline-connectors/mysql.md
@@ -171,6 +171,21 @@ pipeline:
       <td>The chunk size (number of rows) of table snapshot, captured tables are split into multiple chunks when read the snapshot of table.</td>
     </tr>
     <tr>
+      <td>scan.incremental.snapshot.chunk.key-column</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>The chunk key column(s) used to split table snapshots into chunks.
+        By default, the chunk key is the first column of the primary key.
+        For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+        A non-primary-key column can be used, but this may lead to slower query performance.
+        <br>
+        Multiple tables can be assigned different chunk keys using the format <code>&lt;table-pattern&gt;:&lt;column&gt;</code>,
+        with entries separated by semicolons (<code>;</code>).
+        For example: <code>db1.table_[0-9]+:col1;db2.orders:col2</code>.
+      </td>
+    </tr>
+    <tr>
       <td>scan.snapshot.fetch.size</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">1024</td>

--- a/docs/content/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content/docs/connectors/pipeline-connectors/postgres.md
@@ -166,6 +166,8 @@ pipeline:
         A non-primary-key column can be used, but this may lead to slower query performance.
       </td>
     </tr>
+    <tr>
+      <td>scan.snapshot.fetch.size</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">1024</td>
       <td>Integer</td>

--- a/docs/content/docs/connectors/pipeline-connectors/postgres.md
+++ b/docs/content/docs/connectors/pipeline-connectors/postgres.md
@@ -156,7 +156,16 @@ pipeline:
       <td>The chunk size (number of rows) of table snapshot, captured tables are split into multiple chunks when read the snapshot of table.</td>
     </tr>
     <tr>
-      <td>scan.snapshot.fetch.size</td>
+      <td>scan.incremental.snapshot.chunk.key-column</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>String</td>
+      <td>The chunk key column used to split table snapshots into chunks.
+        By default, the chunk key is the first column of the primary key.
+        For tables <b>without a primary key</b>, this option is <b>required</b> and the specified column must be <code>NOT NULL</code>.
+        A non-primary-key column can be used, but this may lead to slower query performance.
+      </td>
+    </tr>
       <td>optional</td>
       <td style="word-wrap: break-word;">1024</td>
       <td>Integer</td>


### PR DESCRIPTION
The `scan.incremental.snapshot.chunk.key-column` option had several gaps
  and inaccuracies in its documentation across multiple connectors:

1. NOT NULL / no-primary-key constraint was undocumented.
The option is required when a captured table has no primary key and the chosen column must be NOT NULL. None of the connector docs mentioned this.

2. Multi-table format was undocumented (MySQL).
The MySQL connector supports `<table-pattern>:<column>[;...]` for assigning different chunk key columns to different tables. This was not documented in either the flink-source or pipeline connector docs.

3. Option was entirely missing from PostgreSQL pipeline connector docs. 

4. Stale option description wording across all connectors.