### PR TITLE
[hotfix] Use explicit UTF-8 charset in getBytes() calls across connectors

### DIFF
--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/utils/SchemaMergingUtils.java
@@ -74,6 +74,7 @@ import org.apache.flink.shaded.guava31.com.google.common.io.BaseEncoding;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -614,7 +615,7 @@ public class SchemaMergingUtils {
         if (originalField instanceof byte[]) {
             return originalField;
         } else {
-            return originalField.toString().getBytes();
+            return originalField.toString().getBytes(StandardCharsets.UTF_8);
         }
     }
 

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/utils/SchemaMergingUtilsTest.java
@@ -54,6 +54,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -1270,6 +1271,6 @@ class SchemaMergingUtilsTest {
     }
 
     private static byte[] binOf(String str) {
-        return str.getBytes();
+        return str.getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/json/debezium/DebeziumJsonSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/json/debezium/DebeziumJsonSerializationSchema.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
@@ -310,7 +311,7 @@ public class DebeziumJsonSerializationSchema implements SerializationSchema<Even
                             .setScale(decimalType.getScale(), RoundingMode.HALF_UP);
                 case BINARY:
                 case VARBINARY:
-                    return defaultValueExpression.getBytes();
+                    return defaultValueExpression.getBytes(StandardCharsets.UTF_8);
                 case CHAR:
                 case VARCHAR:
                 case TIMESTAMP_WITH_LOCAL_TIME_ZONE:

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/table/RowDataTiKVEventDeserializationSchemaBase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-tidb-cdc/src/main/java/org/apache/flink/cdc/connectors/tidb/table/RowDataTiKVEventDeserializationSchemaBase.java
@@ -39,6 +39,7 @@ import org.tikv.kvproto.Kvrpcpb;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -434,7 +435,7 @@ public class RowDataTiKVEventDeserializationSchemaBase implements Serializable {
                 if (object instanceof byte[]) {
                     return object;
                 } else if (object instanceof String) {
-                    return ((String) object).getBytes();
+                    return ((String) object).getBytes(StandardCharsets.UTF_8);
                 } else if (object instanceof ByteBuffer) {
                     ByteBuffer byteBuffer = (ByteBuffer) object;
                     byte[] bytes = new byte[byteBuffer.remaining()];

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/BinaryTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/BinaryTypeReturningClass.java
@@ -21,6 +21,8 @@ import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.udf.UserDefinedFunction;
 
+import java.nio.charset.StandardCharsets;
+
 /** This is an example UDF class for testing purposes only. */
 public class BinaryTypeReturningClass implements UserDefinedFunction {
     @Override
@@ -29,6 +31,6 @@ public class BinaryTypeReturningClass implements UserDefinedFunction {
     }
 
     public byte[] eval() {
-        return "xyzzy".getBytes();
+        return "xyzzy".getBytes(StandardCharsets.UTF_8);
     }
 }

--- a/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarBinaryTypeReturningClass.java
+++ b/flink-cdc-pipeline-udf-examples/src/main/java/org/apache/flink/cdc/udf/examples/java/precision/VarBinaryTypeReturningClass.java
@@ -21,6 +21,8 @@ import org.apache.flink.cdc.common.types.DataType;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.udf.UserDefinedFunction;
 
+import java.nio.charset.StandardCharsets;
+
 /** This is an example UDF class for testing purposes only. */
 public class VarBinaryTypeReturningClass implements UserDefinedFunction {
     @Override
@@ -29,6 +31,6 @@ public class VarBinaryTypeReturningClass implements UserDefinedFunction {
     }
 
     public byte[] eval() {
-        return "xyzzy".getBytes();
+        return "xyzzy".getBytes(StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## What this PR does

Replaces platform-default `String.getBytes()` with `String.getBytes(StandardCharsets.UTF_8)` across multiple modules to ensure consistent encoding behavior regardless of JVM locale or OS configuration.

### Affected files

- `SchemaMergingUtils.java` + test — core schema coercion
- `DebeziumJsonSerializationSchema.java` — Kafka Debezium JSON default value handling
- `RowDataTiKVEventDeserializationSchemaBase.java` — TiDB source connector
- `BinaryTypeReturningClass.java` / `VarBinaryTypeReturningClass.java` — UDF examples

### Why

`String.getBytes()` without an explicit charset uses the JVM's default charset, which varies across environments (e.g., `US-ASCII` on some minimal Docker images, `GBK` on Chinese Windows). This causes silent data corruption when non-ASCII characters are involved. Using `UTF-8` explicitly makes the behavior deterministic.

## Testing

These are straightforward defensive improvements — the fix ensures consistent UTF-8 encoding regardless of JVM locale.

---

Split from #4427 as requested by @yuxiqian.