### PR TITLE
[FLINK-39765][cdc-pipeline/mysql] Implement lineage (FLIP-314) support for mysql source connectors

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/lineage/CDCLineageDataset.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/lineage/CDCLineageDataset.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.lineage;
+
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaField;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.LineageDatasetFacet;
+
+import javax.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** A {@link LineageDataset} implementation for CDC source tables. */
+public class CDCLineageDataset implements LineageDataset {
+
+    private final String name;
+    private final String namespace;
+    private final Map<String, String> config;
+    @Nullable private final LinkedHashMap<String, String> schema;
+
+    /**
+     * Creates a CDC lineage dataset without a schema facet.
+     *
+     * @param name dataset name, usually a concrete table name
+     * @param namespace dataset namespace identifying the source system
+     * @param config config facet values for the dataset
+     */
+    public CDCLineageDataset(String name, String namespace, Map<String, String> config) {
+        this(name, namespace, config, null);
+    }
+
+    /**
+     * Creates a CDC lineage dataset with optional schema metadata.
+     *
+     * @param name dataset name, usually a concrete table name
+     * @param namespace dataset namespace identifying the source system
+     * @param config config facet values for the dataset
+     * @param schema optional ordered map from field name to field type
+     */
+    public CDCLineageDataset(
+            String name,
+            String namespace,
+            Map<String, String> config,
+            @Nullable LinkedHashMap<String, String> schema) {
+        this.name = name;
+        this.namespace = namespace;
+        this.config = config;
+        this.schema = schema;
+    }
+
+    /**
+     * Returns the dataset name.
+     *
+     * @return dataset name, usually a concrete table name
+     */
+    @Override
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns the namespace identifying the source system.
+     *
+     * @return dataset namespace
+     */
+    @Override
+    public String namespace() {
+        return namespace;
+    }
+
+    /**
+     * Returns the dataset facets.
+     *
+     * <p>Every dataset contains a {@code config} facet. Datasets with non-empty schema metadata
+     * also contain a {@code schema} facet.
+     *
+     * @return map of facet name to lineage dataset facet
+     */
+    @Override
+    public Map<String, LineageDatasetFacet> facets() {
+        Map<String, LineageDatasetFacet> facets = new HashMap<>();
+        facets.put(
+                "config",
+                new DatasetConfigFacet() {
+                    @Override
+                    public String name() {
+                        return "config";
+                    }
+
+                    @Override
+                    public Map<String, String> config() {
+                        return config;
+                    }
+                });
+        if (schema != null && !schema.isEmpty()) {
+            facets.put(
+                    "schema",
+                    new DatasetSchemaFacet() {
+                        @Override
+                        public String name() {
+                            return "schema";
+                        }
+
+                        @Override
+                        public Map<String, DatasetSchemaField<String>> fields() {
+                            Map<String, DatasetSchemaField<String>> result = new LinkedHashMap<>();
+                            for (Map.Entry<String, String> entry : schema.entrySet()) {
+                                String fieldName = entry.getKey();
+                                String fieldType = entry.getValue();
+                                result.put(
+                                        fieldName,
+                                        new DatasetSchemaField<String>() {
+                                            @Override
+                                            public String name() {
+                                                return fieldName;
+                                            }
+
+                                            @Override
+                                            public String type() {
+                                                return fieldType;
+                                            }
+                                        });
+                            }
+                            return result;
+                        }
+                    });
+        }
+        return facets;
+    }
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/lineage/CDCSourceLineageVertex.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/lineage/CDCSourceLineageVertex.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import java.util.List;
+
+/** A {@link SourceLineageVertex} implementation for CDC sources. */
+public class CDCSourceLineageVertex implements SourceLineageVertex {
+
+    private final Boundedness boundedness;
+    private final List<LineageDataset> datasets;
+
+    /**
+     * Creates a CDC source lineage vertex.
+     *
+     * @param boundedness source boundedness
+     * @param datasets datasets produced by the source
+     */
+    public CDCSourceLineageVertex(Boundedness boundedness, List<LineageDataset> datasets) {
+        this.boundedness = boundedness;
+        this.datasets = datasets;
+    }
+
+    /**
+     * Returns whether the source is bounded or continuously unbounded.
+     *
+     * @return source boundedness
+     */
+    @Override
+    public Boundedness boundedness() {
+        return boundedness;
+    }
+
+    /**
+     * Returns the datasets produced by the source.
+     *
+     * @return source lineage datasets
+     */
+    @Override
+    public List<LineageDataset> datasets() {
+        return datasets;
+    }
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/lineage/LineageUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/lineage/LineageUtils.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/** Utilities for building lineage vertices from CDC source metadata. */
+public class LineageUtils {
+
+    /**
+     * Builds the dataset namespace for a CDC source.
+     *
+     * <p>The namespace identifies the source system instance, for example {@code
+     * mysql://localhost:3306}.
+     *
+     * @param type CDC source type, such as {@code mysql}
+     * @param hostname source host name
+     * @param port source port
+     * @return namespace used by lineage datasets
+     */
+    public static String getNamespace(String type, String hostname, int port) {
+        return type + "://" + hostname + ":" + port;
+    }
+
+    /**
+     * Builds the config facet values shared by all datasets for a CDC source.
+     *
+     * @param type CDC source type, such as {@code mysql}
+     * @return config facet map for lineage datasets
+     */
+    private static Map<String, String> buildConfigMap(String type) {
+        Map<String, String> config = new HashMap<>();
+        config.put("type", type + "-cdc");
+        return config;
+    }
+
+    /**
+     * Builds a source lineage vertex without schema facets.
+     *
+     * @param type CDC source type, such as {@code mysql}
+     * @param hostname source host name
+     * @param port source port
+     * @param isBounded whether the source is bounded
+     * @param tableList concrete source table names; if empty, a connector-level dataset is used
+     * @return source lineage vertex for the CDC source
+     */
+    public static SourceLineageVertex sourceLineageVertex(
+            String type, String hostname, int port, boolean isBounded, List<String> tableList) {
+        return sourceLineageVertex(type, hostname, port, isBounded, tableList, null);
+    }
+
+    /**
+     * Builds a source lineage vertex for a CDC source.
+     *
+     * <p>When {@code tableList} is not empty, each table becomes one lineage dataset. When it is
+     * empty, a single connector-level dataset is returned. If schemas are provided for a table,
+     * they are attached as schema facets on that table dataset.
+     *
+     * @param type CDC source type, such as {@code mysql}
+     * @param hostname source host name
+     * @param port source port
+     * @param isBounded whether the source is bounded
+     * @param tableList concrete source table names
+     * @param tableSchemas optional map from table name to ordered field name/type pairs
+     * @return source lineage vertex for the CDC source
+     */
+    public static SourceLineageVertex sourceLineageVertex(
+            String type,
+            String hostname,
+            int port,
+            boolean isBounded,
+            List<String> tableList,
+            Map<String, LinkedHashMap<String, String>> tableSchemas) {
+        String namespace = getNamespace(type, hostname, port);
+        Boundedness boundedness =
+                isBounded ? Boundedness.BOUNDED : Boundedness.CONTINUOUS_UNBOUNDED;
+
+        Map<String, String> config = buildConfigMap(type);
+
+        List<LineageDataset> datasets;
+        if (tableList != null && !tableList.isEmpty()) {
+            datasets =
+                    tableList.stream()
+                            .map(
+                                    table -> {
+                                        LinkedHashMap<String, String> schema =
+                                                tableSchemas != null
+                                                        ? tableSchemas.get(table)
+                                                        : null;
+                                        return (LineageDataset)
+                                                new CDCLineageDataset(
+                                                        table, namespace, config, schema);
+                                    })
+                            .collect(Collectors.toList());
+        } else {
+            datasets = Collections.singletonList(new CDCLineageDataset(type, namespace, config));
+        }
+
+        return new CDCSourceLineageVertex(boundedness, datasets);
+    }
+}

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/lineage/LineageUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/lineage/LineageUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.lineage;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.streaming.api.lineage.DatasetConfigFacet;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link LineageUtils}. */
+class LineageUtilsTest {
+
+    @Test
+    void testSourceLineageVertexWithTablesAndSchemas() {
+        LinkedHashMap<String, String> tableSchema = new LinkedHashMap<>();
+        tableSchema.put("id", "int NOT NULL");
+        tableSchema.put("name", "varchar(255)");
+        Map<String, LinkedHashMap<String, String>> tableSchemas =
+                java.util.Collections.singletonMap("db.customers", tableSchema);
+
+        SourceLineageVertex vertex =
+                LineageUtils.sourceLineageVertex(
+                        "mysql",
+                        "mysql-host",
+                        3306,
+                        false,
+                        Arrays.asList("db.customers", "db.orders"),
+                        tableSchemas);
+
+        assertThat(vertex.boundedness()).isEqualTo(Boundedness.CONTINUOUS_UNBOUNDED);
+        assertThat(vertex.datasets())
+                .extracting(LineageDataset::name)
+                .containsExactly("db.customers", "db.orders");
+
+        LineageDataset customers = vertex.datasets().get(0);
+        assertThat(customers.namespace()).isEqualTo("mysql://mysql-host:3306");
+
+        DatasetConfigFacet configFacet = (DatasetConfigFacet) customers.facets().get("config");
+        assertThat(configFacet.config()).containsEntry("type", "mysql-cdc");
+
+        DatasetSchemaFacet schemaFacet = (DatasetSchemaFacet) customers.facets().get("schema");
+        assertThat(schemaFacet.fields().get("id").type()).isEqualTo("int NOT NULL");
+        assertThat(schemaFacet.fields().get("name").type()).isEqualTo("varchar(255)");
+
+        assertThat(vertex.datasets().get(1).facets()).doesNotContainKey("schema");
+    }
+
+    @Test
+    void testSourceLineageVertexWithoutTablesUsesConnectorDataset() {
+        SourceLineageVertex vertex =
+                LineageUtils.sourceLineageVertex(
+                        "mysql", "mysql-host", 3306, true, java.util.Collections.emptyList());
+
+        assertThat(vertex.boundedness()).isEqualTo(Boundedness.BOUNDED);
+        assertThat(vertex.datasets()).hasSize(1);
+        assertThat(vertex.datasets().get(0).name()).isEqualTo("mysql");
+        assertThat(vertex.datasets().get(0).namespace()).isEqualTo("mysql://mysql-host:3306");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -29,9 +29,7 @@ import org.apache.flink.cdc.common.pipeline.RuntimeExecutionMode;
 import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.source.DataSource;
 import org.apache.flink.cdc.common.utils.StringUtils;
-import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlDataSource;
-import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.flink.cdc.connectors.mysql.source.config.ServerIdRange;
 import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
@@ -45,7 +43,6 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectPath;
 
 import com.mysql.cj.conf.PropertyKey;
-import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -228,13 +224,16 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
 
         List<TableId> tableIds = MySqlSchemaUtils.listTables(configFactory.createConfig(0), null);
 
-        // Resolve concrete table names for lineage (always, regardless of binlog mode)
         Selectors tableSelectors = new Selectors.SelectorsBuilder().includeTables(tables).build();
-        List<String> tableList = getTableList(tableIds, tableSelectors);
+        List<String> capturedTables = getTableList(tableIds, tableSelectors);
+        boolean hasIncludedTables = !capturedTables.isEmpty();
         if (tablesExclude != null) {
-            Selectors excludeSelectors =
+            Selectors selectExclude =
                     new Selectors.SelectorsBuilder().includeTables(tablesExclude).build();
-            tableList.removeAll(getTableList(tableIds, excludeSelectors));
+            List<String> excludeTables = getTableList(tableIds, selectExclude);
+            if (!excludeTables.isEmpty()) {
+                capturedTables.removeAll(excludeTables);
+            }
         }
 
         if (scanBinlogNewlyAddedTableEnabled && scanNewlyAddedTableEnabled) {
@@ -248,24 +247,14 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
             configFactory.excludeTableList(tablesExclude);
 
         } else {
-            Selectors selectors = new Selectors.SelectorsBuilder().includeTables(tables).build();
-            List<String> capturedTables = getTableList(tableIds, selectors);
-            if (capturedTables.isEmpty()) {
+            if (!hasIncludedTables) {
                 throw new IllegalArgumentException(
                         "Cannot find any table by the option 'tables' = " + tables);
             }
-            if (tablesExclude != null) {
-                Selectors selectExclude =
-                        new Selectors.SelectorsBuilder().includeTables(tablesExclude).build();
-                List<String> excludeTables = getTableList(tableIds, selectExclude);
-                if (!excludeTables.isEmpty()) {
-                    capturedTables.removeAll(excludeTables);
-                }
-                if (capturedTables.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "Cannot find any table with by the option 'tables.exclude'  = "
-                                    + tablesExclude);
-                }
+            if (capturedTables.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Cannot find any table with by the option 'tables.exclude'  = "
+                                + tablesExclude);
             }
             configFactory.tableList(capturedTables.toArray(new String[0]));
         }
@@ -297,13 +286,9 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
             LOG.info("Add chunkKeyColumn {}.", chunkKeyColumnMap);
             configFactory.chunkKeyColumn(chunkKeyColumnMap);
         }
-        // Fetch table schemas for lineage.
-        Map<String, LinkedHashMap<String, String>> tableSchemas =
-                fetchTableSchemas(configFactory, tableList);
-
         String metadataList = config.get(METADATA_LIST);
         List<MySqlReadableMetadata> readableMetadataList = listReadableMetadata(metadataList);
-        return new MySqlDataSource(configFactory, readableMetadataList, tableList, tableSchemas);
+        return new MySqlDataSource(configFactory, readableMetadataList, capturedTables);
     }
 
     private List<MySqlReadableMetadata> listReadableMetadata(String metadataList) {
@@ -543,50 +528,5 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
                     SERVER_TIME_ZONE.key());
             return ZoneId.systemDefault();
         }
