### PR TITLE
[FLINK-39478][mysql] Persist checkpointIdToFinish and expose enumerat or metrics

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlHybridSplitAssigner.java
@@ -183,6 +183,31 @@ public class MySqlHybridSplitAssigner implements MySqlSplitAssigner {
     }
 
     @Override
+    public int getRemainingSplitsCount() {
+        return snapshotSplitAssigner.getRemainingSplitsCount();
+    }
+
+    @Override
+    public int getRemainingTablesCount() {
+        return snapshotSplitAssigner.getRemainingTablesCount();
+    }
+
+    @Override
+    public int getAssignedSplitsCount() {
+        return snapshotSplitAssigner.getAssignedSplitsCount();
+    }
+
+    @Override
+    public int getFinishedSplitsCount() {
+        return snapshotSplitAssigner.getFinishedSplitsCount();
+    }
+
+    @Override
+    public int getAlreadyProcessedTablesCount() {
+        return snapshotSplitAssigner.getAlreadyProcessedTablesCount();
+    }
+
+    @Override
     public boolean noMoreSplits() {
         return snapshotSplitAssigner.noMoreSplits() && isBinlogSplitAssigned;
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -127,6 +127,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 isTableIdCaseSensitive,
                 true,
                 ChunkSplitterState.NO_SPLITTING_TABLE_STATE,
+                null,
                 enumeratorContext);
     }
 
@@ -148,6 +149,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                 checkpoint.isTableIdCaseSensitive(),
                 checkpoint.isRemainingTablesCheckpointed(),
                 checkpoint.getChunkSplitterState(),
+                checkpoint.getCheckpointIdToFinish(),
                 enumeratorContext);
     }
 
@@ -164,6 +166,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
             boolean isTableIdCaseSensitive,
             boolean isRemainingTablesCheckpointed,
             ChunkSplitterState chunkSplitterState,
+            @Nullable Long checkpointIdToFinish,
             SplitEnumeratorContext<MySqlSplit> enumeratorContext) {
         this.sourceConfig = sourceConfig;
         this.currentParallelism = currentParallelism;
@@ -181,6 +184,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
         this.partition =
                 new MySqlPartition(sourceConfig.getMySqlConnectorConfig().getLogicalName());
         this.enumeratorContext = enumeratorContext;
+        this.checkpointIdToFinish = checkpointIdToFinish;
     }
 
     @Override
@@ -451,26 +455,28 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
 
     @Override
     public SnapshotPendingSplitsState snapshotState(long checkpointId) {
-        SnapshotPendingSplitsState state =
-                new SnapshotPendingSplitsState(
-                        alreadyProcessedTables,
-                        remainingSplits,
-                        assignedSplits,
-                        tableSchemas,
-                        splitFinishedOffsets,
-                        assignerStatus,
-                        remainingTables,
-                        isTableIdCaseSensitive,
-                        true,
-                        chunkSplitter.snapshotState(checkpointId));
-        // we need a complete checkpoint before mark this assigner to be finished, to wait for
-        // all records of snapshot splits are completely processed
+        // We need a complete checkpoint before marking this assigner as finished, to wait for
+        // all records of snapshot splits to be completely processed. Set checkpointIdToFinish
+        // *before* building the state so it is included in this checkpoint — otherwise it would
+        // be lost on restore and would need two more checkpoint cycles to be re-derived
+        // (FLINK-39478).
         if (checkpointIdToFinish == null
                 && AssignerStatus.isAssigningSnapshotSplits(assignerStatus)
                 && allSnapshotSplitsFinished()) {
             checkpointIdToFinish = checkpointId;
         }
-        return state;
+        return new SnapshotPendingSplitsState(
+                alreadyProcessedTables,
+                remainingSplits,
+                assignedSplits,
+                tableSchemas,
+                splitFinishedOffsets,
+                assignerStatus,
+                remainingTables,
+                isTableIdCaseSensitive,
+                true,
+                chunkSplitter.snapshotState(checkpointId),
+                checkpointIdToFinish);
     }
 
     @Override
