### PR TITLE
[FLINK-39834] Fix Oracle UNISTR parsing with embedded concat operator

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/pom.xml
@@ -208,6 +208,14 @@ limitations under the License.
                             </artifactSet>
                             <filters>
                                 <filter>
+                                    <artifact>io.debezium:debezium-connector-oracle</artifact>
+                                    <excludes>
+                                        <exclude>
+                                            io/debezium/connector/oracle/logminer/UnistrHelper.class
+                                        </exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>org.apache.kafka:*</artifact>
                                     <excludes>
                                         <exclude>kafka/kafka-version.properties</exclude>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/UnistrHelper.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/UnistrHelper.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle.logminer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** A utility/helper class to support decoding Oracle Unicode String function values, {@code UNISTR}. */
+public class UnistrHelper {
+
+    private static final String UNITSTR_FUNCTION_START = "UNISTR('";
+    private static final String UNISTR_FUNCTION_END = "')";
+
+    public static boolean isUnistrFunction(String data) {
+        return data != null
+                && data.startsWith(UNITSTR_FUNCTION_START)
+                && data.endsWith(UNISTR_FUNCTION_END);
+    }
+
+    public static String convert(String data) {
+        if (data == null || data.length() == 0) {
+            return data;
+        }
+
+        // Multiple UNISTR function calls maybe concatenated together using "||".
+        // Only split on SQL concatenation operators outside UNISTR quoted data.
+        final List<String> parts = tokenize(data);
+
+        final StringBuilder result = new StringBuilder();
+        for (String part : parts) {
+            final String trimmed = part.trim();
+            if (isUnistrFunction(trimmed)) {
+                result.append(
+                        decode(
+                                trimmed.substring(
+                                        UNITSTR_FUNCTION_START.length(), trimmed.length() - 2)));
+            } else {
+                result.append(data);
+            }
+        }
+        return result.toString();
+    }
+
+    private static String decode(String value) {
+        final StringBuilder result = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '\\' && value.length() >= i + 4) {
+                result.append(
+                        Character.toChars(Integer.parseInt(value.substring(i + 1, i + 5), 16)));
+                i += 4;
+            } else {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+
+    private static List<String> tokenize(String data) {
+        final List<String> parts = new ArrayList<>();
+        final int length = data.length();
+
+        boolean inQuotedData = false;
+        int startIndex = 0;
+
+        for (int i = 0; i < length; i++) {
+            if (stringMatches(data, i, UNITSTR_FUNCTION_START)) {
+                inQuotedData = true;
+                if (startIndex == -1) {
+                    startIndex = i;
+                }
+            } else if (inQuotedData && stringMatches(data, i, UNISTR_FUNCTION_END)) {
+                inQuotedData = false;
+            } else if (!inQuotedData && stringMatches(data, i, "||")) {
+                parts.add(data.substring(startIndex, i).trim());
+
+                i += 1;
+                startIndex = i + 1;
+            }
+        }
+
+        if (startIndex < data.length()) {
+            parts.add(data.substring(startIndex).trim());
+        }
+
+        return parts;
+    }
+
+    private static boolean stringMatches(String str, int index, String token) {
+        return str.regionMatches(index, token, 0, token.length());
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/OracleValueConvertersTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle;
+
+import io.debezium.config.Configuration;
+import io.debezium.relational.Column;
+import io.debezium.relational.ValueConverter;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for Oracle connector-visible value conversion. */
+class OracleValueConvertersTest {
+
+    @Test
+    void shouldConvertLogMinerUnistrValueWithEmbeddedConcatSequence() {
+        ValueConverter converter = converters().converter(nvarcharColumn(), null);
+
+        Object converted =
+                converter.convert(
+                        "UNISTR('\\4E2D\\56FD||\\6B66\\6C49')");
+
+        assertThat(converted).isEqualTo("\u4E2D\u56FD||\u6B66\u6C49");
+    }
+
+    @Test
+    void shouldConvertConcatenatedLogMinerUnistrValues() {
+        ValueConverter converter = converters().converter(nvarcharColumn(), null);
+
+        Object converted =
+                converter.convert(
+                        "UNISTR('\\4E2D\\56FD')||UNISTR('\\6B66\\6C49')");
+
+        assertThat(converted).isEqualTo("\u4E2D\u56FD\u6B66\u6C49");
+    }
+
+    private static OracleValueConverters converters() {
+        Configuration config =
+                Configuration.create()
+                        .with("database.server.name", "test")
+                        .with("database.dbname", "ORCLCDB")
+                        .with("database.hostname", "127.0.0.1")
+                        .with("database.port", 1521)
+                        .with("database.user", "flinkuser")
+                        .with("database.password", "flinkpw")
+                        .build();
+        return new OracleValueConverters(new OracleConnectorConfig(config), null);
+    }
+
+    private static Column nvarcharColumn() {
+        return Column.editor()
+                .name("VAL_NVARCHAR2")
+                .jdbcType(Types.NVARCHAR)
+                .type("NVARCHAR2")
+                .length(100)
+                .optional(false)
+                .create();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/logminer/UnistrHelperTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/logminer/UnistrHelperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle.logminer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnistrHelperTest {
+
+    @Test
+    void shouldConvertUnistrValues() {
+        assertThat(UnistrHelper.convert("UNISTR('\\0412\\044B')")).isEqualTo("\u0412\u044B");
+        assertThat(UnistrHelper.convert("UNISTR('\\0412\\044B')||UNISTR('\\0431\\0443')"))
+                .isEqualTo("\u0412\u044B\u0431\u0443");
+        assertThat(UnistrHelper.convert("UNISTR('\\0412\\044B')  ||  UNISTR('\\0431\\0443')"))
+                .isEqualTo("\u0412\u044B\u0431\u0443");
+    }
+
+    @Test
+    void shouldConvertUnistrValueWithConcatenationCharacterSequence() {
+        assertThat(UnistrHelper.convert("UNISTR('\\4E2D\\56FD||\\6B66\\6C49')"))
+                .isEqualTo("\u4E2D\u56FD||\u6B66\u6C49");
+    }
+
+    @Test
+    void shouldConvertUnistrValueWithEmbeddedConcatenationAndAsciiCharacters() {
+        assertThat(
+                        UnistrHelper.convert(
+                                "UNISTR('\\592A\\5E73\\6D0B\\53CC\\514D4000||"
+                                        + "\\518D\\5236\\9020\\5DF2\\5F55\\5355||"
+                                        + "C440100VEH26071668')"))
+                .isEqualTo(
+                        "\u592A\u5E73\u6D0B\u53CC\u514D4000||"
+                                + "\u518D\u5236\u9020\u5DF2\u5F55\u5355||"
+                                + "C440100VEH26071668");
+    }
+
+    @Test
+    void shouldNotDuplicateOriginalUnistrValueWhenConcatenationSequenceIsInsideFunction() {
+        String unistr =
+                "UNISTR('\\592A\\5E73\\6D0B\\53CC\\514D4000||"
+                        + "\\518D\\5236\\9020\\5DF2\\5F55\\5355||"
+                        + "C440100VEH26071668')";
+
+        assertThat(UnistrHelper.convert(unistr)).doesNotContain("UNISTR(");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-sql-connector-oracle-cdc/pom.xml
@@ -73,6 +73,14 @@ limitations under the License.
                             </artifactSet>
                             <filters>
                                 <filter>
+                                    <artifact>io.debezium:debezium-connector-oracle</artifact>
+                                    <excludes>
+                                        <exclude>
+                                            io/debezium/connector/oracle/logminer/UnistrHelper.class
+                                        </exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>org.apache.kafka:*</artifact>
                                     <excludes>
                                         <exclude>kafka/kafka-version.properties</exclude>


### PR DESCRIPTION
## What is the purpose of the change

This change fixes Oracle CDC UNISTR decoding when the UNISTR quoted payload contains the character sequence `||`.

Oracle LogMiner can emit NVARCHAR2 values as `UNISTR(...)`. The current Debezium 1.9.8.Final `UnistrHelper` splits directly on `||`, so a value like:

```text
UNISTR('\\592A...4000||\\518D...||C440100VEH26071668')
```

can be split into invalid fragments. The fallback path then appends the original expression repeatedly, causing downstream values to contain duplicated `UNISTR(...)` text and potentially exceed sink column length limits.

## Brief change log

- Add a patched `io.debezium.connector.oracle.logminer.UnistrHelper` in the Oracle CDC connector to tokenize UNISTR expressions and split only on SQL concatenation operators outside quoted UNISTR data.
- Add regression tests for normal UNISTR decoding, external UNISTR concatenation, and embedded `||` inside a UNISTR payload.
- Exclude Debezium's original `UnistrHelper.class` from the shaded Oracle pipeline connector so the patched helper is packaged.

## Verifying this change

This change added tests and can be verified as follows:

```bash
mvn -pl flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc \
  -DskipITs -DskipE2eTests -Dcheckstyle.skip -Dspotless.check.skip=true \
  -Dtest=io.debezium.connector.oracle.logminer.UnistrHelperTest test
```

Tests run: 4, Failures: 0, Errors: 0, Skipped: 0.

Apache Jira: https://issues.apache.org/jira/browse/FLINK-39834