### PR TITLE
[FLINK-39748][postgres] Fix snapshot timestamp drift for historical TIMESTAMP/DATE columns

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -45,7 +45,11 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -831,6 +835,41 @@ public class PostgresConnection extends JdbcConnection {
                     // precision,
                     // read the column as a string instead and then re-parse inside the converter.
                     return rs.getString(columnIndex);
+                case PgOid.TIMESTAMP:
+                    {
+                        // LocalDateTime bypasses GregorianCalendar's Julian/Gregorian cutover
+                        // (1582-10-15), which shifts pre-cutover values by N days
+                        // (e.g. 0001-01-01 by 2 days).
+                        LocalDateTime ldt = rs.getObject(columnIndex, LocalDateTime.class);
+                        if (ldt == null) {
+                            return null;
+                        }
+                        // PG +/-infinity surfaces as Timestamp(Long.MAX/MIN_VALUE) via the legacy
+                        // rs.getObject() path; preserve that contract for downstream converters.
+                        if (ldt == LocalDateTime.MAX) {
+                            return new Timestamp(Long.MAX_VALUE);
+                        }
+                        if (ldt == LocalDateTime.MIN) {
+                            return new Timestamp(Long.MIN_VALUE);
+                        }
+                        return ldt;
+                    }
+                case PgOid.TIMESTAMPTZ:
+                    {
+                        OffsetDateTime odt = rs.getObject(columnIndex, OffsetDateTime.class);
+                        if (odt == null) {
+                            return null;
+                        }
+                        if (odt == OffsetDateTime.MAX) {
+                            return new Timestamp(Long.MAX_VALUE);
+                        }
+                        if (odt == OffsetDateTime.MIN) {
+                            return new Timestamp(Long.MIN_VALUE);
+                        }
+                        return odt;
+                    }
+                case PgOid.DATE:
+                    return rs.getObject(columnIndex, LocalDate.class);
                 default:
                     Object x = rs.getObject(columnIndex);
                     if (x != null) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
@@ -39,6 +39,7 @@ import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.relational.Column;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.SnapshotChangeRecordEmitter;
 import io.debezium.relational.Table;
@@ -325,7 +326,10 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
                     rows++;
                     final Object[] row = new Object[columnArray.getGreatestColumnPosition()];
                     for (int i = 0; i < columnArray.getColumns().length; i++) {
-                        row[columnArray.getColumns()[i].position() - 1] = rs.getObject(i + 1);
+                        Column col = columnArray.getColumns()[i];
+                        row[col.position() - 1] =
+                                jdbcConnection.getColumnValue(
+                                        rs, i + 1, col, table, databaseSchema);
                     }
                     if (logTimer.expired()) {
                         long stop = clock.currentTimeInMillis();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
@@ -39,6 +39,7 @@ import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
 import io.debezium.pipeline.source.spi.SnapshotProgressListener;
 import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.relational.Column;
 import io.debezium.relational.RelationalSnapshotChangeEventSource;
 import io.debezium.relational.SnapshotChangeRecordEmitter;
 import io.debezium.relational.Table;
@@ -327,7 +328,10 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
                     rows++;
                     final Object[] row = new Object[columnArray.getGreatestColumnPosition()];
                     for (int i = 0; i < columnArray.getColumns().length; i++) {
-                        row[columnArray.getColumns()[i].position() - 1] = rs.getObject(i + 1);
+                        Column col = columnArray.getColumns()[i];
+                        row[col.position() - 1] =
+                                jdbcConnection.getColumnValue(
+                                        rs, i + 1, col, table, databaseSchema);
                     }
                     if (logTimer.expired()) {
                         long stop = clock.currentTimeInMillis();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -25,12 +25,12 @@ import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceRecords;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import org.apache.flink.cdc.connectors.base.source.metrics.SourceEnumeratorMetrics;
-import org.apache.flink.cdc.connectors.base.utils.SourceRecordUtils;
 import org.apache.flink.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
 import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
 import org.apache.flink.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher;
 import org.apache.flink.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
 import org.apache.flink.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import org.apache.flink.cdc.connectors.base.utils.SourceRecordUtils;
 import org.apache.flink.cdc.connectors.postgres.PostgresTestBase;
 import org.apache.flink.cdc.connectors.postgres.source.PostgresDialect;
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfig;
@@ -337,11 +337,31 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
 
         // Debezium emits TIMESTAMP as MicroTimestamp (long micros from epoch UTC),
         // TIMESTAMPTZ as ZonedTimestamp (ISO string), DATE as days from epoch.
-        assertHistoricalRow(afterById.get(1), "0001-01-01T00:00:00", "0001-01-01T00:00:00Z", LocalDate.of(1, 1, 1));
-        assertHistoricalRow(afterById.get(2), "1582-10-04T00:00:00", "1582-10-04T00:00:00Z", LocalDate.of(1582, 10, 4));
-        assertHistoricalRow(afterById.get(3), "1582-10-15T00:00:00", "1582-10-15T00:00:00Z", LocalDate.of(1582, 10, 15));
-        assertHistoricalRow(afterById.get(4), "1900-12-31T23:59:59.123456", "1900-12-31T23:59:59.123456Z", LocalDate.of(1900, 12, 31));
-        assertHistoricalRow(afterById.get(5), "1901-01-02T00:00:00", "1901-01-02T00:00:00Z", LocalDate.of(1901, 1, 2));
+        assertHistoricalRow(
+                afterById.get(1),
+                "0001-01-01T00:00:00",
+                "0001-01-01T00:00:00Z",
+                LocalDate.of(1, 1, 1));
+        assertHistoricalRow(
+                afterById.get(2),
+                "1582-10-04T00:00:00",
+                "1582-10-04T00:00:00Z",
+                LocalDate.of(1582, 10, 4));
+        assertHistoricalRow(
+                afterById.get(3),
+                "1582-10-15T00:00:00",
+                "1582-10-15T00:00:00Z",
+                LocalDate.of(1582, 10, 15));
+        assertHistoricalRow(
+                afterById.get(4),
+                "1900-12-31T23:59:59.123456",
+                "1900-12-31T23:59:59.123456Z",
+                LocalDate.of(1900, 12, 31));
+        assertHistoricalRow(
+                afterById.get(5),
+                "1901-01-02T00:00:00",
+                "1901-01-02T00:00:00Z",
+                LocalDate.of(1901, 1, 2));
     }
 
     private static void assertHistoricalRow(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceRecords;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import org.apache.flink.cdc.connectors.base.source.metrics.SourceEnumeratorMetrics;
+import org.apache.flink.cdc.connectors.base.utils.SourceRecordUtils;
 import org.apache.flink.cdc.connectors.base.source.reader.external.AbstractScanFetchTask;
 import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
 import org.apache.flink.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher;
@@ -44,16 +45,22 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -73,6 +80,14 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
                     POSTGRES_CONTAINER,
                     "postgres",
                     "customer",
+                    POSTGRES_CONTAINER.getUsername(),
+                    POSTGRES_CONTAINER.getPassword());
+
+    private final UniqueDatabase historicalDatesDatabase =
+            new UniqueDatabase(
+                    POSTGRES_CONTAINER,
+                    "postgres",
+                    "historical_dates",
                     POSTGRES_CONTAINER.getUsername(),
                     POSTGRES_CONTAINER.getPassword());
 
@@ -281,6 +296,91 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
                 ResultSet rs = selectStatement.executeQuery()) {
             assertThat(rs.getFetchSize()).isEqualTo(2);
         }
+    }
+
+    @Test
+    void testHistoricalDatesInSnapshotScan() throws Exception {
+        // Pre-fix, dates before 1582-10-15 are shifted by N days (e.g. 0001-01-01 by 2)
+        // because the snapshot path's rs.getObject() goes through GregorianCalendar.
+        // Post-fix, getColumnValue() reads via java.time types and is calendar-clean.
+        historicalDatesDatabase.createAndInitialize();
+
+        PostgresSourceConfigFactory sourceConfigFactory =
+                getMockPostgresSourceConfigFactory(
+                        historicalDatesDatabase,
+                        "historical_dates",
+                        "date_boundary",
+                        null,
+                        10,
+                        false);
+        PostgresSourceConfig sourceConfig = sourceConfigFactory.create(0);
+        PostgresDialect postgresDialect = new PostgresDialect(sourceConfigFactory.create(0));
+        List<SnapshotSplit> snapshotSplits = getSnapshotSplits(sourceConfig, postgresDialect);
+        PostgresSourceFetchTaskContext taskContext =
+                new PostgresSourceFetchTaskContext(sourceConfig, postgresDialect);
+
+        List<SourceRecord> rawRecords =
+                readRawSnapshotRecords(
+                        reOrderSnapshotSplits(snapshotSplits),
+                        taskContext,
+                        1,
+                        new SnapshotPhaseHooks());
+
+        Map<Integer, Struct> afterById = new HashMap<>();
+        for (SourceRecord r : rawRecords) {
+            if (!SourceRecordUtils.isDataChangeRecord(r)) {
+                continue;
+            }
+            Struct after = ((Struct) r.value()).getStruct("after");
+            afterById.put(after.getInt32("id"), after);
+        }
+
+        // Debezium emits TIMESTAMP as MicroTimestamp (long micros from epoch UTC),
+        // TIMESTAMPTZ as ZonedTimestamp (ISO string), DATE as days from epoch.
+        assertHistoricalRow(afterById.get(1), "0001-01-01T00:00:00", "0001-01-01T00:00:00Z", LocalDate.of(1, 1, 1));
+        assertHistoricalRow(afterById.get(2), "1582-10-04T00:00:00", "1582-10-04T00:00:00Z", LocalDate.of(1582, 10, 4));
+        assertHistoricalRow(afterById.get(3), "1582-10-15T00:00:00", "1582-10-15T00:00:00Z", LocalDate.of(1582, 10, 15));
+        assertHistoricalRow(afterById.get(4), "1900-12-31T23:59:59.123456", "1900-12-31T23:59:59.123456Z", LocalDate.of(1900, 12, 31));
+        assertHistoricalRow(afterById.get(5), "1901-01-02T00:00:00", "1901-01-02T00:00:00Z", LocalDate.of(1901, 1, 2));
+    }
+
+    private static void assertHistoricalRow(
+            Struct after, String expectedTsIso, String expectedTstz, LocalDate expectedDate) {
+        long expectedMicros =
+                LocalDateTime.parse(expectedTsIso).toInstant(ZoneOffset.UTC).getEpochSecond()
+                                * 1_000_000L
+                        + LocalDateTime.parse(expectedTsIso).getNano() / 1_000L;
+        assertThat(after.get("ts")).isEqualTo(expectedMicros);
+        assertThat(after.get("tstz")).isEqualTo(expectedTstz);
+        assertThat(after.get("d")).isEqualTo((int) expectedDate.toEpochDay());
+    }
+
+    private List<SourceRecord> readRawSnapshotRecords(
+            List<SnapshotSplit> snapshotSplits,
+            PostgresSourceFetchTaskContext taskContext,
+            int scanSplitsNum,
+            SnapshotPhaseHooks snapshotPhaseHooks)
+            throws Exception {
+        IncrementalSourceScanFetcher sourceScanFetcher =
+                new IncrementalSourceScanFetcher(taskContext, 0);
+        List<SourceRecord> result = new ArrayList<>();
+        for (int i = 0; i < scanSplitsNum; i++) {
+            SnapshotSplit sqlSplit = snapshotSplits.get(i);
+            if (sourceScanFetcher.isFinished()) {
+                FetchTask<SourceSplitBase> fetchTask =
+                        taskContext.getDataSourceDialect().createFetchTask(sqlSplit);
+                ((AbstractScanFetchTask) fetchTask).setSnapshotPhaseHooks(snapshotPhaseHooks);
+                sourceScanFetcher.submitTask(fetchTask);
+            }
+            Iterator<SourceRecords> res;
+            while ((res = sourceScanFetcher.pollSplitRecords()) != null) {
+                while (res.hasNext()) {
+                    result.addAll(res.next().getSourceRecordList());
+                }
+            }
+        }
+        sourceScanFetcher.close();
+        return result;
     }
 
     private List<String> getDataInSnapshotScan(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
 import org.apache.flink.cdc.connectors.base.source.reader.external.IncrementalSourceScanFetcher;
 import org.apache.flink.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHook;
 import org.apache.flink.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import org.apache.flink.cdc.connectors.base.utils.SourceRecordUtils;
 import org.apache.flink.cdc.connectors.postgres.PostgresTestBase;
 import org.apache.flink.cdc.connectors.postgres.source.PostgresDialect;
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfig;
@@ -44,16 +45,22 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 
 import io.debezium.connector.postgresql.connection.PostgresConnection;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.Test;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,6 +79,14 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
                     POSTGRES_CONTAINER,
                     "postgres",
                     "customer",
+                    POSTGRES_CONTAINER.getUsername(),
+                    POSTGRES_CONTAINER.getPassword());
+
+    private final UniqueDatabase historicalDatesDatabase =
+            new UniqueDatabase(
+                    POSTGRES_CONTAINER,
+                    "postgres",
+                    "historical_dates",
                     POSTGRES_CONTAINER.getUsername(),
                     POSTGRES_CONTAINER.getPassword());
 