@@ -569,6 +575,31 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
 
     public Map<String, BinlogOffset> getSplitFinishedOffsets() {
         return splitFinishedOffsets;
+    }
+
+    @Override
+    public int getRemainingSplitsCount() {
+        return remainingSplits.size();
+    }
+
+    @Override
+    public int getRemainingTablesCount() {
+        return remainingTables.size();
+    }
+
+    @Override
+    public int getAssignedSplitsCount() {
+        return assignedSplits.size();
+    }
+
+    @Override
+    public int getFinishedSplitsCount() {
+        return splitFinishedOffsets.size();
+    }
+
+    @Override
+    public int getAlreadyProcessedTablesCount() {
+        return alreadyProcessedTables.size();
     }
 
     // -------------------------------------------------------------------------------------------

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/MySqlSplitAssigner.java
@@ -106,6 +106,46 @@ public interface MySqlSplitAssigner extends Closeable {
     /** Gets the split assigner status, see {@code AssignerStatus}. */
     AssignerStatus getAssignerStatus();
 
+    /**
+     * Returns the number of snapshot splits split but not yet handed out to readers. Used for
+     * metrics; defaults to {@code 0} for assigners that don't track snapshot splits.
+     */
+    default int getRemainingSplitsCount() {
+        return 0;
+    }
+
+    /**
+     * Returns the number of tables yet to be split into snapshot chunks. Used for metrics; defaults
+     * to {@code 0} for assigners that don't track snapshot splits.
+     */
+    default int getRemainingTablesCount() {
+        return 0;
+    }
+
+    /**
+     * Returns the number of snapshot splits that have been handed out to readers. Used for metrics;
+     * defaults to {@code 0} for assigners that don't track snapshot splits.
+     */
+    default int getAssignedSplitsCount() {
+        return 0;
+    }
+
+    /**
+     * Returns the number of snapshot splits that readers have reported as finished. Used for
+     * metrics; defaults to {@code 0} for assigners that don't track snapshot splits.
+     */
+    default int getFinishedSplitsCount() {
+        return 0;
+    }
+
+    /**
+     * Returns the number of tables that have been fully snapshotted at least once. Used for
+     * metrics; defaults to {@code 0} for assigners that don't track snapshot splits.
+     */
+    default int getAlreadyProcessedTablesCount() {
+        return 0;
+    }
+
     /** Starts assign newly added tables. */
     void startAssignNewlyAddedTables();
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializer.java
@@ -46,7 +46,10 @@ import java.util.Map;
 public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<PendingSplitsState> {
 
     // TODO: need proper implementation of the new version
-    private static final int VERSION = 5;
+    // Version 6 adds the optional checkpointIdToFinish field to SnapshotPendingSplitsState so the
+    // assigner can transition out of *_ASSIGNING after restore without waiting two additional
+    // checkpoint cycles (see FLINK-39478).
+    private static final int VERSION = 6;
     private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
             ThreadLocal.withInitial(() -> new DataOutputSerializer(64));
 
@@ -110,6 +113,7 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
             case 3:
             case 4:
             case 5:
+            case 6:
                 return deserializePendingSplitsState(version, serialized);
             default:
                 throw new IOException("Unknown version: " + version);
@@ -175,6 +179,12 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
                     SerializerUtils.rowToSerializedString(
                             new Object[] {chunkSplitterState.getNextChunkStart().getValue()}));
             out.writeInt(chunkSplitterState.getNextChunkId());
+        }
+
+        Long checkpointIdToFinish = state.getCheckpointIdToFinish();
+        out.writeBoolean(checkpointIdToFinish != null);
+        if (checkpointIdToFinish != null) {
+            out.writeLong(checkpointIdToFinish);
         }
     }
 
@@ -299,6 +309,15 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
                 nextChunkId = in.readInt();
             }
         }
