### PR TITLE
[FLINK-39841][oracle-cdc] Add option to skip analyze table before chunk planning

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleSourceBuilder.java
@@ -261,6 +261,15 @@ public class OracleSourceBuilder<T> {
     }
 
     /**
+     * Whether to execute ANALYZE TABLE before querying ALL_TABLES.NUM_ROWS for approximate row
+     * count during incremental snapshot chunk planning.
+     */
+    public OracleSourceBuilder<T> analyzeTableForApproximateRowCountEnabled(boolean enabled) {
+        this.configFactory.analyzeTableForApproximateRowCountEnabled(enabled);
+        return this;
+    }
+
+    /**
      * Build the {@link OracleIncrementalSource}.
      *
      * @return a OracleParallelSource with the settings made for this builder.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/assigner/splitter/OracleChunkSplitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/assigner/splitter/OracleChunkSplitter.java
@@ -24,6 +24,7 @@ import org.apache.flink.cdc.connectors.base.source.assigner.splitter.JdbcSourceC
 import org.apache.flink.cdc.connectors.base.source.assigner.state.ChunkSplitterState;
 import org.apache.flink.cdc.connectors.base.source.utils.JdbcChunkUtils;
 import org.apache.flink.cdc.connectors.base.utils.ObjectUtils;
+import org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfigFactory;
 import org.apache.flink.cdc.connectors.oracle.source.utils.OracleTypeUtils;
 import org.apache.flink.cdc.connectors.oracle.source.utils.OracleUtils;
 import org.apache.flink.cdc.connectors.oracle.util.ChunkUtils;
@@ -86,7 +87,15 @@ public class OracleChunkSplitter extends JdbcSourceChunkSplitter {
     @Override
     protected Long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId)
             throws SQLException {
-        return OracleUtils.queryApproximateRowCnt(jdbc, tableId);
+        boolean analyzeTableEnabled =
+                Boolean.parseBoolean(
+                        sourceConfig
+                                .getDbzProperties()
+                                .getProperty(
+                                        OracleSourceConfigFactory
+                                                .ANALYZE_TABLE_FOR_APPROXIMATE_ROW_COUNT_ENABLED,
+                                        "true"));
+        return OracleUtils.queryApproximateRowCnt(jdbc, tableId, analyzeTableEnabled);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -39,9 +39,12 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
     private static final long serialVersionUID = 1L;
     private static final String DATABASE_SERVER_NAME = "oracle_logminer";
     private static final String DRIVER_ClASS_NAME = "oracle.jdbc.OracleDriver";
+    public static final String ANALYZE_TABLE_FOR_APPROXIMATE_ROW_COUNT_ENABLED =
+            "scan.incremental.snapshot.analyze-table.enabled";
 
     @Nullable private String url;
     private List<String> schemaList;
+    @Nullable private Boolean analyzeTableForApproximateRowCountEnabled;
 
     /** Url to use when connecting to the Oracle database server. */
     public JdbcSourceConfigFactory url(@Nullable String url) {
@@ -56,6 +59,11 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
      */
     public JdbcSourceConfigFactory schemaList(String... schemaList) {
         this.schemaList = Arrays.asList(schemaList);
+        return this;
+    }
+
+    public JdbcSourceConfigFactory analyzeTableForApproximateRowCountEnabled(boolean enabled) {
+        this.analyzeTableForApproximateRowCountEnabled = enabled;
         return this;
     }
 
@@ -106,6 +114,10 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
         // override the user-defined debezium properties
         if (dbzProperties != null) {
             props.putAll(dbzProperties);
+        }
+
+        if (Boolean.FALSE.equals(analyzeTableForApproximateRowCountEnabled)) {
+            props.setProperty(ANALYZE_TABLE_FOR_APPROXIMATE_ROW_COUNT_ENABLED, "false");
         }
 
         Configuration dbzConfiguration = Configuration.from(props);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceOptions.java
@@ -36,4 +36,11 @@ public class OracleSourceOptions extends JdbcSourceOptions {
                     .intType()
                     .defaultValue(1521)
                     .withDescription("Integer port number of the Oracle database server.");
+
+    public static final ConfigOption<Boolean> SCAN_INCREMENTAL_SNAPSHOT_ANALYZE_TABLE_ENABLED =
+            ConfigOptions.key("scan.incremental.snapshot.analyze-table.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to execute ANALYZE TABLE before querying ALL_TABLES.NUM_ROWS for approximate row count during incremental snapshot chunk planning.");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleUtils.java
@@ -48,15 +48,30 @@ public class OracleUtils {
 
     private OracleUtils() {}
 
-    public static long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId)
-            throws SQLException {
+    public static long queryApproximateRowCnt(
+            JdbcConnection jdbc, TableId tableId, boolean analyzeTableEnabled) throws SQLException {
+        final String rowCountQuery =
+                String.format(
+                        "select NUM_ROWS from all_tables where OWNER = '%s' and TABLE_NAME = '%s'",
+                        tableId.schema(), tableId.table());
+        if (!analyzeTableEnabled) {
+            return jdbc.queryAndMap(
+                    rowCountQuery,
+                    rs -> {
+                        if (!rs.next()) {
+                            throw new SQLException(
+                                    String.format(
+                                            "No result returned after running query [%s]",
+                                            rowCountQuery));
+                        }
+                        return rs.getLong(1);
+                    });
+        }
+
         final String analyzeTable =
                 String.format(
                         "analyze table %s compute statistics for table",
                         quoteSchemaAndTable(tableId));
-        final String rowCountQuery =
-                String.format(
-                        "select NUM_ROWS from all_tables where TABLE_NAME = '%s'", tableId.table());
         return jdbc.execute(analyzeTable)
                 .queryAndMap(
                         rowCountQuery,

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -33,6 +33,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static org.apache.flink.cdc.connectors.base.options.JdbcSourceOptions.CONNECTION_POOL_SIZE;
@@ -56,7 +57,9 @@ import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_ST
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND;
 import static org.apache.flink.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
+import static org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfigFactory.ANALYZE_TABLE_FOR_APPROXIMATE_ROW_COUNT_ENABLED;
 import static org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceOptions.PORT;
+import static org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ANALYZE_TABLE_ENABLED;
 import static org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceOptions.SCHEMA_NAME;
 import static org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceOptions.URL;
 import static org.apache.flink.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
@@ -117,6 +120,8 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         boolean scanNewlyAddedTableEnabled = config.get(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         boolean assignUnboundedChunkFirst =
                 config.get(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        boolean analyzeTableForApproximateRowCount =
+                config.get(SCAN_INCREMENTAL_SNAPSHOT_ANALYZE_TABLE_ENABLED);
 
         if (enableParallelRead) {
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
@@ -130,6 +135,11 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
 
         OptionUtils.printOptions(IDENTIFIER, ((Configuration) config).toMap());
 
+        Properties dbzProperties = getDebeziumProperties(context.getCatalogTable().getOptions());
+        if (!analyzeTableForApproximateRowCount) {
+            dbzProperties.setProperty(ANALYZE_TABLE_FOR_APPROXIMATE_ROW_COUNT_ENABLED, "false");
+        }
+
         return new OracleTableSource(
                 physicalSchema,
                 url,
@@ -140,7 +150,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
                 schemaName,
                 username,
                 password,
-                getDebeziumProperties(context.getCatalogTable().getOptions()),
+                dbzProperties,
                 startupOptions,
                 enableParallelRead,
                 splitSize,
@@ -195,6 +205,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_ANALYZE_TABLE_ENABLED);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -277,6 +277,54 @@ class OracleTableSourceFactoryTest {
     }
 
     @Test
+    void testDisableAnalyzeTableForApproximateRowCount() {
+        Map<String, String> options = getAllRequiredOptions();
+        options.put(
+                org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceOptions
+                        .SCAN_INCREMENTAL_SNAPSHOT_ANALYZE_TABLE_ENABLED
+                        .key(),
+                "false");
+
+        DynamicTableSource actualSource = createTableSource(options);
+        Properties dbzProperties = new Properties();
+        dbzProperties.put(
+                org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfigFactory
+                        .ANALYZE_TABLE_FOR_APPROXIMATE_ROW_COUNT_ENABLED,
+                "false");
+        OracleTableSource expectedSource =
+                new OracleTableSource(
+                        SCHEMA,
+                        null,
+                        MY_PORT,
+                        MY_LOCALHOST,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        MY_SCHEMA,
+                        MY_USERNAME,
+                        MY_PASSWORD,
+                        dbzProperties,
+                        StartupOptions.initial(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
+                        SourceOptions.CHUNK_META_GROUP_SIZE.defaultValue(),
+                        SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        JdbcSourceOptions.CONNECT_TIMEOUT.defaultValue(),
+                        JdbcSourceOptions.CONNECT_MAX_RETRIES.defaultValue(),
+                        JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue(),
+                        JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND
+                                .defaultValue(),
+                        JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
+                                .defaultValue(),
+                        null,
+                        JdbcSourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        JdbcSourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED
+                                .defaultValue());
+        Assertions.assertThat(actualSource).isEqualTo(expectedSource);
+    }
+
+    @Test
     void testStartupFromInitial() {
         Map<String, String> properties = getAllRequiredOptionsWithHost();
         properties.put("scan.startup.mode", "initial");


### PR DESCRIPTION
This PR adds an Oracle CDC option to skip `ANALYZE TABLE` before incremental snapshot chunk planning.

Oracle CDC uses approximate row count from `ALL_TABLES.NUM_ROWS` while planning incremental snapshot chunks. The connector currently runs `ANALYZE TABLE` before reading that value. On large production tables this can be expensive, may require additional privileges, and can delay job startup.

### Changes
- Add `scan.incremental.snapshot.analyze-table.enabled`, enabled by default.
- Propagate the setting to Oracle source configuration and Debezium properties.
- Skip `ANALYZE TABLE` when the option is set to `false`.
- Add table factory coverage for the new option.

### Tests
- Not run locally: Maven currently gets stuck before the test phase while launching Java (`java --enable-native-access=ALL-UNNAMED -version`).