### PR TITLE
[FLINK-39795][connect/mongodb] Fix MongoDB sharded chunk lookup to keep index-backed reads

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/utils/MongoUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/main/java/org/apache/flink/cdc/connectors/mongodb/source/utils/MongoUtils.java
@@ -86,6 +86,7 @@ public class MongoUtils {
     public static final int CHANGE_STREAM_HISTORY_LOST = 286;
     public static final int BSON_OBJECT_TOO_LARGE = 10334;
     public static final int UNKNOWN_FIELD_ERROR = 40415;
+    private static final int MONGO_CHUNKS_UUID_FILTER_VERSION_CODE = 409;
 
     private static final Set<Integer> INVALID_CHANGE_STREAM_ERRORS =
             new HashSet<>(
@@ -380,19 +381,40 @@ public class MongoUtils {
                 collectionFor(mongoClient, TableId.parse("config.chunks"), BsonDocument.class);
         List<BsonDocument> collectionChunks = new ArrayList<>();
 
-        Bson filter =
-                or(
-                        new BsonDocument(NAMESPACE_FIELD, collectionMetadata.get(ID_FIELD)),
-                        // MongoDB 4.9.0 removed ns field of config.chunks collection, using
-                        // collection's uuid instead.
-                        // See: https://jira.mongodb.org/browse/SERVER-53105
-                        new BsonDocument(UUID_FIELD, collectionMetadata.get(UUID_FIELD)));
+        Bson filter = chunksFilter(collectionMetadata, readMongoVersionCode(mongoClient));
 
         chunks.find(filter)
                 .projection(include("min", "max", "shard"))
                 .sort(ascending("min"))
                 .into(collectionChunks);
         return collectionChunks;
+    }
+
+    static Bson chunksFilter(BsonDocument collectionMetadata, @Nullable Integer mongoVersionCode) {
+        Bson nsFilter = new BsonDocument(NAMESPACE_FIELD, collectionMetadata.get(ID_FIELD));
+        Bson uuidFilter = new BsonDocument(UUID_FIELD, collectionMetadata.get(UUID_FIELD));
+
+        if (mongoVersionCode == null) {
+            // Keep old behavior when version detection fails.
+            return or(nsFilter, uuidFilter);
+        }
+
+        // MongoDB 4.9.0 removed ns field from config.chunks and uses collection uuid instead.
+        // See: https://jira.mongodb.org/browse/SERVER-53105
+        return mongoVersionCode >= MONGO_CHUNKS_UUID_FILTER_VERSION_CODE ? uuidFilter : nsFilter;
+    }
+
+    @Nullable
+    static Integer readMongoVersionCode(MongoClient mongoClient) {
+        try {
+            String[] parts = getMongoVersion(mongoClient).split("\\.");
+            int major = Integer.parseInt(parts[0]);
+            int minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+            return major * 100 + minor;
+        } catch (RuntimeException e) {
+            LOG.warn("Failed to read MongoDB version, fallback to chunks $or filter.", e);
+        }
+        return null;
     }
 
     @Nullable
@@ -417,10 +439,15 @@ public class MongoUtils {
 
     public static String getMongoVersion(MongoDBSourceConfig sourceConfig) {
         MongoClient client = MongoClientPool.getInstance().getOrCreateMongoClient(sourceConfig);
-        return client.getDatabase("config")
-                .runCommand(new BsonDocument("buildinfo", new BsonString("")))
-                .get("version")
-                .toString();
+        return getMongoVersion(client);
+    }
+
+    public static String getMongoVersion(MongoClient mongoClient) {
+        return mongoClient
+                .getDatabase("config")
+                .runCommand(new BsonDocument("buildinfo", new BsonString("")), BsonDocument.class)
+                .getString("version")
+                .getValue();
     }
 
     public static MongoClient clientFor(MongoDBSourceConfig sourceConfig) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/LegacyMongoDBContainer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/LegacyMongoDBContainer.java
@@ -42,7 +42,7 @@ public class LegacyMongoDBContainer extends GenericContainer<LegacyMongoDBContai
 
     private static final Logger LOG = LoggerFactory.getLogger(LegacyMongoDBContainer.class);
 
-    private static final String DOCKER_IMAGE_NAME = "mongo:5.0.2";
+    private static final String DEFAULT_DOCKER_IMAGE_NAME = "mongo:5.0.2";
 
     public static final int MONGODB_PORT = 27017;
 
@@ -57,19 +57,25 @@ public class LegacyMongoDBContainer extends GenericContainer<LegacyMongoDBContai
     private static final Pattern COMMENT_PATTERN = Pattern.compile("^(.*)//.*$");
 
     private final ShardingClusterRole clusterRole;
+    private final String dockerImageName;
 
     public LegacyMongoDBContainer(Network network) {
-        this(network, ShardingClusterRole.NONE);
+        this(network, ShardingClusterRole.NONE, DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public LegacyMongoDBContainer(Network network, ShardingClusterRole clusterRole) {
+        this(network, clusterRole, DEFAULT_DOCKER_IMAGE_NAME);
+    }
+
+    public LegacyMongoDBContainer(
+            Network network, ShardingClusterRole clusterRole, String dockerImageName) {
         super(
                 new ImageFromDockerfile()
                         .withFileFromClasspath("random.key", "docker/mongodb/random.key")
                         .withFileFromClasspath("setup.js", "docker/mongodb/setup.js")
                         .withDockerfileFromBuilder(
                                 builder ->
-                                        builder.from(DOCKER_IMAGE_NAME)
+                                        builder.from(dockerImageName)
                                                 .copy(
                                                         "setup.js",
                                                         "/docker-entrypoint-initdb.d/setup.js")
@@ -83,6 +89,7 @@ public class LegacyMongoDBContainer extends GenericContainer<LegacyMongoDBContai
                                                 .env("MONGO_INITDB_DATABASE", "admin")
                                                 .build()));
         this.clusterRole = clusterRole;
+        this.dockerImageName = dockerImageName;
 
         withNetwork(network);
         withNetworkAliases(clusterRole.hostname);
@@ -111,6 +118,8 @@ public class LegacyMongoDBContainer extends GenericContainer<LegacyMongoDBContai
                             MONGO_SUPER_USER,
                             "-p",
                             MONGO_SUPER_PASSWORD,
+                            "--authenticationDatabase",
+                            "admin",
                             "--eval",
                             command);
             LOG.info(execResult.getStdout());
@@ -125,7 +134,10 @@ public class LegacyMongoDBContainer extends GenericContainer<LegacyMongoDBContai
 
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
-        LOG.info("Preparing a MongoDB Container with sharding cluster role {}...", clusterRole);
+        LOG.info(
+                "Preparing MongoDB container image {} with sharding cluster role {}...",
+                dockerImageName,
+                clusterRole);
         if (clusterRole != ShardingClusterRole.ROUTER) {
             initReplicaSet();
         } else {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/LegacyShardedChunkSplitterITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/LegacyShardedChunkSplitterITCase.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.cdc.connectors.mongodb.LegacyMongoDBContainer;
+import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSource;
+import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSourceBuilder;
+import org.apache.flink.cdc.connectors.mongodb.source.utils.MongoUtils;
+import org.apache.flink.cdc.connectors.mongodb.utils.TestTable;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.CloseableIterator;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import io.debezium.relational.TableId;
+import org.assertj.core.api.Assertions;
+import org.bson.Document;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.Network;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.in;
+import static com.mongodb.client.model.Sorts.descending;
+import static org.apache.flink.cdc.connectors.mongodb.LegacyMongoDBContainer.FLINK_USER;
+import static org.apache.flink.cdc.connectors.mongodb.LegacyMongoDBContainer.FLINK_USER_PASSWORD;
+import static org.apache.flink.cdc.connectors.mongodb.LegacyMongoDBContainer.MONGO_SUPER_PASSWORD;
+import static org.apache.flink.cdc.connectors.mongodb.LegacyMongoDBContainer.MONGO_SUPER_USER;
+import static org.apache.flink.cdc.connectors.mongodb.utils.MongoDBTestUtils.fetchRowData;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.catalog.Column.physical;
+
+/** Legacy sharded splitter IT cases for MongoDB version boundaries. */
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
+class LegacyShardedChunkSplitterITCase {
+
+    private static final String PROFILE_NAMESPACE = "config.chunks";
+    private static final String PROFILE_COMMAND_NAMESPACE = "config.$cmd";
+    private static final String TARGET_COLLECTION = "shopping_cart";
+
+    static Stream<Arguments> mongoVersions() {
+        return Stream.of(Arguments.of("4.4.29", "ns"), Arguments.of("5.0.2", "uuid"));
+    }
+
+    @ParameterizedTest(name = "legacy-mongo-{0} filter-{1}")
+    @MethodSource("mongoVersions")
+    void testLegacyShardedChunkSplitterWithSource(String mongoVersion, String expectedFilterField)
+            throws Exception {
+        Network network = Network.newNetwork();
+        LegacyMongoDBContainer config =
+                new LegacyMongoDBContainer(
+                        network,
+                        LegacyMongoDBContainer.ShardingClusterRole.CONFIG,
+                        "mongo:" + mongoVersion);
+        LegacyMongoDBContainer shard =
+                new LegacyMongoDBContainer(
+                        network,
+                        LegacyMongoDBContainer.ShardingClusterRole.SHARD,
+                        "mongo:" + mongoVersion);
+        LegacyMongoDBContainer router =
+                new LegacyMongoDBContainer(
+                        network,
+                        LegacyMongoDBContainer.ShardingClusterRole.ROUTER,
+                        "mongo:" + mongoVersion);
+        shard.dependsOn(config);
+        router.dependsOn(shard);
+
+        MongoClient configClient = null;
+        try {
+            config.start();
+            shard.start();
+            router.start();
+
+            String database = router.executeCommandFileInSeparateDatabase("chunk_test");
+
+            setConfigProfiler(config, 2);
+            Instant queryStart = Instant.now();
+
+            List<String> records = readSnapshotWithSource(router, database);
+            Assertions.assertThat(records).hasSize(20480);
+            Assertions.assertThat(records).contains("+I[1, KIND_1, user_1, my shopping cart 1]");
+            Assertions.assertThat(records)
+                    .contains("+I[20480, KIND_20480, user_20480, my shopping cart 20480]");
+
+            configClient = createMongoClient(config);
+            // In legacy sharding topologies, mongos-level commands are not always visible in
+            // config.profile. Trigger the same chunks read directly against config server.
+            triggerChunksReadForProfiling(configClient, database);
+
+            List<Document> rawProfileEntries =
+                    rawProfileEntries(configClient.getDatabase("config"), queryStart);
+            List<Document> profileEntries =
+                    waitProfiledFindEntries(configClient.getDatabase("config"), queryStart);
+            Assertions.assertThat(profileEntries)
+                    .withFailMessage(
+                            "No matching profile entries. Raw profile entries:\n%s",
+                            profileDebugLines(rawProfileEntries))
+                    .isNotEmpty();
+            Assertions.assertThat(profiledPlanSummaries(profileEntries))
+                    .allMatch(plan -> plan != null && plan.contains("IXSCAN"));
+
+            for (Document entry : profileEntries) {
+                Document filter = findCommandFilter(entry);
+                Assertions.assertThat(filter).isNotNull();
+                Assertions.assertThat(filter).doesNotContainKey("$or");
+                Assertions.assertThat(filter).containsKey(expectedFilterField);
+            }
+        } finally {
+            setConfigProfiler(config, 0);
+            if (configClient != null) {
+                configClient.close();
+            }
+            router.close();
+            shard.close();
+            config.close();
+            network.close();
+        }
+    }
+
+    private void triggerChunksReadForProfiling(MongoClient configClient, String database) {
+        TableId tableId = new TableId(database, null, TARGET_COLLECTION);
+        org.bson.BsonDocument collectionMetadata =
+                MongoUtils.readCollectionMetadata(configClient, tableId);
+        Assertions.assertThat(collectionMetadata).isNotNull();
+        MongoUtils.readChunks(configClient, collectionMetadata);
+    }
+
+    private MongoClient createMongoClient(LegacyMongoDBContainer container) {
+        MongoClientSettings settings =
+                MongoClientSettings.builder()
+                        .applyConnectionString(
+                                new ConnectionString(
+                                        container.getConnectionString(
+                                                MONGO_SUPER_USER, MONGO_SUPER_PASSWORD)))
+                        .build();
+        return MongoClients.create(settings);
+    }
+
+    private void setConfigProfiler(LegacyMongoDBContainer config, int profileLevel) {
+        config.executeCommand(
+                String.format(
+                        "db = db.getSiblingDB('config');"
+                                + "var result = db.runCommand({ profile: %d, slowms: 0 });"
+                                + "if (!result.ok) { throw new Error(tojson(result)); }",
+                        profileLevel));
+    }
+
+    private List<String> readSnapshotWithSource(LegacyMongoDBContainer router, String database)
+            throws Exception {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        java.util.Arrays.asList(
+                                physical("product_no", BIGINT().notNull()),
+                                physical("product_kind", STRING()),
+                                physical("user_id", STRING()),
+                                physical("description", STRING())),
+                        new ArrayList<>(),
+                        UniqueConstraint.primaryKey(
+                                "pk", java.util.Collections.singletonList("product_no")));
+        TestTable table = new TestTable(database, TARGET_COLLECTION, schema);
+
+        MongoDBSource<RowData> source =
+                new MongoDBSourceBuilder<RowData>()
+                        .hosts(router.getHostAndPort())
+                        .databaseList(database)
+                        .collectionList(database + "." + TARGET_COLLECTION)
+                        .username(FLINK_USER)
+                        .password(FLINK_USER_PASSWORD)
+                        .startupOptions(StartupOptions.snapshot())
+                        .scanFullChangelog(false)
+                        .deserializer(table.getDeserializer(false))
+                        .build();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        try (CloseableIterator<RowData> iterator =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "Legacy Mongo source")
+                        .executeAndCollect()) {
+            return fetchRowData(iterator, 20480, table::stringify);
+        }
+    }
+
+    private List<Document> waitProfiledFindEntries(MongoDatabase database, Instant since)
+            throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            List<Document> entries = profiledFindEntries(database, since);
+            if (!entries.isEmpty()) {
+                return entries;
+            }
+            Thread.sleep(200);
+        }
+        return new ArrayList<>();
+    }
+
+    private List<Document> profiledFindEntries(MongoDatabase database, Instant since) {
+        List<Document> entries = rawProfileEntries(database, since);
+        return entries.stream()
+                .filter(LegacyShardedChunkSplitterITCase::isFindOperation)
+                .collect(Collectors.toList());
+    }
+
+    private List<Document> rawProfileEntries(MongoDatabase database, Instant since) {
+        MongoCollection<Document> profile = database.getCollection("system.profile");
+        return profile.find(
+                        and(
+                                in("ns", PROFILE_NAMESPACE, PROFILE_COMMAND_NAMESPACE),
+                                in("op", "query", "command")))
+                .sort(descending("ts"))
+                .limit(200)
+                .into(new ArrayList<>());
+    }
+
+    private static boolean isFindOperation(Document profileEntry) {
+        Document command = profileEntry.get("command", Document.class);
+        return command != null && "chunks".equals(command.getString("find"));
+    }
+
+    private List<String> profiledPlanSummaries(List<Document> entries) {
+        return entries.stream().map(e -> e.getString("planSummary")).collect(Collectors.toList());
+    }
+
+    private String profileDebugLines(List<Document> entries) {
+        return entries.stream()
+                .limit(20)
+                .map(
+                        entry -> {
+                            Document command = entry.get("command", Document.class);
+                            Object find = command == null ? null : command.get("find");
+                            Object filter = command == null ? null : command.get("filter");
+                            return String.format(
+                                    "ns=%s, op=%s, find=%s, filter=%s, plan=%s",
+                                    entry.get("ns"),
+                                    entry.get("op"),
+                                    find,
+                                    filter,
+                                    entry.get("planSummary"));
+                        })
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static Document findCommandFilter(Document profileEntry) {
+        Document command = profileEntry.get("command", Document.class);
+        return command == null ? null : command.get("filter", Document.class);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/LegacyShardedChunkSplitterITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/LegacyShardedChunkSplitterITCase.java
@@ -131,7 +131,11 @@ class LegacyShardedChunkSplitterITCase {
                             profileDebugLines(rawProfileEntries))
                     .isNotEmpty();
             Assertions.assertThat(profiledPlanSummaries(profileEntries))
-                    .allMatch(plan -> plan != null && plan.contains("IXSCAN"));
+                    .allMatch(
+                            plan ->
+                                    plan != null
+                                            && plan.contains("IXSCAN")
+                                            && !plan.contains("COLLSCAN"));
 
             for (Document entry : profileEntries) {
                 Document filter = findCommandFilter(entry);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/ShardedChunkSplitterITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/ShardedChunkSplitterITCase.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mongodb.source.assigners.splitters;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SnapshotSplit;
+import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSource;
+import org.apache.flink.cdc.connectors.mongodb.source.MongoDBSourceBuilder;
+import org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceConfig;
+import org.apache.flink.cdc.connectors.mongodb.source.config.MongoDBSourceConfigFactory;
+import org.apache.flink.cdc.connectors.mongodb.utils.MongoDBContainer;
+import org.apache.flink.cdc.connectors.mongodb.utils.TestTable;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.CloseableIterator;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import io.debezium.relational.TableId;
+import org.assertj.core.api.Assertions;
+import org.bson.Document;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.gte;
+import static com.mongodb.client.model.Filters.in;
+import static com.mongodb.client.model.Sorts.descending;
+import static org.apache.flink.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER;
+import static org.apache.flink.cdc.connectors.mongodb.utils.MongoDBContainer.FLINK_USER_PASSWORD;
+import static org.apache.flink.cdc.connectors.mongodb.utils.MongoDBTestUtils.fetchRowData;
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.catalog.Column.physical;
+
+/** IT tests for shard chunk splitter query plans. */
+@Timeout(value = 240, unit = TimeUnit.SECONDS)
+class ShardedChunkSplitterITCase {
+
+    private static final String TARGET_COLLECTION = "shopping_cart";
+    private static final String PROFILE_NAMESPACE = "config.chunks";
+    private static final int CONFIG_SERVER_PORT = 27019;
+
+    static Stream<Arguments> mongoVersions() {
+        return Stream.of(Arguments.of("6.0.13", "uuid"), Arguments.of("8.0.14", "uuid"));
+    }
+
+    @ParameterizedTest(name = "mongo-{0} filter-{1}")
+    @MethodSource("mongoVersions")
+    void testShardedChunkSplitterReadsChunksWithIndexedPlan(
+            String mongoVersion, String expectedFilterField) throws Exception {
+        MongoDBContainer container = new MongoDBContainer("mongo:" + mongoVersion).withSharding();
+        container.start();
+        MongoClient mongoClient = createMongoClient(container);
+        try {
+            String database = container.executeCommandFileInSeparateDatabase("chunk_test");
+            MongoDBSourceConfig sourceConfig = createSourceConfig(container, database);
+            SplitContext splitContext =
+                    SplitContext.of(sourceConfig, new TableId(database, null, TARGET_COLLECTION));
+
+            setConfigServerProfilerLevel(container, 2);
+            Instant queryStart = Instant.now();
+
+            Collection<SnapshotSplit> splits = ShardedSplitStrategy.INSTANCE.split(splitContext);
+            Assertions.assertThat(splits).isNotEmpty();
+
+            List<String> records = readSnapshotWithSource(container, database);
+            Assertions.assertThat(records).hasSize(20480);
+            Assertions.assertThat(records).contains("+I[1, KIND_1, user_1, my shopping cart 1]");
+            Assertions.assertThat(records)
+                    .contains("+I[20480, KIND_20480, user_20480, my shopping cart 20480]");
+
+            List<Document> profiledEntries =
+                    waitProfiledFindEntries(mongoClient.getDatabase("config"), queryStart);
+            Assertions.assertThat(profiledEntries).isNotEmpty();
+            Assertions.assertThat(profiledPlanSummaries(profiledEntries))
+                    .allMatch(plan -> plan != null && plan.contains("IXSCAN"));
+
+            for (Document entry : profiledEntries) {
+                Document filter = findCommandFilter(entry);
+                Assertions.assertThat(filter).isNotNull();
+                Assertions.assertThat(filter).doesNotContainKey("$or");
+                Assertions.assertThat(filter).containsKey(expectedFilterField);
+            }
+        } finally {
+            setConfigServerProfilerLevel(container, 0);
+            mongoClient.close();
+            container.stop();
+        }
+    }
+
+    private MongoClient createMongoClient(MongoDBContainer container) {
+        MongoClientSettings settings =
+                MongoClientSettings.builder()
+                        .applyConnectionString(
+                                new ConnectionString(container.getConnectionString()))
+                        .build();
+        return MongoClients.create(settings);
+    }
+
+    private MongoDBSourceConfig createSourceConfig(MongoDBContainer container, String database) {
+        return new MongoDBSourceConfigFactory()
+                .hosts(container.getHostAndPort())
+                .databaseList(database)
+                .collectionList(database + "." + TARGET_COLLECTION)
+                .username(FLINK_USER)
+                .password(FLINK_USER_PASSWORD)
+                .splitSizeMB(1)
+                .samplesPerChunk(10)
+                .pollAwaitTimeMillis(500)
+                .create(0);
+    }
+
+    private void setConfigServerProfilerLevel(MongoDBContainer container, int profileLevel) {
+        String command =
+                String.format(
+                        "const cfg = new Mongo('mongodb://127.0.0.1:%d/?directConnection=true');"
+                                + "const database = cfg.getDB('config');"
+                                + "database.runCommand({ profile: %d, slowms: 0 });",
+                        CONFIG_SERVER_PORT, profileLevel);
+        container.executeCommand(command);
+    }
+
+    private List<Document> waitProfiledFindEntries(MongoDatabase database, Instant since)
+            throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            List<Document> entries = profiledFindEntries(database, since);
+            if (!entries.isEmpty()) {
+                return entries;
+            }
+            Thread.sleep(200);
+        }
+        return new ArrayList<>();
+    }
+
+    private List<String> readSnapshotWithSource(MongoDBContainer container, String database)
+            throws Exception {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        java.util.Arrays.asList(
+                                physical("product_no", BIGINT().notNull()),
+                                physical("product_kind", STRING()),
+                                physical("user_id", STRING()),
+                                physical("description", STRING())),
+                        new ArrayList<>(),
+                        UniqueConstraint.primaryKey(
+                                "pk", java.util.Collections.singletonList("product_no")));
+        TestTable table = new TestTable(database, TARGET_COLLECTION, schema);
+        MongoDBSource<RowData> source =
+                new MongoDBSourceBuilder<RowData>()
+                        .hosts(container.getHostAndPort())
+                        .databaseList(database)
+                        .collectionList(database + "." + TARGET_COLLECTION)
+                        .username(FLINK_USER)
+                        .password(FLINK_USER_PASSWORD)
+                        .startupOptions(StartupOptions.snapshot())
+                        .scanFullChangelog(false)
+                        .deserializer(table.getDeserializer(false))
+                        .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        try (CloseableIterator<RowData> iterator =
+                env.fromSource(source, WatermarkStrategy.noWatermarks(), "Mongo source")
+                        .executeAndCollect()) {
+            return fetchRowData(iterator, 20480, table::stringify);
+        }
+    }
+
+    private List<Document> profiledFindEntries(MongoDatabase database, Instant since) {
+        MongoCollection<Document> profile = database.getCollection("system.profile");
+        List<Document> entries =
+                profile.find(
+                                and(
+                                        eq("ns", PROFILE_NAMESPACE),
+                                        in("op", "query", "command"),
+                                        gte("ts", Date.from(since))))
+                        .sort(descending("ts"))
+                        .into(new ArrayList<>());
+        return entries.stream()
+                .filter(ShardedChunkSplitterITCase::isFindOperation)
+                .collect(Collectors.toList());
+    }
+
+    private static boolean isFindOperation(Document profileEntry) {
+        Document command = profileEntry.get("command", Document.class);
+        return command != null && "chunks".equals(command.getString("find"));
+    }
+
+    private List<String> profiledPlanSummaries(List<Document> entries) {
+        return entries.stream().map(e -> e.getString("planSummary")).collect(Collectors.toList());
+    }
+
+    private static Document findCommandFilter(Document profileEntry) {
+        Document command = profileEntry.get("command", Document.class);
+        return command == null ? null : command.get("filter", Document.class);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/ShardedChunkSplitterITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/assigners/splitters/ShardedChunkSplitterITCase.java
@@ -108,7 +108,11 @@ class ShardedChunkSplitterITCase {
                     waitProfiledFindEntries(mongoClient.getDatabase("config"), queryStart);
             Assertions.assertThat(profiledEntries).isNotEmpty();
             Assertions.assertThat(profiledPlanSummaries(profiledEntries))
-                    .allMatch(plan -> plan != null && plan.contains("IXSCAN"));
+                    .allMatch(
+                            plan ->
+                                    plan != null
+                                            && plan.contains("IXSCAN")
+                                            && !plan.contains("COLLSCAN"));
 
             for (Document entry : profiledEntries) {
                 Document filter = findCommandFilter(entry);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/utils/MongoUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/java/org/apache/flink/cdc/connectors/mongodb/source/utils/MongoUtilsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mongodb.source.utils;
+
+import com.mongodb.MongoClientSettings;
+import org.assertj.core.api.Assertions;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonDocument;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.apache.flink.cdc.connectors.mongodb.internal.MongoDBEnvelope.ID_FIELD;
+import static org.apache.flink.cdc.connectors.mongodb.internal.MongoDBEnvelope.NAMESPACE_FIELD;
+import static org.apache.flink.cdc.connectors.mongodb.internal.MongoDBEnvelope.UUID_FIELD;
+
+/** Unit test cases for {@link MongoUtils}. */
+class MongoUtilsTest {
+
+    @Test
+    void testChunksFilterUsesNamespaceOnMongo48AndLower() {
+        BsonDocument collectionMetadata = collectionMetadata();
+
+        BsonDocument filter = toBsonDocument(MongoUtils.chunksFilter(collectionMetadata, 408));
+
+        Assertions.assertThat(filter)
+                .isEqualTo(new BsonDocument(NAMESPACE_FIELD, collectionMetadata.get(ID_FIELD)));
+    }
+
+    @Test
+    void testChunksFilterUsesUuidOnMongo49AndHigher() {
+        BsonDocument collectionMetadata = collectionMetadata();
+
+        BsonDocument filter = toBsonDocument(MongoUtils.chunksFilter(collectionMetadata, 409));
+
+        Assertions.assertThat(filter)
+                .isEqualTo(new BsonDocument(UUID_FIELD, collectionMetadata.get(UUID_FIELD)));
+    }
+
+    @Test
+    void testChunksFilterFallsBackToOrWhenVersionUnknown() {
+        BsonDocument collectionMetadata = collectionMetadata();
+
+        BsonDocument filter = toBsonDocument(MongoUtils.chunksFilter(collectionMetadata, null));
+
+        Assertions.assertThat(filter.keySet()).containsExactly("$or");
+        Assertions.assertThat(filter.getArray("$or"))
+                .isEqualTo(
+                        new BsonArray(
+                                Arrays.asList(
+                                        new BsonDocument(
+                                                NAMESPACE_FIELD, collectionMetadata.get(ID_FIELD)),
+                                        new BsonDocument(
+                                                UUID_FIELD, collectionMetadata.get(UUID_FIELD)))));
+    }
+
+    private static BsonDocument toBsonDocument(Bson bson) {
+        return bson.toBsonDocument(
+                BsonDocument.class, MongoClientSettings.getDefaultCodecRegistry());
+    }
+
+    private static BsonDocument collectionMetadata() {
+        return new BsonDocument(ID_FIELD, new BsonString("db.coll"))
+                .append(UUID_FIELD, new BsonBinary(new byte[] {1, 2, 3, 4}));
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/resources/docker/mongodb/setup.js
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mongodb-cdc/src/test/resources/docker/mongodb/setup.js
@@ -42,3 +42,29 @@ db.createUser(
    ]
  }
 );
+
+// Some legacy sharded tests execute admin commands (e.g. profile on config DB).
+// Ensure superuser exists and always has required privileges.
+if (!db.getUser('superuser')) {
+    db.createUser(
+        {
+            user: 'superuser',
+            pwd: 'superpw',
+            roles: [
+                { role: 'root', db: 'admin' },
+                { role: 'dbAdmin', db: 'config' }
+            ]
+        }
+    );
+} else {
+    db.updateUser(
+        'superuser',
+        {
+            pwd: 'superpw',
+            roles: [
+                { role: 'root', db: 'admin' },
+                { role: 'dbAdmin', db: 'config' }
+            ]
+        }
+    );
+}


### PR DESCRIPTION
This closes FLINK-39795.

The previous $or filter (ns or uuid) could prevent index-backed sorting on config.chunks, leading to in-memory sort and failures like “Sort operation used more than the maximum XXXX bytes of RAM”. Instead we choose the filter by MongoDB server version (with fallback handling) to ensure query read is in IXSCAN.

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (please specify the tool below)

Generated-by: Claude 1.9255.2 (Claude Opus 4.7)