+
+        Long checkpointIdToFinish = null;
+        if (version >= 6) {
+            boolean hasCheckpointIdToFinish = in.readBoolean();
+            if (hasCheckpointIdToFinish) {
+                checkpointIdToFinish = in.readLong();
+            }
+        }
+
         return new SnapshotPendingSplitsState(
                 alreadyProcessedTables,
                 remainingSchemalessSplits,
@@ -314,7 +333,8 @@ public class PendingSplitsStateSerializer implements SimpleVersionedSerializer<P
                         : new ChunkSplitterState(
                                 splittingTableId,
                                 ChunkSplitterState.ChunkBound.middleOf(nextChunkStart),
-                                nextChunkId));
+                                nextChunkId),
+                checkpointIdToFinish);
     }
 
     private HybridPendingSplitsState deserializeHybridPendingSplitsState(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/SnapshotPendingSplitsState.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/SnapshotPendingSplitsState.java
@@ -27,6 +27,8 @@ import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSchemalessSnapsho
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.TableChanges.TableChange;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -75,6 +77,14 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
     /** The data structure to record the state of a {@link ChunkSplitter}. */
     private final ChunkSplitterState chunkSplitterState;
 
+    /**
+     * The checkpoint id that, once completed, allows the assigner to transition out of an {@code
+     * *_ASSIGNING} status after all snapshot splits have finished. Persisted across restores so the
+     * state machine can advance without waiting for two additional checkpoint cycles to re-derive
+     * it. {@code null} when the assigner has not yet observed "all snapshot splits finished".
+     */
+    @Nullable private final Long checkpointIdToFinish;
+
     public SnapshotPendingSplitsState(
             List<TableId> alreadyProcessedTables,
             List<MySqlSchemalessSnapshotSplit> remainingSplits,
@@ -86,6 +96,32 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
             boolean isTableIdCaseSensitive,
             boolean isRemainingTablesCheckpointed,
             ChunkSplitterState chunkSplitterState) {
+        this(
+                alreadyProcessedTables,
+                remainingSplits,
+                assignedSplits,
+                tableSchemas,
+                splitFinishedOffsets,
+                assignerStatus,
+                remainingTables,
+                isTableIdCaseSensitive,
+                isRemainingTablesCheckpointed,
+                chunkSplitterState,
+                null);
+    }
+
+    public SnapshotPendingSplitsState(
+            List<TableId> alreadyProcessedTables,
+            List<MySqlSchemalessSnapshotSplit> remainingSplits,
+            LinkedHashMap<String, MySqlSchemalessSnapshotSplit> assignedSplits,
+            Map<TableId, TableChange> tableSchemas,
+            Map<String, BinlogOffset> splitFinishedOffsets,
+            AssignerStatus assignerStatus,
+            List<TableId> remainingTables,
+            boolean isTableIdCaseSensitive,
+            boolean isRemainingTablesCheckpointed,
+            ChunkSplitterState chunkSplitterState,
+            @Nullable Long checkpointIdToFinish) {
         // FLINK-38061: make defensive copy to avoid potential concurrent modification of the
         // collections.
         this.alreadyProcessedTables = new ArrayList<>(alreadyProcessedTables);
@@ -98,6 +134,7 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         this.isRemainingTablesCheckpointed = isRemainingTablesCheckpointed;
         this.tableSchemas = new HashMap<>(tableSchemas);
         this.chunkSplitterState = chunkSplitterState;
+        this.checkpointIdToFinish = checkpointIdToFinish;
     }
 
     public List<TableId> getAlreadyProcessedTables() {
@@ -140,6 +177,11 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
         return chunkSplitterState;
     }
 
+    @Nullable
+    public Long getCheckpointIdToFinish() {
+        return checkpointIdToFinish;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -157,7 +199,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 && Objects.equals(remainingSplits, that.remainingSplits)
                 && Objects.equals(assignedSplits, that.assignedSplits)
                 && Objects.equals(splitFinishedOffsets, that.splitFinishedOffsets)
-                && Objects.equals(chunkSplitterState, that.chunkSplitterState);
+                && Objects.equals(chunkSplitterState, that.chunkSplitterState)
+                && Objects.equals(checkpointIdToFinish, that.checkpointIdToFinish);
     }
 
     @Override
@@ -171,7 +214,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 assignerStatus,
                 isTableIdCaseSensitive,
                 isRemainingTablesCheckpointed,
-                chunkSplitterState);
+                chunkSplitterState,
+                checkpointIdToFinish);
     }
 
     @Override
