### PR TITLE
[FLINK-39758] Fix DECIMAL OOB in SchemaMergingUtils

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
@@ -453,11 +453,7 @@ public class SchemaMergingUtils {
                 Math.max(
                         decimalType.getPrecision(),
                         decimalType.getScale() + getNumericPrecision(otherType));
-        if (resultPrecision <= DecimalType.MAX_PRECISION) {
-            return DataTypes.DECIMAL(resultPrecision, decimalType.getScale());
-        } else {
-            return DataTypes.STRING();
-        }
+        return createDecimalBounded(resultPrecision, decimalType.getScale());
     }
 
     @VisibleForTesting

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
@@ -435,15 +435,7 @@ public class SchemaMergingUtils {
                             lhsDecimal.getPrecision() - lhsDecimal.getScale(),
                             rhsDecimal.getPrecision() - rhsDecimal.getScale());
             int resultScale = Math.max(lhsDecimal.getScale(), rhsDecimal.getScale());
-            Preconditions.checkArgument(
-                    resultIntDigits + resultScale <= DecimalType.MAX_PRECISION,
-                    String.format(
-                            "Failed to merge %s and %s type into DECIMAL. %d precision digits required, %d available",
-                            lType,
-                            rType,
-                            resultIntDigits + resultScale,
-                            DecimalType.MAX_PRECISION));
-            return DataTypes.DECIMAL(resultIntDigits + resultScale, resultScale);
+            return createDecimalBounded(resultIntDigits + resultScale, resultScale);
         } else if (lType instanceof DecimalType && rType.is(DataTypeFamily.EXACT_NUMERIC)) {
             // Merge decimal and int
             return mergeExactNumericsIntoDecimal((DecimalType) lType, rType);
@@ -934,5 +926,14 @@ public class SchemaMergingUtils {
         mergingTree.put(MapType.class, ImmutableList.of(stringType));
         mergingTree.put(VariantType.class, ImmutableList.of(stringType));
         return mergingTree;
+    }
+
+    static DecimalType createDecimalBounded(int precision, int scale) {
+        if (precision > DecimalType.MAX_PRECISION) {
+            int lossDigits = precision - DecimalType.MAX_PRECISION;
+            return DataTypes.DECIMAL(precision - lossDigits, scale - lossDigits);
+        } else {
+            return DataTypes.DECIMAL(precision, scale);
+        }
     }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaUtils.java
@@ -51,6 +51,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.cdc.common.utils.SchemaMergingUtils.createDecimalBounded;
+
 /** Utils for {@link Schema} to perform the ability of evolution. */
 @PublicEvolving
 public class SchemaUtils {
@@ -575,15 +577,7 @@ public class SchemaUtils {
                             lhsDecimal.getPrecision() - lhsDecimal.getScale(),
                             rhsDecimal.getPrecision() - rhsDecimal.getScale());
             int resultScale = Math.max(lhsDecimal.getScale(), rhsDecimal.getScale());
-            Preconditions.checkArgument(
-                    resultIntDigits + resultScale <= DecimalType.MAX_PRECISION,
-                    String.format(
-                            "Failed to merge %s and %s type into DECIMAL. %d precision digits required, %d available",
-                            lType,
-                            rType,
-                            resultIntDigits + resultScale,
-                            DecimalType.MAX_PRECISION));
-            mergedType = DataTypes.DECIMAL(resultIntDigits + resultScale, resultScale);
+            mergedType = createDecimalBounded(resultIntDigits + resultScale, resultScale);
         } else if (lType instanceof DecimalType && rType.is(DataTypeFamily.EXACT_NUMERIC)) {
             // Merge decimal and int
             mergedType = mergeExactNumericsIntoDecimal((DecimalType) lType, rType);
@@ -608,12 +602,7 @@ public class SchemaUtils {
                 Math.max(
                         decimalType.getPrecision(),
                         decimalType.getScale() + getNumericPrecision(otherType));
-        Preconditions.checkArgument(
-                resultPrecision <= DecimalType.MAX_PRECISION,
-                String.format(
-                        "Failed to merge %s and %s type into DECIMAL. %d precision digits required, %d available",
-                        decimalType, otherType, resultPrecision, DecimalType.MAX_PRECISION));
-        return DataTypes.DECIMAL(resultPrecision, decimalType.getScale());
+        return createDecimalBounded(resultPrecision, decimalType.getScale());
     }
 
     @Deprecated

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaUtilsTest.java
@@ -314,21 +314,15 @@ class SchemaUtilsTest {
                 .isEqualTo(DataTypes.DECIMAL(12, 4));
 
         // Test overflow decimal conversions
-        Assertions.assertThatThrownBy(
-                        () ->
-                                SchemaUtils.inferWiderType(
-                                        DataTypes.DECIMAL(5, 5), DataTypes.DECIMAL(38, 0)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "Failed to merge DECIMAL(5, 5) NOT NULL and DECIMAL(38, 0) NOT NULL type into DECIMAL. 43 precision digits required, 38 available");
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(
+                                DataTypes.DECIMAL(5, 5), DataTypes.DECIMAL(38, 0)))
+                .isEqualTo(DataTypes.DECIMAL(38, 0));
 
-        Assertions.assertThatThrownBy(
-                        () ->
-                                SchemaUtils.inferWiderType(
-                                        DataTypes.DECIMAL(38, 0), DataTypes.DECIMAL(5, 5)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessage(
-                        "Failed to merge DECIMAL(38, 0) NOT NULL and DECIMAL(5, 5) NOT NULL type into DECIMAL. 43 precision digits required, 38 available");
+        Assertions.assertThat(
+                        SchemaUtils.inferWiderType(
+                                DataTypes.DECIMAL(38, 0), DataTypes.DECIMAL(5, 5)))
+                .isEqualTo(DataTypes.DECIMAL(38, 0));
 
         // Test merging with nullability
         Assertions.assertThat(

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -1402,8 +1402,8 @@ class FlinkPipelineComposerITCase {
                         .map(
                                 s ->
                                         s.replace(
-                                                "{}",
-                                                "default_namespace.default_schema.default_everything_merged"))
+                                                "tableId={}",
+                                                "tableId=default_namespace.default_schema.default_everything_merged"))
                         .collect(Collectors.toList());
 
         runGenericMergingTest(
@@ -1429,7 +1429,7 @@ class FlinkPipelineComposerITCase {
                         3,
                         "1234567890123456.789",
                         List.of(
-                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(21, 5)}, primaryKeys=id, options=()}",
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(10, 5)}, primaryKeys=id, options=()}",
                                 "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(21, 5)}, oldTypeMapping={dec=DECIMAL(10, 5)}, comments={}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 12345.54321], op=INSERT, meta=()}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}")),

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -33,7 +33,6 @@ import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.Event;
-import org.apache.flink.cdc.common.event.InitializeTablesEvent;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.pipeline.PipelineOptions;
@@ -68,7 +67,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -1432,34 +1430,9 @@ class FlinkPipelineComposerITCase {
                         "1234567890123456.789",
                         List.of(
                                 "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(21, 5)}, primaryKeys=id, options=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 12345.54321], op=INSERT, meta=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}"),
-                        true),
-                Arguments.of(
-                        10,
-                        5,
-                        "12345.54321",
-                        19,
-                        3,
-                        "1234567890123456.789",
-                        List.of(
-                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(10, 5)}, primaryKeys=id, options=()}",
                                 "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(21, 5)}, oldTypeMapping={dec=DECIMAL(10, 5)}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 12345.54321], op=INSERT, meta=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}"),
-                        false),
-                Arguments.of(
-                        25,
-                        16,
-                        "123456789.1234567890123456",
-                        32,
-                        32,
-                        "0.12345678901234567890123456789012",
-                        List.of(
-                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 29)}, primaryKeys=id, options=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 123456789.12345678901234560000000000000], op=INSERT, meta=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 0.12345678901234567890123456789], op=INSERT, meta=()}"),
-                        true),
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}")),
                 Arguments.of(
                         25,
                         16,
@@ -1471,20 +1444,7 @@ class FlinkPipelineComposerITCase {
                                 "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(25, 16)}, primaryKeys=id, options=()}",
                                 "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 29)}, oldTypeMapping={dec=DECIMAL(25, 16)}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 123456789.12345678901234560000000000000], op=INSERT, meta=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 0.12345678901234567890123456789], op=INSERT, meta=()}"),
-                        false),
-                Arguments.of(
-                        38,
-                        38,
-                        "0.12345678901234567890123456789012345678",
-                        38,
-                        0,
-                        "12345678901234567890123456789012345678",
-                        List.of(
-                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 0)}, primaryKeys=id, options=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 0], op=INSERT, meta=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 12345678901234567890123456789012345678], op=INSERT, meta=()}"),
-                        true),
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 0.12345678901234567890123456789], op=INSERT, meta=()}")),
                 Arguments.of(
                         38,
                         38,
@@ -1496,11 +1456,10 @@ class FlinkPipelineComposerITCase {
                                 "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 38)}, primaryKeys=id, options=()}",
                                 "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 0)}, oldTypeMapping={dec=DECIMAL(38, 38)}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 0], op=INSERT, meta=()}",
-                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 12345678901234567890123456789012345678], op=INSERT, meta=()}"),
-                        false));
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 12345678901234567890123456789012345678], op=INSERT, meta=()}")));
     }
 