@@ -325,6 +340,111 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
                 ResultSet rs = selectStatement.executeQuery()) {
             assertThat(rs.getFetchSize()).isEqualTo(2);
         }
+    }
+
+    @Test
+    void testHistoricalDatesInSnapshotScan() throws Exception {
+        // Pre-fix, dates before 1582-10-15 are shifted by N days (e.g. 0001-01-01 by 2)
+        // because the snapshot path's rs.getObject() goes through GregorianCalendar.
+        // Post-fix, getColumnValue() reads via java.time types and is calendar-clean.
+        historicalDatesDatabase.createAndInitialize();
+
+        PostgresSourceConfigFactory sourceConfigFactory =
+                getMockPostgresSourceConfigFactory(
+                        historicalDatesDatabase,
+                        "historical_dates",
+                        "date_boundary",
+                        null,
+                        10,
+                        false);
+        PostgresSourceConfig sourceConfig = sourceConfigFactory.create(0);
+        PostgresDialect postgresDialect = new PostgresDialect(sourceConfigFactory.create(0));
+        List<SnapshotSplit> snapshotSplits = getSnapshotSplits(sourceConfig, postgresDialect);
+        PostgresSourceFetchTaskContext taskContext =
+                new PostgresSourceFetchTaskContext(sourceConfig, postgresDialect);
+
+        List<SourceRecord> rawRecords =
+                readRawSnapshotRecords(
+                        reOrderSnapshotSplits(snapshotSplits),
+                        taskContext,
+                        1,
+                        new SnapshotPhaseHooks());
+
+        Map<Integer, Struct> afterById = new HashMap<>();
+        for (SourceRecord r : rawRecords) {
+            if (!SourceRecordUtils.isDataChangeRecord(r)) {
+                continue;
+            }
+            Struct after = ((Struct) r.value()).getStruct("after");
+            afterById.put(after.getInt32("id"), after);
+        }
+
+        // Debezium emits TIMESTAMP as MicroTimestamp (long micros from epoch UTC),
+        // TIMESTAMPTZ as ZonedTimestamp (ISO string), DATE as days from epoch.
+        assertHistoricalRow(
+                afterById.get(1),
+                "0001-01-01T00:00:00",
+                "0001-01-01T00:00:00Z",
+                LocalDate.of(1, 1, 1));
+        assertHistoricalRow(
+                afterById.get(2),
+                "1582-10-04T00:00:00",
+                "1582-10-04T00:00:00Z",
+                LocalDate.of(1582, 10, 4));
+        assertHistoricalRow(
+                afterById.get(3),
+                "1582-10-15T00:00:00",
+                "1582-10-15T00:00:00Z",
+                LocalDate.of(1582, 10, 15));
+        assertHistoricalRow(
+                afterById.get(4),
+                "1900-12-31T23:59:59.123456",
+                "1900-12-31T23:59:59.123456Z",
+                LocalDate.of(1900, 12, 31));
+        assertHistoricalRow(
+                afterById.get(5),
+                "1901-01-02T00:00:00",
+                "1901-01-02T00:00:00Z",
+                LocalDate.of(1901, 1, 2));
+    }
+
+    private static void assertHistoricalRow(
+            Struct after, String expectedTsIso, String expectedTstz, LocalDate expectedDate) {
+        long expectedMicros =
+                LocalDateTime.parse(expectedTsIso).toInstant(ZoneOffset.UTC).getEpochSecond()
+                                * 1_000_000L
+                        + LocalDateTime.parse(expectedTsIso).getNano() / 1_000L;
+        assertThat(after.get("ts")).isEqualTo(expectedMicros);
+        assertThat(after.get("tstz")).isEqualTo(expectedTstz);
+        assertThat(after.get("d")).isEqualTo((int) expectedDate.toEpochDay());
+    }
+
+    private List<SourceRecord> readRawSnapshotRecords(
+            List<SnapshotSplit> snapshotSplits,
+            PostgresSourceFetchTaskContext taskContext,
+            int scanSplitsNum,
+            SnapshotPhaseHooks snapshotPhaseHooks)
+            throws Exception {
+        IncrementalSourceScanFetcher sourceScanFetcher =
+                new IncrementalSourceScanFetcher(taskContext, 0);
+        List<SourceRecord> result = new ArrayList<>();
+        for (int i = 0; i < scanSplitsNum; i++) {
+            SnapshotSplit sqlSplit = snapshotSplits.get(i);
+            if (sourceScanFetcher.isFinished()) {
+                FetchTask<SourceSplitBase> fetchTask =
+                        taskContext.getDataSourceDialect().createFetchTask(sqlSplit);
+                ((AbstractScanFetchTask) fetchTask).setSnapshotPhaseHooks(snapshotPhaseHooks);
+                sourceScanFetcher.submitTask(fetchTask);
+            }
+            Iterator<SourceRecords> res;
+            while ((res = sourceScanFetcher.pollSplitRecords()) != null) {
+                while (res.hasNext()) {
+                    result.addAll(res.next().getSourceRecordList());
+                }
+            }
+        }
+        sourceScanFetcher.close();
+        return result;
     }
 
     private List<String> getDataInSnapshotScan(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/historical_dates.sql
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/historical_dates.sql
@@ -1,0 +1,41 @@
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Boundary dates around the Julian/Gregorian cutover (1582-10-15) and the
+-- Asia/Shanghai LMT switch (1901). Used to verify the snapshot path reads
+-- TIMESTAMP / TIMESTAMPTZ / DATE values via java.time types instead of
+-- falling through GregorianCalendar.
+DROP SCHEMA IF EXISTS historical_dates CASCADE;
+CREATE SCHEMA historical_dates;
+SET search_path TO historical_dates, public;
+
+CREATE TABLE date_boundary
+(
+    id   INTEGER NOT NULL,
+    ts   TIMESTAMP(6),
+    tstz TIMESTAMP(6) WITH TIME ZONE,
+    d    DATE,
+    PRIMARY KEY (id)
+);
+
+ALTER TABLE historical_dates.date_boundary
+    REPLICA IDENTITY FULL;
+
+INSERT INTO historical_dates.date_boundary VALUES
+    (1, '0001-01-01 00:00:00', '0001-01-01 00:00:00+00', '0001-01-01'),
+    (2, '1582-10-04 00:00:00', '1582-10-04 00:00:00+00', '1582-10-04'),
+    (3, '1582-10-15 00:00:00', '1582-10-15 00:00:00+00', '1582-10-15'),
+    (4, '1900-12-31 23:59:59.123456', '1900-12-31 23:59:59.123456+00', '1900-12-31'),
+    (5, '1901-01-02 00:00:00', '1901-01-02 00:00:00+00', '1901-01-02');


### PR DESCRIPTION
This closes FLINK-39748.

The Postgres CDC snapshot path reads column values via a bare `rs.getObject(i + 1)` in `PostgresScanFetchTask`. For TIMESTAMP / TIMESTAMPTZ / DATE columns, the PG JDBC driver constructs the returned `java.sql.Timestamp` / `java.sql.Date` through `GregorianCalendar` (default Julian/Gregorian cutover at 1582-10-15) using the JVM default time zone. This makes pre-cutover dates drift by N days (e.g. `0001-01-01` by 2 days), and also adds an LMT delta on JVMs whose default zone has an LMT segment (e.g. `Asia/Shanghai` is `+08:05:43` until 1901, vs `+08:00:00` after).

The Postgres logical decoding (streaming) path does not pass through `GregorianCalendar`, so the same row produces different Debezium records on snapshot vs streaming, breaking idempotent UPSERT semantics for downstream sinks.

This patch:

1. Routes the snapshot path through `PostgresConnection.getColumnValue`, which already does per-type dispatch for `MONEY` / `BIT` / `NUMERIC` / `TIME` / `TIMETZ`, by replacing the bare `rs.getObject(i + 1)` in `PostgresScanFetchTask.createDataEventsForTable` with `jdbcConnection.getColumnValue(rs, i + 1, column, table, databaseSchema)`. This mirrors how Debezium's own `RelationalSnapshotChangeEventSource` reads rows.

2. Extends the switch in `PostgresConnection.getColumnValue` with three new cases for `PgOid.TIMESTAMP` / `TIMESTAMPTZ` / `DATE`, reading the columns as `java.time.LocalDateTime` / `OffsetDateTime` / `LocalDate` via `rs.getObject(columnIndex, ...class)`. This bypasses `GregorianCalendar`. PG `+/-infinity` sentinels are preserved as `Timestamp(Long.MAX/MIN_VALUE)` to keep the existing downstream contract.

A regression test in `PostgresScanFetchTaskTest` snapshots boundary dates (`0001-01-01`, `1582-10-04`, `1582-10-15`, `1900-12-31`, `1901-01-02`, and a microsecond-precision value) for TIMESTAMP and DATE columns and asserts the produced Debezium record values match the proleptic-UTC expectation.