### PR TITLE
[FLINK-39842][oracle-cdc] Support timestamp startup by resolving SCN

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Field;
+import io.debezium.connector.oracle.OracleConnectorConfig.ConnectorAdapter;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.Tables.ColumnNameFilter;
+import io.debezium.util.Strings;
+import oracle.jdbc.OracleTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Clob;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class OracleConnection extends JdbcConnection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnection.class);
+
+    /** Returned by column metadata in Oracle if no scale is set; */
+    private static final int ORACLE_UNSET_SCALE = -127;
+
+    /** Pattern to identify system generated indices and column names. */
+    private static final Pattern SYS_NC_PATTERN =
+            Pattern.compile("^SYS_NC(?:_OID|_ROWINFO|[0-9][0-9][0-9][0-9][0-9])\\$$");
+
+    /** Pattern to identify abstract data type indices and column names. */
+    private static final Pattern ADT_INDEX_NAMES_PATTERN = Pattern.compile("^\".*\"\\.\".*\".*");
+
+    /**
+     * Pattern to identify a hidden column based on redefining a table with the {@code ROWID}
+     * option.
+     */
+    private static final Pattern MROW_PATTERN = Pattern.compile("^M_ROW\\$\\$");
+
+    /** A field for the raw jdbc url. This field has no default value. */
+    private static final Field URL = Field.create("url", "Raw JDBC url");
+
+    /** The database version. */
+    private final OracleDatabaseVersion databaseVersion;
+
+    private static final String QUOTED_CHARACTER = "\"";
+
+    public OracleConnection(JdbcConfiguration config, Supplier<ClassLoader> classLoaderSupplier) {
+        this(config, classLoaderSupplier, true);
+    }
+
+    public OracleConnection(
+            JdbcConfiguration config,
+            Supplier<ClassLoader> classLoaderSupplier,
+            boolean showVersion) {
+        super(
+                config,
+                resolveConnectionFactory(config),
+                classLoaderSupplier,
+                QUOTED_CHARACTER,
+                QUOTED_CHARACTER);
+        this.databaseVersion = resolveOracleDatabaseVersion();
+        if (showVersion) {
+            LOGGER.info("Database Version: {}", databaseVersion.getBanner());
+        }
+    }
+
+    public void setSessionToPdb(String pdbName) {
+        Statement statement = null;
+
+        try {
+            statement = connection().createStatement();
+            statement.execute("alter session set container=" + pdbName);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (statement != null) {
+                try {
+                    statement.close();
+                } catch (SQLException e) {
+                    LOGGER.error("Couldn't close statement", e);
+                }
+            }
+        }
+    }
+
+    public void resetSessionToCdb() {
+        Statement statement = null;
+
+        try {
+            statement = connection().createStatement();
+            statement.execute("alter session set container=cdb$root");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (statement != null) {
+                try {
+                    statement.close();
+                } catch (SQLException e) {
+                    LOGGER.error("Couldn't close statement", e);
+                }
+            }
+        }
+    }
+
+    public OracleDatabaseVersion getOracleVersion() {
+        return databaseVersion;
+    }
+
+    private OracleDatabaseVersion resolveOracleDatabaseVersion() {
+        String versionStr;
+        try {
+            try {
+                // Oracle 18.1 introduced BANNER_FULL as the new column rather than BANNER
+                // This column uses a different format than the legacy BANNER.
+                versionStr =
+                        queryAndMap(
+                                "SELECT BANNER_FULL FROM V$VERSION WHERE BANNER_FULL LIKE 'Oracle Database%'",
+                                (rs) -> {
+                                    if (rs.next()) {
+                                        return rs.getString(1);
+                                    }
+                                    return null;
+                                });
+            } catch (SQLException e) {
+                // exception ignored
+                if (e.getMessage().contains("ORA-00904: \"BANNER_FULL\"")) {
+                    LOGGER.debug(
+                            "BANNER_FULL column not in V$VERSION, using BANNER column as fallback");
+                    versionStr = null;
+                } else {
+                    throw e;
+                }
+            }
+
+            // For databases prior to 18.1, a SQLException will be thrown due to BANNER_FULL not
+            // being a column and
+            // this will cause versionStr to remain null, use fallback column BANNER for versions
+            // prior to 18.1.
+            if (versionStr == null) {
+                versionStr =
+                        queryAndMap(
+                                "SELECT BANNER FROM V$VERSION WHERE BANNER LIKE 'Oracle Database%'",
+                                (rs) -> {
+                                    if (rs.next()) {
+                                        return rs.getString(1);
+                                    }
+                                    return null;
+                                });
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to resolve Oracle database version", e);
+        }
+
+        if (versionStr == null) {
+            throw new RuntimeException("Failed to resolve Oracle database version");
+        }
+
+        return OracleDatabaseVersion.parse(versionStr);
+    }
+
+    @Override
+    public Set<TableId> readTableNames(
+            String databaseCatalog,
+            String schemaNamePattern,
+            String tableNamePattern,
+            String[] tableTypes)
+            throws SQLException {
+
+        Set<TableId> tableIds =
+                super.readTableNames(null, schemaNamePattern, tableNamePattern, tableTypes);
+
+        return tableIds.stream()
+                .map(t -> new TableId(databaseCatalog, t.schema(), t.table()))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Retrieves all {@code TableId} in a given database catalog, filtering certain ids that should
+     * be omitted from the returned set such as special spatial tables and index-organized tables.
+     *
+     * @param catalogName the catalog/database name
+     * @return set of all table ids for existing table objects
+     * @throws SQLException if a database exception occurred
+     */
+    protected Set<TableId> getAllTableIds(String catalogName) throws SQLException {
+        final String query =
+                "select owner, table_name from all_tables "
+                        +
+                        // filter special spatial tables
+                        "where table_name NOT LIKE 'MDRT_%' "
+                        + "and table_name NOT LIKE 'MDRS_%' "
+                        + "and table_name NOT LIKE 'MDXT_%' "
+                        +
+                        // filter index-organized-tables
+                        "and (table_name NOT LIKE 'SYS_IOT_OVER_%' and IOT_NAME IS NULL) "
+                        +
+                        // filter nested tables
+                        "and nested = 'NO'"
+                        +
+                        // filter parent tables of nested tables
+                        "and table_name not in (select PARENT_TABLE_NAME from ALL_NESTED_TABLES)";
+
+        Set<TableId> tableIds = new HashSet<>();
+        query(
+                query,
+                (rs) -> {
+                    while (rs.next()) {
+                        tableIds.add(new TableId(catalogName, rs.getString(1), rs.getString(2)));
+                    }
+                    LOGGER.trace("TableIds are: {}", tableIds);
+                });
+
+        return tableIds;
+    }
+
+    // todo replace metadata with something like this
+    private ResultSet getTableColumnsInfo(String schemaNamePattern, String tableName)
+            throws SQLException {
+        String columnQuery =
+                "select column_name, data_type, data_length, data_precision, data_scale, default_length, density, char_length from "
+                        + "all_tab_columns where owner like '"
+                        + schemaNamePattern
+                        + "' and table_name='"
+                        + tableName
+                        + "'";
+
+        PreparedStatement statement = connection().prepareStatement(columnQuery);
+        return statement.executeQuery();
+    }
+
+    // this is much faster, we will use it until full replacement of the metadata usage TODO
+    public void readSchemaForCapturedTables(
+            Tables tables,
+            String databaseCatalog,
+            String schemaNamePattern,
+            ColumnNameFilter columnFilter,
+            boolean removeTablesNotFoundInJdbc,
+            Set<TableId> capturedTables)
+            throws SQLException {
+
+        Set<TableId> tableIdsBefore = new HashSet<>(tables.tableIds());
+
+        DatabaseMetaData metadata = connection().getMetaData();
+        Map<TableId, List<Column>> columnsByTable = new HashMap<>();
+
+        for (TableId tableId : capturedTables) {
+            try (ResultSet columnMetadata =
+                    metadata.getColumns(
+                            databaseCatalog, schemaNamePattern, tableId.table(), null)) {
+                while (columnMetadata.next()) {
+                    // add all whitelisted columns
+                    readTableColumn(columnMetadata, tableId, columnFilter)
+                            .ifPresent(
+                                    column -> {
+                                        columnsByTable
+                                                .computeIfAbsent(tableId, t -> new ArrayList<>())
+                                                .add(column.create());
+                                    });
+                }
+            }
+        }
+
+        // Read the metadata for the primary keys ...
+        for (Map.Entry<TableId, List<Column>> tableEntry : columnsByTable.entrySet()) {
+            // First get the primary key information, which must be done for *each* table ...
+            List<String> pkColumnNames = readPrimaryKeyNames(metadata, tableEntry.getKey());
+
+            // Then define the table ...
+            List<Column> columns = tableEntry.getValue();
+            Collections.sort(columns);
+            tables.overwriteTable(tableEntry.getKey(), columns, pkColumnNames, null);
+        }
+
+        if (removeTablesNotFoundInJdbc) {
+            // Remove any definitions for tables that were not found in the database metadata ...
+            tableIdsBefore.removeAll(columnsByTable.keySet());
+            tableIdsBefore.forEach(tables::removeTable);
+        }
+    }
+
+    @Override
+    protected String resolveCatalogName(String catalogName) {
+        final String pdbName = config().getString("pdb.name");
+        return (!Strings.isNullOrEmpty(pdbName) ? pdbName : config().getString("dbname"))
+                .toUpperCase();
+    }
+
+    @Override
+    public List<String> readTableUniqueIndices(DatabaseMetaData metadata, TableId id)
+            throws SQLException {
+        return super.readTableUniqueIndices(metadata, id.toDoubleQuoted());
+    }
+
+    @Override
+    public Optional<Timestamp> getCurrentTimestamp() throws SQLException {
+        return queryAndMap(
+                "SELECT CURRENT_TIMESTAMP FROM DUAL",
+                rs -> rs.next() ? Optional.of(rs.getTimestamp(1)) : Optional.empty());
+    }
+
+    @Override
+    protected boolean isTableUniqueIndexIncluded(String indexName, String columnName) {
+        if (columnName != null) {
+            return !SYS_NC_PATTERN.matcher(columnName).matches()
+                    && !ADT_INDEX_NAMES_PATTERN.matcher(columnName).matches()
+                    && !MROW_PATTERN.matcher(columnName).matches();
+        }
+        return false;
+    }
+
+    /**
+     * Get the current, most recent system change number.
+     *
+     * @return the current system change number
+     * @throws SQLException if an exception occurred
+     * @throws IllegalStateException if the query does not return at least one row
+     */
+    public Scn getCurrentScn() throws SQLException {
+        return queryAndMap(
+                "SELECT CURRENT_SCN FROM V$DATABASE",
+                (rs) -> {
+                    if (rs.next()) {
+                        return Scn.valueOf(rs.getString(1));
+                    }
+                    throw new IllegalStateException("Could not get SCN");
+                });
+    }
+
+    /**
+     * Generate a given table's DDL metadata.
+     *
+     * @param tableId table identifier, should never be {@code null}
+     * @return generated DDL
+     * @throws SQLException if an exception occurred obtaining the DDL metadata
+     * @throws NonRelationalTableException the table is not a relational table
+     */
+    public String getTableMetadataDdl(TableId tableId)
+            throws SQLException, NonRelationalTableException {
+        try {
+            // This table contains all available objects that are considered relational & object
+            // based.
+            // By querying for TABLE_TYPE is null, we are explicitly confirming what if an entry
+            // exists
+            // that the table is in-fact a relational table and if the result set is empty, the
+            // object
+            // is another type, likely an object-based table, in which case we cannot generate DDL.
+            final String tableType =
+                    "SELECT COUNT(1) FROM ALL_ALL_TABLES WHERE OWNER='"
+                            + tableId.schema()
+                            + "' AND TABLE_NAME='"
+                            + tableId.table()
+                            + "' AND TABLE_TYPE IS NULL";
+            if (queryAndMap(tableType, rs -> rs.next() ? rs.getInt(1) : 0) == 0) {
+                throw new NonRelationalTableException(
+                        "Table " + tableId + " is not a relational table");
+            }
+
+            // The storage and segment attributes aren't necessary
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'STORAGE', false); end;");
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'SEGMENT_ATTRIBUTES', false); end;");
+            // In case DDL is returned as multiple DDL statements, this allows the parser to parse
+            // each separately.
+            // This is only critical during streaming as during snapshot the table structure is
+            // built from JDBC driver queries.
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'SQLTERMINATOR', true); end;");
+            return queryAndMap(
+                    "SELECT dbms_metadata.get_ddl('TABLE','"
+                            + tableId.table()
+                            + "','"
+                            + tableId.schema()
+                            + "') FROM DUAL",
+                    rs -> {
+                        if (!rs.next()) {
+                            throw new DebeziumException(
+                                    "Could not get DDL metadata for table: " + tableId);
+                        }
+
+                        Object res = rs.getObject(1);
+                        return ((Clob) res).getSubString(1, (int) ((Clob) res).length());
+                    });
+        } finally {
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'DEFAULT'); end;");
+        }
+    }
+
+    /**
+     * Get the current connection's session statistic by name.
+     *
+     * @param name the name of the statistic to be fetched, must not be {@code null}
+     * @return the session statistic value, never {@code null}
+     * @throws SQLException if an exception occurred obtaining the session statistic value
+     */
+    public Long getSessionStatisticByName(String name) throws SQLException {
+        return queryAndMap(
+                "SELECT VALUE FROM v$statname n, v$mystat m WHERE n.name='"
+                        + name
+                        + "' AND n.statistic#=m.statistic#",
+                rs -> rs.next() ? rs.getLong(1) : 0L);
+    }
+
+    /**
+     * Returns whether the given table exists or not.
+     *
+     * @param tableName table name, should not be {@code null}
+     * @return true if the table exists, false if it does not
+     * @throws SQLException if a database exception occurred
+     */
+    public boolean isTableExists(String tableName) throws SQLException {
+        return queryAndMap(
+                "SELECT COUNT(1) FROM USER_TABLES WHERE TABLE_NAME = '" + tableName + "'",
+                rs -> rs.next() && rs.getLong(1) > 0);
+    }
+
+    public boolean isTableExists(TableId tableId) throws SQLException {
+        return queryAndMap(
+                "SELECT COUNT(1) FROM ALL_TABLES WHERE OWNER = '"
+                        + tableId.schema()
+                        + "' AND TABLE_NAME = '"
+                        + tableId.table()
+                        + "'",
+                rs -> rs.next() && rs.getLong(1) > 0);
+    }
+
+    /**
+     * Returns whether the given table is empty or not.
+     *
+     * @param tableName table name, should not be {@code null}
+     * @return true if the table has no records, false otherwise
+     * @throws SQLException if a database exception occurred
+     */
+    public boolean isTableEmpty(String tableName) throws SQLException {
+        return getRowCount(tableName) == 0L;
+    }
+
+    /**
+     * Returns the number of rows in a given table.
+     *
+     * @param tableName table name, should not be {@code null}
+     * @return the number of rows
+     * @throws SQLException if a database exception occurred
+     */
+    public long getRowCount(String tableName) throws SQLException {
+        return queryAndMap(
+                "SELECT COUNT(1) FROM " + tableName,
+                rs -> {
+                    if (rs.next()) {
+                        return rs.getLong(1);
+                    }
+                    return 0L;
+                });
+    }
+
+    public <T> T singleOptionalValue(String query, ResultSetExtractor<T> extractor)
+            throws SQLException {
+        return queryAndMap(query, rs -> rs.next() ? extractor.apply(rs) : null);
+    }
+
+    @Override
+    public String buildSelectWithRowLimits(
+            TableId tableId,
+            int limit,
+            String projection,
+            Optional<String> condition,
+            String orderBy) {
+        final TableId table = new TableId(null, tableId.schema(), tableId.table());
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(projection).append(" FROM ");
+        sql.append(quotedTableIdString(table));
+        if (condition.isPresent()) {
+            sql.append(" WHERE ").append(condition.get());
+        }
+        if (getOracleVersion().getMajor() < 12) {
+            sql.insert(0, " SELECT * FROM (")
+                    .append(" ORDER BY ")
+                    .append(orderBy)
+                    .append(")")
+                    .append(" WHERE ROWNUM <=")
+                    .append(limit);
+        } else {
+            sql.append(" ORDER BY ")
+                    .append(orderBy)
+                    .append(" FETCH NEXT ")
+                    .append(limit)
+                    .append(" ROWS ONLY");
+        }
+        return sql.toString();
+    }
+
+    public static String connectionString(JdbcConfiguration config) {
+        return config.getString(URL) != null
+                ? config.getString(URL)
+                : ConnectorAdapter.parse(config.getString("connection.adapter")).getConnectionUrl();
+    }
+
+    private static ConnectionFactory resolveConnectionFactory(JdbcConfiguration config) {
+        return JdbcConnection.patternBasedFactory(connectionString(config));
+    }
+
+    /**
+     * Determine whether the Oracle server has the archive log enabled.
+     *
+     * @return {@code true} if the server's {@code LOG_MODE} is set to {@code ARCHIVELOG}, or {@code
+     *     false} otherwise
+     */
+    protected boolean isArchiveLogMode() {
+        try {
+            final String mode =
+                    queryAndMap(
+                            "SELECT LOG_MODE FROM V$DATABASE",
+                            rs -> rs.next() ? rs.getString(1) : "");
+            LOGGER.debug("LOG_MODE={}", mode);
+            return "ARCHIVELOG".equalsIgnoreCase(mode);
+        } catch (SQLException e) {
+            throw new DebeziumException(
+                    "Unexpected error while connecting to Oracle and looking at LOG_MODE mode: ",
+                    e);
+        }
+    }
+
+    /**
+     * Resolve a system change number to a timestamp, return value is in database timezone.
+     *
+     * <p>The SCN to TIMESTAMP mapping is only retained for the duration of the flashback query
+     * area. This means that eventually the mapping between these values are no longer kept by
+     * Oracle and making a call with a SCN value that has aged out will result in an ORA-08181
+     * error. This function explicitly checks for this use case and if a ORA-08181 error is thrown,
+     * it is therefore treated as if a value does not exist returning an empty optional value.
+     *
+     * @param scn the system change number, must not be {@code null}
+     * @return an optional timestamp when the system change number occurred
+     * @throws SQLException if a database exception occurred
+     */
+    static Instant readScnTimestamp(ResultSet rs, int columnIndex) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnIndex);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    public Optional<Instant> getScnToTimestamp(Scn scn) throws SQLException {
+        try {
+            return queryAndMap(
+                    "SELECT scn_to_timestamp('" + scn + "') FROM DUAL",
+                    rs ->
+                            rs.next()
+                                    ? Optional.ofNullable(readScnTimestamp(rs, 1))
+                                    : Optional.empty());
+        } catch (SQLException e) {
+            if (e.getMessage().startsWith("ORA-08181")) {
+                // ORA-08181 specified number is not a valid system change number
+                // This happens when the SCN provided is outside the flashback area range
+                // This should be treated as a value is not available rather than an error
+                return Optional.empty();
+            }
+            // Any other SQLException should be thrown
+            throw e;
+        }
+    }
+
+    @Override
+    protected ColumnEditor overrideColumn(ColumnEditor column) {
+        // This allows the column state to be overridden before default-value resolution so that the
+        // output of the default value is within the same precision as that of the column values.
+        if (OracleTypes.TIMESTAMP == column.jdbcType()) {
+            column.length(column.scale().orElse(Column.UNSET_INT_VALUE)).scale(null);
+        } else if (OracleTypes.NUMBER == column.jdbcType()) {
+            column.scale().filter(s -> s == ORACLE_UNSET_SCALE).ifPresent(s -> column.scale(null));
+        }
+        return column;
+    }
+
+    @Override
+    protected Map<TableId, List<Column>> getColumnsDetails(
+            String databaseCatalog,
+            String schemaNamePattern,
+            String tableName,
+            Tables.TableFilter tableFilter,
+            ColumnNameFilter columnFilter,
+            DatabaseMetaData metadata,
+            Set<TableId> viewIds)
+            throws SQLException {
+        // The Oracle JDBC driver expects that if the table name contains a "/" character that
+        // the table name is pre-escaped prior to the JDBC driver call, or else it throws an
+        // exception about the character sequence being improperly escaped.
+        if (tableName != null && tableName.contains("/")) {
+            tableName = tableName.replace("/", "//");
+        }
+        return super.getColumnsDetails(
+                databaseCatalog,
+                schemaNamePattern,
+                tableName,
+                tableFilter,
+                columnFilter,
+                metadata,
+                viewIds);
+    }
+
+    /**
+     * An exception that indicates the operation failed because the table is not a relational table.
+     */
+    public static class NonRelationalTableException extends DebeziumException {
+        public NonRelationalTableException(String message) {
+            super(message);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import io.debezium.DebeziumException;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.RelationalSnapshotChangeEventSource;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link StreamingChangeEventSource} for Oracle.
+ *
+ * @author Gunnar Morling
+ */
+public class OracleSnapshotChangeEventSource
+        extends RelationalSnapshotChangeEventSource<OraclePartition, OracleOffsetContext> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(OracleSnapshotChangeEventSource.class);
+
+    private final OracleConnectorConfig connectorConfig;
+    private final OracleConnection jdbcConnection;
+    private final OracleDatabaseSchema databaseSchema;
+
+    public OracleSnapshotChangeEventSource(
+            OracleConnectorConfig connectorConfig,
+            OracleConnection jdbcConnection,
+            OracleDatabaseSchema schema,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            Clock clock,
+            SnapshotProgressListener<OraclePartition> snapshotProgressListener) {
+        super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
+
+        this.connectorConfig = connectorConfig;
+        this.jdbcConnection = jdbcConnection;
+        this.databaseSchema = schema;
+    }
+
+    @Override
+    protected SnapshottingTask getSnapshottingTask(
+            OraclePartition partition, OracleOffsetContext previousOffset) {
+        boolean snapshotSchema = true;
+        boolean snapshotData = true;
+
+        // found a previous offset and the earlier snapshot has completed
+        if (previousOffset != null && !previousOffset.isSnapshotRunning()) {
+            LOGGER.info("The previous offset has been found.");
+            snapshotSchema = databaseSchema.isStorageInitializationExecuted();
+            snapshotData = false;
+        } else {
+            LOGGER.info("No previous offset has been found.");
+            snapshotData = connectorConfig.getSnapshotMode().includeData();
+        }
+
+        if (snapshotData && snapshotSchema) {
+            LOGGER.info(
+                    "According to the connector configuration both schema and data will be snapshot.");
+        } else if (snapshotSchema) {
+            LOGGER.info("According to the connector configuration only schema will be snapshot.");
+        }
+
+        return new SnapshottingTask(snapshotSchema, snapshotData);
+    }
+
+    @Override
+    protected SnapshotContext<OraclePartition, OracleOffsetContext> prepare(
+            OraclePartition partition) throws Exception {
+        if (connectorConfig.getPdbName() != null) {
+            jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+        }
+
+        return new OracleSnapshotContext(partition, connectorConfig.getCatalogName());
+    }
+
+    @Override
+    protected Set<TableId> getAllTableIds(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx) throws Exception {
+        return jdbcConnection.getAllTableIds(ctx.catalogName);
+        // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
+        // return jdbcConnection.readTableNames(ctx.catalogName, null, null, new String[] {"TABLE"}
+        // );
+    }
+
+    @Override
+    protected void lockTablesForSchemaSnapshot(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
+            throws SQLException, InterruptedException {
+        if (connectorConfig.getSnapshotLockingMode().usesLocking()) {
+            ((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint =
+                    jdbcConnection.connection().setSavepoint("dbz_schema_snapshot");
+
+            try (Statement statement = jdbcConnection.connection().createStatement()) {
+                for (TableId tableId : snapshotContext.capturedTables) {
+                    if (!sourceContext.isRunning()) {
+                        throw new InterruptedException(
+                                "Interrupted while locking table " + tableId);
+                    }
+
+                    LOGGER.debug("Locking table {}", tableId);
+                    statement.execute("LOCK TABLE " + quote(tableId) + " IN ROW SHARE MODE");
+                }
+            }
+        } else {
+            LOGGER.info("Schema locking was disabled in connector configuration");
+        }
+    }
+
+    @Override
+    protected void releaseSchemaSnapshotLocks(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
+            throws SQLException {
+        if (connectorConfig.getSnapshotLockingMode().usesLocking()) {
+            jdbcConnection
+                    .connection()
+                    .rollback(((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint);
+        }
+    }
+
+    @Override
+    protected void determineSnapshotOffset(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx,
+            OracleOffsetContext previousOffset)
+            throws Exception {
+        // Support the existence of the case when the previous offset.
+        // e.g., schema_only_recovery snapshot mode
+        if (previousOffset != null) {
+            ctx.offset = previousOffset;
+            tryStartingSnapshot(ctx);
+            return;
+        }
+
+        ctx.offset =
+                connectorConfig
+                        .getAdapter()
+                        .determineSnapshotOffset(ctx, connectorConfig, jdbcConnection);
+    }
+
+    @Override
+    protected void readTableStructure(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            OracleOffsetContext offsetContext)
+            throws SQLException, InterruptedException {
+        Set<TableId> capturedSchemaTables;
+        if (databaseSchema.storeOnlyCapturedTables()) {
+            capturedSchemaTables = snapshotContext.capturedTables;
+            LOGGER.info(
+                    "Only captured tables schema should be captured, capturing: {}",
+                    capturedSchemaTables);
+        } else {
+            capturedSchemaTables = snapshotContext.capturedSchemaTables;
+            LOGGER.info(
+                    "All eligible tables schema should be captured, capturing: {}",
+                    capturedSchemaTables);
+        }
+
+        Set<String> schemas =
+                capturedSchemaTables.stream().map(TableId::schema).collect(Collectors.toSet());
+
+        // reading info only for the schemas we're interested in as per the set of captured tables;
+        // while the passed table name filter alone would skip all non-included tables, reading the
+        // schema
+        // would take much longer that way
+        for (String schema : schemas) {
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException(
+                        "Interrupted while reading structure of schema " + schema);
+            }
+
+            // todo: DBZ-137 the new readSchemaForCapturedTables seems to cause failures.
+            // For now, reverted to the default readSchema implementation as the intended goal
+            // with the new implementation was to be faster, not change behavior.
+            // if
+            // (connectorConfig.getAdapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER)) {
+            // jdbcConnection.readSchemaForCapturedTables(
+            // snapshotContext.tables,
+            // snapshotContext.catalogName,
+            // schema,
+            // connectorConfig.getColumnFilter(),
+            // false,
+            // snapshotContext.capturedTables);
+            // }
+            // else {
+            jdbcConnection.readSchema(snapshotContext.tables, null, schema, null, null, false);
+            // }
+        }
+    }
+
+    @Override
+    protected String enhanceOverriddenSelect(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            String overriddenSelect,
+            TableId tableId) {
+        String snapshotOffset = (String) snapshotContext.offset.getOffset().get(SourceInfo.SCN_KEY);
+        String token = connectorConfig.getTokenToReplaceInSnapshotPredicate();
+        if (token != null) {
+            return overriddenSelect.replaceAll(token, " AS OF SCN " + snapshotOffset);
+        }
+        return overriddenSelect;
+    }
+
+    @Override
+    protected void createSchemaChangeEventsForTables(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            SnapshottingTask snapshottingTask)
+            throws Exception {
+        tryStartingSnapshot(snapshotContext);
+        for (Iterator<TableId> iterator = snapshotContext.capturedSchemaTables.iterator();
+                iterator.hasNext(); ) {
+            final TableId tableId = iterator.next();
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException(
+                        "Interrupted while capturing schema of table " + tableId);
+            }
+
+            LOGGER.info("Capturing structure of table {}", tableId);
+
+            Table table = snapshotContext.tables.forTable(tableId);
+
+            if (schema().isHistorized()) {
+                snapshotContext.offset.event(tableId, getClock().currentTime());
+
+                // If data are not snapshotted then the last schema change must set last snapshot
+                // flag
+                if (!snapshottingTask.snapshotData() && !iterator.hasNext()) {
+                    lastSnapshotRecord(snapshotContext);
+                }
+
+                dispatcher.dispatchSchemaChangeEvent(
+                        snapshotContext.partition,
+                        table.id(),
+                        (receiver) -> {
+                            try {
+                                receiver.schemaChangeEvent(
+                                        getCreateTableEvent(snapshotContext, table));
+                            } catch (Exception e) {
+                                throw new DebeziumException(e);
+                            }
+                        });
+            }
+        }
+    }
+
+    @Override
+    protected SchemaChangeEvent getCreateTableEvent(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            Table table)
+            throws SQLException {
+        return SchemaChangeEvent.ofCreate(
+                snapshotContext.partition,
+                snapshotContext.offset,
+                snapshotContext.catalogName,
+                table.id().schema(),
+                jdbcConnection.getTableMetadataDdl(table.id()),
+                table,
+                true);
+    }
+
+    @Override
+    protected Instant getSnapshotSourceTimestamp(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            TableId tableId) {
+        try {
+            Optional<Instant> snapshotTs =
+                    jdbcConnection.getScnToTimestamp(snapshotContext.offset.getScn());
+            if (!snapshotTs.isPresent()) {
+                throw new ConnectException("Failed reading SCN timestamp from source database");
+            }
+
+            return snapshotTs.get();
+        } catch (SQLException e) {
+            throw new ConnectException("Failed reading SCN timestamp from source database", e);
+        }
+    }
+
+    /**
+     * Generate a valid Oracle query string for the specified table and columns
+     *
+     * @param tableId the table to generate a query for
+     * @return a valid query string
+     */
+    @Override
+    protected Optional<String> getSnapshotSelect(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            TableId tableId,
+            List<String> columns) {
+        final OracleOffsetContext offset = snapshotContext.offset;
+        final String snapshotOffset = offset.getScn().toString();
+        String snapshotSelectColumns = columns.stream().collect(Collectors.joining(", "));
+        assert snapshotOffset != null;
+        return Optional.of(
+                String.format(
+                        "SELECT %s FROM %s AS OF SCN %s",
+                        snapshotSelectColumns, quote(tableId), snapshotOffset));
+    }
+
+    @Override
+    protected void complete(SnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext) {
+        if (connectorConfig.getPdbName() != null) {
+            jdbcConnection.resetSessionToCdb();
+        }
+    }
+
+    private static String quote(TableId tableId) {
+        return TableId.parse(tableId.schema() + "." + tableId.table(), true).toDoubleQuotedString();
+    }
+
+    /** Mutable context which is populated in the course of snapshotting. */
+    private static class OracleSnapshotContext
+            extends RelationalSnapshotContext<OraclePartition, OracleOffsetContext> {
+
+        private Savepoint preSchemaSnapshotSavepoint;
+
+        public OracleSnapshotContext(OraclePartition partition, String catalogName)
+                throws SQLException {
+            super(partition, catalogName);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -797,10 +797,10 @@ public class LogMinerStreamingChangeEventSource
                                 Scn.valueOf(
                                         connectorConfig.getLogMiningScnGapDetectionGapSizeMin()))
                         > 0) {
-                    Optional<OffsetDateTime> prevEndScnTimestamp =
+                    Optional<Instant> prevEndScnTimestamp =
                             connection.getScnToTimestamp(prevEndScn);
                     if (prevEndScnTimestamp.isPresent()) {
-                        Optional<OffsetDateTime> currentScnTimestamp =
+                        Optional<Instant> currentScnTimestamp =
                                 connection.getScnToTimestamp(currentScn);
                         if (currentScnTimestamp.isPresent()) {
                             long timeDeltaMs =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.connectors.oracle.source.config;
 
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfigFactory;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
 
 import io.debezium.config.Configuration;
@@ -136,5 +137,23 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
                 skipSnapshotBackfill,
                 scanNewlyAddedTableEnabled,
                 assignUnboundedChunkFirst);
+    }
+
+    @Override
+    public JdbcSourceConfigFactory startupOptions(StartupOptions startupOptions) {
+        switch (startupOptions.startupMode) {
+            case INITIAL:
+            case SNAPSHOT:
+            case LATEST_OFFSET:
+            case SPECIFIC_OFFSETS:
+            case COMMITTED_OFFSETS:
+            case TIMESTAMP:
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported startup mode: " + startupOptions.startupMode);
+        }
+        this.startupOptions = startupOptions;
+        return this;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffset.java
@@ -35,6 +35,7 @@ public class RedoLogOffset extends Offset {
     public static final String SCN_KEY = "scn";
     public static final String COMMIT_SCN_KEY = "commit_scn";
     public static final String LCR_POSITION_KEY = "lcr_position";
+    public static final String STARTUP_TIMESTAMP_MILLIS_KEY = "startup_timestamp_millis";
 
     public static final RedoLogOffset INITIAL_OFFSET = new RedoLogOffset(0L);
     public static final RedoLogOffset NO_STOPPING_OFFSET = new RedoLogOffset(Long.MIN_VALUE);
@@ -44,14 +45,25 @@ public class RedoLogOffset extends Offset {
     }
 
     public RedoLogOffset(Long scn) {
-        this(scn, 0L, null);
+        this(scn, 0L, null, null);
     }
 
     public RedoLogOffset(Long scn, Long commitScn, @Nullable String lcrPosition) {
+        this(scn, commitScn, lcrPosition, null);
+    }
+
+    public RedoLogOffset(
+            Long scn,
+            Long commitScn,
+            @Nullable String lcrPosition,
+            @Nullable Long startupTimestampMillis) {
         Map<String, String> offsetMap = new HashMap<>();
         offsetMap.put(SCN_KEY, String.valueOf(scn));
         offsetMap.put(COMMIT_SCN_KEY, String.valueOf(commitScn));
         offsetMap.put(LCR_POSITION_KEY, lcrPosition);
+        if (startupTimestampMillis != null) {
+            offsetMap.put(STARTUP_TIMESTAMP_MILLIS_KEY, String.valueOf(startupTimestampMillis));
+        }
         this.offset = offsetMap;
     }
 
@@ -65,6 +77,12 @@ public class RedoLogOffset extends Offset {
 
     public String getLcrPosition() {
         return offset.get(LCR_POSITION_KEY);
+    }
+
+    @Nullable
+    public Long getStartupTimestampMillis() {
+        String timestampMillis = offset.get(STARTUP_TIMESTAMP_MILLIS_KEY);
+        return timestampMillis == null ? null : Long.valueOf(timestampMillis);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffsetFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffsetFactory.java
@@ -48,8 +48,7 @@ public class RedoLogOffsetFactory extends OffsetFactory {
 
     @Override
     public Offset createTimestampOffset(long timestampMillis) {
-        throw new UnsupportedOperationException(
-                "Do not support to create RedoLogOffset by timestamp.");
+        return new RedoLogOffset(0L, 0L, null, timestampMillis);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/EventProcessorFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/EventProcessorFactory.java
@@ -30,6 +30,7 @@ import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
+import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.logminer.processor.LogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.infinispan.EmbeddedInfinispanLogMinerEventProcessor;
@@ -65,7 +66,8 @@ public class EventProcessorFactory {
             OracleDatabaseSchema schema,
             OracleStreamingChangeEventSourceMetrics metrics,
             ErrorHandler errorHandler,
-            StreamSplit redoLogSplit) {
+            StreamSplit redoLogSplit,
+            Long startupTimestampMillis) {
         final OracleConnectorConfig.LogMiningBufferType bufferType =
                 connectorConfig.getLogMiningBufferType();
         if (bufferType.equals(OracleConnectorConfig.LogMiningBufferType.MEMORY)) {
@@ -80,7 +82,8 @@ public class EventProcessorFactory {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         } else if (bufferType.equals(
                 OracleConnectorConfig.LogMiningBufferType.INFINISPAN_EMBEDDED)) {
             return new CDCEmbeddedInfinispanLogMinerEventProcessor(
@@ -94,7 +97,8 @@ public class EventProcessorFactory {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         } else if (bufferType.equals(OracleConnectorConfig.LogMiningBufferType.INFINISPAN_REMOTE)) {
             return new CDCRemoteInfinispanLogMinerEventProcessor(
                     context,
@@ -107,7 +111,8 @@ public class EventProcessorFactory {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         } else {
             throw new IllegalArgumentException(
                     "not support this type of bufferType: " + bufferType);
@@ -124,6 +129,7 @@ public class EventProcessorFactory {
 
         private ChangeEventSource.ChangeEventSourceContext context;
         private final WatermarkDispatcher watermarkDispatcher;
+        private final StartupTimestampFilter startupTimestampFilter;
 
         public CDCMemoryLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
@@ -136,7 +142,8 @@ public class EventProcessorFactory {
                 OracleDatabaseSchema schema,
                 OracleStreamingChangeEventSourceMetrics metrics,
                 ErrorHandler errorHandler,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     context,
                     connectorConfig,
@@ -150,6 +157,7 @@ public class EventProcessorFactory {
             this.errorHandler = errorHandler;
             this.context = context;
             this.watermarkDispatcher = watermarkDispatcher;
+            this.startupTimestampFilter = new StartupTimestampFilter(startupTimestampMillis);
         }
 
         @Override
@@ -157,6 +165,9 @@ public class EventProcessorFactory {
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
                     partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
+                return;
+            }
+            if (startupTimestampFilter.shouldSkip(row)) {
                 return;
             }
             super.processRow(partition, row);
@@ -174,6 +185,7 @@ public class EventProcessorFactory {
 
         private ChangeEventSource.ChangeEventSourceContext context;
         private final WatermarkDispatcher watermarkDispatcher;
+        private final StartupTimestampFilter startupTimestampFilter;
 
         public CDCEmbeddedInfinispanLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
@@ -186,7 +198,8 @@ public class EventProcessorFactory {
                 OracleDatabaseSchema schema,
                 OracleStreamingChangeEventSourceMetrics metrics,
                 ErrorHandler errorHandler,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     context,
                     connectorConfig,
@@ -200,6 +213,7 @@ public class EventProcessorFactory {
             this.errorHandler = errorHandler;
             this.context = context;
             this.watermarkDispatcher = watermarkDispatcher;
+            this.startupTimestampFilter = new StartupTimestampFilter(startupTimestampMillis);
         }
 
         @Override
@@ -207,6 +221,9 @@ public class EventProcessorFactory {
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
                     partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
+                return;
+            }
+            if (startupTimestampFilter.shouldSkip(row)) {
                 return;
             }
             super.processRow(partition, row);
@@ -224,6 +241,7 @@ public class EventProcessorFactory {
 
         private ChangeEventSource.ChangeEventSourceContext context;
         private final WatermarkDispatcher watermarkDispatcher;
+        private final StartupTimestampFilter startupTimestampFilter;
 
         public CDCRemoteInfinispanLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
@@ -236,7 +254,8 @@ public class EventProcessorFactory {
                 OracleDatabaseSchema schema,
                 OracleStreamingChangeEventSourceMetrics metrics,
                 ErrorHandler errorHandler,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     context,
                     connectorConfig,
@@ -250,6 +269,7 @@ public class EventProcessorFactory {
             this.errorHandler = errorHandler;
             this.context = context;
             this.watermarkDispatcher = watermarkDispatcher;
+            this.startupTimestampFilter = new StartupTimestampFilter(startupTimestampMillis);
         }
 
         @Override
@@ -259,8 +279,63 @@ public class EventProcessorFactory {
                     partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
                 return;
             }
+            if (startupTimestampFilter.shouldSkip(row)) {
+                return;
+            }
             super.processRow(partition, row);
         }
+    }
+
+    private static class StartupTimestampFilter {
+        private final Long startupTimestampMillis;
+        private boolean reachedTimestamp;
+        private long filtered;
+        private boolean seekStarted;
+
+        private StartupTimestampFilter(Long startupTimestampMillis) {
+            this.startupTimestampMillis = startupTimestampMillis;
+        }
+
+        private boolean shouldSkip(LogMinerEventRow row) {
+            if (startupTimestampMillis == null
+                    || reachedTimestamp
+                    || !isRowMutation(row.getEventType())) {
+                return false;
+            }
+            if (!seekStarted) {
+                seekStarted = true;
+                LOG.info(
+                        "Begin to seek Oracle redo log to startup timestamp {}.",
+                        startupTimestampMillis);
+            }
+            if (row.getChangeTime() != null
+                    && row.getChangeTime().toEpochMilli() >= startupTimestampMillis) {
+                reachedTimestamp = true;
+                LOG.info(
+                        "Successfully seek Oracle redo log to startup timestamp {} with filtered {} change events.",
+                        startupTimestampMillis,
+                        filtered);
+                return false;
+            }
+            filtered++;
+            if (filtered % 10000 == 0) {
+                LOG.info(
+                        "Seeking Oracle redo log to startup timestamp {} with filtered {} change events.",
+                        startupTimestampMillis,
+                        filtered);
+            }
+            return true;
+        }
+    }
+
+    private static boolean isRowMutation(EventType eventType) {
+        return EventType.INSERT.equals(eventType)
+                || EventType.UPDATE.equals(eventType)
+                || EventType.DELETE.equals(eventType)
+                || EventType.SELECT_LOB_LOCATOR.equals(eventType)
+                || EventType.LOB_WRITE.equals(eventType)
+                || EventType.LOB_ERASE.equals(eventType)
+                || EventType.LOB_TRIM.equals(eventType);
     }
 
     public static boolean reachEndingOffset(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -141,7 +141,8 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                 context.getDatabaseSchema(),
                 context.getSourceConfig().getOriginDbzConnectorConfig(),
                 context.getStreamingChangeEventSourceMetrics(),
-                backfillRedoLogSplit);
+                backfillRedoLogSplit,
+                null);
     }
 
     /** A wrapped task to fetch snapshot split of table. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
@@ -70,8 +70,10 @@ import org.slf4j.LoggerFactory;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleConnectionUtils.createOracleConnection;
+import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleConnectionUtils.resolveRedoLogOffsetByTimestamp;
 import static org.apache.flink.cdc.connectors.oracle.util.ChunkUtils.getChunkKeyColumn;
 
 /** The context for fetch task that fetching data of snapshot split from Oracle data source. */
@@ -86,6 +88,7 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     private OracleTaskContext taskContext;
     private OracleOffsetContext offsetContext;
     private OraclePartition partition;
+    private Long startupTimestampMillis;
 
     private SnapshotChangeEventSourceMetrics<OraclePartition> snapshotChangeEventSourceMetrics;
     private OracleStreamingChangeEventSourceMetrics streamingChangeEventSourceMetrics;
@@ -272,12 +275,54 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     /** Loads the connector's persistent offset (if present) via the given loader. */
     private OracleOffsetContext loadStartingOffsetState(
             OffsetContext.Loader<OracleOffsetContext> loader, SourceSplitBase oracleSplit) {
-        Offset offset =
-                oracleSplit.isSnapshotSplit()
-                        ? RedoLogOffset.INITIAL_OFFSET
-                        : oracleSplit.asStreamSplit().getStartingOffset();
+        StartingOffsetResolution resolution =
+                resolveStartingOffset(
+                        oracleSplit,
+                        timestampMillis ->
+                                resolveRedoLogOffsetByTimestamp(connection, timestampMillis));
+        startupTimestampMillis = resolution.startupTimestampMillis;
+        return loader.load(resolution.offset.getOffset());
+    }
 
-        return loader.load(offset.getOffset());
+    public Long getStartupTimestampMillis() {
+        return startupTimestampMillis;
+    }
+
+    static StartingOffsetResolution resolveStartingOffset(
+            SourceSplitBase oracleSplit, Function<Long, Offset> timestampOffsetResolver) {
+        Offset offset = RedoLogOffset.INITIAL_OFFSET;
+        Long resolvedStartupTimestampMillis = null;
+        if (!oracleSplit.isSnapshotSplit()) {
+            offset = oracleSplit.asStreamSplit().getStartingOffset();
+            if (offset instanceof RedoLogOffset) {
+                final Long splitStartupTimestampMillis =
+                        ((RedoLogOffset) offset).getStartupTimestampMillis();
+                if (splitStartupTimestampMillis != null) {
+                    resolvedStartupTimestampMillis = splitStartupTimestampMillis;
+                    offset = timestampOffsetResolver.apply(splitStartupTimestampMillis);
+                }
+            }
+        }
+
+        return new StartingOffsetResolution(offset, resolvedStartupTimestampMillis);
+    }
+
+    static class StartingOffsetResolution {
+        private final Offset offset;
+        private final Long startupTimestampMillis;
+
+        private StartingOffsetResolution(Offset offset, Long startupTimestampMillis) {
+            this.offset = offset;
+            this.startupTimestampMillis = startupTimestampMillis;
+        }
+
+        Offset getOffset() {
+            return offset;
+        }
+
+        Long getStartupTimestampMillis() {
+            return startupTimestampMillis;
+        }
     }
 
     private void validateAndLoadDatabaseHistory(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
@@ -64,7 +64,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                         sourceFetchContext.getDatabaseSchema(),
                         sourceFetchContext.getSourceConfig().getOriginDbzConnectorConfig(),
                         sourceFetchContext.getStreamingChangeEventSourceMetrics(),
-                        split);
+                        split,
+                        sourceFetchContext.getStartupTimestampMillis());
         StoppableChangeEventSourceContext changeEventSourceContext =
                 new StoppableChangeEventSourceContext();
         redoLogSplitReadTask.execute(
@@ -105,6 +106,7 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
         private final OracleDatabaseSchema schema;
 
         private final OracleStreamingChangeEventSourceMetrics metrics;
+        private final Long startupTimestampMillis;
 
         public RedoLogSplitReadTask(
                 OracleConnectorConfig connectorConfig,
@@ -115,7 +117,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                 OracleDatabaseSchema schema,
                 Configuration jdbcConfig,
                 OracleStreamingChangeEventSourceMetrics metrics,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     connectorConfig,
                     connection,
@@ -133,6 +136,7 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
             this.connection = connection;
             this.metrics = metrics;
             this.schema = schema;
+            this.startupTimestampMillis = startupTimestampMillis;
         }
 
         @Override
@@ -163,7 +167,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -31,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -46,8 +49,19 @@ public class OracleConnectionUtils {
     /** Returned by column metadata in Oracle if no scale is set. */
     private static final int ORACLE_UNSET_SCALE = -127;
 
+    private static final int ORA_TIMESTAMP_TO_SCN_OUT_OF_RANGE = 8181;
+    private static final int ORA_TIMESTAMP_TO_SCN_INVALID_TIMESTAMP = 8186;
+
     /** show current scn sql in oracle. */
     private static final String SHOW_CURRENT_SCN = "SELECT CURRENT_SCN FROM V$DATABASE";
+
+    private static final String SHOW_SCN_BY_TIMESTAMP = "SELECT timestamp_to_scn(?) FROM DUAL";
+    private static final String SHOW_OLDEST_AVAILABLE_SCN =
+            "SELECT MIN(FIRST_CHANGE#) FROM ("
+                    + "SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$LOG "
+                    + "UNION "
+                    + "SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$ARCHIVED_LOG WHERE STATUS='A'"
+                    + ")";
 
     /** Creates a new {@link OracleSourceConnection}, but not open the connection. */
     public static OracleSourceConnection createOracleConnection(Configuration configuration) {
@@ -86,6 +100,103 @@ public class OracleConnectionUtils {
                             + "'. Make sure your server is correctly configured",
                     e);
         }
+    }
+
+    @FunctionalInterface
+    interface ScnSupplier {
+        Scn get() throws SQLException;
+    }
+
+    /** Resolve the startup timestamp to a readable redo-log offset. */
+    public static RedoLogOffset resolveRedoLogOffsetByTimestamp(
+            OracleConnection connection, long startupTimestampMillis) {
+        return resolveRedoLogOffsetByTimestamp(
+                startupTimestampMillis,
+                () ->
+                        connection.prepareQueryAndMap(
+                                SHOW_SCN_BY_TIMESTAMP,
+                                statement ->
+                                        statement.setTimestamp(
+                                                1,
+                                                Timestamp.from(
+                                                        Instant.ofEpochMilli(
+                                                                startupTimestampMillis))),
+                                rs -> {
+                                    if (rs.next()) {
+                                        final String value = rs.getString(1);
+                                        return value == null ? null : Scn.valueOf(value);
+                                    }
+                                    return null;
+                                }),
+                () ->
+                        connection.queryAndMap(
+                                SHOW_OLDEST_AVAILABLE_SCN,
+                                rs -> {
+                                    if (rs.next()) {
+                                        final String value = rs.getString(1);
+                                        return value == null ? Scn.NULL : Scn.valueOf(value);
+                                    }
+                                    return Scn.NULL;
+                                }));
+    }
+
+    static RedoLogOffset resolveRedoLogOffsetByTimestamp(
+            long startupTimestampMillis,
+            ScnSupplier timestampScnSupplier,
+            ScnSupplier oldestScnSupplier) {
+        try {
+            final Scn timestampScn = timestampScnSupplier.get();
+
+            if (timestampScn != null && !timestampScn.isNull()) {
+                LOG.info(
+                        "Resolved startup timestamp {} to Oracle SCN {}.",
+                        startupTimestampMillis,
+                        timestampScn);
+                return new RedoLogOffset(timestampScn.subtract(Scn.ONE).longValue());
+            }
+        } catch (SQLException e) {
+            if (isTimestampToScnFallbackError(e)) {
+                LOG.warn(
+                        "Cannot resolve startup timestamp {} to SCN due to {}, fallback to oldest available SCN.",
+                        startupTimestampMillis,
+                        e.getMessage());
+            } else {
+                throw new FlinkRuntimeException(
+                        "Cannot resolve startup timestamp "
+                                + startupTimestampMillis
+                                + " to Oracle SCN.",
+                        e);
+            }
+        }
+
+        try {
+            final Scn oldestScn = oldestScnSupplier.get();
+            if (oldestScn == null || oldestScn.isNull()) {
+                throw new FlinkRuntimeException(
+                        "Cannot resolve oldest available Oracle SCN for startup timestamp "
+                                + startupTimestampMillis);
+            }
+            LOG.warn(
+                    "Fallback startup timestamp {} to oldest available Oracle SCN {}.",
+                    startupTimestampMillis,
+                    oldestScn);
+            return new RedoLogOffset(oldestScn.subtract(Scn.ONE).longValue());
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException(
+                    "Cannot query oldest available Oracle SCN for startup timestamp "
+                            + startupTimestampMillis,
+                    e);
+        }
+    }
+
+    private static boolean isTimestampToScnFallbackError(SQLException e) {
+        if (e.getErrorCode() == ORA_TIMESTAMP_TO_SCN_OUT_OF_RANGE
+                || e.getErrorCode() == ORA_TIMESTAMP_TO_SCN_INVALID_TIMESTAMP) {
+            return true;
+        }
+        String message = e.getMessage();
+        return message != null
+                && (message.startsWith("ORA-08181") || message.startsWith("ORA-08186"));
     }
 
     public static List<TableId> listTables(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -53,6 +53,7 @@ import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_IN
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_STARTUP_MODE;
+import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND;
 import static org.apache.flink.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
@@ -195,6 +196,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
         return options;
     }
 
@@ -204,6 +206,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
     private static final String SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS = "specific-offset";
     private static final String SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS_PREFIX =
             "scan.startup.specific-offset.";
+    private static final String SCAN_STARTUP_MODE_VALUE_TIMESTAMP = "timestamp";
 
     private static StartupOptions getStartupOptions(
             ReadableConfig config, Map<String, String> options) {
@@ -219,14 +222,17 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
             case SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS:
                 Map<String, String> offsetMap = getSpecificOffsetMap(options);
                 return StartupOptions.specificOffset(offsetMap);
+            case SCAN_STARTUP_MODE_VALUE_TIMESTAMP:
+                return StartupOptions.timestamp(config.get(SCAN_STARTUP_TIMESTAMP_MILLIS));
             default:
                 throw new ValidationException(
                         String.format(
-                                "Invalid value for option '%s'. Supported values are [%s, %s, %s], but was: %s",
+                                "Invalid value for option '%s'. Supported values are [%s, %s, %s, %s], but was: %s",
                                 SCAN_STARTUP_MODE.key(),
                                 SCAN_STARTUP_MODE_VALUE_INITIAL,
                                 SCAN_STARTUP_MODE_VALUE_SNAPSHOT,
                                 SCAN_STARTUP_MODE_VALUE_LATEST,
+                                SCAN_STARTUP_MODE_VALUE_TIMESTAMP,
                                 modeString));
         }
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for Oracle SCN timestamp compatibility helpers. */
+class OracleConnectionTest {
+
+    @Test
+    void testReadScnTimestampUsesTimestampMapping() throws Exception {
+        Timestamp timestamp = Timestamp.valueOf("2026-04-08 13:49:08");
+        ResultSet rs = resultSet(timestamp);
+
+        Instant actual = OracleConnection.readScnTimestamp(rs, 1);
+
+        assertThat(actual).isEqualTo(timestamp.toInstant());
+    }
+
+    @Test
+    void testReadScnTimestampAllowsNullTimestamp() throws Exception {
+        ResultSet rs = resultSet(null);
+
+        Instant actual = OracleConnection.readScnTimestamp(rs, 1);
+
+        assertThat(actual).isNull();
+    }
+
+    private static ResultSet resultSet(Timestamp timestamp) {
+        InvocationHandler handler =
+                (proxy, method, args) -> {
+                    String name = method.getName();
+                    if ("getTimestamp".equals(name)) {
+                        return timestamp;
+                    }
+                    if ("getObject".equals(name) && args != null && args.length == 2) {
+                        throw new SQLException("OffsetDateTime path should not be used");
+                    }
+                    if ("wasNull".equals(name)) {
+                        return timestamp == null;
+                    }
+                    if ("unwrap".equals(name)) {
+                        return null;
+                    }
+                    if ("isWrapperFor".equals(name)) {
+                        return false;
+                    }
+                    throw new UnsupportedOperationException("Unexpected method: " + name);
+                };
+        return (ResultSet)
+                Proxy.newProxyInstance(
+                        OracleConnectionTest.class.getClassLoader(),
+                        new Class[] {ResultSet.class},
+                        handler);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.config;
+
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link OracleSourceConfigFactory#startupOptions(StartupOptions)}. */
+class OracleSourceConfigFactoryTest {
+
+    @Test
+    void testAcceptTimestampStartupMode() {
+        OracleSourceConfigFactory factory = new OracleSourceConfigFactory();
+
+        assertThatCode(() -> factory.startupOptions(StartupOptions.timestamp(1700000000000L)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testAcceptSpecificOffsetsStartupMode() {
+        OracleSourceConfigFactory factory = new OracleSourceConfigFactory();
+
+        assertThatCode(
+                        () ->
+                                factory.startupOptions(
+                                        StartupOptions.specificOffset(
+                                                Collections.singletonMap("scn", "123456"))))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectUnsupportedStartupMode() {
+        OracleSourceConfigFactory factory = new OracleSourceConfigFactory();
+
+        assertThatThrownBy(() -> factory.startupOptions(StartupOptions.earliest()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Unsupported startup mode");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/RedoLogOffsetFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/RedoLogOffsetFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader;
+
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffsetFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link RedoLogOffsetFactory}. */
+class RedoLogOffsetFactoryTest {
+
+    @Test
+    void testCreateTimestampOffset() {
+        long startupTimestampMillis = 1700000000000L;
+        RedoLogOffsetFactory offsetFactory = new RedoLogOffsetFactory();
+        RedoLogOffset offset =
+                (RedoLogOffset) offsetFactory.createTimestampOffset(startupTimestampMillis);
+
+        assertThat(offset.getScn()).isEqualTo("0");
+        assertThat(offset.getStartupTimestampMillis()).isEqualTo(startupTimestampMillis);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContextTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContextTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
+
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for startup-offset resolution in {@link OracleSourceFetchTaskContext}. */
+class OracleSourceFetchTaskContextTest {
+
+    @Test
+    void testDoNotResolveTimestampAgainWhenRestoredFromSpecificScnOffset() {
+        StreamSplit restoredSplit =
+                new StreamSplit(
+                        StreamSplit.STREAM_SPLIT_ID,
+                        new RedoLogOffset(123L),
+                        RedoLogOffset.NO_STOPPING_OFFSET,
+                        new ArrayList<>(),
+                        new HashMap<>(),
+                        0);
+        AtomicInteger resolveCalls = new AtomicInteger();
+
+        OracleSourceFetchTaskContext.StartingOffsetResolution resolution =
+                OracleSourceFetchTaskContext.resolveStartingOffset(
+                        restoredSplit,
+                        timestampMillis -> {
+                            resolveCalls.incrementAndGet();
+                            return new RedoLogOffset(999L);
+                        });
+
+        assertThat(resolveCalls.get()).isZero();
+        assertThat(resolution.getStartupTimestampMillis()).isNull();
+        assertThat(((RedoLogOffset) resolution.getOffset()).getScn()).isEqualTo("123");
+    }
+
+    @Test
+    void testResolveTimestampOffsetForStreamSplitWhenTimestampMarkerExists() {
+        long startupTimestampMillis = 1700000000000L;
+        StreamSplit timestampSplit =
+                new StreamSplit(
+                        StreamSplit.STREAM_SPLIT_ID,
+                        new RedoLogOffset(0L, 0L, null, startupTimestampMillis),
+                        RedoLogOffset.NO_STOPPING_OFFSET,
+                        new ArrayList<>(),
+                        new HashMap<>(),
+                        0);
+        AtomicInteger resolveCalls = new AtomicInteger();
+        AtomicLong observedTimestamp = new AtomicLong(-1L);
+
+        OracleSourceFetchTaskContext.StartingOffsetResolution resolution =
+                OracleSourceFetchTaskContext.resolveStartingOffset(
+                        timestampSplit,
+                        timestampMillis -> {
+                            resolveCalls.incrementAndGet();
+                            observedTimestamp.set(timestampMillis);
+                            return new RedoLogOffset(456L);
+                        });
+
+        assertThat(resolveCalls.get()).isEqualTo(1);
+        assertThat(observedTimestamp.get()).isEqualTo(startupTimestampMillis);
+        assertThat(resolution.getStartupTimestampMillis()).isEqualTo(startupTimestampMillis);
+        assertThat(((RedoLogOffset) resolution.getOffset()).getScn()).isEqualTo("456");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.utils;
+
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import io.debezium.connector.oracle.Scn;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link OracleConnectionUtils}. */
+class OracleConnectionUtilsTest {
+
+    @Test
+    void testResolveTimestampScnAsExclusiveLowerBound() {
+        long startupTimestampMillis = 1700000000000L;
+
+        RedoLogOffset offset =
+                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                        startupTimestampMillis, () -> Scn.valueOf("456"), () -> Scn.valueOf("1"));
+
+        assertThat(offset.getScn()).isEqualTo("455");
+    }
+
+    @Test
+    void testFallbackToOldestAvailableScnWhenTimestampCannotBeMapped() {
+        long startupTimestampMillis = 1700000000000L;
+
+        RedoLogOffset offset =
+                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                        startupTimestampMillis,
+                        () -> {
+                            throw new SQLException(
+                                    "ORA-08181: specified number is not a valid system change number");
+                        },
+                        () -> Scn.valueOf("123456"));
+
+        assertThat(offset.getScn()).isEqualTo("123455");
+    }
+
+    @Test
+    void testFallbackToOldestAvailableScnWhenTimestampIsInvalid() {
+        long startupTimestampMillis = 1700000000000L;
+
+        RedoLogOffset offset =
+                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                        startupTimestampMillis,
+                        () -> {
+                            throw new SQLException(
+                                    "ORA-08186: invalid timestamp specified", "72000", 8186);
+                        },
+                        () -> Scn.valueOf("223344"));
+
+        assertThat(offset.getScn()).isEqualTo("223343");
+    }
+
+    @Test
+    void testThrowWhenTimestampQueryFailedWithUnexpectedSQLException() {
+        long startupTimestampMillis = 1700000000000L;
+
+        assertThatThrownBy(
+                        () ->
+                                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                                        startupTimestampMillis,
+                                        () -> {
+                                            throw new SQLException(
+                                                    "ORA-01017: invalid username/password");
+                                        },
+                                        () -> Scn.valueOf("123456")))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining("Cannot resolve startup timestamp");
+    }
+
+    @Test
+    void testThrowWhenFallbackOldestScnIsUnavailable() {
+        long startupTimestampMillis = 1700000000000L;
+
+        assertThatThrownBy(
+                        () ->
+                                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                                        startupTimestampMillis, () -> null, () -> Scn.NULL))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining("Cannot resolve oldest available Oracle SCN");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -357,6 +357,47 @@ class OracleTableSourceFactoryTest {
     }
 
     @Test
+    void testStartupFromTimestamp() {
+        long startupTimestampMillis = 1700000000000L;
+        Map<String, String> properties = getAllRequiredOptionsWithHost();
+        properties.put("scan.startup.mode", "timestamp");
+        properties.put("scan.startup.timestamp-millis", String.valueOf(startupTimestampMillis));
+
+        DynamicTableSource actualSource = createTableSource(properties);
+        OracleTableSource expectedSource =
+                new OracleTableSource(
+                        SCHEMA,
+                        null,
+                        MY_PORT,
+                        MY_LOCALHOST,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        MY_SCHEMA,
+                        MY_USERNAME,
+                        MY_PASSWORD,
+                        PROPERTIES,
+                        StartupOptions.timestamp(startupTimestampMillis),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
+                        SourceOptions.CHUNK_META_GROUP_SIZE.defaultValue(),
+                        SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        JdbcSourceOptions.CONNECT_TIMEOUT.defaultValue(),
+                        JdbcSourceOptions.CONNECT_MAX_RETRIES.defaultValue(),
+                        JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue(),
+                        JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND
+                                .defaultValue(),
+                        JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
+                                .defaultValue(),
+                        null,
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        SourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED
+                                .defaultValue());
+        Assertions.assertThat(actualSource).isEqualTo(expectedSource);
+    }
+
+    @Test
     void testMetadataColumns() {
         Map<String, String> properties = getAllRequiredOptions();
 
@@ -444,7 +485,7 @@ class OracleTableSourceFactoryTest {
                         })
                 .hasStackTraceContaining(
                         "Invalid value for option 'scan.startup.mode'. Supported values are "
-                                + "[initial, snapshot, latest-offset], "
+                                + "[initial, snapshot, latest-offset, timestamp], "
                                 + "but was: abc");
     }
 


### PR DESCRIPTION
This PR makes Oracle CDC timestamp startup usable by resolving the requested startup timestamp to an Oracle SCN and using that SCN as the actual stream offset.

Oracle streaming positions are represented by SCN. The common timestamp startup option therefore needs Oracle-specific conversion before the stream split can start from the requested point in time.

### Changes
- Create Oracle timestamp startup offsets.
- Resolve timestamp startup offsets to Oracle SCN before loading stream offset state.
- Add Oracle connection helpers for current SCN and SCN-to-timestamp conversion.
- Add local Debezium Oracle overrides needed by this connector version.
- Add unit coverage for offset creation, timestamp-to-SCN resolution, source config propagation, and table factory startup mode handling.

### Tests
- Not run locally: Maven currently gets stuck before the test phase while launching Java (`java --enable-native-access=ALL-UNNAMED -version`).