@@ -195,6 +239,8 @@ public class SnapshotPendingSplitsState extends PendingSplitsState {
                 + isRemainingTablesCheckpointed
                 + ", chunkSplitterState="
                 + chunkSplitterState
+                + ", checkpointIdToFinish="
+                + checkpointIdToFinish
                 + '}';
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/enumerator/MySqlSourceEnumerator.java
@@ -36,6 +36,7 @@ import org.apache.flink.cdc.connectors.mysql.source.events.FinishedSnapshotSplit
 import org.apache.flink.cdc.connectors.mysql.source.events.FinishedSnapshotSplitsRequestEvent;
 import org.apache.flink.cdc.connectors.mysql.source.events.LatestFinishedSplitsNumberEvent;
 import org.apache.flink.cdc.connectors.mysql.source.events.LatestFinishedSplitsNumberRequestEvent;
+import org.apache.flink.cdc.connectors.mysql.source.metrics.MySqlSourceEnumeratorMetrics;
 import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
 import org.apache.flink.cdc.connectors.mysql.source.split.FinishedSnapshotSplitInfo;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
@@ -99,12 +100,22 @@ public class MySqlSourceEnumerator implements SplitEnumerator<MySqlSplit, Pendin
     @Override
     public void start() {
         splitAssigner.open();
+        registerMetrics();
         requestBinlogSplitUpdateIfNeed();
         this.context.callAsync(
                 this::getRegisteredReader,
                 this::syncWithReaders,
                 CHECK_EVENT_INTERVAL,
                 CHECK_EVENT_INTERVAL);
+    }
+
+    private void registerMetrics() {
+        try {
+            new MySqlSourceEnumeratorMetrics(context.metricGroup(), splitAssigner);
+        } catch (Throwable t) {
+            // Defensive: never fail enumerator start because of metric registration.
+            LOG.warn("Failed to register MySQL CDC enumerator metrics.", t);
+        }
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceEnumeratorMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceEnumeratorMetrics.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.metrics;
+
+import org.apache.flink.cdc.connectors.mysql.source.assigners.MySqlSplitAssigner;
+import org.apache.flink.cdc.connectors.mysql.source.enumerator.MySqlSourceEnumerator;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * Enumerator-side metrics for the MySQL CDC source. Exposes the {@link
+ * org.apache.flink.cdc.connectors.mysql.source.assigners.AssignerStatus} of the split assigner and
+ * aggregate snapshot progress counters so operators can observe whether the assigner state machine
+ * is making progress -- particularly when {@code scan.newly-added-table.enabled=true} keeps the
+ * assigner in one of the {@code *_ASSIGNING} states for an extended snapshot.
+ *
+ * <p>Registered by {@link MySqlSourceEnumerator}.
+ */
+public class MySqlSourceEnumeratorMetrics {
+
+    // Metric names
+    public static final String ASSIGNER_STATUS = "assignerStatus";
+    public static final String ASSIGNER_STATUS_NAME = "assignerStatusName";
+    public static final String NUM_REMAINING_TABLES = "numRemainingTables";
+    public static final String NUM_REMAINING_SNAPSHOT_SPLITS = "numRemainingSnapshotSplits";
+    public static final String NUM_ASSIGNED_SNAPSHOT_SPLITS = "numAssignedSnapshotSplits";
+    public static final String NUM_FINISHED_SNAPSHOT_SPLITS = "numFinishedSnapshotSplits";
+    public static final String NUM_ALREADY_PROCESSED_TABLES = "numAlreadyProcessedTables";
+
+    public MySqlSourceEnumeratorMetrics(MetricGroup metricGroup, MySqlSplitAssigner splitAssigner) {
+        metricGroup.gauge(ASSIGNER_STATUS, () -> splitAssigner.getAssignerStatus().getStatusCode());
+        metricGroup.gauge(ASSIGNER_STATUS_NAME, () -> splitAssigner.getAssignerStatus().name());
+        metricGroup.gauge(NUM_REMAINING_TABLES, splitAssigner::getRemainingTablesCount);
+        metricGroup.gauge(NUM_REMAINING_SNAPSHOT_SPLITS, splitAssigner::getRemainingSplitsCount);
+        metricGroup.gauge(NUM_ASSIGNED_SNAPSHOT_SPLITS, splitAssigner::getAssignedSplitsCount);
+        metricGroup.gauge(NUM_FINISHED_SNAPSHOT_SPLITS, splitAssigner::getFinishedSplitsCount);
+        metricGroup.gauge(
+                NUM_ALREADY_PROCESSED_TABLES, splitAssigner::getAlreadyProcessedTablesCount);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializerTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/assigners/state/PendingSplitsStateSerializerTest.java
@@ -30,6 +30,7 @@ import io.debezium.relational.TableEditor;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.TableChanges;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -60,6 +61,7 @@ class PendingSplitsStateSerializerTest {
         return Stream.of(
                 Arguments.of(getTestSnapshotPendingSplitsState(true)),
                 Arguments.of(getTestSnapshotPendingSplitsState(false)),
+                Arguments.of(getTestSnapshotPendingSplitsStateWithCheckpointIdToFinish()),
                 Arguments.of(getTestHybridPendingSplitsState(false)),
                 Arguments.of(getTestHybridPendingSplitsState(true)),
                 Arguments.of(getTestBinlogPendingSplitsState()));
@@ -89,6 +91,40 @@ class PendingSplitsStateSerializerTest {
                                     .keySet())
                     .isEqualTo(getTestTableSchema(tableId0, tableId1).keySet());
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    void testCheckpointIdToFinishRoundTrip(PendingSplitsState state) throws Exception {
+        PendingSplitsState deserialized = serializeAndDeserializeSourceEnumState(state);
+        if (state instanceof SnapshotPendingSplitsState) {
+            Assertions.assertThat(
+                            ((SnapshotPendingSplitsState) deserialized).getCheckpointIdToFinish())
+                    .isEqualTo(((SnapshotPendingSplitsState) state).getCheckpointIdToFinish());
+        } else if (state instanceof HybridPendingSplitsState) {
+            Assertions.assertThat(
+                            ((HybridPendingSplitsState) deserialized)
+                                    .getSnapshotPendingSplits()
+                                    .getCheckpointIdToFinish())
+                    .isEqualTo(
+                            ((HybridPendingSplitsState) state)
+                                    .getSnapshotPendingSplits()
+                                    .getCheckpointIdToFinish());
+        }
+    }
+
+    @Test
+    void testDeserializeV5MissingCheckpointIdToFinish() throws Exception {
+        // FLINK-39478: v5 read path predates checkpointIdToFinish; deserializing a payload as v5
+        // must not attempt to read the new trailing field and must return null for it.
+        SnapshotPendingSplitsState state = getTestSnapshotPendingSplitsState(false);
+        final PendingSplitsStateSerializer serializer =
+                new PendingSplitsStateSerializer(MySqlSplitSerializer.INSTANCE);
+        byte[] serialized = serializer.serialize(state);
+        PendingSplitsState restored = serializer.deserialize(5, serialized);
+        Assertions.assertThat(restored).isInstanceOf(SnapshotPendingSplitsState.class);
+        Assertions.assertThat(((SnapshotPendingSplitsState) restored).getCheckpointIdToFinish())
+                .isNull();
     }
 
     @ParameterizedTest
@@ -195,6 +231,25 @@ class PendingSplitsStateSerializerTest {
                     true,
                     ChunkSplitterState.NO_SPLITTING_TABLE_STATE);
         }
+    }
+
+    private static SnapshotPendingSplitsState
+            getTestSnapshotPendingSplitsStateWithCheckpointIdToFinish() {
+        // Reuse the base state and overlay a non-null checkpointIdToFinish, exercising the
+        // FLINK-39478 backward-compat serialization path (version >= 6).
+        SnapshotPendingSplitsState base = getTestSnapshotPendingSplitsState(false);
+        return new SnapshotPendingSplitsState(
+                base.getAlreadyProcessedTables(),
+                base.getRemainingSplits(),
+                base.getAssignedSplits(),
+                base.getTableSchemas(),
+                base.getSplitFinishedOffsets(),
+                base.getSnapshotAssignerStatus(),
+                base.getRemainingTables(),
+                base.isTableIdCaseSensitive(),
+                base.isRemainingTablesCheckpointed(),
+                base.getChunkSplitterState(),
+                42L);
     }
 
     private static HybridPendingSplitsState getTestHybridPendingSplitsState(


### PR DESCRIPTION
## What is the purpose of the change

Fixes FLINK-39478 — when `scan.newly-added-table.enabled=true` and a job restarts mid-snapshot of a newly-added table, the affected table can silently stop emitting events for the rest of the job's lifetime. The root cause is that `MySqlSnapshotSplitAssigner.checkpointIdToFinish` — the field that gates the `NEWLY_ADDED_ASSIGNING → NEWLY_ADDED_ASSIGNING_SNAPSHOT_FINISHED` transition — is transient (`@Nullable`, not in `SnapshotPendingSplitsState`), and on restore must be re-derived over two more checkpoint cycles (one `snapshotState()` to set it, one `notifyCheckpointComplete()` to act on it). If a second restart lands inside that recovery window, the field resets and the state machine stalls. The table remains in the pipeline config and the job appears healthy, but produces zero data thereafter. Reported in production on two ~100M-row tables; the non-deterministic "survived first restart, died on second" pattern is consistent with the timing race described above.

This change persists `checkpointIdToFinish` into the checkpointed state so the state machine can resume in one step after restore, and adds enumerator-side metrics (`assignerStatus`, aggregate snapshot progress counters) so operators can observe whether the assigner is making progress during long newly-added-table snapshots — the lack of which made the original incident extremely hard to diagnose. The companion fix for the multi-step `BinlogSplitUpdateRequest/Ack` handshake between states 3→4 (fix direction #2 in the JIRA) is deferred to a follow-up because it touches the enumerator↔reader RPC protocol and has a larger blast radius — this PR addresses what we believe is the most likely root cause of the observed incidents, plus the observability gap.

## Brief change log
- Added `@Nullable Long checkpointIdToFinish` to `SnapshotPendingSplitsState` (flink-connector-mysql-cdc), with a new 11-arg constructor. The pre-existing 10-arg constructor is preserved as a delegating overload that defaults the new field to `null`, so all existing call sites compile unchanged and no test fixture data needs to change.
- `snapshotState()` in `MySqlSnapshotSplitAssigner` now sets `checkpointIdToFinish` **before** building the state object, so the value is captured in the same checkpoint instead of the next one — eliminating the 2-checkpoint recovery window after a restart.
- Bumped `PendingSplitsStateSerializer` from `VERSION = 5` to `VERSION = 6`. The serialize path writes a trailing `boolean present + long value`; the deserialize path reads the trailer only when `version >= 6`. v5 payloads continue to deserialize with `checkpointIdToFinish=null`, so no savepoint migration is required.
- New `MySqlSourceEnumeratorMetrics` (flink-connector-mysql-cdc) exposes the following gauges on the enumerator metric group: `assignerStatus` (status code), `assignerStatusName` (status name), `numRemainingTables`, `numRemainingSnapshotSplits`, `numAssignedSnapshotSplits`, `numFinishedSnapshotSplits`, `numAlreadyProcessedTables`. Registered from `MySqlSourceEnumerator#start`, wrapped in a try/catch so metric-registration failures can never break enumerator startup.
- Added five `default int get*Count()` accessors to `MySqlSplitAssigner` (`getRemainingSplitsCount`, `getRemainingTablesCount`, `getAssignedSplitsCount`, `getFinishedSplitsCount`, `getAlreadyProcessedTablesCount`). Default returns `0`, preserving source-compatibility for any external implementor. Overridden in `MySqlSnapshotSplitAssigner` and delegated in `MySqlHybridSplitAssigner`; `MySqlBinlogSplitAssigner` uses the no-op defaults (its phase has no snapshot work to report).
- Extended `PendingSplitsStateSerializerTest` with a new round-trip case carrying a non-null `checkpointIdToFinish`, plus a v5-payload backward-compat test confirming the field reads back as `null` on the old code path.

## Verifying this change

This change persists one additional field and registers new metric gauges; no existing data path or split-assignment logic is altered. Verification:

- New parameterized test variant in `PendingSplitsStateSerializerTest` (`getTestSnapshotPendingSplitsStateWithCheckpointIdToFinish`) covers snapshot- and hybrid-state round-trips with a non-null `checkpointIdToFinish` (42L). All 31 tests in the class pass.
- New `testDeserializeV5MissingCheckpointIdToFinish` asserts that a payload deserialized under the previous version number reads `checkpointIdToFinish=null` and does not attempt to read the v6 trailer — exercises the version-gated read branch.
- Existing `equals`/`hashCode` round-trip in `PendingSplitsStateSerializerTest` now also exercises the new field via state equality (the field is included in both methods).
- `mvn test-compile` passes for the whole `flink-connector-mysql-cdc` module, validating that the new interface defaults don't break any existing implementor (including the test-only assigner subclasses).
- `mvn spotless:check` passes on the changed module.

Note: `MySqlSnapshotSplitAssignerTest` and `MySqlHybridSplitAssignerTest` were not runnable in the local environment because they spin up MySQL via testcontainers (Docker not available). They should pass unchanged in CI — none of their fixture data construction needed updating thanks to the preserved 10-arg constructor overload.

A deterministic IT case that injects a restart between `snapshotState()` setting `checkpointIdToFinish` and `notifyCheckpointComplete()` acting on it — i.e., a regression test that fails on `master` and passes on this branch — is the natural next step but is outside the scope of this PR. Happy to add it as a follow-up if reviewers prefer; it requires some thought about how to deterministically schedule the restart at the vulnerable window without flaking.

## Does this pull request potentially affect one of the following parts

- **Dependencies (does it add or upgrade a dependency):** no
- **The public API, i.e., is any changed class annotated with `@Public(Evolving)`:** the `MySqlSplitAssigner` interface is `@Internal`, not `@PublicEvolving` — the new `default` methods are nonetheless source- and binary-compatible for any external implementor (defaults return `0`). `SnapshotPendingSplitsState` is also internal to the connector. No `@PublicEvolving` surface is touched.
- **The serializers:** yes — `PendingSplitsStateSerializer` is bumped from version 5 to version 6. The new payload appends a `boolean + (optional) long`. The deserializer accepts versions 1–6; v5 payloads deserialize unchanged (with `checkpointIdToFinish=null`), so existing savepoints/checkpoints restore without migration.
- **The runtime per-record code paths (performance sensitive):** no — `checkpointIdToFinish` is read/written only at checkpoint and restore. Metric gauges are lazily evaluated by Flink's reporter; their suppliers are `O(1)` (size lookups + a field read).
- **Anything that affects deployment or recovery (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper):** yes — the checkpointed enumerator state schema changes (additive, backward-compatible). Existing checkpoints/savepoints restore cleanly via the v5 read path.
- **The S3 file system connector:** no

## Documentation

- **Does this pull request introduce a new feature?** It introduces new enumerator metrics (`assignerStatus`, plus aggregate snapshot progress gauges) on the MySQL CDC source. The state-persistence change is a bug fix rather than a feature.
- **If yes, how is the feature documented?** Inline Javadoc on `MySqlSourceEnumeratorMetrics` and on each metric-name constant documents the contract. The metric names follow the same convention as the existing `SourceEnumeratorMetrics` in `flink-cdc-base`. No standalone docs page change is required for this PR; if maintainers prefer, the MySQL connector's metrics table in the docs can be extended in a follow-up.

## Was generative AI tooling used to co-author this PR?
- [x] Yes — Claude was used as a pair-programming assistant for discussing the approach, locating the fragile state-machine windows in the code, and drafting the implementation. All code was reviewed, understood, and verified by the author.

Generated-by: Claude Opus 4.7