### PR TITLE
[FLINK-39797] Support disabling automatic table creation

### DIFF
--- a/docs/content.zh/docs/connectors/pipeline-connectors/fluss.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/fluss.md
@@ -100,6 +100,13 @@ Pipeline Connector Options
       <td>用于建立与 Fluss 集群初始连接的主机/端口对列表。 </td>
     </tr>
     <tr>
+      <td>target.table.create.mode</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">CREATE_IF_NOT_EXISTS</td>
+      <td>Enum</td>
+      <td>目标端建表行为。使用 <code>CREATE_IF_NOT_EXISTS</code> 自动创建缺失的 Fluss 表；使用 <code>ERROR_IF_NOT_EXISTS</code> 要求目标 Fluss 表必须提前存在。</td>
+    </tr>
+    <tr>
       <td>bucket.key</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
@@ -138,6 +145,8 @@ Pipeline Connector Options
 * 支持 Fluss 主键表和日志表。
 
 * 关于自动建表
+  * 默认通过 `target.table.create.mode: CREATE_IF_NOT_EXISTS` 启用自动建表。
+  * 如需在 Flink CDC 外部提前创建目标表，可将 `target.table.create.mode` 设置为 `ERROR_IF_NOT_EXISTS`。该模式下目标表必须已存在；已有的 Fluss schema 兼容性检查仍按原逻辑执行。
   * 没有分区键
   * 桶数量由 `bucket.num` 选项控制
   * 数据分布由 `bucket.key` 选项控制。对于主键表，若未指定分桶键，则分桶键默认为主键（不含分区键）；对于无主键的日志表，若未指定分桶键，则数据将随机分配到各个桶中。 

--- a/docs/content.zh/docs/connectors/pipeline-connectors/maxcompute.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/maxcompute.md
@@ -94,6 +94,13 @@ pipeline:
       <td>Sink 的名称.</td>
     </tr>
     <tr>
+      <td>target.table.create.mode</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">CREATE_IF_NOT_EXISTS</td>
+      <td>Enum</td>
+      <td>目标端建表行为。使用 <code>CREATE_IF_NOT_EXISTS</code> 自动创建缺失的 MaxCompute 表；使用 <code>ERROR_IF_NOT_EXISTS</code> 要求目标 MaxCompute 表必须提前存在。</td>
+    </tr>
+    <tr>
       <td>access-id</td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
@@ -198,6 +205,8 @@ pipeline:
 
 * 链接器 支持自动建表，将MaxCompute表与源表的位置关系、数据类型进行自动映射（参见下文映射表），当源表有主键时，自动创建
   MaxCompute Delta 表，否则创建普通 MaxCompute 表（Append表）
+  * 默认通过 `target.table.create.mode: CREATE_IF_NOT_EXISTS` 启用自动建表。
+  * 如需在 Flink CDC 外部提前创建目标表，可将 `target.table.create.mode` 设置为 `ERROR_IF_NOT_EXISTS`。该模式下目标表必须已存在；已有的 MaxCompute schema 和主键兼容性检查仍按原逻辑执行。
 * 当写入普通 MaxCompute 表（Append表）时，会忽略`delete`操作，`update`操作会被视为`insert`操作
 * 目前仅支持 at-least-once，Delta 表由于主键特性能够实现幂等写
 * 对于表结构变更同步

--- a/docs/content/docs/connectors/pipeline-connectors/fluss.md
+++ b/docs/content/docs/connectors/pipeline-connectors/fluss.md
@@ -101,6 +101,13 @@ Pipeline Connector Options
       <td>The bootstrap servers for the Fluss sink connection. </td>
     </tr>
     <tr>
+      <td>target.table.create.mode</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">CREATE_IF_NOT_EXISTS</td>
+      <td>Enum</td>
+      <td>Behavior for handling target table creation. Use <code>CREATE_IF_NOT_EXISTS</code> to automatically create missing Fluss tables, or <code>ERROR_IF_NOT_EXISTS</code> to require target Fluss tables to already exist.</td>
+    </tr>
+    <tr>
       <td>bucket.key</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>
@@ -140,6 +147,8 @@ Pipeline Connector Options
 * Support Fluss primary key table and log table.
 
 * For creating table automatically
+  * Automatic table creation is enabled by default with `target.table.create.mode: CREATE_IF_NOT_EXISTS`.
+  * To require target tables to be created outside Flink CDC, set `target.table.create.mode` to `ERROR_IF_NOT_EXISTS`. In this mode, the target table must already exist. Existing Fluss schema compatibility checks still apply.
   * There is no partition key
   * The number of buckets is controlled by `bucket.num`
   * The distribution keys are controlled by option `bucket.key`. For primary key table and a bucket key is not specified, the bucket key will be used as primary key(excluding the partition key). For log table has no primary key and the bucket key is not specified, the data will be distributed to each bucket randomly. 