-    @ParameterizedTest(name = "merge Decimal({0}, {1}) and Decimal({3}, {4}), atFirst: {7}")
+    @ParameterizedTest(name = "merge Decimal({0}, {1}) and Decimal({3}, {4})")
     @MethodSource("decimalOOB")
     void testMergingDecimalWithOutOfBoundPrecisions(
             int decimal1Precision,
@@ -1509,8 +1468,7 @@ class FlinkPipelineComposerITCase {
             int decimal2Precision,
             int decimal2Scale,
             String decimal2,
-            List<String> expectedOutput,
-            boolean mergeAtFirst)
+            List<String> expectedOutput)
             throws Exception {
         TableId tableId1 = TableId.tableId("test_database", "test_table_1");
         TableId tableId2 = TableId.tableId("test_database", "test_table_2");
@@ -1533,16 +1491,8 @@ class FlinkPipelineComposerITCase {
                 new BinaryRecordDataGenerator(
                         schema2.getColumnDataTypes().toArray(new DataType[0]));
         List<Event> events = new ArrayList<>();
-        if (mergeAtFirst) {
-            events.add(
-                    new InitializeTablesEvent(
-                            List.of(
-                                    new CreateTableEvent(tableId1, schema1),
-                                    new CreateTableEvent(tableId2, schema2))));
-        } else {
-            events.add(new CreateTableEvent(tableId1, schema1));
-            events.add(new CreateTableEvent(tableId2, schema2));
-        }
+        events.add(new CreateTableEvent(tableId1, schema1));
+        events.add(new CreateTableEvent(tableId2, schema2));
         events.add(
                 DataChangeEvent.insertEvent(
                         tableId1,

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.Event;
+import org.apache.flink.cdc.common.event.InitializeTablesEvent;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.pipeline.PipelineOptions;
@@ -64,7 +65,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -1371,53 +1375,8 @@ class FlinkPipelineComposerITCase {
     @ParameterizedTest
     @EnumSource
     void testMergingDecimalWithVariousPrecisions(ValuesDataSink.SinkApi sinkApi) throws Exception {
-        FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
-
-        // Setup value source
-        Configuration sourceConfig = new Configuration();
-        sourceConfig.set(
-                ValuesDataSourceOptions.EVENT_SET_ID,
-                ValuesDataSourceHelper.EventSetId.CUSTOM_SOURCE_EVENTS);
-
         List<Event> events = generateDecimalColumnEvents("default_table_");
-        ValuesDataSourceHelper.setSourceEvents(Collections.singletonList(events));
-
-        SourceDef sourceDef =
-                new SourceDef(ValuesDataFactory.IDENTIFIER, "Value Source", sourceConfig);
-
-        // Setup value sink
-        Configuration sinkConfig = new Configuration();
-        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
-        SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
-
-        // Setup pipeline
-        Configuration pipelineConfig = new Configuration();
-        pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, 1);
-        pipelineConfig.set(
-                PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR, SchemaChangeBehavior.EVOLVE);
-        PipelineDef pipelineDef =
-                new PipelineDef(
-                        sourceDef,
-                        sinkDef,
-                        Collections.singletonList(
-                                new RouteDef(
-                                        "default_namespace.default_schema.default_table_\\.*",
-                                        "default_namespace.default_schema.default_everything_merged",
-                                        null,
-                                        "Merge all decimal columns with different precision")),
-                        Collections.emptyList(),
-                        Collections.emptyList(),
-                        pipelineConfig);
-
-        // Execute the pipeline
-        PipelineExecution execution = composer.compose(pipelineDef);
-
-        execution.execute();
-
-        // Check the order and content of all received events
-        String[] outputEvents = outCaptor.toString().trim().split("\n");
-
-        String[] expected =
+        List<String> expected =
                 Stream.of(
                                 "CreateTableEvent{tableId={}, schema=columns={`id` INT,`name` STRING,`age` INT,`fav_num` TINYINT}, primaryKeys=id, options=()}",
                                 "DataChangeEvent{tableId={}, before=[], after=[1, Alice, 17, 1], op=INSERT, meta=()}",
@@ -1445,11 +1404,228 @@ class FlinkPipelineComposerITCase {
                         .map(
                                 s ->
                                         s.replace(
-                                                "tableId={}",
-                                                "tableId=default_namespace.default_schema.default_everything_merged"))
-                        .toArray(String[]::new);
+                                                "{}",
+                                                "default_namespace.default_schema.default_everything_merged"))
+                        .collect(Collectors.toList());
 
-        assertThat(outputEvents).containsExactlyInAnyOrder(expected);
+        runGenericMergingTest(
+                sinkApi,
+                List.of(),
+                List.of(
+                        new RouteDef(
+                                "default_namespace.default_schema.default_table_\\.*",
+                                "default_namespace.default_schema.default_everything_merged",
+                                null,
+                                "Merge all decimal columns with different precision")),
+                events,
+                expected);
+    }
+
+    static Stream<Arguments> decimalOOB() {
+        return Stream.of(
+                Arguments.of(
+                        10,
+                        5,
+                        "12345.54321",
+                        19,
+                        3,
+                        "1234567890123456.789",
+                        List.of(
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(21, 5)}, primaryKeys=id, options=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 12345.54321], op=INSERT, meta=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}"),
+                        true),
+                Arguments.of(
+                        10,
+                        5,
+                        "12345.54321",
+                        19,
+                        3,
+                        "1234567890123456.789",
+                        List.of(
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(10, 5)}, primaryKeys=id, options=()}",
+                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(21, 5)}, oldTypeMapping={dec=DECIMAL(10, 5)}}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 12345.54321], op=INSERT, meta=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}"),
+                        false),
+                Arguments.of(
+                        25,
+                        16,
+                        "123456789.1234567890123456",
+                        32,
+                        32,
+                        "0.12345678901234567890123456789012",
+                        List.of(
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 29)}, primaryKeys=id, options=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 123456789.12345678901234560000000000000], op=INSERT, meta=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 0.12345678901234567890123456789], op=INSERT, meta=()}"),
+                        true),
+                Arguments.of(
+                        25,
+                        16,
+                        "123456789.1234567890123456",
+                        32,
+                        32,
+                        "0.12345678901234567890123456789012",
+                        List.of(
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(25, 16)}, primaryKeys=id, options=()}",
+                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 29)}, oldTypeMapping={dec=DECIMAL(25, 16)}}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 123456789.12345678901234560000000000000], op=INSERT, meta=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 0.12345678901234567890123456789], op=INSERT, meta=()}"),
+                        false),
+                Arguments.of(
+                        38,
+                        38,
+                        "0.12345678901234567890123456789012345678",
+                        38,
+                        0,
+                        "12345678901234567890123456789012345678",
+                        List.of(
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 0)}, primaryKeys=id, options=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 0], op=INSERT, meta=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 12345678901234567890123456789012345678], op=INSERT, meta=()}"),
+                        true),
+                Arguments.of(
+                        38,
+                        38,
+                        "0.12345678901234567890123456789012345678",
+                        38,
+                        0,
+                        "12345678901234567890123456789012345678",
+                        List.of(
+                                "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 38)}, primaryKeys=id, options=()}",
+                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 0)}, oldTypeMapping={dec=DECIMAL(38, 38)}}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 0], op=INSERT, meta=()}",
+                                "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 12345678901234567890123456789012345678], op=INSERT, meta=()}"),
+                        false));
+    }
+
+    @ParameterizedTest(name = "merge Decimal({0}, {1}) and Decimal({3}, {4}), atFirst: {7}")
+    @MethodSource("decimalOOB")
+    void testMergingDecimalWithOutOfBoundPrecisions(
+            int decimal1Precision,
+            int decimal1Scale,
+            String decimal1,
+            int decimal2Precision,
+            int decimal2Scale,
+            String decimal2,
+            List<String> expectedOutput,
+            boolean mergeAtFirst)
+            throws Exception {
+        TableId tableId1 = TableId.tableId("test_database", "test_table_1");
+        TableId tableId2 = TableId.tableId("test_database", "test_table_2");
+        Schema schema1 =
+                Schema.newBuilder()
+                        .physicalColumn("id", DataTypes.BIGINT().notNull())
+                        .physicalColumn("dec", DataTypes.DECIMAL(decimal1Precision, decimal1Scale))
+                        .primaryKey("id")
+                        .build();
+        Schema schema2 =
+                Schema.newBuilder()
+                        .physicalColumn("id", DataTypes.BIGINT().notNull())
+                        .physicalColumn("dec", DataTypes.DECIMAL(decimal2Precision, decimal2Scale))
+                        .primaryKey("id")
+                        .build();
+        BinaryRecordDataGenerator generator1 =
+                new BinaryRecordDataGenerator(
+                        schema1.getColumnDataTypes().toArray(new DataType[0]));
+        BinaryRecordDataGenerator generator2 =
+                new BinaryRecordDataGenerator(
+                        schema2.getColumnDataTypes().toArray(new DataType[0]));
+        List<Event> events = new ArrayList<>();
+        if (mergeAtFirst) {
+            events.add(
+                    new InitializeTablesEvent(
+                            List.of(
+                                    new CreateTableEvent(tableId1, schema1),
+                                    new CreateTableEvent(tableId2, schema2))));
+        } else {
+            events.add(new CreateTableEvent(tableId1, schema1));
+            events.add(new CreateTableEvent(tableId2, schema2));
+        }
+        events.add(
+                DataChangeEvent.insertEvent(
+                        tableId1,
+                        generator1.generate(
+                                new Object[] {
+                                    1L,
+                                    DecimalData.fromBigDecimal(
+                                            new BigDecimal(decimal1),
+                                            decimal1Precision,
+                                            decimal1Scale)
+                                })));
+        events.add(
+                DataChangeEvent.insertEvent(
+                        tableId2,
+                        generator2.generate(
+                                new Object[] {
+                                    2L,
+                                    DecimalData.fromBigDecimal(
+                                            new BigDecimal(decimal2),
+                                            decimal2Precision,
+                                            decimal2Scale)
+                                })));
+
+        runGenericMergingTest(
+                ValuesDataSink.SinkApi.SINK_V2,
+                List.of(),
+                List.of(
+                        new RouteDef(
+                                "test_database.test_table_\\.*",
+                                "test_database.merged",
+                                null,
+                                "Merge all decimal columns with different precision")),
+                events,
+                expectedOutput);
+    }
+
+    void runGenericMergingTest(
+            ValuesDataSink.SinkApi sinkApi,
+            List<TransformDef> transformDef,
+            List<RouteDef> routeDef,
+            List<Event> events,
+            List<String> expectedOutput)
+            throws Exception {
+        FlinkPipelineComposer composer = FlinkPipelineComposer.ofMiniCluster();
+
+        // Setup value source
+        Configuration sourceConfig = new Configuration();
+        sourceConfig.set(
+                ValuesDataSourceOptions.EVENT_SET_ID,
+                ValuesDataSourceHelper.EventSetId.CUSTOM_SOURCE_EVENTS);
+
+        ValuesDataSourceHelper.setSourceEvents(Collections.singletonList(events));
+
+        SourceDef sourceDef =
+                new SourceDef(ValuesDataFactory.IDENTIFIER, "Value Source", sourceConfig);
+
+        // Setup value sink
+        Configuration sinkConfig = new Configuration();
+        sinkConfig.set(ValuesDataSinkOptions.SINK_API, sinkApi);
+        SinkDef sinkDef = new SinkDef(ValuesDataFactory.IDENTIFIER, "Value Sink", sinkConfig);
+
+        // Setup pipeline
+        Configuration pipelineConfig = new Configuration();
+        pipelineConfig.set(PipelineOptions.PIPELINE_PARALLELISM, 1);
+        pipelineConfig.set(
+                PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR, SchemaChangeBehavior.EVOLVE);
+        PipelineDef pipelineDef =
+                new PipelineDef(
+                        sourceDef,
+                        sinkDef,
+                        routeDef,
+                        transformDef,
+                        Collections.emptyList(),
+                        pipelineConfig);
+
+        // Execute the pipeline
+        PipelineExecution execution = composer.compose(pipelineDef);
+
+        execution.execute();
+
+        // Check the order and content of all received events
+        String[] outputEvents = outCaptor.toString().trim().split("\n");
+        assertThat(outputEvents).containsExactlyInAnyOrderElementsOf(expectedOutput);
     }
 
     private List<Event> generateTemporalColumnEvents(String tableNamePrefix) {

--- a/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
+++ b/flink-cdc-composer/src/test/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposerITCase.java
@@ -1430,7 +1430,7 @@ class FlinkPipelineComposerITCase {
                         "1234567890123456.789",
                         List.of(
                                 "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(21, 5)}, primaryKeys=id, options=()}",
-                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(21, 5)}, oldTypeMapping={dec=DECIMAL(10, 5)}}",
+                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(21, 5)}, oldTypeMapping={dec=DECIMAL(10, 5)}, comments={}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 12345.54321], op=INSERT, meta=()}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 1234567890123456.78900], op=INSERT, meta=()}")),
                 Arguments.of(
@@ -1442,7 +1442,7 @@ class FlinkPipelineComposerITCase {
                         "0.12345678901234567890123456789012",
                         List.of(
                                 "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(25, 16)}, primaryKeys=id, options=()}",
-                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 29)}, oldTypeMapping={dec=DECIMAL(25, 16)}}",
+                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 29)}, oldTypeMapping={dec=DECIMAL(25, 16)}, comments={}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 123456789.12345678901234560000000000000], op=INSERT, meta=()}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 0.12345678901234567890123456789], op=INSERT, meta=()}")),
                 Arguments.of(
@@ -1454,7 +1454,7 @@ class FlinkPipelineComposerITCase {
                         "12345678901234567890123456789012345678",
                         List.of(
                                 "CreateTableEvent{tableId=test_database.merged, schema=columns={`id` BIGINT NOT NULL,`dec` DECIMAL(38, 38)}, primaryKeys=id, options=()}",
-                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 0)}, oldTypeMapping={dec=DECIMAL(38, 38)}}",
+                                "AlterColumnTypeEvent{tableId=test_database.merged, typeMapping={dec=DECIMAL(38, 0)}, oldTypeMapping={dec=DECIMAL(38, 38)}, comments={}}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[1, 0], op=INSERT, meta=()}",
                                 "DataChangeEvent{tableId=test_database.merged, before=[], after=[2, 12345678901234567890123456789012345678], op=INSERT, meta=()}")));
     }


