### PR TITLE
[FLINK-39840][pipeline-connector/oracle] Fix Oracle pipeline table identifiers

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleEventDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleEventDeserializer.java
@@ -144,8 +144,9 @@ public class OracleEventDeserializer extends DebeziumEventDeserializationSchema 
 
     @Override
     protected TableId getTableId(SourceRecord record) {
-        String[] parts = record.topic().split("\\.");
-        return TableId.tableId(parts[1], parts[2]);
+        io.debezium.relational.TableId dbzTableId =
+                org.apache.flink.cdc.connectors.base.utils.SourceRecordUtils.getTableId(record);
+        return TableId.tableId(dbzTableId.catalog(), dbzTableId.schema(), dbzTableId.table());
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/parser/OracleAlterTableParserListener.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/parser/OracleAlterTableParserListener.java
@@ -348,6 +348,6 @@ public class OracleAlterTableParserListener extends BaseParserListener {
 
     private org.apache.flink.cdc.common.event.TableId toCdcTableId(TableId dbzTableId) {
         return org.apache.flink.cdc.common.event.TableId.tableId(
-                dbzTableId.schema(), dbzTableId.table());
+                dbzTableId.catalog(), dbzTableId.schema(), dbzTableId.table());
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/OraclePipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/OraclePipelineRecordEmitter.java
@@ -85,15 +85,13 @@ public class OraclePipelineRecordEmitter extends IncrementalSourceRecordEmitter<
             }
             for (TableId tableId : capturedTableIds) {
                 Schema schema = OracleSchemaUtils.getSchema(jdbc, tableId);
-                createTableEventCache.put(
+                TableId capturedTableId =
                         new TableId(
                                 sourceConfig.getDbzConnectorConfig().getDatabaseName(),
                                 tableId.catalog(),
-                                tableId.table()),
-                        new CreateTableEvent(
-                                org.apache.flink.cdc.common.event.TableId.tableId(
-                                        tableId.catalog(), tableId.table()),
-                                schema));
+                                tableId.table());
+                createTableEventCache.put(
+                        capturedTableId, new CreateTableEvent(toCdcTableId(capturedTableId), schema));
             }
             this.isBounded = StartupOptions.snapshot().equals(sourceConfig.getStartupOptions());
         } catch (SQLException e) {
@@ -146,12 +144,13 @@ public class OraclePipelineRecordEmitter extends IncrementalSourceRecordEmitter<
     private CreateTableEvent sendCreateTableEvent(
             JdbcConnection jdbc, TableId tableId, SourceOutput<Event> output) {
         Schema schema = OracleSchemaUtils.getSchema(jdbc, tableId);
-        CreateTableEvent createTableEvent =
-                new CreateTableEvent(
-                        org.apache.flink.cdc.common.event.TableId.tableId(
-                                tableId.schema(), tableId.table()),
-                        schema);
+        CreateTableEvent createTableEvent = new CreateTableEvent(toCdcTableId(tableId), schema);
         output.collect(createTableEvent);
         return createTableEvent;
+    }
+
+    static org.apache.flink.cdc.common.event.TableId toCdcTableId(TableId tableId) {
+        return org.apache.flink.cdc.common.event.TableId.tableId(
+                tableId.catalog(), tableId.schema(), tableId.table());
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/test/java/org/apache/flink/cdc/connectors/oracle/source/OracleEventDeserializerTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/test/java/org/apache/flink/cdc/connectors/oracle/source/OracleEventDeserializerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source;
+
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.debezium.table.DebeziumChangelogMode;
+
+import io.debezium.data.Envelope;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OracleEventDeserializerTest {
+
+    @Test
+    void shouldDeserializeSourceStructToDatabaseSchemaTableId() {
+        TestOracleEventDeserializer deserializer = new TestOracleEventDeserializer();
+        Schema sourceSchema =
+                SchemaBuilder.struct()
+                        .field("db", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("schema", Schema.OPTIONAL_STRING_SCHEMA)
+                        .field("table", Schema.OPTIONAL_STRING_SCHEMA)
+                        .build();
+        Schema valueSchema =
+                SchemaBuilder.struct().field(Envelope.FieldName.SOURCE, sourceSchema).build();
+        Struct source =
+                new Struct(sourceSchema)
+                        .put("db", "DLZSJT")
+                        .put("schema", "SOUTH")
+                        .put("table", "T_IM_SALEISSUEENTRY");
+        Struct value = new Struct(valueSchema).put(Envelope.FieldName.SOURCE, source);
+        SourceRecord record =
+                new SourceRecord(
+                        null,
+                        null,
+                        "oracle_logminer.SOUTH.T_IM_SALEISSUEENTRY",
+                        null,
+                        null,
+                        null,
+                        valueSchema,
+                        value);
+
+        TableId tableId = deserializer.getTableId(record);
+
+        assertThat(tableId.getNamespace()).isEqualTo("DLZSJT");
+        assertThat(tableId.getSchemaName()).isEqualTo("SOUTH");
+        assertThat(tableId.getTableName()).isEqualTo("T_IM_SALEISSUEENTRY");
+        assertThat(tableId.toString()).isEqualTo("DLZSJT.SOUTH.T_IM_SALEISSUEENTRY");
+    }
+
+    private static class TestOracleEventDeserializer extends OracleEventDeserializer {
+        private TestOracleEventDeserializer() {
+            super(DebeziumChangelogMode.ALL, true, Collections.emptyList());
+        }
+
+        @Override
+        public TableId getTableId(SourceRecord record) {
+            return super.getTableId(record);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/test/java/org/apache/flink/cdc/connectors/oracle/source/parser/OracleAntlrDdlParserTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/test/java/org/apache/flink/cdc/connectors/oracle/source/parser/OracleAntlrDdlParserTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.parser;
+
+import org.apache.flink.cdc.common.event.AddColumnEvent;
+import org.apache.flink.cdc.common.event.DropColumnEvent;
+import org.apache.flink.cdc.common.event.RenameColumnEvent;
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+
+import io.debezium.relational.Tables;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OracleAntlrDdlParserTest {
+
+    private static final String DATABASE_NAME = "DLZSJT";
+    private static final String SCHEMA_NAME = "WHZSJT";
+    private static final TableId TABLE_ID = TableId.tableId(DATABASE_NAME, SCHEMA_NAME, "PRODUCTS");
+
+    @Test
+    void shouldIncludeDatabaseSchemaAndTableInAddColumnEvent() {
+        SchemaChangeEvent event =
+                parseSingleSchemaChangeEvent("ALTER TABLE PRODUCTS ADD COL_ADDED VARCHAR2(100)");
+
+        assertThat(event).isInstanceOf(AddColumnEvent.class);
+        assertThat(event.tableId()).isEqualTo(TABLE_ID);
+    }
+
+    @Test
+    void shouldIncludeDatabaseSchemaAndTableInDropColumnEvent() {
+        SchemaChangeEvent event =
+                parseSingleSchemaChangeEvent("ALTER TABLE PRODUCTS DROP COLUMN COL_DROPPED");
+
+        assertThat(event).isInstanceOf(DropColumnEvent.class);
+        assertThat(event.tableId()).isEqualTo(TABLE_ID);
+    }
+
+    @Test
+    void shouldIncludeDatabaseSchemaAndTableInRenameColumnEvent() {
+        SchemaChangeEvent event =
+                parseSingleSchemaChangeEvent(
+                        "ALTER TABLE PRODUCTS RENAME COLUMN COL_OLD TO COL_NEW");
+
+        assertThat(event).isInstanceOf(RenameColumnEvent.class);
+        assertThat(event.tableId()).isEqualTo(TABLE_ID);
+    }
+
+    private static SchemaChangeEvent parseSingleSchemaChangeEvent(String ddl) {
+        OracleAntlrDdlParser parser = new OracleAntlrDdlParser(DATABASE_NAME, SCHEMA_NAME);
+        parser.setCurrentDatabase(DATABASE_NAME);
+        parser.parse(ddl, new Tables());
+
+        List<SchemaChangeEvent> events = parser.getAndClearParsedEvents();
+        assertThat(events).hasSize(1);
+        return events.get(0);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/OraclePipelineRecordEmitterTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/OraclePipelineRecordEmitterTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader;
+
+import io.debezium.relational.TableId;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OraclePipelineRecordEmitterTest {
+
+    @Test
+    void shouldEmitPipelineTableIdWithDatabaseSchemaAndTable() {
+        org.apache.flink.cdc.common.event.TableId tableId =
+                OraclePipelineRecordEmitter.toCdcTableId(
+                        new TableId("DLZSJT", "WHZSJT", "T_IM_SALEISSUEENTRY"));
+
+        assertThat(tableId.getNamespace()).isEqualTo("DLZSJT");
+        assertThat(tableId.getSchemaName()).isEqualTo("WHZSJT");
+        assertThat(tableId.getTableName()).isEqualTo("T_IM_SALEISSUEENTRY");
+        assertThat(tableId.toString()).isEqualTo("DLZSJT.WHZSJT.T_IM_SALEISSUEENTRY");
+    }
+}


### PR DESCRIPTION
This PR fixes Oracle pipeline table identifiers so data change events, schema change events, and CreateTableEvent consistently use the full `database.schema.table` identifier.

Without this, some paths drop the database/catalog part and emit only `schema.table`, which can break downstream routing and schema evolution when jobs rely on three-part table IDs.

### Changes
- Read data change table IDs from the Debezium SourceRecord source struct instead of parsing the Kafka topic.
- Preserve the Debezium catalog/database part when converting schema change table IDs.
- Emit CreateTableEvent with the same full table identifier.
- Add unit coverage for data events, DDL parsing, and CreateTableEvent ID conversion.

### Tests
- Attempted: `mvn -pl flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle -DskipITs -Dspotless.check.skip=true -Dcheckstyle.skip=true -Dtest=OracleEventDeserializerTest,OracleAntlrDdlParserTest,OraclePipelineRecordEmitterTest test`
- Result: local Maven did not reach the test phase and got stuck while launching Java (`java --enable-native-access=ALL-UNNAMED -version`).