### PR TITLE
[hotfix] Use explicit UTF-8 charset in coerceToBytes and guard Optional.get() in Kafka serializers

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
@@ -74,6 +74,7 @@ import org.apache.flink.shaded.guava31.com.google.common.io.BaseEncoding;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -614,7 +615,7 @@ public class SchemaMergingUtils {
         if (originalField instanceof byte[]) {
             return originalField;
         } else {
-            return originalField.toString().getBytes();
+            return originalField.toString().getBytes(StandardCharsets.UTF_8);
         }
     }
 

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -1270,6 +1271,6 @@ class SchemaMergingUtilsTest {
     }
 
     private static byte[] binOf(String str) {
-        return str.getBytes();
+        return str.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -162,7 +162,14 @@ public class DorisMetadataApplier implements MetadataApplier {
         Map<String, FieldSchema> fieldSchemaMap = new LinkedHashMap<>();
         List<String> columnNameList = schema.getColumnNames();
         for (String columnName : columnNameList) {
-            Column column = schema.getColumn(columnName).get();
+            Column column =
+                    schema.getColumn(columnName)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Column '"
+                                                            + columnName
+                                                            + "' not found in schema"));
             String typeString;
             if (column.getType() instanceof LocalZonedTimestampType
                     || column.getType() instanceof TimestampType

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/utils/DorisSchemaUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/utils/DorisSchemaUtils.java
@@ -91,7 +91,15 @@ public class DorisSchemaUtils {
             return null;
         }
 
-        DataType dataType = schema.getColumn(partitionKey).get().getType();
+        DataType dataType =
+                schema.getColumn(partitionKey)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Partition key column '"
+                                                        + partitionKey
+                                                        + "' not found in schema"))
+                        .getType();
         return isValidDataType(dataType) ? new Tuple2<>(partitionKey, partitionUnit) : null;
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/json/debezium/DebeziumJsonSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/json/debezium/DebeziumJsonSerializationSchema.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
@@ -310,7 +311,7 @@ public class DebeziumJsonSerializationSchema implements SerializationSchema<Even
                             .setScale(decimalType.getScale(), RoundingMode.HALF_UP);
                 case BINARY:
                 case VARBINARY:
-                    return defaultValueExpression.getBytes();
+                    return defaultValueExpression.getBytes(StandardCharsets.UTF_8);
                 case CHAR:
                 case VARCHAR:
                 case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/CsvSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/CsvSerializationSchema.java
@@ -106,7 +106,14 @@ public class CsvSerializationSchema implements SerializationSchema<Event> {
         DataField[] fields = new DataField[schema.primaryKeys().size() + 1];
         fields[0] = DataTypes.FIELD("TableId", DataTypes.STRING());
         for (int i = 0; i < schema.primaryKeys().size(); i++) {
-            Column column = schema.getColumn(schema.primaryKeys().get(i)).get();
+            Column column =
+                    schema.getColumn(schema.primaryKeys().get(i))
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Primary key column '"
+                                                            + schema.primaryKeys().get(i)
+                                                            + "' not found in schema"));
             fields[i + 1] = DataTypes.FIELD(column.getName(), column.getType());
         }
         // the row should never be null

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/JsonSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/JsonSerializationSchema.java
@@ -129,7 +129,14 @@ public class JsonSerializationSchema implements SerializationSchema<Event> {
         DataField[] fields = new DataField[schema.primaryKeys().size() + 1];
         fields[0] = DataTypes.FIELD("TableId", DataTypes.STRING());
         for (int i = 0; i < schema.primaryKeys().size(); i++) {
-            Column column = schema.getColumn(schema.primaryKeys().get(i)).get();
+            Column column =
+                    schema.getColumn(schema.primaryKeys().get(i))
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Primary key column '"
+                                                            + schema.primaryKeys().get(i)
+                                                            + "' not found in schema"));
             fields[i + 1] = DataTypes.FIELD(column.getName(), column.getType());
         }
         // the row should never be null

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -75,7 +75,14 @@ public class StarRocksUtils {
         // so reorder the columns in the source schema to make primary key columns at the front
         List<Column> orderedColumns = new ArrayList<>();
         for (String primaryKey : schema.primaryKeys()) {
-            orderedColumns.add(schema.getColumn(primaryKey).get());
+            orderedColumns.add(
+                    schema.getColumn(primaryKey)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Primary key column '"
+                                                            + primaryKey
+                                                            + "' not found in schema")));
         }
         for (Column column : schema.getColumns()) {
             if (!schema.primaryKeys().contains(column.getName())) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/table/RowDataTiKVEventDeserializationSchemaBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/table/RowDataTiKVEventDeserializationSchemaBase.java
@@ -39,6 +39,7 @@ import org.tikv.kvproto.Kvrpcpb;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -434,7 +435,7 @@ public class RowDataTiKVEventDeserializationSchemaBase implements Serializable {
                 if (object instanceof byte[]) {
                     return object;
                 } else if (object instanceof String) {
-                    return ((String) object).getBytes();
+                    return ((String) object).getBytes(StandardCharsets.UTF_8);
                 } else if (object instanceof ByteBuffer) {
                     ByteBuffer byteBuffer = (ByteBuffer) object;
                     byte[] bytes = new byte[byteBuffer.remaining()];

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/BinaryTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/BinaryTypeReturningClass.java
@@ -21,6 +21,8 @@ import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.udf.UserDefinedFunction;
 
+import java.nio.charset.StandardCharsets;
+
 /** This is an example UDF class for testing purposes only. */
 public class BinaryTypeReturningClass implements UserDefinedFunction {
     @Override
@@ -29,6 +31,6 @@ public class BinaryTypeReturningClass implements UserDefinedFunction {
     }
 
     public byte[] eval() {
-        return "xyzzy".getBytes();
+        return "xyzzy".getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarBinaryTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarBinaryTypeReturningClass.java
@@ -21,6 +21,8 @@ import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.udf.UserDefinedFunction;
 
+import java.nio.charset.StandardCharsets;
+
 /** This is an example UDF class for testing purposes only. */
 public class VarBinaryTypeReturningClass implements UserDefinedFunction {
     @Override
@@ -29,6 +31,6 @@ public class VarBinaryTypeReturningClass implements UserDefinedFunction {
     }
 
     public byte[] eval() {
-        return "xyzzy".getBytes();
+        return "xyzzy".getBytes(StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## What this PR does

This PR fixes two minor but important issues:

### 1. Platform-default charset in `SchemaMergingUtils.coerceToBytes()`

**File:** `flink-cdc-common/.../SchemaMergingUtils.java:617`

`originalField.toString().getBytes()` uses the platform-default charset, which can vary across JVM configurations and operating systems. This causes inconsistent behavior when converting fields to bytes during schema evolution.

**Fix:** Use `StandardCharsets.UTF_8` explicitly.

### 2. Unchecked `Optional.get()` in Kafka serialization schemas

**Files:**
- `CsvSerializationSchema.java:109`
- `JsonSerializationSchema.java:132`

Both files call `schema.getColumn(...).get()` without checking if the Optional is present. If a primary key column is missing from the schema (e.g., after schema evolution), this throws a bare `NoSuchElementException` with no context.

**Fix:** Replace with `orElseThrow()` that includes the missing column name in the error message.

## Testing

These are straightforward defensive improvements:
- The charset fix ensures consistent UTF-8 encoding regardless of JVM locale
- The Optional guard improves error diagnostics without changing happy-path behavior