-    }
-
-    /** Fetch table schemas for lineage schema facets. */
-    private static Map<String, LinkedHashMap<String, String>> fetchTableSchemas(
-            MySqlSourceConfigFactory configFactory, List<String> tableList) {
-        Map<String, LinkedHashMap<String, String>> schemas = new HashMap<>();
-        if (tableList == null || tableList.isEmpty()) {
-            return schemas;
-        }
-        try {
-            MySqlSourceConfig sourceConfig = configFactory.createConfig(0);
-            try (MySqlConnection jdbc = DebeziumUtils.createMySqlConnection(sourceConfig)) {
-                for (String table : tableList) {
-                    try {
-                        TableId tableId = TableId.parse(table);
-                        LinkedHashMap<String, String> fields = new LinkedHashMap<>();
-                        jdbc.query(
-                                "SHOW COLUMNS FROM "
-                                        + quoteIdentifier(tableId.getTableName())
-                                        + " FROM "
-                                        + quoteIdentifier(tableId.getSchemaName()),
-                                rs -> {
-                                    while (rs.next()) {
-                                        String name = rs.getString("Field");
-                                        String type = rs.getString("Type");
-                                        String nullable = rs.getString("Null");
-                                        fields.put(
-                                                name,
-                                                "YES".equals(nullable) ? type : type + " NOT NULL");
-                                    }
-                                });
-                        schemas.put(table, fields);
-                    } catch (Exception e) {
-                        LOG.warn("Failed to fetch schema for table {}: {}", table, e.getMessage());
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.warn("Failed to fetch table schemas for lineage: {}", e.getMessage());
-        }
-        return schemas;
-    }
-
-    private static String quoteIdentifier(String identifier) {
-        return "`" + identifier.replace("`", "``") + "`";
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -29,7 +29,9 @@ import org.apache.flink.cdc.common.pipeline.RuntimeExecutionMode;
 import org.apache.flink.cdc.common.schema.Selectors;
 import org.apache.flink.cdc.common.source.DataSource;
 import org.apache.flink.cdc.common.utils.StringUtils;
+import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlDataSource;
+import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.flink.cdc.connectors.mysql.source.config.ServerIdRange;
 import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
@@ -43,6 +45,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectPath;
 
 import com.mysql.cj.conf.PropertyKey;
+import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +58,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -224,6 +228,15 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
 
         List<TableId> tableIds = MySqlSchemaUtils.listTables(configFactory.createConfig(0), null);
 
+        // Resolve concrete table names for lineage (always, regardless of binlog mode)
+        Selectors tableSelectors = new Selectors.SelectorsBuilder().includeTables(tables).build();
+        List<String> tableList = getTableList(tableIds, tableSelectors);
+        if (tablesExclude != null) {
+            Selectors excludeSelectors =
+                    new Selectors.SelectorsBuilder().includeTables(tablesExclude).build();
+            tableList.removeAll(getTableList(tableIds, excludeSelectors));
+        }
+
         if (scanBinlogNewlyAddedTableEnabled && scanNewlyAddedTableEnabled) {
             throw new IllegalArgumentException(
                     "If both scan.binlog.newly-added-table.enabled and scan.newly-added-table.enabled are true, data maybe duplicate after restore");
@@ -266,9 +279,9 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
                 if (splits.length == 2) {
                     Selectors chunkKeySelector =
                             new Selectors.SelectorsBuilder().includeTables(splits[0]).build();
-                    List<ObjectPath> tableList =
+                    List<ObjectPath> chunkKeyTables =
                             getChunkKeyColumnTableList(tableIds, chunkKeySelector);
-                    for (ObjectPath table : tableList) {
+                    for (ObjectPath table : chunkKeyTables) {
                         chunkKeyColumnMap.put(table, splits[1]);
                     }
                 } else {
@@ -284,9 +297,13 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
             LOG.info("Add chunkKeyColumn {}.", chunkKeyColumnMap);
             configFactory.chunkKeyColumn(chunkKeyColumnMap);
         }
+        // Fetch table schemas for lineage.
+        Map<String, LinkedHashMap<String, String>> tableSchemas =
+                fetchTableSchemas(configFactory, tableList);
+
         String metadataList = config.get(METADATA_LIST);
         List<MySqlReadableMetadata> readableMetadataList = listReadableMetadata(metadataList);
-        return new MySqlDataSource(configFactory, readableMetadataList);
+        return new MySqlDataSource(configFactory, readableMetadataList, tableList, tableSchemas);
     }
 
     private List<MySqlReadableMetadata> listReadableMetadata(String metadataList) {
@@ -526,5 +543,50 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
                     SERVER_TIME_ZONE.key());
             return ZoneId.systemDefault();
         }
+    }
+
+    /** Fetch table schemas for lineage schema facets. */
+    private static Map<String, LinkedHashMap<String, String>> fetchTableSchemas(
+            MySqlSourceConfigFactory configFactory, List<String> tableList) {
+        Map<String, LinkedHashMap<String, String>> schemas = new HashMap<>();
+        if (tableList == null || tableList.isEmpty()) {
+            return schemas;
+        }
+        try {
+            MySqlSourceConfig sourceConfig = configFactory.createConfig(0);
+            try (MySqlConnection jdbc = DebeziumUtils.createMySqlConnection(sourceConfig)) {
+                for (String table : tableList) {
+                    try {
+                        TableId tableId = TableId.parse(table);
+                        LinkedHashMap<String, String> fields = new LinkedHashMap<>();
+                        jdbc.query(
+                                "SHOW COLUMNS FROM "
+                                        + quoteIdentifier(tableId.getTableName())
+                                        + " FROM "
+                                        + quoteIdentifier(tableId.getSchemaName()),
+                                rs -> {
+                                    while (rs.next()) {
+                                        String name = rs.getString("Field");
+                                        String type = rs.getString("Type");
+                                        String nullable = rs.getString("Null");
+                                        fields.put(
+                                                name,
+                                                "YES".equals(nullable) ? type : type + " NOT NULL");
+                                    }
+                                });
+                        schemas.put(table, fields);
+                    } catch (Exception e) {
+                        LOG.warn("Failed to fetch schema for table {}: {}", table, e.getMessage());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch table schemas for lineage: {}", e.getMessage());
+        }
+        return schemas;
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        return "`" + identifier.replace("`", "``") + "`";
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSource.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSource.java
@@ -35,9 +35,7 @@ import org.apache.flink.cdc.debezium.table.DebeziumChangelogMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /** A {@link DataSource} for mysql cdc connector. */
 @Internal
@@ -46,30 +44,27 @@ public class MySqlDataSource implements DataSource {
     private final MySqlSourceConfigFactory configFactory;
     private final MySqlSourceConfig sourceConfig;
     private final List<String> tableList;
-    private final Map<String, LinkedHashMap<String, String>> tableSchemas;
 
     private List<MySqlReadableMetadata> readableMetadataList;
 
     public MySqlDataSource(MySqlSourceConfigFactory configFactory) {
-        this(configFactory, new ArrayList<>(), null, null);
+        this(configFactory, new ArrayList<>(), null);
     }
 
     public MySqlDataSource(
             MySqlSourceConfigFactory configFactory,
             List<MySqlReadableMetadata> readableMetadataList) {
-        this(configFactory, readableMetadataList, null, null);
+        this(configFactory, readableMetadataList, null);
     }
 
     public MySqlDataSource(
             MySqlSourceConfigFactory configFactory,
             List<MySqlReadableMetadata> readableMetadataList,
-            List<String> tableList,
-            Map<String, LinkedHashMap<String, String>> tableSchemas) {
+            List<String> tableList) {
         this.configFactory = configFactory;
         this.sourceConfig = configFactory.createConfig(0);
         this.readableMetadataList = readableMetadataList;
         this.tableList = tableList;
-        this.tableSchemas = tableSchemas;
     }
 
     @Override
@@ -100,8 +95,7 @@ public class MySqlDataSource implements DataSource {
                                         sourceReaderMetrics,
                                         sourceConfig,
                                         isTableIdCaseInsensitive),
-                        tableList,
-                        tableSchemas);
+                        tableList);
 
         return FlinkSourceProvider.of(source);
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSource.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSource.java
@@ -35,7 +35,9 @@ import org.apache.flink.cdc.debezium.table.DebeziumChangelogMode;
 import io.debezium.relational.RelationalDatabaseConnectorConfig;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /** A {@link DataSource} for mysql cdc connector. */
 @Internal
@@ -43,19 +45,31 @@ public class MySqlDataSource implements DataSource {
 
     private final MySqlSourceConfigFactory configFactory;
     private final MySqlSourceConfig sourceConfig;
+    private final List<String> tableList;
+    private final Map<String, LinkedHashMap<String, String>> tableSchemas;
 
     private List<MySqlReadableMetadata> readableMetadataList;
 
     public MySqlDataSource(MySqlSourceConfigFactory configFactory) {
-        this(configFactory, new ArrayList<>());
+        this(configFactory, new ArrayList<>(), null, null);
     }
 
     public MySqlDataSource(
             MySqlSourceConfigFactory configFactory,
             List<MySqlReadableMetadata> readableMetadataList) {
+        this(configFactory, readableMetadataList, null, null);
+    }
+
+    public MySqlDataSource(
+            MySqlSourceConfigFactory configFactory,
+            List<MySqlReadableMetadata> readableMetadataList,
+            List<String> tableList,
+            Map<String, LinkedHashMap<String, String>> tableSchemas) {
         this.configFactory = configFactory;
         this.sourceConfig = configFactory.createConfig(0);
         this.readableMetadataList = readableMetadataList;
+        this.tableList = tableList;
+        this.tableSchemas = tableSchemas;
     }
 
     @Override
@@ -85,7 +99,9 @@ public class MySqlDataSource implements DataSource {
                                         deserializer,
                                         sourceReaderMetrics,
                                         sourceConfig,
-                                        isTableIdCaseInsensitive));
+                                        isTableIdCaseInsensitive),
+                        tableList,
+                        tableSchemas);
 
         return FlinkSourceProvider.of(source);
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSourceFactoryTest.java
@@ -20,8 +20,12 @@ package org.apache.flink.cdc.connectors.mysql.source;
 import org.apache.flink.cdc.common.configuration.ConfigOption;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.factories.Factory;
+import org.apache.flink.cdc.common.source.FlinkSourceProvider;
 import org.apache.flink.cdc.connectors.mysql.factory.MySqlDataSourceFactory;
 import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ObjectPath;
 
@@ -74,6 +78,40 @@ class MySqlDataSourceFactoryTest extends MySqlSourceTestBase {
         MySqlDataSource dataSource = (MySqlDataSource) factory.createDataSource(context);
         assertThat(dataSource.getSourceConfig().getTableList())
                 .isEqualTo(Arrays.asList(inventoryDatabase.getDatabaseName() + ".products"));
+    }
+
+    @Test
+    void testCreateSourceLineage() {
+        inventoryDatabase.createAndInitialize();
+        Map<String, String> options = new HashMap<>();
+        options.put(HOSTNAME.key(), MYSQL_CONTAINER.getHost());
+        options.put(PORT.key(), String.valueOf(MYSQL_CONTAINER.getDatabasePort()));
+        options.put(USERNAME.key(), TEST_USER);
+        options.put(PASSWORD.key(), TEST_PASSWORD);
+        options.put(TABLES.key(), inventoryDatabase.getDatabaseName() + ".prod\\.*");
+        Factory.Context context = new MockContext(Configuration.fromMap(options));
+
+        MySqlDataSourceFactory factory = new MySqlDataSourceFactory();
+        MySqlDataSource dataSource = (MySqlDataSource) factory.createDataSource(context);
+        FlinkSourceProvider sourceProvider =
+                (FlinkSourceProvider) dataSource.getEventSourceProvider();
+        SourceLineageVertex lineageVertex =
+                (SourceLineageVertex)
+                        ((LineageVertexProvider) sourceProvider.getSource()).getLineageVertex();
+
+        assertThat(lineageVertex.datasets()).hasSize(1);
+        assertThat(lineageVertex.datasets().get(0).name())
+                .isEqualTo(inventoryDatabase.getDatabaseName() + ".products");
+        assertThat(lineageVertex.datasets().get(0).namespace())
+                .isEqualTo(
+                        "mysql://"
+                                + MYSQL_CONTAINER.getHost()
+                                + ":"
+                                + MYSQL_CONTAINER.getDatabasePort());
+
+        DatasetSchemaFacet schemaFacet =
+                (DatasetSchemaFacet) lineageVertex.datasets().get(0).facets().get("schema");
+        assertThat(schemaFacet.fields()).containsKeys("id", "name", "description", "weight");
     }
 
     @Test

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.common.lineage.LineageUtils;
 import org.apache.flink.cdc.connectors.mysql.MySqlValidator;
 import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
 import org.apache.flink.cdc.connectors.mysql.source.assigners.MySqlBinlogSplitAssigner;
@@ -54,6 +55,8 @@ import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.api.lineage.LineageVertex;
+import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import io.debezium.jdbc.JdbcConnection;
@@ -61,6 +64,9 @@ import io.debezium.jdbc.JdbcConnection;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 
 /**
@@ -93,7 +99,9 @@ import java.util.function.Supplier;
  */
 @Internal
 public class MySqlSource<T>
-        implements Source<T, MySqlSplit, PendingSplitsState>, ResultTypeQueryable<T> {
+        implements Source<T, MySqlSplit, PendingSplitsState>,
+                ResultTypeQueryable<T>,
+                LineageVertexProvider {
 
     private static final long serialVersionUID = 1L;
 
@@ -102,6 +110,8 @@ public class MySqlSource<T>
     private final MySqlSourceConfigFactory configFactory;
     private final DebeziumDeserializationSchema<T> deserializationSchema;
     private final RecordEmitterSupplier<T> recordEmitterSupplier;
+    private final List<String> tableList;
+    private final Map<String, LinkedHashMap<String, String>> tableSchemas;
 
     // Actions to perform during the snapshot phase.
     // This field is introduced for testing purpose, for example testing if changes made in the
@@ -138,9 +148,20 @@ public class MySqlSource<T>
             MySqlSourceConfigFactory configFactory,
             DebeziumDeserializationSchema<T> deserializationSchema,
             RecordEmitterSupplier<T> recordEmitterSupplier) {
+        this(configFactory, deserializationSchema, recordEmitterSupplier, null, null);
+    }
+
+    MySqlSource(
+            MySqlSourceConfigFactory configFactory,
+            DebeziumDeserializationSchema<T> deserializationSchema,
+            RecordEmitterSupplier<T> recordEmitterSupplier,
+            List<String> tableList,
+            Map<String, LinkedHashMap<String, String>> tableSchemas) {
         this.configFactory = configFactory;
         this.deserializationSchema = deserializationSchema;
         this.recordEmitterSupplier = recordEmitterSupplier;
+        this.tableList = tableList;
+        this.tableSchemas = tableSchemas;
     }
 
     public MySqlSourceConfigFactory getConfigFactory() {
@@ -155,6 +176,18 @@ public class MySqlSource<T>
         } else {
             return Boundedness.CONTINUOUS_UNBOUNDED;
         }
+    }
+
+    @Override
+    public LineageVertex getLineageVertex() {
+        MySqlSourceConfig sourceConfig = configFactory.createConfig(0);
+        return LineageUtils.sourceLineageVertex(
+                "mysql",
+                sourceConfig.getHostname(),
+                sourceConfig.getPort(),
+                sourceConfig.getStartupOptions().isSnapshotOnly(),
+                tableList,
+                tableSchemas);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.annotation.PublicEvolving;
 import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.lineage.LineageUtils;
 import org.apache.flink.cdc.connectors.mysql.MySqlValidator;
 import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
@@ -59,15 +60,20 @@ import org.apache.flink.streaming.api.lineage.LineageVertex;
 import org.apache.flink.streaming.api.lineage.LineageVertexProvider;
 import org.apache.flink.util.FlinkRuntimeException;
 
+import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.jdbc.JdbcConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * The MySQL CDC Source based on FLIP-27 and Watermark Signal Algorithm which supports parallel
@@ -105,13 +111,15 @@ public class MySqlSource<T>
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOG = LoggerFactory.getLogger(MySqlSource.class);
+
     private static final String ENUMERATOR_SERVER_NAME = "mysql_source_split_enumerator";
 
     private final MySqlSourceConfigFactory configFactory;
     private final DebeziumDeserializationSchema<T> deserializationSchema;
     private final RecordEmitterSupplier<T> recordEmitterSupplier;
     private final List<String> tableList;
-    private final Map<String, LinkedHashMap<String, String>> tableSchemas;
+    private transient Map<String, LinkedHashMap<String, String>> fetchedLineageTableSchemas;
 
     // Actions to perform during the snapshot phase.
     // This field is introduced for testing purpose, for example testing if changes made in the
@@ -148,20 +156,18 @@ public class MySqlSource<T>
             MySqlSourceConfigFactory configFactory,
             DebeziumDeserializationSchema<T> deserializationSchema,
             RecordEmitterSupplier<T> recordEmitterSupplier) {
-        this(configFactory, deserializationSchema, recordEmitterSupplier, null, null);
+        this(configFactory, deserializationSchema, recordEmitterSupplier, null);
     }
 
     MySqlSource(
             MySqlSourceConfigFactory configFactory,
             DebeziumDeserializationSchema<T> deserializationSchema,
             RecordEmitterSupplier<T> recordEmitterSupplier,
-            List<String> tableList,
-            Map<String, LinkedHashMap<String, String>> tableSchemas) {
+            List<String> tableList) {
         this.configFactory = configFactory;
         this.deserializationSchema = deserializationSchema;
         this.recordEmitterSupplier = recordEmitterSupplier;
-        this.tableList = tableList;
-        this.tableSchemas = tableSchemas;
+        this.tableList = tableList == null ? null : new ArrayList<>(tableList);
     }
 
     public MySqlSourceConfigFactory getConfigFactory() {
@@ -181,13 +187,80 @@ public class MySqlSource<T>
     @Override
     public LineageVertex getLineageVertex() {
         MySqlSourceConfig sourceConfig = configFactory.createConfig(0);
+
+        /*
+         * Note: Flink collects lineage during job graph construction, so this includes tables that
+         * already exist when the job is submitted. If `scan.binlog.newly-added-table.enabled` later
+         * captures newly created tables while the job is running, those tables appear in lineage
+         * in the next job submission.
+         */
         return LineageUtils.sourceLineageVertex(
                 "mysql",
                 sourceConfig.getHostname(),
                 sourceConfig.getPort(),
                 sourceConfig.getStartupOptions().isSnapshotOnly(),
                 tableList,
-                tableSchemas);
+                fetchLineageTableSchemas(sourceConfig));
+    }
+
+    /** Fetch table schemas for lineage schema facets, only called when lineage is enabled. */
+    private synchronized Map<String, LinkedHashMap<String, String>> fetchLineageTableSchemas(
+            MySqlSourceConfig sourceConfig) {
+        if (fetchedLineageTableSchemas != null) {
+            return fetchedLineageTableSchemas;
+        }
+        Map<String, LinkedHashMap<String, String>> schemas = new HashMap<>();
+        if (tableList == null || tableList.isEmpty()) {
+            fetchedLineageTableSchemas = schemas;
+            return fetchedLineageTableSchemas;
+        }
+        List<TableId> tableIds =
+                tableList.stream().map(TableId::parse).collect(Collectors.toList());
+        tableList.forEach(table -> schemas.put(table, new LinkedHashMap<>()));
+        try (MySqlConnection jdbc = DebeziumUtils.createMySqlConnection(sourceConfig)) {
+            jdbc.query(
+                    "SELECT TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE "
+                            + "FROM information_schema.COLUMNS WHERE "
+                            + tableFilter(tableIds)
+                            + " ORDER BY TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION",
+                    rs -> {
+                        while (rs.next()) {
+                            String table =
+                                    TableId.tableId(
+                                                    rs.getString("TABLE_SCHEMA"),
+                                                    rs.getString("TABLE_NAME"))
+                                            .toString();
+                            LinkedHashMap<String, String> fields = schemas.get(table);
+                            if (fields != null) {
+                                String type = rs.getString("COLUMN_TYPE");
+                                String nullable = rs.getString("IS_NULLABLE");
+                                fields.put(
+                                        rs.getString("COLUMN_NAME"),
+                                        "YES".equals(nullable) ? type : type + " NOT NULL");
+                            }
+                        }
+                    });
+        } catch (Exception e) {
+            LOG.warn("Failed to fetch table schemas for lineage: {}", e.getMessage());
+        }
+        fetchedLineageTableSchemas = schemas;
+        return fetchedLineageTableSchemas;
+    }
+
+    private static String tableFilter(List<TableId> tableIds) {
+        return tableIds.stream()
+                .map(
+                        tableId ->
+                                "(TABLE_SCHEMA = "
+                                        + quoteStringLiteral(tableId.getSchemaName())
+                                        + " AND TABLE_NAME = "
+                                        + quoteStringLiteral(tableId.getTableName())
+                                        + ")")
+                .collect(Collectors.joining(" OR "));
+    }
+
+    private static String quoteStringLiteral(String literal) {
+        return "'" + literal.replace("'", "''") + "'";
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceLineageTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceLineageTest.java
@@ -20,7 +20,6 @@ package org.apache.flink.cdc.connectors.mysql.source;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
-import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
 import org.apache.flink.streaming.api.lineage.LineageDataset;
 import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
 
@@ -28,9 +27,6 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.time.ZoneId;
-import java.util.Arrays;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,34 +34,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MySqlSourceLineageTest {
 
     @Test
-    void testGetLineageVertexUsesInjectedTablesAndSchemas() {
-        LinkedHashMap<String, String> customersSchema = new LinkedHashMap<>();
-        customersSchema.put("id", "int NOT NULL");
-        customersSchema.put("name", "varchar(255)");
-        Map<String, LinkedHashMap<String, String>> tableSchemas =
-                java.util.Collections.singletonMap("db.customers", customersSchema);
-
+    void testGetLineageVertexFallsBackToConnectorDatasetWithoutTables() {
         MySqlSource<String> source =
                 new MySqlSource<>(
                         configFactory(StartupOptions.initial()),
                         null,
-                        (metrics, sourceConfig) -> null,
-                        Arrays.asList("db.customers", "db.orders"),
-                        tableSchemas);
+                        (metrics, sourceConfig) -> null);
 
         SourceLineageVertex vertex = (SourceLineageVertex) source.getLineageVertex();
 
         assertThat(vertex.boundedness()).isEqualTo(Boundedness.CONTINUOUS_UNBOUNDED);
-        assertThat(vertex.datasets())
-                .extracting(LineageDataset::name)
-                .containsExactly("db.customers", "db.orders");
+        assertThat(vertex.datasets()).extracting(LineageDataset::name).containsExactly("mysql");
         assertThat(vertex.datasets().get(0).namespace()).isEqualTo("mysql://mysql-host:3307");
-
-        DatasetSchemaFacet schemaFacet =
-                (DatasetSchemaFacet) vertex.datasets().get(0).facets().get("schema");
-        assertThat(schemaFacet.fields().get("id").type()).isEqualTo("int NOT NULL");
-        assertThat(schemaFacet.fields().get("name").type()).isEqualTo("varchar(255)");
-        assertThat(vertex.datasets().get(1).facets()).doesNotContainKey("schema");
+        assertThat(vertex.datasets().get(0).facets()).doesNotContainKey("schema");
     }
 
     @Test
@@ -74,9 +55,7 @@ class MySqlSourceLineageTest {
                 new MySqlSource<>(
                         configFactory(StartupOptions.snapshot()),
                         null,
-                        (metrics, sourceConfig) -> null,
-                        java.util.Collections.singletonList("db.customers"),
-                        java.util.Collections.emptyMap());
+                        (metrics, sourceConfig) -> null);
 
         SourceLineageVertex vertex = (SourceLineageVertex) source.getLineageVertex();
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceLineageTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceLineageTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
+import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
+import org.apache.flink.streaming.api.lineage.DatasetSchemaFacet;
+import org.apache.flink.streaming.api.lineage.LineageDataset;
+import org.apache.flink.streaming.api.lineage.SourceLineageVertex;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for MySQL source lineage. */
+class MySqlSourceLineageTest {
+
+    @Test
+    void testGetLineageVertexUsesInjectedTablesAndSchemas() {
+        LinkedHashMap<String, String> customersSchema = new LinkedHashMap<>();
+        customersSchema.put("id", "int NOT NULL");
+        customersSchema.put("name", "varchar(255)");
+        Map<String, LinkedHashMap<String, String>> tableSchemas =
+                java.util.Collections.singletonMap("db.customers", customersSchema);
+
+        MySqlSource<String> source =
+                new MySqlSource<>(
+                        configFactory(StartupOptions.initial()),
+                        null,
+                        (metrics, sourceConfig) -> null,
+                        Arrays.asList("db.customers", "db.orders"),
+                        tableSchemas);
+
+        SourceLineageVertex vertex = (SourceLineageVertex) source.getLineageVertex();
+
+        assertThat(vertex.boundedness()).isEqualTo(Boundedness.CONTINUOUS_UNBOUNDED);
+        assertThat(vertex.datasets())
+                .extracting(LineageDataset::name)
+                .containsExactly("db.customers", "db.orders");
+        assertThat(vertex.datasets().get(0).namespace()).isEqualTo("mysql://mysql-host:3307");
+
+        DatasetSchemaFacet schemaFacet =
+                (DatasetSchemaFacet) vertex.datasets().get(0).facets().get("schema");
+        assertThat(schemaFacet.fields().get("id").type()).isEqualTo("int NOT NULL");
+        assertThat(schemaFacet.fields().get("name").type()).isEqualTo("varchar(255)");
+        assertThat(vertex.datasets().get(1).facets()).doesNotContainKey("schema");
+    }
+
+    @Test
+    void testGetLineageVertexUsesBoundednessFromStartupOptions() {
+        MySqlSource<String> source =
+                new MySqlSource<>(
+                        configFactory(StartupOptions.snapshot()),
+                        null,
+                        (metrics, sourceConfig) -> null,
+                        java.util.Collections.singletonList("db.customers"),
+                        java.util.Collections.emptyMap());
+
+        SourceLineageVertex vertex = (SourceLineageVertex) source.getLineageVertex();
+
+        assertThat(vertex.boundedness()).isEqualTo(Boundedness.BOUNDED);
+    }
+
+    private MySqlSourceConfigFactory configFactory(StartupOptions startupOptions) {
+        return new MySqlSourceConfigFactory()
+                .startupOptions(startupOptions)
+                .databaseList("db")
+                .tableList("db.customers")
+                .includeSchemaChanges(false)
+                .hostname("mysql-host")
+                .port(3307)
+                .splitSize(10)
+                .fetchSize(2)
+                .connectTimeout(Duration.ofSeconds(20))
+                .username("user")
+                .password("password")
+                .serverTimeZone(ZoneId.of("UTC").toString());
+    }
+}


### PR DESCRIPTION
Jira ticket: https://issues.apache.org/jira/browse/FLINK-39765

**Summary**: Adds Flink native lineage support ([FLIP-314](https://cwiki.apache.org/confluence/display/FLINK/FLIP-294%3A+Support+Customized+Catalog+Modification+Listener)) for the MySQL CDC source.

**Description**: 
- Implement `LineageVertexProvider` on MySqlSource so that OpenLineage events report captured MySQL tables as input datasets with schema metadata.
- This improves lineage for wildcard table patterns, including `scan.binlog.newly-added-table.enabled` jobs, for tables that already exist when the job is submitted. Tables created after job startup are captured at runtime but will only appear in lineage in the next job submission.
- Add shared lineage utilities in flink-cdc-common for reuse by other source connectors

**Testing**: 
- Added tests for the changes done
- Did manual tests to generate lineage events in openlineage format using native flink APIs, full event looks like: https://i.fluffy.cc/Xmw4KBHbx1wVMbcFvVxk7V45bB4MClZ3.html
- Example of how a single mysql table looks like:
```
{
      "namespace": "mysql://localhost:3306",
      "name": "testdb.users",
      "facets": {
        "schema": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.47.1/integration/flink",
          "_schemaURL": "https://openlineage.io/spec/facets/1-2-0/SchemaDatasetFacet.json#/$defs/SchemaDatasetFacet",
          "fields": [
            {
              "name": "id",
              "type": "int NOT NULL"
            },
            {
              "name": "name",
              "type": "varchar(100)"
            },
            {
              "name": "age",
              "type": "int"
            },
            {
              "name": "created_at",
              "type": "timestamp"
            }
          ]
        },
        "symlinks": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.47.1/integration/flink",
          "_schemaURL": "https://openlineage.io/spec/facets/1-0-1/SymlinksDatasetFacet.json#/$defs/SymlinksDatasetFacet",
          "identifiers": []
        },
        "config": {
          "_producer": "https://github.com/OpenLineage/OpenLineage/tree/1.47.1/integration/flink",
          "_schemaURL": "https://openlineage.io/spec/2-0-2/OpenLineage.json#/$defs/DatasetFacet",
          "type": "mysql-cdc"
        }
      }
    }
```