### PR DESCRIPTION
**Summary**

This commit fixes the DECIMAL precision overflow (Out-Of-Bounds) issue in SchemaMergingUtils and SchemaUtils, which previously caused pipeline failures when merging DECIMAL types from multiple tables with significantly different precisions and scales.

**Key Changes**

1. New createDecimalBounded Utility Method

- Introduced createDecimalBounded method in SchemaMergingUtils to handle DECIMAL precision overflow gracefully
- When computed precision exceeds DecimalType.MAX_PRECISION (38), the method truncates scale digits instead of throwing an exception
- Truncation formula: lossDigits = precision - MAX_PRECISION, then resultPrecision = precision - lossDigits, resultScale = scale - lossDigits
- Follows the same approach as Flink SQL for handling DECIMAL overflow

2. SchemaMergingUtils Fix

- Replaced Preconditions.checkArgument with createDecimalBounded call in mergeDecimalTypes()
- Removed the hard failure that threw IllegalArgumentException when merged precision exceeded 38
- SchemaUtils Fix
- Applied the same createDecimalBounded fix in inferWiderType() for DECIMAL-to-DECIMAL merging
- Applied the same fix in mergeExactNumericsIntoDecimal() for DECIMAL-to-integer merging

3. Comprehensive Testing

- Updated SchemaUtilsTest to verify that overflow cases now return bounded DECIMAL types instead of throwing exceptions
- Added testMergingDecimalWithOutOfBoundPrecisions with 6 parameterized test cases covering various overflow scenarios
- Refactored FlinkPipelineComposerITCase to support generic merging test infrastructure via runGenericMergingTest

**Before fix:** Merging DECIMAL(5, 5) and DECIMAL(38, 0) throws IllegalArgumentException (requires precision 43, max 38)
**After fix:** Merging DECIMAL(5, 5) and DECIMAL(38, 0) returns DECIMAL(38, 0)

**JIRA Reference**

[https://issues.apache.org/jira/browse/FLINK-39758](url)