--- a/docs/content/docs/connectors/pipeline-connectors/maxcompute.md
+++ b/docs/content/docs/connectors/pipeline-connectors/maxcompute.md
@@ -94,6 +94,13 @@ pipeline:
       <td>The name of the sink.</td>
     </tr>
     <tr>
+      <td>target.table.create.mode</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">CREATE_IF_NOT_EXISTS</td>
+      <td>Enum</td>
+      <td>Behavior for handling target table creation. Use <code>CREATE_IF_NOT_EXISTS</code> to automatically create missing MaxCompute tables, or <code>ERROR_IF_NOT_EXISTS</code> to require target MaxCompute tables to already exist.</td>
+    </tr>
+    <tr>
       <td>access-id</td>
       <td>required</td>
       <td style="word-wrap: break-word;">(none)</td>
@@ -193,6 +200,8 @@ pipeline:
 ## Usage Instructions
 
 * The connector supports automatic table creation, automatically mapping the location relationship and data types between MaxCompute tables and source tables (see the mapping table below). When the source table has a primary key, a MaxCompute Delta table is automatically created; otherwise, a regular MaxCompute table (Append table) is created.
+  * Automatic table creation is enabled by default with `target.table.create.mode: CREATE_IF_NOT_EXISTS`.
+  * To require target tables to be created outside Flink CDC, set `target.table.create.mode` to `ERROR_IF_NOT_EXISTS`. In this mode, the target table must already exist. Existing MaxCompute schema and primary key compatibility checks still apply.
 * When writing to a regular MaxCompute table (Append table), the delete operation will be ignored, and the update operation will be treated as an insert operation.
 * Currently, only at-least-once is supported. Delta tables can achieve idempotent writes due to their primary key characteristics.
 * For synchronization of table structure changes:

--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParser.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParser.java
@@ -21,6 +21,7 @@ import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.event.SchemaChangeEventTypeFamily;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
 import org.apache.flink.cdc.common.utils.ChangeEventUtils;
 import org.apache.flink.cdc.common.utils.Preconditions;
 import org.apache.flink.cdc.common.utils.StringUtils;
@@ -53,6 +54,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.flink.cdc.common.pipeline.PipelineOptions.PIPELINE_SCHEMA_CHANGE_BEHAVIOR;
+import static org.apache.flink.cdc.common.sink.SinkOptions.TARGET_TABLE_CREATE_MODE;
 import static org.apache.flink.cdc.common.utils.ChangeEventUtils.resolveSchemaEvolutionOptions;
 import static org.apache.flink.cdc.common.utils.Preconditions.checkNotNull;
 
@@ -264,6 +266,10 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
         Map<String, String> sinkMap =
                 mapper.convertValue(sinkNode, new TypeReference<Map<String, String>>() {});
 
