### PR TITLE
[hotfix] Guard Optional.get() in Doris connector schema lookups

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/sink/DorisMetadataApplier.java
@@ -162,7 +162,14 @@ public class DorisMetadataApplier implements MetadataApplier {
         Map<String, FieldSchema> fieldSchemaMap = new LinkedHashMap<>();
         List<String> columnNameList = schema.getColumnNames();
         for (String columnName : columnNameList) {
-            Column column = schema.getColumn(columnName).get();
+            Column column =
+                    schema.getColumn(columnName)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Column '"
+                                                            + columnName
+                                                            + "' not found in schema"));
             String typeString;
             if (column.getType() instanceof LocalZonedTimestampType
                     || column.getType() instanceof TimestampType

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/utils/DorisSchemaUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-doris/src/main/java/org/apache/flink/cdc/connectors/doris/utils/DorisSchemaUtils.java
@@ -91,7 +91,15 @@ public class DorisSchemaUtils {
             return null;
         }
 
-        DataType dataType = schema.getColumn(partitionKey).get().getType();
+        DataType dataType =
+                schema.getColumn(partitionKey)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                "Partition key column '"
+                                                        + partitionKey
+                                                        + "' not found in schema"))
+                        .getType();
         return isValidDataType(dataType) ? new Tuple2<>(partitionKey, partitionUnit) : null;
     }
 


### PR DESCRIPTION
## What this PR does

Replaces bare `Optional.get()` calls with `Optional.orElseThrow()` in the Doris pipeline connector to provide meaningful error messages when columns are missing from the schema.

### Affected files

- `DorisMetadataApplier.java` — column lookup during schema evolution
- `DorisSchemaUtils.java` — partition key column lookup

### Why

`Optional.get()` throws a bare `NoSuchElementException` with no context when the Optional is empty. This makes debugging difficult when a primary key or partition key column is unexpectedly missing (e.g., after schema evolution). Using `orElseThrow()` with a descriptive message including the column name makes failures immediately diagnosable.

## Testing

Behavioral change only in the error path — happy-path behavior is unchanged.

---

Split from #4427 as requested by @yuxiqian.