### PR TITLE
[FLINK-39824][mysql] Cache relational table filter results

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/CachedTableFilter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/CachedTableFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.relational;
+
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheLoader;
+import org.apache.flink.shaded.guava31.com.google.common.cache.LoadingCache;
+
+import io.debezium.relational.Tables.TableFilter;
+
+/** A bounded cache for table filter results. */
+public class CachedTableFilter implements TableFilter {
+
+    private static final long TABLE_FILTER_CACHE_MAXIMUM_SIZE = 1024;
+
+    private final TableFilter rawTableFilter;
+    private final LoadingCache<TableId, Boolean> tableFilterCache;
+
+    private CachedTableFilter(TableFilter rawTableFilter) {
+        this.rawTableFilter = rawTableFilter;
+        this.tableFilterCache =
+                CacheBuilder.newBuilder()
+                        .maximumSize(TABLE_FILTER_CACHE_MAXIMUM_SIZE)
+                        .build(
+                                new CacheLoader<TableId, Boolean>() {
+                                    @Override
+                                    public Boolean load(TableId tableId) {
+                                        return rawTableFilter.isIncluded(tableId);
+                                    }
+                                });
+    }
+
+    /** Wraps the given filter in a cache, or returns it unchanged if it is already cached. */
+    public static CachedTableFilter from(TableFilter tableFilter) {
+        if (tableFilter instanceof CachedTableFilter) {
+            return (CachedTableFilter) tableFilter;
+        }
+        return new CachedTableFilter(tableFilter);
+    }
+
+    /** Returns a new cached filter that also requires the additional filter to match. */
+    public CachedTableFilter withAdditionalFilter(TableFilter additionalFilter) {
+        TableFilter rawFilter = rawTableFilter;
+        return new CachedTableFilter(
+                tableId -> rawFilter.isIncluded(tableId) && additionalFilter.isIncluded(tableId));
+    }
+
+    @Override
+    public boolean isIncluded(TableId tableId) {
+        return tableFilterCache.getUnchecked(tableId);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/CachedTableFilter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/CachedTableFilter.java
@@ -23,10 +23,12 @@ import org.apache.flink.shaded.guava31.com.google.common.cache.LoadingCache;
 
 import io.debezium.relational.Tables.TableFilter;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /** A bounded cache for table filter results. */
 public class CachedTableFilter implements TableFilter {
 
-    private static final long TABLE_FILTER_CACHE_MAXIMUM_SIZE = 1024;
+    private static final long TABLE_FILTER_CACHE_MAXIMUM_SIZE = 32 * 1024;
 
     private final TableFilter rawTableFilter;
     private final LoadingCache<TableId, Boolean> tableFilterCache;
@@ -47,6 +49,7 @@ public class CachedTableFilter implements TableFilter {
 
     /** Wraps the given filter in a cache, or returns it unchanged if it is already cached. */
     public static CachedTableFilter from(TableFilter tableFilter) {
+        checkNotNull(tableFilter);
         if (tableFilter instanceof CachedTableFilter) {
             return (CachedTableFilter) tableFilter;
         }
@@ -55,6 +58,7 @@ public class CachedTableFilter implements TableFilter {
 
     /** Returns a new cached filter that also requires the additional filter to match. */
     public CachedTableFilter withAdditionalFilter(TableFilter additionalFilter) {
+        checkNotNull(additionalFilter);
         TableFilter rawFilter = rawTableFilter;
         return new CachedTableFilter(
                 tableId -> rawFilter.isIncluded(tableId) && additionalFilter.isIncluded(tableId));

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
@@ -20,7 +20,9 @@ import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_EX
 /**
  * Copied from Debezium 1.9.8.Final.
  *
- * <p>Line 146: add a method to update the tableFilter variable.
+ * <p>Line 97: cache table filter results.
+ *
+ * <p>Line 147: add a method to update the tableFilter variable.
  */
 public class RelationalTableFilters implements DataCollectionFilters {
 
@@ -92,7 +94,7 @@ public class RelationalTableFilters implements DataCollectionFilters {
                         ? tablePredicate.and(systemTablesFilter::isIncluded)
                         : tablePredicate;
 
-        this.tableFilter = finalTablePredicate::test;
+        this.tableFilter = CachedTableFilter.from(finalTablePredicate::test);
 
         // Define the database filter using the include and exclude lists for database names ...
         this.databaseFilter =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/io/debezium/relational/RelationalTableFilters.java
@@ -20,9 +20,9 @@ import static io.debezium.relational.RelationalDatabaseConnectorConfig.COLUMN_EX
 /**
  * Copied from Debezium 1.9.8.Final.
  *
- * <p>Line 97: cache table filter results.
+ * <p>Line 98: cache table filter results.
  *
- * <p>Line 147: add a method to update the tableFilter variable.
+ * <p>Line 148: add a method to update the tableFilter variable.
  */
 public class RelationalTableFilters implements DataCollectionFilters {
 
@@ -94,7 +94,8 @@ public class RelationalTableFilters implements DataCollectionFilters {
                         ? tablePredicate.and(systemTablesFilter::isIncluded)
                         : tablePredicate;
 
-        this.tableFilter = CachedTableFilter.from(finalTablePredicate::test);
+        TableFilter initialTableFilter = finalTablePredicate::test;
+        this.tableFilter = CachedTableFilter.from(initialTableFilter);
 
         // Define the database filter using the include and exclude lists for database names ...
         this.databaseFilter =
@@ -116,7 +117,7 @@ public class RelationalTableFilters implements DataCollectionFilters {
 
         this.schemaSnapshotFilter =
                 config.getBoolean(DatabaseHistory.STORE_ONLY_CAPTURED_TABLES_DDL)
-                        ? eligibleSchemaPredicate.and(tableFilter::isIncluded)::test
+                        ? eligibleSchemaPredicate.and(initialTableFilter::isIncluded)::test
                         : eligibleSchemaPredicate::test;
 
         this.excludeColumns =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/test/java/io/debezium/relational/CachedTableFilterTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/test/java/io/debezium/relational/CachedTableFilterTest.java
@@ -91,6 +91,7 @@ class CachedTableFilterTest {
     @Test
     void testCacheSizeIsBounded() {
         AtomicInteger invocationCount = new AtomicInteger();
+        int numberOfTableIds = 32 * 1024 + 1;
         TableFilter cachedTableFilter =
                 CachedTableFilter.from(
                         tableId -> {
@@ -98,14 +99,14 @@ class CachedTableFilterTest {
                             return true;
                         });
         List<TableId> tableIds = new ArrayList<>();
-        for (int i = 0; i < 1025; i++) {
+        for (int i = 0; i < numberOfTableIds; i++) {
             tableIds.add(new TableId("test_db", null, "table_" + i));
         }
 
         tableIds.forEach(cachedTableFilter::isIncluded);
-        assertThat(invocationCount).hasValue(1025);
+        assertThat(invocationCount).hasValue(numberOfTableIds);
 
         tableIds.forEach(cachedTableFilter::isIncluded);
-        assertThat(invocationCount).hasValueGreaterThan(1025);
+        assertThat(invocationCount).hasValueGreaterThan(numberOfTableIds);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/test/java/io/debezium/relational/CachedTableFilterTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/test/java/io/debezium/relational/CachedTableFilterTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.relational;
+
+import io.debezium.relational.Tables.TableFilter;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CachedTableFilterTest {
+
+    @Test
+    void testCachesPositiveAndNegativeResultsForEquivalentTableIds() {
+        AtomicInteger invocationCount = new AtomicInteger();
+        CachedTableFilter cachedTableFilter =
+                CachedTableFilter.from(
+                        tableId -> {
+                            invocationCount.incrementAndGet();
+                            return tableId.table().startsWith("orders");
+                        });
+
+        TableId includedTable = new TableId("test_db", null, "orders_1");
+        TableId sameIncludedTable = new TableId("test_db", null, "orders_1");
+        TableId unmatchedTable = new TableId("test_db", null, "customers");
+        TableId sameUnmatchedTable = new TableId("test_db", null, "customers");
+
+        assertThat(cachedTableFilter.isIncluded(includedTable)).isTrue();
+        assertThat(cachedTableFilter.isIncluded(sameIncludedTable)).isTrue();
+        assertThat(cachedTableFilter.isIncluded(unmatchedTable)).isFalse();
+        assertThat(cachedTableFilter.isIncluded(sameUnmatchedTable)).isFalse();
+        assertThat(invocationCount).hasValue(2);
+    }
+
+    @Test
+    void testFromReturnsCachedFilterUnchanged() {
+        CachedTableFilter cachedTableFilter = CachedTableFilter.from(tableId -> true);
+
+        assertThat(CachedTableFilter.from(cachedTableFilter)).isSameAs(cachedTableFilter);
+    }
+
+    @Test
+    void testAdditionalFilterCreatesSingleCacheOverRawDelegate() {
+        AtomicInteger rawFilterInvocationCount = new AtomicInteger();
+        AtomicInteger additionalFilterInvocationCount = new AtomicInteger();
+        CachedTableFilter cachedTableFilter =
+                CachedTableFilter.from(
+                        tableId -> {
+                            rawFilterInvocationCount.incrementAndGet();
+                            return true;
+                        });
+        TableId tableId = new TableId("test_db", null, "orders_1");
+
+        assertThat(cachedTableFilter.isIncluded(tableId)).isTrue();
+
+        CachedTableFilter combinedFilter =
+                cachedTableFilter.withAdditionalFilter(
+                        ignored -> {
+                            additionalFilterInvocationCount.incrementAndGet();
+                            return false;
+                        });
+
+        assertThat(combinedFilter).isNotSameAs(cachedTableFilter);
+        assertThat(combinedFilter.isIncluded(tableId)).isFalse();
+        assertThat(combinedFilter.isIncluded(tableId)).isFalse();
+        assertThat(rawFilterInvocationCount).hasValue(2);
+        assertThat(additionalFilterInvocationCount).hasValue(1);
+
+        assertThat(cachedTableFilter.isIncluded(tableId)).isTrue();
+        assertThat(rawFilterInvocationCount).hasValue(2);
+    }
+
+    @Test
+    void testCacheSizeIsBounded() {
+        AtomicInteger invocationCount = new AtomicInteger();
+        TableFilter cachedTableFilter =
+                CachedTableFilter.from(
+                        tableId -> {
+                            invocationCount.incrementAndGet();
+                            return true;
+                        });
+        List<TableId> tableIds = new ArrayList<>();
+        for (int i = 0; i < 1025; i++) {
+            tableIds.add(new TableId("test_db", null, "table_" + i));
+        }
+
+        tableIds.forEach(cachedTableFilter::isIncluded);
+        assertThat(invocationCount).hasValue(1025);
+
+        tableIds.forEach(cachedTableFilter::isIncluded);
+        assertThat(invocationCount).hasValueGreaterThan(1025);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/test/java/io/debezium/relational/RelationalTableFiltersTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/test/java/io/debezium/relational/RelationalTableFiltersTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.relational;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.Tables.TableFilter;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RelationalTableFiltersTest {
+
+    @Test
+    void testInitialTableFilterIsCached() {
+        RelationalTableFilters tableFilters = createTableFilters();
+
+        assertThat(tableFilters.dataCollectionFilter()).isInstanceOf(CachedTableFilter.class);
+    }
+
+    @Test
+    void testSetDataCollectionFiltersRetainsReplacement() {
+        RelationalTableFilters tableFilters = createTableFilters();
+        TableFilter replacementFilter = tableId -> false;
+
+        tableFilters.setDataCollectionFilters(replacementFilter);
+
+        assertThat(tableFilters.dataCollectionFilter()).isSameAs(replacementFilter);
+    }
+
+    private static RelationalTableFilters createTableFilters() {
+        return new RelationalTableFilters(
+                Configuration.empty(), tableId -> true, TableId::toString);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -22,6 +22,10 @@ import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
 import org.apache.flink.cdc.connectors.mysql.table.StartupOptions;
 import org.apache.flink.table.catalog.ObjectPath;
 
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava31.com.google.common.cache.CacheLoader;
+import org.apache.flink.shaded.guava31.com.google.common.cache.LoadingCache;
+
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.relational.RelationalTableFilters;
@@ -35,7 +39,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -43,6 +46,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** A MySql Source configuration which is used by {@link MySqlSource}. */
 public class MySqlSourceConfig implements Serializable {
     private static final long serialVersionUID = 1L;
+    private static final Duration TABLE_FILTER_CACHE_EXPIRE_DURATION = Duration.ofHours(1);
+    private static final long TABLE_FILTER_CACHE_MAXIMUM_SIZE = 1024;
 
     private final String hostname;
     private final int port;
@@ -283,10 +288,19 @@ public class MySqlSourceConfig implements Serializable {
 
     static Tables.TableFilter createCachedTableFilter(
             Tables.TableFilter tableFilter, @Nullable Selectors excludeTableFilter) {
-        Map<TableId, Boolean> tableFilterCache = new ConcurrentHashMap<>();
-        return tableId ->
-                tableFilterCache.computeIfAbsent(
-                        tableId, id -> isTableIncluded(tableFilter, excludeTableFilter, id));
+        LoadingCache<TableId, Boolean> tableFilterCache =
+                CacheBuilder.newBuilder()
+                        .expireAfterAccess(TABLE_FILTER_CACHE_EXPIRE_DURATION)
+                        .maximumSize(TABLE_FILTER_CACHE_MAXIMUM_SIZE)
+                        .build(
+                                new CacheLoader<TableId, Boolean>() {
+                                    @Override
+                                    public Boolean load(TableId tableId) {
+                                        return isTableIncluded(
+                                                tableFilter, excludeTableFilter, tableId);
+                                    }
+                                });
+        return tableFilterCache::getUnchecked;
     }
 
     private static boolean isTableIncluded(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -146,11 +147,7 @@ public class MySqlSourceConfig implements Serializable {
         Tables.TableFilter tableFilter = dbzMySqlConfig.getTableFilters().dataCollectionFilter();
         dbzMySqlConfig
                 .getTableFilters()
-                .setDataCollectionFilters(
-                        (TableId tableId) ->
-                                tableFilter.isIncluded(tableId)
-                                        && (excludeTableFilter == null
-                                                || !excludeTableFilter.isMatch(tableId)));
+                .setDataCollectionFilters(createCachedTableFilter(tableFilter, excludeTableFilter));
         this.jdbcProperties = jdbcProperties;
         this.chunkKeyColumns = chunkKeyColumns;
         this.skipSnapshotBackfill = skipSnapshotBackfill;
@@ -282,6 +279,22 @@ public class MySqlSourceConfig implements Serializable {
     public Predicate<TableId> getTableFilter() {
         RelationalTableFilters tableFilters = dbzMySqlConfig.getTableFilters();
         return tableId -> tableFilters.dataCollectionFilter().isIncluded(tableId);
+    }
+
+    static Tables.TableFilter createCachedTableFilter(
+            Tables.TableFilter tableFilter, @Nullable Selectors excludeTableFilter) {
+        Map<TableId, Boolean> tableFilterCache = new ConcurrentHashMap<>();
+        return tableId ->
+                tableFilterCache.computeIfAbsent(
+                        tableId, id -> isTableIncluded(tableFilter, excludeTableFilter, id));
+    }
+
+    private static boolean isTableIncluded(
+            Tables.TableFilter tableFilter,
+            @Nullable Selectors excludeTableFilter,
+            TableId tableId) {
+        return tableFilter.isIncluded(tableId)
+                && (excludeTableFilter == null || !excludeTableFilter.isMatch(tableId));
     }
 
     public Properties getJdbcProperties() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.catalog.ObjectPath;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.relational.CachedTableFilter;
 import io.debezium.relational.RelationalTableFilters;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
@@ -143,14 +144,16 @@ public class MySqlSourceConfig implements Serializable {
                 (excludeTableList == null
                         ? null
                         : new Selectors.SelectorsBuilder().includeTables(excludeTableList).build());
-        Tables.TableFilter tableFilter = dbzMySqlConfig.getTableFilters().dataCollectionFilter();
-        dbzMySqlConfig
-                .getTableFilters()
-                .setDataCollectionFilters(
-                        (TableId tableId) ->
-                                tableFilter.isIncluded(tableId)
-                                        && (excludeTableFilter == null
-                                                || !excludeTableFilter.isMatch(tableId)));
+        if (excludeTableFilter != null) {
+            Tables.TableFilter tableFilter =
+                    dbzMySqlConfig.getTableFilters().dataCollectionFilter();
+            dbzMySqlConfig
+                    .getTableFilters()
+                    .setDataCollectionFilters(
+                            CachedTableFilter.from(tableFilter)
+                                    .withAdditionalFilter(
+                                            tableId -> !excludeTableFilter.isMatch(tableId)));
+        }
         this.jdbcProperties = jdbcProperties;
         this.chunkKeyColumns = chunkKeyColumns;
         this.skipSnapshotBackfill = skipSnapshotBackfill;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.config;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MySqlSourceConfig}. */
+class MySqlSourceConfigTest {
+
+    @Test
+    void testCachesTableFilterResults() {
+        AtomicInteger filterInvocationCount = new AtomicInteger();
+        Tables.TableFilter cachedTableFilter =
+                MySqlSourceConfig.createCachedTableFilter(
+                        tableId -> {
+                            filterInvocationCount.incrementAndGet();
+                            return tableId.table().startsWith("orders");
+                        },
+                        null);
+
+        TableId includedTable = new TableId("test_db", null, "orders_1");
+        TableId unmatchedTable = new TableId("test_db", null, "customers");
+
+        assertThat(cachedTableFilter.isIncluded(includedTable)).isTrue();
+        assertThat(cachedTableFilter.isIncluded(includedTable)).isTrue();
+        assertThat(cachedTableFilter.isIncluded(unmatchedTable)).isFalse();
+        assertThat(cachedTableFilter.isIncluded(unmatchedTable)).isFalse();
+        assertThat(filterInvocationCount).hasValue(2);
+    }
+
+    @Test
+    void testTableFilterWithExcludeTableList() {
+        MySqlSourceConfig config =
+                new MySqlSourceConfigFactory()
+                        .hostname("localhost")
+                        .username("user")
+                        .password("password")
+                        .databaseList("test_db")
+                        .tableList("test_db\\.orders_.*")
+                        .excludeTableList("test_db.orders_skip")
+                        .createConfig(0);
+
+        Predicate<TableId> tableFilter = config.getTableFilter();
+        TableId includedTable = new TableId("test_db", null, "orders_1");
+        TableId excludedTable = new TableId("test_db", null, "orders_skip");
+        TableId unmatchedTable = new TableId("test_db", null, "customers");
+
+        assertThat(tableFilter.test(includedTable)).isTrue();
+        assertThat(tableFilter.test(excludedTable)).isFalse();
+        assertThat(tableFilter.test(unmatchedTable)).isFalse();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigTest.java
@@ -41,12 +41,16 @@ class MySqlSourceConfigTest {
                         null);
 
         TableId includedTable = new TableId("test_db", null, "orders_1");
+        TableId sameIncludedTable = new TableId("test_db", null, "orders_1");
         TableId unmatchedTable = new TableId("test_db", null, "customers");
+        TableId sameUnmatchedTable = new TableId("test_db", null, "customers");
 
         assertThat(cachedTableFilter.isIncluded(includedTable)).isTrue();
         assertThat(cachedTableFilter.isIncluded(includedTable)).isTrue();
+        assertThat(cachedTableFilter.isIncluded(sameIncludedTable)).isTrue();
         assertThat(cachedTableFilter.isIncluded(unmatchedTable)).isFalse();
         assertThat(cachedTableFilter.isIncluded(unmatchedTable)).isFalse();
+        assertThat(cachedTableFilter.isIncluded(sameUnmatchedTable)).isFalse();
         assertThat(filterInvocationCount).hasValue(2);
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.config;
+
+import io.debezium.relational.CachedTableFilter;
+import io.debezium.relational.TableId;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link MySqlSourceConfig}. */
+class MySqlSourceConfigTest {
+
+    @Test
+    void testTableFilterWithExcludeTableList() {
+        MySqlSourceConfig config =
+                new MySqlSourceConfigFactory()
+                        .hostname("localhost")
+                        .username("user")
+                        .password("password")
+                        .databaseList("test_db")
+                        .tableList("test_db\\.orders_.*")
+                        .excludeTableList("test_db.orders_skip")
+                        .createConfig(0);
+
+        Predicate<TableId> tableFilter = config.getTableFilter();
+        TableId includedTable = new TableId("test_db", null, "orders_1");
+        TableId excludedTable = new TableId("test_db", null, "orders_skip");
+        TableId unmatchedTable = new TableId("test_db", null, "customers");
+
+        assertThat(config.getTableFilters().dataCollectionFilter())
+                .isInstanceOf(CachedTableFilter.class);
+        assertThat(tableFilter.test(includedTable)).isTrue();
+        assertThat(tableFilter.test(excludedTable)).isFalse();
+        assertThat(tableFilter.test(unmatchedTable)).isFalse();
+    }
+}


### PR DESCRIPTION
# What is the purpose of the change

  This PR reduces high CPU usage in MySQL CDC source when synchronizing a large number of tables.

  In large-table scenarios, MySQL binlog event processing may repeatedly check whether the same TableId should be included by the configured table filters. The hot path goes through Debezium's table filter
  predicates, which rely on regex matching:

```
java.util.regex.Matcher.match
java.util.regex.Matcher.matches
io.debezium.relational.RelationalTableFilters
io.debezium.connector.mysql.MySqlStreamingChangeEventSource.informAboutUnknownTableIfRequired
```

flame graph:

<img width="2154" height="1602" alt="20260602-203520 (1)" src="https://github.com/user-attachments/assets/21ac19b9-f572-4532-81fd-62a1c4c83ae9" />

  When the table list is large or the regex patterns are complex, repeatedly evaluating the same table filter result can consume significant CPU and cause TaskManager CPU usage to stay close to 100%.

  This PR caches the table filter result by TableId after constructing the Debezium table filter. The cached filter preserves the existing semantics of the Debezium include filter and Flink CDC excludeTableList, while avoiding repeated regex evaluation for the same table.

  # Brief change log

  - Cache MySQL CDC table filter results by TableId in MySqlSourceConfig
  - Preserve existing include/exclude table filter semantics when using the cached filter
  - Add unit tests to verify repeated checks for the same table reuse the cached result
  - Add unit tests to verify excludeTableList behavior is unchanged
  
   No configuration option is added because this only caches deterministic table filter results and does not change filtering semantics.

  # Verifying this change

  This change is verified by unit tests:

  - MySqlSourceConfigTest#testCachesTableFilterResults
  - MySqlSourceConfigTest#testTableFilterWithExcludeTableList

  Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e. is any changed class annotated with @Public(@PublicEvolving): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: no

  # Documentation

  Does this pull request introduce a new feature? no

  If yes, how is the feature documented? not applicable
  
 