### PR TITLE
[hotfix] Guard Optional.get() in Kafka and StarRocks connector schema lookups

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/CsvSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/CsvSerializationSchema.java
@@ -106,7 +106,14 @@ public class CsvSerializationSchema implements SerializationSchema<Event> {
         DataField[] fields = new DataField[schema.primaryKeys().size() + 1];
         fields[0] = DataTypes.FIELD("TableId", DataTypes.STRING());
         for (int i = 0; i < schema.primaryKeys().size(); i++) {
-            Column column = schema.getColumn(schema.primaryKeys().get(i)).get();
+            Column column =
+                    schema.getColumn(schema.primaryKeys().get(i))
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Primary key column '"
+                                                            + schema.primaryKeys().get(i)
+                                                            + "' not found in schema"));
             fields[i + 1] = DataTypes.FIELD(column.getName(), column.getType());
         }
         // the row should never be null

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/CsvSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/CsvSerializationSchema.java
@@ -106,13 +106,14 @@ public class CsvSerializationSchema implements SerializationSchema<Event> {
         DataField[] fields = new DataField[schema.primaryKeys().size() + 1];
         fields[0] = DataTypes.FIELD("TableId", DataTypes.STRING());
         for (int i = 0; i < schema.primaryKeys().size(); i++) {
+            String primaryKey = schema.primaryKeys().get(i);
             Column column =
-                    schema.getColumn(schema.primaryKeys().get(i))
+                    schema.getColumn(primaryKey)
                             .orElseThrow(
                                     () ->
                                             new IllegalStateException(
                                                     "Primary key column '"
-                                                            + schema.primaryKeys().get(i)
+                                                            + primaryKey
                                                             + "' not found in schema"));
             fields[i + 1] = DataTypes.FIELD(column.getName(), column.getType());
         }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/JsonSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/JsonSerializationSchema.java
@@ -129,7 +129,14 @@ public class JsonSerializationSchema implements SerializationSchema<Event> {
         DataField[] fields = new DataField[schema.primaryKeys().size() + 1];
         fields[0] = DataTypes.FIELD("TableId", DataTypes.STRING());
         for (int i = 0; i < schema.primaryKeys().size(); i++) {
-            Column column = schema.getColumn(schema.primaryKeys().get(i)).get();
+            Column column =
+                    schema.getColumn(schema.primaryKeys().get(i))
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Primary key column '"
+                                                            + schema.primaryKeys().get(i)
+                                                            + "' not found in schema"));
             fields[i + 1] = DataTypes.FIELD(column.getName(), column.getType());
         }
         // the row should never be null

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/JsonSerializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-kafka/src/main/java/org/apache/flink/cdc/connectors/kafka/serialization/JsonSerializationSchema.java
@@ -129,13 +129,14 @@ public class JsonSerializationSchema implements SerializationSchema<Event> {
         DataField[] fields = new DataField[schema.primaryKeys().size() + 1];
         fields[0] = DataTypes.FIELD("TableId", DataTypes.STRING());
         for (int i = 0; i < schema.primaryKeys().size(); i++) {
+            String primaryKey = schema.primaryKeys().get(i);
             Column column =
-                    schema.getColumn(schema.primaryKeys().get(i))
+                    schema.getColumn(primaryKey)
                             .orElseThrow(
                                     () ->
                                             new IllegalStateException(
                                                     "Primary key column '"
-                                                            + schema.primaryKeys().get(i)
+                                                            + primaryKey
                                                             + "' not found in schema"));
             fields[i + 1] = DataTypes.FIELD(column.getName(), column.getType());
         }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-starrocks/src/main/java/org/apache/flink/cdc/connectors/starrocks/sink/StarRocksUtils.java
@@ -75,7 +75,14 @@ public class StarRocksUtils {
         // so reorder the columns in the source schema to make primary key columns at the front
         List<Column> orderedColumns = new ArrayList<>();
         for (String primaryKey : schema.primaryKeys()) {
-            orderedColumns.add(schema.getColumn(primaryKey).get());
+            orderedColumns.add(
+                    schema.getColumn(primaryKey)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalStateException(
+                                                    "Primary key column '"
+                                                            + primaryKey
+                                                            + "' not found in schema")));
         }
         for (Column column : schema.getColumns()) {
             if (!schema.primaryKeys().contains(column.getName())) {


### PR DESCRIPTION
## What this PR does

Replaces bare `Optional.get()` calls with `Optional.orElseThrow()` in the Kafka and StarRocks pipeline connectors to provide meaningful error messages when primary key columns are missing from the schema.

### Affected files

- `CsvSerializationSchema.java` — CSV serialization primary key lookup
- `JsonSerializationSchema.java` — JSON serialization primary key lookup
- `StarRocksUtils.java` — StarRocks primary key column ordering

### Why

`Optional.get()` throws a bare `NoSuchElementException` with no context when the Optional is empty. This makes debugging difficult when a primary key column is unexpectedly missing (e.g., after schema evolution). Using `orElseThrow()` with a descriptive message including the column name makes failures immediately diagnosable.

## Testing

Behavioral change only in the error path — happy-path behavior is unchanged.

---

Split from #4427 as requested by @yuxiqian.