### PR TITLE
[FLINK-39833][pipeline][starrocks] Escape special characters in column comment and default value when building DDL

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksEnrichedCatalog.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksEnrichedCatalog.java
@@ -191,11 +191,18 @@ public class StarRocksEnrichedCatalog extends StarRocksCatalog {
         builder.append(" ");
         builder.append(column.isNullable() ? "NULL" : "NOT NULL");
         if (column.getDefaultValue().isPresent()) {
-            builder.append(String.format(" DEFAULT \"%s\"", column.getDefaultValue().get()));
+            builder.append(
+                    String.format(
+                            " DEFAULT \"%s\"",
+                            StarRocksUtils.escapeSqlStringLiteral(column.getDefaultValue().get())));
         }
 
         if (column.getColumnComment().isPresent()) {
-            builder.append(String.format(" COMMENT \"%s\"", column.getColumnComment().get()));
+            builder.append(
+                    String.format(
+                            " COMMENT \"%s\"",
+                            StarRocksUtils.escapeSqlStringLiteral(
+                                    column.getColumnComment().get())));
         }
         return builder.toString();
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplier.java
@@ -158,10 +158,13 @@ public class StarRocksMetadataApplier implements MetadataApplier {
                     new StarRocksColumn.Builder()
                             .setColumnName(column.getName())
                             .setOrdinalPosition(-1)
-                            .setColumnComment(column.getComment())
+                            .setColumnComment(
+                                    StarRocksUtils.escapeSqlStringLiteral(column.getComment()))
                             .setDefaultValue(
-                                    StarRocksUtils.convertInvalidTimestampDefaultValue(
-                                            column.getDefaultValueExpression(), column.getType()));
+                                    StarRocksUtils.escapeSqlStringLiteral(
+                                            StarRocksUtils.convertInvalidTimestampDefaultValue(
+                                                    column.getDefaultValueExpression(),
+                                                    column.getType())));
             toStarRocksDataType(column, false, builder, tableCreateConfig.getUnicodeCharMaxBytes());
             addColumns.add(builder.build());
         }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -91,10 +91,12 @@ public class StarRocksUtils {
                     new StarRocksColumn.Builder()
                             .setColumnName(column.getName())
                             .setOrdinalPosition(i)
-                            .setColumnComment(column.getComment())
+                            .setColumnComment(escapeSqlStringLiteral(column.getComment()))
                             .setDefaultValue(
-                                    convertInvalidTimestampDefaultValue(
-                                            column.getDefaultValueExpression(), column.getType()));
+                                    escapeSqlStringLiteral(
+                                            convertInvalidTimestampDefaultValue(
+                                                    column.getDefaultValueExpression(),
+                                                    column.getType())));
             toStarRocksDataType(
                     column,
                     i < primaryKeyCount,
@@ -529,5 +531,32 @@ public class StarRocksUtils {
         }
 
         return defaultValue;
+    }
+
+    public static String escapeSqlStringLiteral(String value) {
+        if (value == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(value.length() + 8);
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '"':
+                    sb.append("\"\"");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                default:
+                    sb.append(c);
+            }
+        }
+        return sb.toString();
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksMetadataApplierITCase.java
@@ -617,6 +617,145 @@ class StarRocksMetadataApplierITCase extends StarRocksSinkTestBase {
         assertEqualsInOrder(expected, actual);
     }
 