+        TargetTableCreateMode targetTableCreateMode =
+                Configuration.fromMap(sinkMap).get(TARGET_TABLE_CREATE_MODE);
+        sinkMap.remove(TARGET_TABLE_CREATE_MODE.key());
+
         // "type" field is required
         String type =
                 checkNotNull(
@@ -274,7 +280,8 @@ public class YamlPipelineDefinitionParser implements PipelineDefinitionParser {
         // "name" field is optional
         String name = sinkMap.remove(NAME_KEY);
 
-        return new SinkDef(type, name, Configuration.fromMap(sinkMap), declaredSETypes);
+        return new SinkDef(
+                type, name, Configuration.fromMap(sinkMap), declaredSETypes, targetTableCreateMode);
     }
 
     private RouteDef toRouteDef(JsonNode routeNode) {

--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/parser/YamlPipelineDefinitionParserTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.cli.parser;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.pipeline.PipelineOptions;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
 import org.apache.flink.cdc.composer.definition.ModelDef;
 import org.apache.flink.cdc.composer.definition.PipelineDef;
 import org.apache.flink.cdc.composer.definition.RouteDef;
@@ -325,6 +326,52 @@ class YamlPipelineDefinitionParserTest {
         // Test case 7: Lenient mode with specified include, create.table should be auto-added
         testSchemaEvolutionTypesParsing(
                 "lenient", "[add.column]", null, ImmutableSet.of(ADD_COLUMN, CREATE_TABLE));
+    }
+
+    @Test
+    void testTargetTableCreateModeParsing() throws Exception {
+        YamlPipelineDefinitionParser parser = new YamlPipelineDefinitionParser();
+
+        PipelineDef defaultPipelineDef =
+                parser.parse(
+                        "source:\n"
+                                + "  type: foo\n"
+                                + "sink:\n"
+                                + "  type: bar\n"
+                                + "  bootstrap.servers: localhost:9123\n",
+                        new Configuration());
+        assertThat(defaultPipelineDef.getSink().getTargetTableCreateMode())
+                .isEqualTo(TargetTableCreateMode.CREATE_IF_NOT_EXISTS);
+        assertThat(defaultPipelineDef.getSink().getConfig().toMap())
+                .containsEntry("bootstrap.servers", "localhost:9123")
+                .doesNotContainKey("target.table.create.mode");
+
+        PipelineDef errorIfNotExistsPipelineDef =
+                parser.parse(
+                        "source:\n"
+                                + "  type: foo\n"
+                                + "sink:\n"
+                                + "  type: bar\n"
+                                + "  target.table.create.mode: ERROR_IF_NOT_EXISTS\n"
+                                + "  bootstrap.servers: localhost:9123\n",
+                        new Configuration());
+        assertThat(errorIfNotExistsPipelineDef.getSink().getTargetTableCreateMode())
+                .isEqualTo(TargetTableCreateMode.ERROR_IF_NOT_EXISTS);
+        assertThat(errorIfNotExistsPipelineDef.getSink().getConfig().toMap())
+                .containsEntry("bootstrap.servers", "localhost:9123")
+                .doesNotContainKey("target.table.create.mode");
+
+        assertThatThrownBy(
+                        () ->
+                                parser.parse(
+                                        "source:\n"
+                                                + "  type: foo\n"
+                                                + "sink:\n"
+                                                + "  type: bar\n"
+                                                + "  target.table.create.mode: INVALID\n",
+                                        new Configuration()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("target.table.create.mode");
     }
 
     private void testSchemaEvolutionTypesParsing(

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/pipeline/TargetTableCreateMode.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/pipeline/TargetTableCreateMode.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.pipeline;
+
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
+
+/** Behavior for handling target table creation when receiving a create table event. */
+@PublicEvolving
+public enum TargetTableCreateMode {
+    /** Create the target table if it does not exist. */
+    CREATE_IF_NOT_EXISTS,
+
+    /** Fail if the target table does not exist. */
+    ERROR_IF_NOT_EXISTS
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/SinkOptions.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/SinkOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.sink;
+
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.common.configuration.ConfigOption;
+import org.apache.flink.cdc.common.configuration.ConfigOptions;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
+
+/** Common options for pipeline sinks. */
+@PublicEvolving
+public class SinkOptions {
+
+    public static final ConfigOption<TargetTableCreateMode> TARGET_TABLE_CREATE_MODE =
+            ConfigOptions.key("target.table.create.mode")
+                    .enumType(TargetTableCreateMode.class)
+                    .defaultValue(TargetTableCreateMode.CREATE_IF_NOT_EXISTS)
+                    .withDescription(
+                            "Behavior for handling target table creation when receiving a create table event.");
+
+    private SinkOptions() {}
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/SupportsTargetTableExistenceCheck.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/SupportsTargetTableExistenceCheck.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.sink;
+
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.common.event.TableId;
+
+/** Capability for sinks that can check whether a target table already exists. */
+@PublicEvolving
+public interface SupportsTargetTableExistenceCheck {
+
+    /** Returns whether the target table exists. */
+    boolean targetTableExists(TableId tableId);
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/TargetTableCreateModeMetadataApplier.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/TargetTableCreateModeMetadataApplier.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.sink;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.SchemaChangeEventType;
+import org.apache.flink.cdc.common.exceptions.SchemaEvolveException;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
+import org.apache.flink.table.api.ValidationException;
+
+import java.util.Set;
+
+/** A {@link MetadataApplier} wrapper that applies the configured target table create mode. */
+@Internal
+public class TargetTableCreateModeMetadataApplier implements MetadataApplier {
+
+    private final MetadataApplier delegate;
+    private final TargetTableCreateMode targetTableCreateMode;
+
+    private TargetTableCreateModeMetadataApplier(
+            MetadataApplier delegate, TargetTableCreateMode targetTableCreateMode) {
+        this.delegate = delegate;
+        this.targetTableCreateMode = targetTableCreateMode;
+    }
+
+    public static MetadataApplier wrap(
+            MetadataApplier delegate, TargetTableCreateMode targetTableCreateMode, String sinkType) {
+        if (targetTableCreateMode == TargetTableCreateMode.CREATE_IF_NOT_EXISTS) {
+            return delegate;
+        }
+        if (!(delegate instanceof SupportsTargetTableExistenceCheck)) {
+            throw new ValidationException(
+                    String.format(
+                            "Sink '%s' does not support '%s=%s'. The sink metadata applier must implement %s.",
+                            sinkType,
+                            SinkOptions.TARGET_TABLE_CREATE_MODE.key(),
+                            targetTableCreateMode,
+                            SupportsTargetTableExistenceCheck.class.getSimpleName()));
+        }
+        return new TargetTableCreateModeMetadataApplier(delegate, targetTableCreateMode);
+    }
+
+    @Override
+    public void applySchemaChange(SchemaChangeEvent schemaChangeEvent)
+            throws SchemaEvolveException {
+        if (targetTableCreateMode == TargetTableCreateMode.ERROR_IF_NOT_EXISTS
+                && schemaChangeEvent instanceof CreateTableEvent) {
+            CreateTableEvent createTableEvent = (CreateTableEvent) schemaChangeEvent;
+            SupportsTargetTableExistenceCheck existenceCheck =
+                    (SupportsTargetTableExistenceCheck) delegate;
+            if (!existenceCheck.targetTableExists(createTableEvent.tableId())) {
+                throw new ValidationException(
+                        "Target table does not exist: " + createTableEvent.tableId());
+            }
+        }
+        delegate.applySchemaChange(schemaChangeEvent);
+    }
+
+    @Override
+    public MetadataApplier setAcceptedSchemaEvolutionTypes(
+            Set<SchemaChangeEventType> schemaEvolutionTypes) {
+        delegate.setAcceptedSchemaEvolutionTypes(schemaEvolutionTypes);
+        return this;
+    }
+
+    @Override
+    public boolean acceptsSchemaEvolutionType(SchemaChangeEventType schemaChangeEventType) {
+        return delegate.acceptsSchemaEvolutionType(schemaChangeEventType);
+    }
+
+    @Override
+    public Set<SchemaChangeEventType> getSupportedSchemaEvolutionTypes() {
+        return delegate.getSupportedSchemaEvolutionTypes();
+    }
+
+    @Override
+    public void close() throws Exception {
+        delegate.close();
+    }
+}

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/sink/TargetTableCreateModeMetadataApplierTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/sink/TargetTableCreateModeMetadataApplierTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.sink;
+
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.DropTableEvent;
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link TargetTableCreateModeMetadataApplier}. */
+class TargetTableCreateModeMetadataApplierTest {
+
+    private static final TableId TABLE_ID = TableId.tableId("db", "table");
+    private static final CreateTableEvent CREATE_TABLE_EVENT =
+            new CreateTableEvent(
+                    TABLE_ID,
+                    Schema.newBuilder()
+                            .physicalColumn("id", DataTypes.INT())
+                            .physicalColumn("name", DataTypes.STRING())
+                            .build());
+
+    @Test
+    void testCreateIfNotExistsDelegatesCreateTableEvent() {
+        TestMetadataApplier delegate = new TestMetadataApplier(true);
+
+        MetadataApplier applier =
+                TargetTableCreateModeMetadataApplier.wrap(
+                        delegate, TargetTableCreateMode.CREATE_IF_NOT_EXISTS, "test");
+        applier.applySchemaChange(CREATE_TABLE_EVENT);
+
+        assertThat(delegate.applySchemaChangeCalled).isTrue();
+    }
+
+    @Test
+    void testErrorIfNotExistsFailsWhenTargetTableDoesNotExist() {
+        TestMetadataApplier delegate = new TestMetadataApplier(false);
+
+        MetadataApplier applier =
+                TargetTableCreateModeMetadataApplier.wrap(
+                        delegate, TargetTableCreateMode.ERROR_IF_NOT_EXISTS, "test");
+
+        assertThatThrownBy(() -> applier.applySchemaChange(CREATE_TABLE_EVENT))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining("Target table does not exist");
+        assertThat(delegate.applySchemaChangeCalled).isFalse();
+    }
+
+    @Test
+    void testErrorIfNotExistsDelegatesCreateTableEventWhenTargetTableExists() {
+        TestMetadataApplier delegate = new TestMetadataApplier(true);
+
+        MetadataApplier applier =
+                TargetTableCreateModeMetadataApplier.wrap(
+                        delegate, TargetTableCreateMode.ERROR_IF_NOT_EXISTS, "test");
+        applier.applySchemaChange(CREATE_TABLE_EVENT);
+
+        assertThat(delegate.applySchemaChangeCalled).isTrue();
+    }
+
+    @Test
+    void testErrorIfNotExistsDelegatesNonCreateTableEvent() {
+        TestMetadataApplier delegate = new TestMetadataApplier(true);
+
+        MetadataApplier applier =
+                TargetTableCreateModeMetadataApplier.wrap(
+                        delegate, TargetTableCreateMode.ERROR_IF_NOT_EXISTS, "test");
+        applier.applySchemaChange(new DropTableEvent(TABLE_ID));
+
+        assertThat(delegate.applySchemaChangeCalled).isTrue();
+    }
+
+    @Test
+    void testErrorIfNotExistsRequiresExistenceCheckCapability() {
+        assertThatThrownBy(
+                        () ->
+                                TargetTableCreateModeMetadataApplier.wrap(
+                                        new MetadataApplier() {
+                                            @Override
+                                            public void applySchemaChange(
+                                                    SchemaChangeEvent schemaChangeEvent) {}
+                                        },
+                                        TargetTableCreateMode.ERROR_IF_NOT_EXISTS,
+                                        "test"))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining("target.table.create.mode=ERROR_IF_NOT_EXISTS");
+    }
+
+    private static class TestMetadataApplier
+            implements MetadataApplier, SupportsTargetTableExistenceCheck {
+
+        private final boolean targetTableExists;
+        private boolean applySchemaChangeCalled;
+
+        private TestMetadataApplier(boolean targetTableExists) {
+            this.targetTableExists = targetTableExists;
+        }
+
+        @Override
+        public void applySchemaChange(SchemaChangeEvent schemaChangeEvent) {
+            applySchemaChangeCalled = true;
+        }
+
+        @Override
+        public boolean targetTableExists(TableId tableId) {
+            return targetTableExists;
+        }
+    }
+}

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/SinkDef.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/definition/SinkDef.java
@@ -20,6 +20,7 @@ package org.apache.flink.cdc.composer.definition;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.event.SchemaChangeEventTypeFamily;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
 
 import javax.annotation.Nullable;
 
@@ -46,6 +47,7 @@ public class SinkDef {
     @Nullable private final String name;
     private final Configuration config;
     private final Set<SchemaChangeEventType> includedSchemaEvolutionTypes;
+    private final TargetTableCreateMode targetTableCreateMode;
 
     public SinkDef(String type, @Nullable String name, Configuration config) {
         this.type = type;
@@ -53,6 +55,7 @@ public class SinkDef {
         this.config = config;
         this.includedSchemaEvolutionTypes =
                 Arrays.stream(SchemaChangeEventTypeFamily.ALL).collect(Collectors.toSet());
+        this.targetTableCreateMode = TargetTableCreateMode.CREATE_IF_NOT_EXISTS;
     }
 
     public SinkDef(
@@ -60,10 +63,25 @@ public class SinkDef {
             @Nullable String name,
             Configuration config,
             Set<SchemaChangeEventType> includedSchemaEvolutionTypes) {
+        this(
+                type,
+                name,
+                config,
+                includedSchemaEvolutionTypes,
+                TargetTableCreateMode.CREATE_IF_NOT_EXISTS);
+    }
+
+    public SinkDef(
+            String type,
+            @Nullable String name,
+            Configuration config,
+            Set<SchemaChangeEventType> includedSchemaEvolutionTypes,
+            TargetTableCreateMode targetTableCreateMode) {
         this.type = type;
         this.name = name;
         this.config = config;
         this.includedSchemaEvolutionTypes = includedSchemaEvolutionTypes;
+        this.targetTableCreateMode = targetTableCreateMode;
     }
 
     public String getType() {
@@ -82,6 +100,10 @@ public class SinkDef {
         return includedSchemaEvolutionTypes;
     }
 
+    public TargetTableCreateMode getTargetTableCreateMode() {
+        return targetTableCreateMode;
+    }
+
     @Override
     public String toString() {
         return "SinkDef{"
@@ -95,6 +117,8 @@ public class SinkDef {
                 + config
                 + ", includedSchemaEvolutionTypes="
                 + includedSchemaEvolutionTypes
+                + ", targetTableCreateMode="
+                + targetTableCreateMode
                 + '}';
     }
 
@@ -111,11 +135,12 @@ public class SinkDef {
                 && Objects.equals(name, sinkDef.name)
                 && Objects.equals(config, sinkDef.config)
                 && Objects.equals(
-                        includedSchemaEvolutionTypes, sinkDef.includedSchemaEvolutionTypes);
+                        includedSchemaEvolutionTypes, sinkDef.includedSchemaEvolutionTypes)
+                && targetTableCreateMode == sinkDef.targetTableCreateMode;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, name, config, includedSchemaEvolutionTypes);
+        return Objects.hash(type, name, config, includedSchemaEvolutionTypes, targetTableCreateMode);
     }
 }

--- a/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
+++ b/flink-cdc-composer/src/main/java/org/apache/flink/cdc/composer/flink/FlinkPipelineComposer.java
@@ -25,10 +25,13 @@ import org.apache.flink.cdc.common.pipeline.PipelineOptions;
 import org.apache.flink.cdc.common.pipeline.RuntimeExecutionMode;
 import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
 import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.common.sink.TargetTableCreateModeMetadataApplier;
 import org.apache.flink.cdc.common.source.DataSource;
 import org.apache.flink.cdc.composer.PipelineComposer;
 import org.apache.flink.cdc.composer.PipelineExecution;
 import org.apache.flink.cdc.composer.definition.PipelineDef;
+import org.apache.flink.cdc.composer.definition.SinkDef;
 import org.apache.flink.cdc.composer.flink.coordination.OperatorIDGenerator;
 import org.apache.flink.cdc.composer.flink.translator.DataSinkTranslator;
 import org.apache.flink.cdc.composer.flink.translator.DataSourceTranslator;
@@ -168,6 +171,8 @@ public class FlinkPipelineComposer implements PipelineComposer {
                 sourceTranslator.createDataSource(pipelineDef.getSource(), pipelineDefConfig, env);
         DataSink dataSink =
                 sinkTranslator.createDataSink(pipelineDef.getSink(), pipelineDefConfig, env);
+        MetadataApplier metadataApplier =
+                createMetadataApplier(dataSink.getMetadataApplier(), pipelineDef);
 
         boolean isParallelMetadataSource = dataSource.isParallelMetadataSource();
 
@@ -215,11 +220,7 @@ public class FlinkPipelineComposer implements PipelineComposer {
                     schemaOperatorTranslator.translateDistributed(
                             partitionedStream,
                             parallelism,
-                            dataSink.getMetadataApplier()
-                                    .setAcceptedSchemaEvolutionTypes(
-                                            pipelineDef
-                                                    .getSink()
-                                                    .getIncludedSchemaEvolutionTypes()),
+                            metadataApplier,
                             pipelineDef.getRoute(),
                             pipelineDef.getRouteMode());
 
@@ -231,11 +232,7 @@ public class FlinkPipelineComposer implements PipelineComposer {
                             stream,
                             parallelism,
                             isBatchMode,
-                            dataSink.getMetadataApplier()
-                                    .setAcceptedSchemaEvolutionTypes(
-                                            pipelineDef
-                                                    .getSink()
-                                                    .getIncludedSchemaEvolutionTypes()),
+                            metadataApplier,
                             pipelineDef.getRoute(),
                             pipelineDef.getRouteMode());
 
@@ -259,6 +256,14 @@ public class FlinkPipelineComposer implements PipelineComposer {
                 isBatchMode,
                 schemaOperatorIDGenerator.generate(),
                 operatorUidGenerator);
+    }
+
+    private MetadataApplier createMetadataApplier(
+            MetadataApplier metadataApplier, PipelineDef pipelineDef) {
+        SinkDef sinkDef = pipelineDef.getSink();
+        return TargetTableCreateModeMetadataApplier.wrap(
+                        metadataApplier, sinkDef.getTargetTableCreateMode(), sinkDef.getType())
+                .setAcceptedSchemaEvolutionTypes(sinkDef.getIncludedSchemaEvolutionTypes());
     }
 
     private void addFrameworkJars() {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussMetaDataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussMetaDataApplier.java
@@ -26,6 +26,7 @@ import org.apache.flink.cdc.common.event.SchemaChangeEventTypeFamily;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.common.sink.SupportsTargetTableExistenceCheck;
 import org.apache.flink.table.api.ValidationException;
 
 import org.apache.fluss.client.Connection;
@@ -54,7 +55,7 @@ import static org.apache.flink.cdc.connectors.fluss.utils.FlussConversions.toFlu
 import static org.apache.flink.cdc.connectors.fluss.utils.FlussConversions.toFlussType;
 
 /** {@link MetadataApplier} for fluss. */
-public class FlussMetaDataApplier implements MetadataApplier {
+public class FlussMetaDataApplier implements MetadataApplier, SupportsTargetTableExistenceCheck {
     private static final Logger LOG = LoggerFactory.getLogger(FlussMetaDataApplier.class);
     private final Configuration flussClientConfig;
     private final Map<String, String> tableProperties;
@@ -128,8 +129,23 @@ public class FlussMetaDataApplier implements MetadataApplier {
                 // sanity check to prevent unexpected table schema evolution.
                 sanityCheck(inferredFlussTable, currentTableInfo);
             }
+        } catch (ValidationException e) {
+            throw e;
         } catch (Exception e) {
             LOG.error("Failed to apply schema change {}", event, e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean targetTableExists(TableId tableId) {
+        try (Connection connection = ConnectionFactory.createConnection(flussClientConfig);
+                Admin admin = connection.getAdmin()) {
+            TablePath tablePath = new TablePath(tableId.getSchemaName(), tableId.getTableName());
+            return admin.databaseExists(tablePath.getDatabaseName()).get()
+                    && admin.tableExists(tablePath).get();
+        } catch (Exception e) {
+            LOG.error("Failed to check whether Fluss table {} exists.", tableId, e);
             throw new RuntimeException(e);
         }
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/test/java/org/apache/flink/cdc/connectors/fluss/sink/FlussMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/test/java/org/apache/flink/cdc/connectors/fluss/sink/FlussMetadataApplierTest.java
@@ -21,10 +21,14 @@ import org.apache.flink.cdc.common.event.AddColumnEvent;
 import org.apache.flink.cdc.common.event.CreateTableEvent;
 import org.apache.flink.cdc.common.event.DropTableEvent;
 import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
 import org.apache.flink.cdc.common.schema.Column;
 import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.common.sink.TargetTableCreateModeMetadataApplier;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.types.IntType;
+import org.apache.flink.table.api.ValidationException;
 
 import org.apache.fluss.client.Connection;
 import org.apache.fluss.client.ConnectionFactory;
@@ -602,6 +606,32 @@ public class FlussMetadataApplierTest {
                         Collections.emptyMap(),
                         Collections.emptyMap())) {
             applier.applySchemaChange(new CreateTableEvent(tableId, sameSchema));
+        }
+    }
+
+    @Test
+    void testErrorIfNotExistsModeFailsWhenTargetTableIsMissing() throws Exception {
+        TableId tableId = TableId.tableId("default_namespace", DATABASE_NAME, "table1");
+        Schema schema =
+                Schema.newBuilder()
+                        .physicalColumn("id", DataTypes.INT())
+                        .physicalColumn("name", DataTypes.STRING())
+                        .build();
+        CreateTableEvent createTableEvent = new CreateTableEvent(tableId, schema);
+
+        try (FlussMetaDataApplier applier =
+                new FlussMetaDataApplier(
+                        FLUSS_CLUSTER_EXTENSION.getClientConfig(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap())) {
+            MetadataApplier wrappedApplier =
+                    TargetTableCreateModeMetadataApplier.wrap(
+                            applier, TargetTableCreateMode.ERROR_IF_NOT_EXISTS, "fluss");
+            assertThatThrownBy(() -> wrappedApplier.applySchemaChange(createTableEvent))
+                    .isExactlyInstanceOf(ValidationException.class)
+                    .hasMessageContaining("Target table does not exist");
+            assertThat(admin.databaseExists(DATABASE_NAME).get()).isFalse();
         }
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/main/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeMetadataApplier.java
@@ -26,9 +26,11 @@ import org.apache.flink.cdc.common.event.DropColumnEvent;
 import org.apache.flink.cdc.common.event.DropTableEvent;
 import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.event.TruncateTableEvent;
 import org.apache.flink.cdc.common.exceptions.SchemaEvolveException;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.common.sink.SupportsTargetTableExistenceCheck;
 import org.apache.flink.cdc.connectors.maxcompute.options.MaxComputeOptions;
 import org.apache.flink.cdc.connectors.maxcompute.utils.MaxComputeUtils;
 import org.apache.flink.cdc.connectors.maxcompute.utils.SchemaEvolutionUtils;
@@ -42,7 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A {@link MetadataApplier} for "MaxCompute" connector. */
-public class MaxComputeMetadataApplier implements MetadataApplier {
+public class MaxComputeMetadataApplier
+        implements MetadataApplier, SupportsTargetTableExistenceCheck {
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(MaxComputeMetadataApplier.class);
 
@@ -58,9 +61,10 @@ public class MaxComputeMetadataApplier implements MetadataApplier {
         try {
             if (schemaChangeEvent instanceof CreateTableEvent) {
                 CreateTableEvent createTableEvent = (CreateTableEvent) schemaChangeEvent;
-                if (MaxComputeUtils.isTableExist(maxComputeOptions, createTableEvent.tableId())) {
+                if (targetTableExists(createTableEvent.tableId())) {
                     Table table =
-                            MaxComputeUtils.getTable(maxComputeOptions, createTableEvent.tableId());
+                            MaxComputeUtils.getTable(
+                                    maxComputeOptions, createTableEvent.tableId());
                     TableSchema expectSchema =
                             TypeConvertUtils.toMaxCompute(createTableEvent.getSchema());
                     if (!MaxComputeUtils.schemaEquals(table.getSchema(), expectSchema)) {
@@ -125,5 +129,10 @@ public class MaxComputeMetadataApplier implements MetadataApplier {
         } catch (OdpsException e) {
             throw new SchemaEvolveException(schemaChangeEvent, e.getMessage(), e);
         }
+    }
+
+    @Override
+    public boolean targetTableExists(TableId tableId) {
+        return MaxComputeUtils.isTableExist(maxComputeOptions, tableId);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeMetadataApplierTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute/src/test/java/org/apache/flink/cdc/connectors/maxcompute/MaxComputeMetadataApplierTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.maxcompute;
+
+import org.apache.flink.cdc.common.event.CreateTableEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.pipeline.TargetTableCreateMode;
+import org.apache.flink.cdc.common.schema.Schema;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.common.sink.TargetTableCreateModeMetadataApplier;
+import org.apache.flink.cdc.common.types.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+
+import com.aliyun.odps.OdpsException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link MaxComputeMetadataApplier}. */
+class MaxComputeMetadataApplierTest extends EmulatorTestBase {
+
+    private static final TableId MISSING_TABLE =
+            TableId.tableId("MC_METADATA_APPLIER_MISSING_TABLE");
+    private static final TableId WRAPPER_MISSING_TABLE =
+            TableId.tableId("MC_METADATA_APPLIER_WRAPPER_MISSING_TABLE");
+
+    @AfterEach
+    void deleteTables() throws OdpsException {
+        odpsInstance.tables().delete(MISSING_TABLE.getTableName(), true);
+        odpsInstance.tables().delete(WRAPPER_MISSING_TABLE.getTableName(), true);
+    }
+
+    @Test
+    void testTargetTableExistsReturnsFalseWhenTargetTableIsMissing() {
+        MaxComputeMetadataApplier applier = new MaxComputeMetadataApplier(testOptions);
+
+        assertThat(applier.targetTableExists(MISSING_TABLE)).isFalse();
+    }
+
+    @Test
+    void testErrorIfNotExistsModeFailsWhenTargetTableIsMissing() {
+        MaxComputeMetadataApplier applier = new MaxComputeMetadataApplier(testOptions);
+        MetadataApplier wrappedApplier =
+                TargetTableCreateModeMetadataApplier.wrap(
+                        applier, TargetTableCreateMode.ERROR_IF_NOT_EXISTS, "maxcompute");
+
+        assertThatThrownBy(
+                        () ->
+                                wrappedApplier.applySchemaChange(
+                                        new CreateTableEvent(
+                                                WRAPPER_MISSING_TABLE, createSchema())))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining("Target table does not exist");
+        assertThat(applier.targetTableExists(WRAPPER_MISSING_TABLE)).isFalse();
+    }
+
+    private static Schema createSchema() {
+        return Schema.newBuilder()
+                .physicalColumn("PK", DataTypes.BIGINT())
+                .physicalColumn("ID1", DataTypes.BIGINT())
+                .physicalColumn("ID2", DataTypes.BIGINT())
+                .primaryKey("PK")
+                .build();
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change

Introduce a framework-level sink option `target.table.create.mode` to control whether Flink CDC is allowed to create a missing target table when handling `CreateTableEvent`.

The default mode is `CREATE_IF_NOT_EXISTS`, so existing behavior is unchanged. The new `ERROR_IF_NOT_EXISTS` mode requires the target table to already exist and fails fast if it is missing. This is useful when target tables are managed outside Flink CDC.

This PR does not introduce a framework-level schema validation abstraction. In `ERROR_IF_NOT_EXISTS` mode, the framework only checks target table existence before delegating the `CreateTableEvent` to the original sink `MetadataApplier`. If the target table exists, sink-specific create-table handling still runs as before, including any existing schema, primary key, partition key, or other compatibility checks.

This PR enables `ERROR_IF_NOT_EXISTS` for Fluss and MaxCompute. Other pipeline connectors keep their existing behavior and fail fast if configured with `target.table.create.mode=ERROR_IF_NOT_EXISTS` before they implement target table existence checks.

### Brief change log

- Add common sink option `target.table.create.mode` with default `CREATE_IF_NOT_EXISTS`.
- Add `TargetTableCreateMode` and `TargetTableCreateModeMetadataApplier` to apply the configured target table creation policy.
- Add `SupportsTargetTableExistenceCheck` for sinks that can check whether a target table already exists.
- Parse `target.table.create.mode` from pipeline sink configuration and pass it through `SinkDef` to `FlinkPipelineComposer`.
- Implement target table existence checks for Fluss and MaxCompute metadata appliers.
- Keep schema compatibility checks sink-specific by delegating `CreateTableEvent` to the original sink metadata applier when the target table exists.
- Document `target.table.create.mode` for Fluss and MaxCompute.

### Verifying this change

- Added common wrapper tests for `TargetTableCreateModeMetadataApplier`.
- Added YAML parser tests for `target.table.create.mode`.
- Added Fluss coverage for `ERROR_IF_NOT_EXISTS` missing-table failure.
- Added MaxCompute coverage for target table existence check and `ERROR_IF_NOT_EXISTS` missing-table failure.
- Ran:
  - `mvn -pl flink-cdc-common,flink-cdc-cli,flink-cdc-composer -am -DskipITs -Dcheckstyle.skip -Drat.skip=true -Dspotless.check.skip=true -DfailIfNoTests=false -DskipUTs=false -Dtest=TargetTableCreateModeMetadataApplierTest,YamlPipelineDefinitionParserTest,FlinkPipelineComposerTest test`
  - `mvn -pl flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss -am -DskipITs -Dcheckstyle.skip -Drat.skip=true -Dspotless.check.skip=true -DfailIfNoTests=false -DskipUTs=false -Dtest=FlussMetadataApplierTest test`
  - `mvn -pl flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss -am -DskipITs -Dcheckstyle.skip -Drat.skip=true -Dspotless.check.skip=true -DfailIfNoTests=false -DskipUTs=false -Dtest=FlussDataSinkFactoryTest test`
  - `mvn -pl flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-maxcompute -am -DskipTests -DskipITs -Dcheckstyle.skip -Drat.skip=true -Dspotless.check.skip=true -DfailIfNoTests=false test`
  - `git diff --check`

### Documentation

Updated Fluss and MaxCompute pipeline connector documentation for the new common sink option:

- `target.table.create.mode`
  - `CREATE_IF_NOT_EXISTS`: default; create missing target tables as before.
  - `ERROR_IF_NOT_EXISTS`: require target tables to already exist and fail if they are missing.

The documentation also clarifies that existing sink-specific compatibility checks still apply after the target table existence check passes.