+    @Test
+    void testSpecialCharactersInCommentAndDefaultValueInCreateTable() throws Exception {
+        TableId tableId =
+                TableId.tableId(
+                        StarRocksContainer.STARROCKS_DATABASE_NAME,
+                        StarRocksContainer.STARROCKS_TABLE_NAME);
+
+        Schema schema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(
+                                new PhysicalColumn(
+                                        "col_backslash",
+                                        DataTypes.VARCHAR(100),
+                                        "comment with \\ backslash",
+                                        "default\\value"))
+                        .column(
+                                new PhysicalColumn(
+                                        "col_quote",
+                                        DataTypes.VARCHAR(100),
+                                        "comment with \" double quote",
+                                        "default\"value"))
+                        .column(
+                                new PhysicalColumn(
+                                        "col_newline",
+                                        DataTypes.VARCHAR(100),
+                                        "comment with \n newline",
+                                        "default\nvalue"))
+                        .column(
+                                new PhysicalColumn(
+                                        "col_mixed",
+                                        DataTypes.VARCHAR(100),
+                                        "mixed \\ and \" and \n chars",
+                                        "mix\\ed\"val\nue"))
+                        .primaryKey("id")
+                        .build();
+
+        runJobWithEvents(Collections.singletonList(new CreateTableEvent(tableId, schema)));
+
+        List<String> actual = inspectTableSchema(tableId);
+
+        List<String> expected =
+                Arrays.asList(
+                        "id | int | NO | true | null",
+                        "col_backslash | varchar(300) | YES | false | default\\value",
+                        "col_quote | varchar(300) | YES | false | default\"value",
+                        "col_newline | varchar(300) | YES | false | default\nvalue",
+                        "col_mixed | varchar(300) | YES | false | mix\\ed\"val\nue");
+
+        assertEqualsInOrder(expected, actual);
+
+        List<String> comments = inspectColumnComments(tableId);
+        List<String> expectedComments =
+                Arrays.asList(
+                        "id | ",
+                        "col_backslash | comment with \\ backslash",
+                        "col_quote | comment with \" double quote",
+                        "col_newline | comment with \n newline",
+                        "col_mixed | mixed \\ and \" and \n chars");
+
+        assertEqualsInOrder(expectedComments, comments);
+    }
+
+    @Test
+    void testSpecialCharactersInCommentAndDefaultValueInAddColumn() throws Exception {
+        TableId tableId =
+                TableId.tableId(
+                        StarRocksContainer.STARROCKS_DATABASE_NAME,
+                        StarRocksContainer.STARROCKS_TABLE_NAME);
+
+        Schema initialSchema =
+                Schema.newBuilder()
+                        .column(new PhysicalColumn("id", DataTypes.INT().notNull(), null))
+                        .column(new PhysicalColumn("name", DataTypes.VARCHAR(50), null))
+                        .primaryKey("id")
+                        .build();
+
+        List<Event> events = new ArrayList<>();
+        events.add(new CreateTableEvent(tableId, initialSchema));
+
+        events.add(
+                new AddColumnEvent(
+                        tableId,
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        new PhysicalColumn(
+                                                "col_backslash",
+                                                DataTypes.VARCHAR(100),
+                                                "comment with \\ backslash",
+                                                "default\\value")))));
+
+        events.add(
+                new AddColumnEvent(
+                        tableId,
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        new PhysicalColumn(
+                                                "col_quote",
+                                                DataTypes.VARCHAR(100),
+                                                "comment with \" double quote",
+                                                "default\"value")))));
+
+        events.add(
+                new AddColumnEvent(
+                        tableId,
+                        Collections.singletonList(
+                                new AddColumnEvent.ColumnWithPosition(
+                                        new PhysicalColumn(
+                                                "col_newline",
+                                                DataTypes.VARCHAR(100),
+                                                "comment with \n newline",
+                                                "default\nvalue")))));
+
+        runJobWithEvents(events);
+
+        List<String> actual = inspectTableSchema(tableId);
+
+        List<String> expected =
+                Arrays.asList(
+                        "id | int | NO | true | null",
+                        "name | varchar(150) | YES | false | null",
+                        "col_backslash | varchar(300) | YES | false | default\\value",
+                        "col_quote | varchar(300) | YES | false | default\"value",
+                        "col_newline | varchar(300) | YES | false | default\nvalue");
+
+        assertEqualsInOrder(expected, actual);
+
+        List<String> comments = inspectColumnComments(tableId);
+        List<String> expectedComments =
+                Arrays.asList(
+                        "id | ",
+                        "name | ",
+                        "col_backslash | comment with \\ backslash",
+                        "col_quote | comment with \" double quote",
+                        "col_newline | comment with \n newline");
+
+        assertEqualsInOrder(expectedComments, comments);
+    }
+
     /** Microsecond variant: '0000-00-00 00:00:00.000000'. */
     private static final String INVALID_DATETIME_WITH_MICROS = "0000-00-00 00:00:00.000000";
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtilsTest.java
@@ -506,4 +506,49 @@ class StarRocksUtilsTest {
         BinaryRecordData record = generator.generate(new Object[] {null});
         assertThat(getter.getFieldOrNull(record)).isNull();
     }
+
+    @Test
+    void testEscapeSqlStringLiteralNull() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral(null)).isNull();
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralNoSpecialChars() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("hello world")).isEqualTo("hello world");
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralBackslash() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("path\\to\\file"))
+                .isEqualTo("path\\\\to\\\\file");
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralDoubleQuote() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("say \"hello\""))
+                .isEqualTo("say \"\"hello\"\"");
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralNewline() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("line1\nline2"))
+                .isEqualTo("line1\\nline2");
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralCarriageReturn() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("line1\rline2"))
+                .isEqualTo("line1\\rline2");
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralMixed() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("a\\b\"c\nd\re"))
+                .isEqualTo("a\\\\b\"\"c\\nd\\re");
+    }
+
+    @Test
+    void testEscapeSqlStringLiteralEmpty() {
+        assertThat(StarRocksUtils.escapeSqlStringLiteral("")).isEqualTo("");
+    }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksSinkTestBase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/test/java/org/apache/flink/cdc/connectors/starrocks/sink/utils/StarRocksSinkTestBase.java
@@ -207,6 +207,25 @@ public class StarRocksSinkTestBase extends TestLogger {
         return results;
     }
 
+    public List<String> inspectColumnComments(TableId tableId) throws SQLException {
+        List<String> results = new ArrayList<>();
+        ResultSet rs =
+                STARROCKS_CONTAINER
+                        .createConnection("")
+                        .createStatement()
+                        .executeQuery(
+                                String.format(
+                                        "SELECT COLUMN_NAME, COLUMN_COMMENT FROM information_schema.columns "
+                                                + "WHERE TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s' "
+                                                + "ORDER BY ORDINAL_POSITION",
+                                        tableId.getSchemaName(), tableId.getTableName()));
+
+        while (rs.next()) {
+            results.add(rs.getString("COLUMN_NAME") + " | " + rs.getString("COLUMN_COMMENT"));
+        }
+        return results;
+    }
+
     public List<String> fetchTableContent(TableId tableId, int columnCount) throws SQLException {
         List<String> results = new ArrayList<>();
         ResultSet rs =


### PR DESCRIPTION
When the StarRocks pipeline connector builds DDL statements (CREATE TABLE / ALTER TABLE ADD COLUMN), special characters in column comments and default values (such as backslash `\`, double quote `"`, newline `\n`, carriage return `\r`) are not properly escaped.

This causes the generated DDL to be syntactically invalid, leading to schema synchronization failures at runtime.

### Root Cause

The column comment and default value strings are directly interpolated into the DDL template `DEFAULT "..."` and `COMMENT "..."` without any escaping.

### Fix

Introduce a utility method `StarRocksUtils.escapeSqlStringLiteral()` that escapes:
- `\` → `\\`
- `"` → `""`
- `\n` / `\r` → space

Apply this escaping in:
- `StarRocksEnrichedCatalog` (CREATE TABLE DDL building)
- `StarRocksMetadataApplier` (ALTER TABLE ADD COLUMN)
- `StarRocksUtils` (initial schema conversion and table comment)
