### PR TITLE
[FLINK-39843][oracle-cdc] Support Oracle XStream streaming

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/pom.xml
@@ -95,11 +95,17 @@ limitations under the License.
             <artifactId>ojdbc8</artifactId>
             <version>19.3.0.0</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>xstreams</artifactId>
+            <version>${xdb.version}</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>com.oracle.database.xml</groupId>
             <artifactId>xdb</artifactId>
             <version>${xdb.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import io.debezium.DebeziumException;
+import io.debezium.config.Field;
+import io.debezium.connector.oracle.OracleConnectorConfig.ConnectorAdapter;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.Tables.ColumnNameFilter;
+import io.debezium.util.Strings;
+import oracle.jdbc.OracleTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Clob;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class OracleConnection extends JdbcConnection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OracleConnection.class);
+
+    /** Returned by column metadata in Oracle if no scale is set; */
+    private static final int ORACLE_UNSET_SCALE = -127;
+
+    /** Pattern to identify system generated indices and column names. */
+    private static final Pattern SYS_NC_PATTERN =
+            Pattern.compile("^SYS_NC(?:_OID|_ROWINFO|[0-9][0-9][0-9][0-9][0-9])\\$$");
+
+    /** Pattern to identify abstract data type indices and column names. */
+    private static final Pattern ADT_INDEX_NAMES_PATTERN = Pattern.compile("^\".*\"\\.\".*\".*");
+
+    /**
+     * Pattern to identify a hidden column based on redefining a table with the {@code ROWID}
+     * option.
+     */
+    private static final Pattern MROW_PATTERN = Pattern.compile("^M_ROW\\$\\$");
+
+    /** A field for the raw jdbc url. This field has no default value. */
+    private static final Field URL = Field.create("url", "Raw JDBC url");
+
+    /** The database version. */
+    private final OracleDatabaseVersion databaseVersion;
+
+    private static final String QUOTED_CHARACTER = "\"";
+
+    public OracleConnection(JdbcConfiguration config, Supplier<ClassLoader> classLoaderSupplier) {
+        this(config, classLoaderSupplier, true);
+    }
+
+    public OracleConnection(
+            JdbcConfiguration config,
+            Supplier<ClassLoader> classLoaderSupplier,
+            boolean showVersion) {
+        super(
+                config,
+                resolveConnectionFactory(config),
+                classLoaderSupplier,
+                QUOTED_CHARACTER,
+                QUOTED_CHARACTER);
+        this.databaseVersion = resolveOracleDatabaseVersion();
+        if (showVersion) {
+            LOGGER.info("Database Version: {}", databaseVersion.getBanner());
+        }
+    }
+
+    public void setSessionToPdb(String pdbName) {
+        Statement statement = null;
+
+        try {
+            statement = connection().createStatement();
+            statement.execute("alter session set container=" + pdbName);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (statement != null) {
+                try {
+                    statement.close();
+                } catch (SQLException e) {
+                    LOGGER.error("Couldn't close statement", e);
+                }
+            }
+        }
+    }
+
+    public void resetSessionToCdb() {
+        Statement statement = null;
+
+        try {
+            statement = connection().createStatement();
+            statement.execute("alter session set container=cdb$root");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (statement != null) {
+                try {
+                    statement.close();
+                } catch (SQLException e) {
+                    LOGGER.error("Couldn't close statement", e);
+                }
+            }
+        }
+    }
+
+    public OracleDatabaseVersion getOracleVersion() {
+        return databaseVersion;
+    }
+
+    private OracleDatabaseVersion resolveOracleDatabaseVersion() {
+        String versionStr;
+        try {
+            try {
+                // Oracle 18.1 introduced BANNER_FULL as the new column rather than BANNER
+                // This column uses a different format than the legacy BANNER.
+                versionStr =
+                        queryAndMap(
+                                "SELECT BANNER_FULL FROM V$VERSION WHERE BANNER_FULL LIKE 'Oracle Database%'",
+                                (rs) -> {
+                                    if (rs.next()) {
+                                        return rs.getString(1);
+                                    }
+                                    return null;
+                                });
+            } catch (SQLException e) {
+                // exception ignored
+                if (e.getMessage().contains("ORA-00904: \"BANNER_FULL\"")) {
+                    LOGGER.debug(
+                            "BANNER_FULL column not in V$VERSION, using BANNER column as fallback");
+                    versionStr = null;
+                } else {
+                    throw e;
+                }
+            }
+
+            // For databases prior to 18.1, a SQLException will be thrown due to BANNER_FULL not
+            // being a column and
+            // this will cause versionStr to remain null, use fallback column BANNER for versions
+            // prior to 18.1.
+            if (versionStr == null) {
+                versionStr =
+                        queryAndMap(
+                                "SELECT BANNER FROM V$VERSION WHERE BANNER LIKE 'Oracle Database%'",
+                                (rs) -> {
+                                    if (rs.next()) {
+                                        return rs.getString(1);
+                                    }
+                                    return null;
+                                });
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to resolve Oracle database version", e);
+        }
+
+        if (versionStr == null) {
+            throw new RuntimeException("Failed to resolve Oracle database version");
+        }
+
+        return OracleDatabaseVersion.parse(versionStr);
+    }
+
+    @Override
+    public Set<TableId> readTableNames(
+            String databaseCatalog,
+            String schemaNamePattern,
+            String tableNamePattern,
+            String[] tableTypes)
+            throws SQLException {
+
+        Set<TableId> tableIds =
+                super.readTableNames(null, schemaNamePattern, tableNamePattern, tableTypes);
+
+        return tableIds.stream()
+                .map(t -> new TableId(databaseCatalog, t.schema(), t.table()))
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Retrieves all {@code TableId} in a given database catalog, filtering certain ids that should
+     * be omitted from the returned set such as special spatial tables and index-organized tables.
+     *
+     * @param catalogName the catalog/database name
+     * @return set of all table ids for existing table objects
+     * @throws SQLException if a database exception occurred
+     */
+    protected Set<TableId> getAllTableIds(String catalogName) throws SQLException {
+        final String query =
+                "select owner, table_name from all_tables "
+                        +
+                        // filter special spatial tables
+                        "where table_name NOT LIKE 'MDRT_%' "
+                        + "and table_name NOT LIKE 'MDRS_%' "
+                        + "and table_name NOT LIKE 'MDXT_%' "
+                        +
+                        // filter index-organized-tables
+                        "and (table_name NOT LIKE 'SYS_IOT_OVER_%' and IOT_NAME IS NULL) "
+                        +
+                        // filter nested tables
+                        "and nested = 'NO'"
+                        +
+                        // filter parent tables of nested tables
+                        "and table_name not in (select PARENT_TABLE_NAME from ALL_NESTED_TABLES)";
+
+        Set<TableId> tableIds = new HashSet<>();
+        query(
+                query,
+                (rs) -> {
+                    while (rs.next()) {
+                        tableIds.add(new TableId(catalogName, rs.getString(1), rs.getString(2)));
+                    }
+                    LOGGER.trace("TableIds are: {}", tableIds);
+                });
+
+        return tableIds;
+    }
+
+    // todo replace metadata with something like this
+    private ResultSet getTableColumnsInfo(String schemaNamePattern, String tableName)
+            throws SQLException {
+        String columnQuery =
+                "select column_name, data_type, data_length, data_precision, data_scale, default_length, density, char_length from "
+                        + "all_tab_columns where owner like '"
+                        + schemaNamePattern
+                        + "' and table_name='"
+                        + tableName
+                        + "'";
+
+        PreparedStatement statement = connection().prepareStatement(columnQuery);
+        return statement.executeQuery();
+    }
+
+    // this is much faster, we will use it until full replacement of the metadata usage TODO
+    public void readSchemaForCapturedTables(
+            Tables tables,
+            String databaseCatalog,
+            String schemaNamePattern,
+            ColumnNameFilter columnFilter,
+            boolean removeTablesNotFoundInJdbc,
+            Set<TableId> capturedTables)
+            throws SQLException {
+
+        Set<TableId> tableIdsBefore = new HashSet<>(tables.tableIds());
+
+        DatabaseMetaData metadata = connection().getMetaData();
+        Map<TableId, List<Column>> columnsByTable = new HashMap<>();
+
+        for (TableId tableId : capturedTables) {
+            try (ResultSet columnMetadata =
+                    metadata.getColumns(
+                            databaseCatalog, schemaNamePattern, tableId.table(), null)) {
+                while (columnMetadata.next()) {
+                    // add all whitelisted columns
+                    readTableColumn(columnMetadata, tableId, columnFilter)
+                            .ifPresent(
+                                    column -> {
+                                        columnsByTable
+                                                .computeIfAbsent(tableId, t -> new ArrayList<>())
+                                                .add(column.create());
+                                    });
+                }
+            }
+        }
+
+        // Read the metadata for the primary keys ...
+        for (Map.Entry<TableId, List<Column>> tableEntry : columnsByTable.entrySet()) {
+            // First get the primary key information, which must be done for *each* table ...
+            List<String> pkColumnNames = readPrimaryKeyNames(metadata, tableEntry.getKey());
+
+            // Then define the table ...
+            List<Column> columns = tableEntry.getValue();
+            Collections.sort(columns);
+            tables.overwriteTable(tableEntry.getKey(), columns, pkColumnNames, null);
+        }
+
+        if (removeTablesNotFoundInJdbc) {
+            // Remove any definitions for tables that were not found in the database metadata ...
+            tableIdsBefore.removeAll(columnsByTable.keySet());
+            tableIdsBefore.forEach(tables::removeTable);
+        }
+    }
+
+    @Override
+    protected String resolveCatalogName(String catalogName) {
+        final String pdbName = config().getString("pdb.name");
+        return (!Strings.isNullOrEmpty(pdbName) ? pdbName : config().getString("dbname"))
+                .toUpperCase();
+    }
+
+    @Override
+    public List<String> readTableUniqueIndices(DatabaseMetaData metadata, TableId id)
+            throws SQLException {
+        return super.readTableUniqueIndices(metadata, id.toDoubleQuoted());
+    }
+
+    @Override
+    public Optional<Timestamp> getCurrentTimestamp() throws SQLException {
+        return queryAndMap(
+                "SELECT CURRENT_TIMESTAMP FROM DUAL",
+                rs -> rs.next() ? Optional.of(rs.getTimestamp(1)) : Optional.empty());
+    }
+
+    @Override
+    protected boolean isTableUniqueIndexIncluded(String indexName, String columnName) {
+        if (columnName != null) {
+            return !SYS_NC_PATTERN.matcher(columnName).matches()
+                    && !ADT_INDEX_NAMES_PATTERN.matcher(columnName).matches()
+                    && !MROW_PATTERN.matcher(columnName).matches();
+        }
+        return false;
+    }
+
+    /**
+     * Get the current, most recent system change number.
+     *
+     * @return the current system change number
+     * @throws SQLException if an exception occurred
+     * @throws IllegalStateException if the query does not return at least one row
+     */
+    public Scn getCurrentScn() throws SQLException {
+        return queryAndMap(
+                "SELECT CURRENT_SCN FROM V$DATABASE",
+                (rs) -> {
+                    if (rs.next()) {
+                        return Scn.valueOf(rs.getString(1));
+                    }
+                    throw new IllegalStateException("Could not get SCN");
+                });
+    }
+
+    /**
+     * Generate a given table's DDL metadata.
+     *
+     * @param tableId table identifier, should never be {@code null}
+     * @return generated DDL
+     * @throws SQLException if an exception occurred obtaining the DDL metadata
+     * @throws NonRelationalTableException the table is not a relational table
+     */
+    public String getTableMetadataDdl(TableId tableId)
+            throws SQLException, NonRelationalTableException {
+        try {
+            // This table contains all available objects that are considered relational & object
+            // based.
+            // By querying for TABLE_TYPE is null, we are explicitly confirming what if an entry
+            // exists
+            // that the table is in-fact a relational table and if the result set is empty, the
+            // object
+            // is another type, likely an object-based table, in which case we cannot generate DDL.
+            final String tableType =
+                    "SELECT COUNT(1) FROM ALL_ALL_TABLES WHERE OWNER='"
+                            + tableId.schema()
+                            + "' AND TABLE_NAME='"
+                            + tableId.table()
+                            + "' AND TABLE_TYPE IS NULL";
+            if (queryAndMap(tableType, rs -> rs.next() ? rs.getInt(1) : 0) == 0) {
+                throw new NonRelationalTableException(
+                        "Table " + tableId + " is not a relational table");
+            }
+
+            // The storage and segment attributes aren't necessary
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'STORAGE', false); end;");
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'SEGMENT_ATTRIBUTES', false); end;");
+            // In case DDL is returned as multiple DDL statements, this allows the parser to parse
+            // each separately.
+            // This is only critical during streaming as during snapshot the table structure is
+            // built from JDBC driver queries.
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'SQLTERMINATOR', true); end;");
+            return queryAndMap(
+                    "SELECT dbms_metadata.get_ddl('TABLE','"
+                            + tableId.table()
+                            + "','"
+                            + tableId.schema()
+                            + "') FROM DUAL",
+                    rs -> {
+                        if (!rs.next()) {
+                            throw new DebeziumException(
+                                    "Could not get DDL metadata for table: " + tableId);
+                        }
+
+                        Object res = rs.getObject(1);
+                        return ((Clob) res).getSubString(1, (int) ((Clob) res).length());
+                    });
+        } finally {
+            executeWithoutCommitting(
+                    "begin dbms_metadata.set_transform_param(DBMS_METADATA.SESSION_TRANSFORM, 'DEFAULT'); end;");
+        }
+    }
+
+    /**
+     * Get the current connection's session statistic by name.
+     *
+     * @param name the name of the statistic to be fetched, must not be {@code null}
+     * @return the session statistic value, never {@code null}
+     * @throws SQLException if an exception occurred obtaining the session statistic value
+     */
+    public Long getSessionStatisticByName(String name) throws SQLException {
+        return queryAndMap(
+                "SELECT VALUE FROM v$statname n, v$mystat m WHERE n.name='"
+                        + name
+                        + "' AND n.statistic#=m.statistic#",
+                rs -> rs.next() ? rs.getLong(1) : 0L);
+    }
+
+    /**
+     * Returns whether the given table exists or not.
+     *
+     * @param tableName table name, should not be {@code null}
+     * @return true if the table exists, false if it does not
+     * @throws SQLException if a database exception occurred
+     */
+    public boolean isTableExists(String tableName) throws SQLException {
+        return queryAndMap(
+                "SELECT COUNT(1) FROM USER_TABLES WHERE TABLE_NAME = '" + tableName + "'",
+                rs -> rs.next() && rs.getLong(1) > 0);
+    }
+
+    public boolean isTableExists(TableId tableId) throws SQLException {
+        return queryAndMap(
+                "SELECT COUNT(1) FROM ALL_TABLES WHERE OWNER = '"
+                        + tableId.schema()
+                        + "' AND TABLE_NAME = '"
+                        + tableId.table()
+                        + "'",
+                rs -> rs.next() && rs.getLong(1) > 0);
+    }
+
+    /**
+     * Returns whether the given table is empty or not.
+     *
+     * @param tableName table name, should not be {@code null}
+     * @return true if the table has no records, false otherwise
+     * @throws SQLException if a database exception occurred
+     */
+    public boolean isTableEmpty(String tableName) throws SQLException {
+        return getRowCount(tableName) == 0L;
+    }
+
+    /**
+     * Returns the number of rows in a given table.
+     *
+     * @param tableName table name, should not be {@code null}
+     * @return the number of rows
+     * @throws SQLException if a database exception occurred
+     */
+    public long getRowCount(String tableName) throws SQLException {
+        return queryAndMap(
+                "SELECT COUNT(1) FROM " + tableName,
+                rs -> {
+                    if (rs.next()) {
+                        return rs.getLong(1);
+                    }
+                    return 0L;
+                });
+    }
+
+    public <T> T singleOptionalValue(String query, ResultSetExtractor<T> extractor)
+            throws SQLException {
+        return queryAndMap(query, rs -> rs.next() ? extractor.apply(rs) : null);
+    }
+
+    @Override
+    public String buildSelectWithRowLimits(
+            TableId tableId,
+            int limit,
+            String projection,
+            Optional<String> condition,
+            String orderBy) {
+        final TableId table = new TableId(null, tableId.schema(), tableId.table());
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(projection).append(" FROM ");
+        sql.append(quotedTableIdString(table));
+        if (condition.isPresent()) {
+            sql.append(" WHERE ").append(condition.get());
+        }
+        if (getOracleVersion().getMajor() < 12) {
+            sql.insert(0, " SELECT * FROM (")
+                    .append(" ORDER BY ")
+                    .append(orderBy)
+                    .append(")")
+                    .append(" WHERE ROWNUM <=")
+                    .append(limit);
+        } else {
+            sql.append(" ORDER BY ")
+                    .append(orderBy)
+                    .append(" FETCH NEXT ")
+                    .append(limit)
+                    .append(" ROWS ONLY");
+        }
+        return sql.toString();
+    }
+
+    public static String connectionString(JdbcConfiguration config) {
+        return config.getString(URL) != null
+                ? config.getString(URL)
+                : ConnectorAdapter.parse(config.getString("connection.adapter")).getConnectionUrl();
+    }
+
+    private static ConnectionFactory resolveConnectionFactory(JdbcConfiguration config) {
+        return JdbcConnection.patternBasedFactory(connectionString(config));
+    }
+
+    /**
+     * Determine whether the Oracle server has the archive log enabled.
+     *
+     * @return {@code true} if the server's {@code LOG_MODE} is set to {@code ARCHIVELOG}, or {@code
+     *     false} otherwise
+     */
+    protected boolean isArchiveLogMode() {
+        try {
+            final String mode =
+                    queryAndMap(
+                            "SELECT LOG_MODE FROM V$DATABASE",
+                            rs -> rs.next() ? rs.getString(1) : "");
+            LOGGER.debug("LOG_MODE={}", mode);
+            return "ARCHIVELOG".equalsIgnoreCase(mode);
+        } catch (SQLException e) {
+            throw new DebeziumException(
+                    "Unexpected error while connecting to Oracle and looking at LOG_MODE mode: ",
+                    e);
+        }
+    }
+
+    /**
+     * Resolve a system change number to a timestamp, return value is in database timezone.
+     *
+     * <p>The SCN to TIMESTAMP mapping is only retained for the duration of the flashback query
+     * area. This means that eventually the mapping between these values are no longer kept by
+     * Oracle and making a call with a SCN value that has aged out will result in an ORA-08181
+     * error. This function explicitly checks for this use case and if a ORA-08181 error is thrown,
+     * it is therefore treated as if a value does not exist returning an empty optional value.
+     *
+     * @param scn the system change number, must not be {@code null}
+     * @return an optional timestamp when the system change number occurred
+     * @throws SQLException if a database exception occurred
+     */
+    static Instant readScnTimestamp(ResultSet rs, int columnIndex) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnIndex);
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    public Optional<Instant> getScnToTimestamp(Scn scn) throws SQLException {
+        try {
+            return queryAndMap(
+                    "SELECT scn_to_timestamp('" + scn + "') FROM DUAL",
+                    rs ->
+                            rs.next()
+                                    ? Optional.ofNullable(readScnTimestamp(rs, 1))
+                                    : Optional.empty());
+        } catch (SQLException e) {
+            if (e.getMessage().startsWith("ORA-08181")) {
+                // ORA-08181 specified number is not a valid system change number
+                // This happens when the SCN provided is outside the flashback area range
+                // This should be treated as a value is not available rather than an error
+                return Optional.empty();
+            }
+            // Any other SQLException should be thrown
+            throw e;
+        }
+    }
+
+    @Override
+    protected ColumnEditor overrideColumn(ColumnEditor column) {
+        // This allows the column state to be overridden before default-value resolution so that the
+        // output of the default value is within the same precision as that of the column values.
+        if (OracleTypes.TIMESTAMP == column.jdbcType()) {
+            column.length(column.scale().orElse(Column.UNSET_INT_VALUE)).scale(null);
+        } else if (OracleTypes.NUMBER == column.jdbcType()) {
+            column.scale().filter(s -> s == ORACLE_UNSET_SCALE).ifPresent(s -> column.scale(null));
+        }
+        return column;
+    }
+
+    @Override
+    protected Map<TableId, List<Column>> getColumnsDetails(
+            String databaseCatalog,
+            String schemaNamePattern,
+            String tableName,
+            Tables.TableFilter tableFilter,
+            ColumnNameFilter columnFilter,
+            DatabaseMetaData metadata,
+            Set<TableId> viewIds)
+            throws SQLException {
+        // The Oracle JDBC driver expects that if the table name contains a "/" character that
+        // the table name is pre-escaped prior to the JDBC driver call, or else it throws an
+        // exception about the character sequence being improperly escaped.
+        if (tableName != null && tableName.contains("/")) {
+            tableName = tableName.replace("/", "//");
+        }
+        return super.getColumnsDetails(
+                databaseCatalog,
+                schemaNamePattern,
+                tableName,
+                tableFilter,
+                columnFilter,
+                metadata,
+                viewIds);
+    }
+
+    /**
+     * An exception that indicates the operation failed because the table is not a relational table.
+     */
+    public static class NonRelationalTableException extends DebeziumException {
+        public NonRelationalTableException(String message) {
+            super(message);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/OracleSnapshotChangeEventSource.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle;
+
+import io.debezium.DebeziumException;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.RelationalSnapshotChangeEventSource;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link StreamingChangeEventSource} for Oracle.
+ *
+ * @author Gunnar Morling
+ */
+public class OracleSnapshotChangeEventSource
+        extends RelationalSnapshotChangeEventSource<OraclePartition, OracleOffsetContext> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(OracleSnapshotChangeEventSource.class);
+
+    private final OracleConnectorConfig connectorConfig;
+    private final OracleConnection jdbcConnection;
+    private final OracleDatabaseSchema databaseSchema;
+
+    public OracleSnapshotChangeEventSource(
+            OracleConnectorConfig connectorConfig,
+            OracleConnection jdbcConnection,
+            OracleDatabaseSchema schema,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            Clock clock,
+            SnapshotProgressListener<OraclePartition> snapshotProgressListener) {
+        super(connectorConfig, jdbcConnection, schema, dispatcher, clock, snapshotProgressListener);
+
+        this.connectorConfig = connectorConfig;
+        this.jdbcConnection = jdbcConnection;
+        this.databaseSchema = schema;
+    }
+
+    @Override
+    protected SnapshottingTask getSnapshottingTask(
+            OraclePartition partition, OracleOffsetContext previousOffset) {
+        boolean snapshotSchema = true;
+        boolean snapshotData = true;
+
+        // found a previous offset and the earlier snapshot has completed
+        if (previousOffset != null && !previousOffset.isSnapshotRunning()) {
+            LOGGER.info("The previous offset has been found.");
+            snapshotSchema = databaseSchema.isStorageInitializationExecuted();
+            snapshotData = false;
+        } else {
+            LOGGER.info("No previous offset has been found.");
+            snapshotData = connectorConfig.getSnapshotMode().includeData();
+        }
+
+        if (snapshotData && snapshotSchema) {
+            LOGGER.info(
+                    "According to the connector configuration both schema and data will be snapshot.");
+        } else if (snapshotSchema) {
+            LOGGER.info("According to the connector configuration only schema will be snapshot.");
+        }
+
+        return new SnapshottingTask(snapshotSchema, snapshotData);
+    }
+
+    @Override
+    protected SnapshotContext<OraclePartition, OracleOffsetContext> prepare(
+            OraclePartition partition) throws Exception {
+        if (connectorConfig.getPdbName() != null) {
+            jdbcConnection.setSessionToPdb(connectorConfig.getPdbName());
+        }
+
+        return new OracleSnapshotContext(partition, connectorConfig.getCatalogName());
+    }
+
+    @Override
+    protected Set<TableId> getAllTableIds(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx) throws Exception {
+        return jdbcConnection.getAllTableIds(ctx.catalogName);
+        // this very slow approach(commented out), it took 30 minutes on an instance with 600 tables
+        // return jdbcConnection.readTableNames(ctx.catalogName, null, null, new String[] {"TABLE"}
+        // );
+    }
+
+    @Override
+    protected void lockTablesForSchemaSnapshot(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
+            throws SQLException, InterruptedException {
+        if (connectorConfig.getSnapshotLockingMode().usesLocking()) {
+            ((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint =
+                    jdbcConnection.connection().setSavepoint("dbz_schema_snapshot");
+
+            try (Statement statement = jdbcConnection.connection().createStatement()) {
+                for (TableId tableId : snapshotContext.capturedTables) {
+                    if (!sourceContext.isRunning()) {
+                        throw new InterruptedException(
+                                "Interrupted while locking table " + tableId);
+                    }
+
+                    LOGGER.debug("Locking table {}", tableId);
+                    statement.execute("LOCK TABLE " + quote(tableId) + " IN ROW SHARE MODE");
+                }
+            }
+        } else {
+            LOGGER.info("Schema locking was disabled in connector configuration");
+        }
+    }
+
+    @Override
+    protected void releaseSchemaSnapshotLocks(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext)
+            throws SQLException {
+        if (connectorConfig.getSnapshotLockingMode().usesLocking()) {
+            jdbcConnection
+                    .connection()
+                    .rollback(((OracleSnapshotContext) snapshotContext).preSchemaSnapshotSavepoint);
+        }
+    }
+
+    @Override
+    protected void determineSnapshotOffset(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> ctx,
+            OracleOffsetContext previousOffset)
+            throws Exception {
+        // Support the existence of the case when the previous offset.
+        // e.g., schema_only_recovery snapshot mode
+        if (previousOffset != null) {
+            ctx.offset = previousOffset;
+            tryStartingSnapshot(ctx);
+            return;
+        }
+
+        ctx.offset =
+                connectorConfig
+                        .getAdapter()
+                        .determineSnapshotOffset(ctx, connectorConfig, jdbcConnection);
+    }
+
+    @Override
+    protected void readTableStructure(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            OracleOffsetContext offsetContext)
+            throws SQLException, InterruptedException {
+        Set<TableId> capturedSchemaTables;
+        if (databaseSchema.storeOnlyCapturedTables()) {
+            capturedSchemaTables = snapshotContext.capturedTables;
+            LOGGER.info(
+                    "Only captured tables schema should be captured, capturing: {}",
+                    capturedSchemaTables);
+        } else {
+            capturedSchemaTables = snapshotContext.capturedSchemaTables;
+            LOGGER.info(
+                    "All eligible tables schema should be captured, capturing: {}",
+                    capturedSchemaTables);
+        }
+
+        Set<String> schemas =
+                capturedSchemaTables.stream().map(TableId::schema).collect(Collectors.toSet());
+
+        // reading info only for the schemas we're interested in as per the set of captured tables;
+        // while the passed table name filter alone would skip all non-included tables, reading the
+        // schema
+        // would take much longer that way
+        for (String schema : schemas) {
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException(
+                        "Interrupted while reading structure of schema " + schema);
+            }
+
+            // todo: DBZ-137 the new readSchemaForCapturedTables seems to cause failures.
+            // For now, reverted to the default readSchema implementation as the intended goal
+            // with the new implementation was to be faster, not change behavior.
+            // if
+            // (connectorConfig.getAdapter().equals(OracleConnectorConfig.ConnectorAdapter.LOG_MINER)) {
+            // jdbcConnection.readSchemaForCapturedTables(
+            // snapshotContext.tables,
+            // snapshotContext.catalogName,
+            // schema,
+            // connectorConfig.getColumnFilter(),
+            // false,
+            // snapshotContext.capturedTables);
+            // }
+            // else {
+            jdbcConnection.readSchema(snapshotContext.tables, null, schema, null, null, false);
+            // }
+        }
+    }
+
+    @Override
+    protected String enhanceOverriddenSelect(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            String overriddenSelect,
+            TableId tableId) {
+        String snapshotOffset = (String) snapshotContext.offset.getOffset().get(SourceInfo.SCN_KEY);
+        String token = connectorConfig.getTokenToReplaceInSnapshotPredicate();
+        if (token != null) {
+            return overriddenSelect.replaceAll(token, " AS OF SCN " + snapshotOffset);
+        }
+        return overriddenSelect;
+    }
+
+    @Override
+    protected void createSchemaChangeEventsForTables(
+            ChangeEventSourceContext sourceContext,
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            SnapshottingTask snapshottingTask)
+            throws Exception {
+        tryStartingSnapshot(snapshotContext);
+        for (Iterator<TableId> iterator = snapshotContext.capturedSchemaTables.iterator();
+                iterator.hasNext(); ) {
+            final TableId tableId = iterator.next();
+            if (!sourceContext.isRunning()) {
+                throw new InterruptedException(
+                        "Interrupted while capturing schema of table " + tableId);
+            }
+
+            LOGGER.info("Capturing structure of table {}", tableId);
+
+            Table table = snapshotContext.tables.forTable(tableId);
+
+            if (schema().isHistorized()) {
+                snapshotContext.offset.event(tableId, getClock().currentTime());
+
+                // If data are not snapshotted then the last schema change must set last snapshot
+                // flag
+                if (!snapshottingTask.snapshotData() && !iterator.hasNext()) {
+                    lastSnapshotRecord(snapshotContext);
+                }
+
+                dispatcher.dispatchSchemaChangeEvent(
+                        snapshotContext.partition,
+                        table.id(),
+                        (receiver) -> {
+                            try {
+                                receiver.schemaChangeEvent(
+                                        getCreateTableEvent(snapshotContext, table));
+                            } catch (Exception e) {
+                                throw new DebeziumException(e);
+                            }
+                        });
+            }
+        }
+    }
+
+    @Override
+    protected SchemaChangeEvent getCreateTableEvent(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            Table table)
+            throws SQLException {
+        return SchemaChangeEvent.ofCreate(
+                snapshotContext.partition,
+                snapshotContext.offset,
+                snapshotContext.catalogName,
+                table.id().schema(),
+                jdbcConnection.getTableMetadataDdl(table.id()),
+                table,
+                true);
+    }
+
+    @Override
+    protected Instant getSnapshotSourceTimestamp(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            TableId tableId) {
+        try {
+            Optional<Instant> snapshotTs =
+                    jdbcConnection.getScnToTimestamp(snapshotContext.offset.getScn());
+            if (!snapshotTs.isPresent()) {
+                throw new ConnectException("Failed reading SCN timestamp from source database");
+            }
+
+            return snapshotTs.get();
+        } catch (SQLException e) {
+            throw new ConnectException("Failed reading SCN timestamp from source database", e);
+        }
+    }
+
+    /**
+     * Generate a valid Oracle query string for the specified table and columns
+     *
+     * @param tableId the table to generate a query for
+     * @return a valid query string
+     */
+    @Override
+    protected Optional<String> getSnapshotSelect(
+            RelationalSnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
+            TableId tableId,
+            List<String> columns) {
+        final OracleOffsetContext offset = snapshotContext.offset;
+        final String snapshotOffset = offset.getScn().toString();
+        String snapshotSelectColumns = columns.stream().collect(Collectors.joining(", "));
+        assert snapshotOffset != null;
+        return Optional.of(
+                String.format(
+                        "SELECT %s FROM %s AS OF SCN %s",
+                        snapshotSelectColumns, quote(tableId), snapshotOffset));
+    }
+
+    @Override
+    protected void complete(SnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext) {
+        if (connectorConfig.getPdbName() != null) {
+            jdbcConnection.resetSessionToCdb();
+        }
+    }
+
+    private static String quote(TableId tableId) {
+        return TableId.parse(tableId.schema() + "." + tableId.table(), true).toDoubleQuotedString();
+    }
+
+    /** Mutable context which is populated in the course of snapshotting. */
+    private static class OracleSnapshotContext
+            extends RelationalSnapshotContext<OraclePartition, OracleOffsetContext> {
+
+        private Savepoint preSchemaSnapshotSavepoint;
+
+        public OracleSnapshotContext(OraclePartition partition, String catalogName)
+                throws SQLException {
+            super(partition, catalogName);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/LogMinerStreamingChangeEventSource.java
@@ -797,10 +797,10 @@ public class LogMinerStreamingChangeEventSource
                                 Scn.valueOf(
                                         connectorConfig.getLogMiningScnGapDetectionGapSizeMin()))
                         > 0) {
-                    Optional<OffsetDateTime> prevEndScnTimestamp =
+                    Optional<Instant> prevEndScnTimestamp =
                             connection.getScnToTimestamp(prevEndScn);
                     if (prevEndScnTimestamp.isPresent()) {
-                        Optional<OffsetDateTime> currentScnTimestamp =
+                        Optional<Instant> currentScnTimestamp =
                                 connection.getScnToTimestamp(currentScn);
                         if (currentScnTimestamp.isPresent()) {
                             long timeDeltaMs =

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategy.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategy.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle.logminer.logwriter;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
+import io.debezium.util.Strings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Oracle RAC LogWriter flush strategy with service-name compatible JDBC URL rewriting.
+ *
+ * <p>Debezium 1.9.8 recreates RAC node connections by only overriding hostname/port. That path
+ * works for SID-style URLs, but it can generate invalid JDBC connect strings when the connector
+ * uses service-name URLs such as {@code jdbc:oracle:thin:@//host:port/service}. This local copy
+ * preserves the upstream behavior while rebuilding a node-specific URL for each RAC flush
+ * connection.
+ */
+public class RacCommitLogWriterFlushStrategy implements LogWriterFlushStrategy {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(RacCommitLogWriterFlushStrategy.class);
+    private static final String JDBC_URL_KEY = "url";
+    private static final Pattern SERVICE_NAME_URL_PATTERN =
+            Pattern.compile(
+                    "^(jdbc:oracle:[^:]+:@//)([^/:]+):(\\d+)(/.*)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SID_URL_PATTERN =
+            Pattern.compile(
+                    "^(jdbc:oracle:[^:]+:@)([^/:]+):(\\d+)(:.*)$", Pattern.CASE_INSENSITIVE);
+
+    private final Map<String, CommitLogWriterFlushStrategy> flushStrategies = new HashMap<>();
+    private final OracleStreamingChangeEventSourceMetrics streamingMetrics;
+    private final JdbcConfiguration jdbcConfiguration;
+    private final Set<String> hosts;
+    private final String connectorRawJdbcUrl;
+    private final String connectorDatabaseName;
+    private final String connectorUsername;
+    private final String connectorPassword;
+
+    public RacCommitLogWriterFlushStrategy(
+            OracleConnectorConfig connectorConfig,
+            JdbcConfiguration jdbcConfig,
+            OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+        this.jdbcConfiguration = jdbcConfig;
+        this.streamingMetrics = streamingMetrics;
+        this.hosts =
+                connectorConfig.getRacNodes().stream()
+                        .map(String::toUpperCase)
+                        .collect(Collectors.toSet());
+        this.connectorRawJdbcUrl = connectorConfig.getConfig().getString(OracleConnectorConfig.URL);
+        this.connectorDatabaseName = connectorConfig.getDatabaseName();
+        this.connectorUsername = connectorConfig.getJdbcConfig().getUser();
+        this.connectorPassword = connectorConfig.getJdbcConfig().getPassword();
+        recreateRacNodeFlushStrategies();
+    }
+
+    @Override
+    public void close() {
+        closeRacNodeFlushStrategies();
+        flushStrategies.clear();
+    }
+
+    @Override
+    public String getHost() {
+        return String.join(", ", hosts);
+    }
+
+    @Override
+    public void flush(Scn currentScn) throws InterruptedException {
+        Instant startTime = Instant.now();
+        if (flushStrategies.isEmpty()) {
+            throw new DebeziumException("No RAC node addresses supplied or currently connected");
+        }
+
+        boolean recreateConnections = false;
+        for (Map.Entry<String, CommitLogWriterFlushStrategy> entry : flushStrategies.entrySet()) {
+            final CommitLogWriterFlushStrategy strategy = entry.getValue();
+            try {
+                strategy.flush(currentScn);
+            } catch (Exception e) {
+                LOGGER.warn("Failed to flush LGWR buffer on RAC node '{}'", strategy.getHost(), e);
+                recreateConnections = true;
+            }
+        }
+
+        if (recreateConnections) {
+            recreateRacNodeFlushStrategies();
+            LOGGER.warn(
+                    "Not all LGWR buffers were flushed, waiting 3 seconds for Oracle to flush automatically.");
+            Metronome metronome = Metronome.sleeper(Duration.ofSeconds(3), Clock.SYSTEM);
+            try {
+                metronome.pause();
+            } catch (InterruptedException e) {
+                LOGGER.warn("The LGWR buffer wait was interrupted.");
+                throw e;
+            }
+        }
+
+        LOGGER.trace("LGWR flush took {} to complete.", Duration.between(startTime, Instant.now()));
+    }
+
+    private void recreateRacNodeFlushStrategies() {
+        closeRacNodeFlushStrategies();
+        flushStrategies.clear();
+
+        for (String hostName : hosts) {
+            try {
+                final String[] parts = hostName.split(":");
+                flushStrategies.put(
+                        hostName, createHostFlushStrategy(parts[0], Integer.parseInt(parts[1])));
+            } catch (SQLException e) {
+                throw new DebeziumException("Cannot connect to RAC node '" + hostName + "'", e);
+            }
+        }
+    }
+
+    private CommitLogWriterFlushStrategy createHostFlushStrategy(String hostName, Integer port)
+            throws SQLException {
+        JdbcConfiguration jdbcHostConfig =
+                buildHostJdbcConfiguration(
+                        jdbcConfiguration,
+                        connectorRawJdbcUrl,
+                        connectorDatabaseName,
+                        connectorUsername,
+                        connectorPassword,
+                        hostName,
+                        port);
+        LOGGER.debug(
+                "Creating flush connection to RAC node '{}' with jdbc url '{}' user='{}' passwordPresent={}",
+                hostName,
+                jdbcHostConfig.getString(JDBC_URL_KEY),
+                jdbcHostConfig.getUser(),
+                !Strings.isNullOrEmpty(jdbcHostConfig.getPassword()));
+        return new CommitLogWriterFlushStrategy(jdbcHostConfig);
+    }
+
+    static JdbcConfiguration buildHostJdbcConfiguration(
+            JdbcConfiguration jdbcConfiguration, String hostName, Integer port) {
+        return buildHostJdbcConfiguration(
+                jdbcConfiguration, null, null, null, null, hostName, port);
+    }
+
+    static JdbcConfiguration buildHostJdbcConfiguration(
+            JdbcConfiguration jdbcConfiguration,
+            String rawJdbcUrl,
+            String databaseName,
+            String username,
+            String password,
+            String hostName,
+            Integer port) {
+        JdbcConfiguration.Builder builder =
+                JdbcConfiguration.copy(jdbcConfiguration)
+                        .with(JdbcConfiguration.HOSTNAME, hostName)
+                        .with(JdbcConfiguration.PORT, port);
+        if (!Strings.isNullOrEmpty(username)) {
+            builder.with(JdbcConfiguration.USER, username);
+        }
+        if (!Strings.isNullOrEmpty(password)) {
+            builder.with(JdbcConfiguration.PASSWORD, password);
+        }
+        String jdbcUrl =
+                resolveJdbcUrl(jdbcConfiguration, rawJdbcUrl, databaseName, hostName, port);
+        if (!Strings.isNullOrEmpty(jdbcUrl)) {
+            builder.with(JDBC_URL_KEY, jdbcUrl);
+        }
+        return JdbcConfiguration.adapt(builder.build());
+    }
+
+    static String resolveJdbcUrl(
+            JdbcConfiguration jdbcConfiguration, String hostName, Integer port) {
+        return resolveJdbcUrl(jdbcConfiguration, null, null, hostName, port);
+    }
+
+    static String resolveJdbcUrl(
+            JdbcConfiguration jdbcConfiguration,
+            String rawJdbcUrl,
+            String databaseName,
+            String hostName,
+            Integer port) {
+        if (!Strings.isNullOrEmpty(rawJdbcUrl)) {
+            return rewriteJdbcUrl(rawJdbcUrl, hostName, port);
+        }
+
+        String jdbcUrl = jdbcConfiguration.getString(JDBC_URL_KEY);
+        if (!Strings.isNullOrEmpty(jdbcUrl)) {
+            return rewriteJdbcUrl(jdbcUrl, hostName, port);
+        }
+
+        if (!Strings.isNullOrEmpty(databaseName)) {
+            return "jdbc:oracle:thin:@//" + hostName + ":" + port + "/" + databaseName;
+        }
+
+        String fallbackDatabase = jdbcConfiguration.getString(JdbcConfiguration.DATABASE);
+        if (!Strings.isNullOrEmpty(fallbackDatabase)) {
+            return "jdbc:oracle:thin:@//" + hostName + ":" + port + "/" + fallbackDatabase;
+        }
+
+        return null;
+    }
+
+    static String rewriteJdbcUrl(String jdbcUrl, String hostName, Integer port) {
+        Matcher serviceNameMatcher = SERVICE_NAME_URL_PATTERN.matcher(jdbcUrl);
+        if (serviceNameMatcher.matches()) {
+            return serviceNameMatcher.group(1)
+                    + hostName
+                    + ":"
+                    + port
+                    + serviceNameMatcher.group(4);
+        }
+
+        Matcher sidMatcher = SID_URL_PATTERN.matcher(jdbcUrl);
+        if (sidMatcher.matches()) {
+            return sidMatcher.group(1) + hostName + ":" + port + sidMatcher.group(4);
+        }
+
+        return jdbcUrl;
+    }
+
+    private void closeRacNodeFlushStrategies() {
+        for (CommitLogWriterFlushStrategy strategy : flushStrategies.values()) {
+            try {
+                strategy.close();
+            } catch (Exception e) {
+                LOGGER.warn("Failed to close RAC connection to node '{}'", strategy.getHost(), e);
+                streamingMetrics.incrementWarningCount();
+            }
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/xstream/LcrEventHandler.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.xstream;
+
+import io.debezium.DebeziumException;
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnection.NonRelationalTableException;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleDatabaseSchema;
+import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
+import io.debezium.connector.oracle.OracleSchemaChangeEventEmitter;
+import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
+import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.xstream.XstreamStreamingChangeEventSource.PositionAndScn;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+import io.debezium.util.Strings;
+import oracle.streams.ChunkColumnValue;
+import oracle.streams.DDLLCR;
+import oracle.streams.DefaultRowLCR;
+import oracle.streams.LCR;
+import oracle.streams.RowLCR;
+import oracle.streams.StreamsException;
+import oracle.streams.XStreamLCRCallbackHandler;
+import oracle.streams.XStreamOut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Handler for Oracle DDL and DML events. Just forwards events to the {@link EventDispatcher}.
+ *
+ * @author Gunnar Morling
+ */
+class LcrEventHandler implements XStreamLCRCallbackHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LcrEventHandler.class);
+
+    private final OracleConnectorConfig connectorConfig;
+    private final ErrorHandler errorHandler;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
+    private final Clock clock;
+    private final OracleDatabaseSchema schema;
+    private final OraclePartition partition;
+    private final OracleOffsetContext offsetContext;
+    private final boolean tablenameCaseInsensitive;
+    private final XstreamStreamingChangeEventSource eventSource;
+    private final OracleStreamingChangeEventSourceMetrics streamingMetrics;
+    private final Map<String, ChunkColumnValues> columnChunks;
+    private RowLCR currentRow;
+
+    public LcrEventHandler(
+            OracleConnectorConfig connectorConfig,
+            ErrorHandler errorHandler,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            Clock clock,
+            OracleDatabaseSchema schema,
+            OraclePartition partition,
+            OracleOffsetContext offsetContext,
+            boolean tablenameCaseInsensitive,
+            XstreamStreamingChangeEventSource eventSource,
+            OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+        this.connectorConfig = connectorConfig;
+        this.errorHandler = errorHandler;
+        this.dispatcher = dispatcher;
+        this.clock = clock;
+        this.schema = schema;
+        this.partition = partition;
+        this.offsetContext = offsetContext;
+        this.tablenameCaseInsensitive = tablenameCaseInsensitive;
+        this.eventSource = eventSource;
+        this.streamingMetrics = streamingMetrics;
+        this.columnChunks = new LinkedHashMap<>();
+    }
+
+    @Override
+    public void processLCR(LCR lcr) throws StreamsException {
+        LOGGER.trace("Received LCR {}", lcr);
+        try {
+            // First set watermark to flush messages seen
+            setWatermark();
+            columnChunks.clear();
+
+            final LcrPosition lcrPosition = new LcrPosition(lcr.getPosition());
+
+            // After a restart it may happen we get the event with the last processed LCR again
+            LcrPosition offsetLcrPosition = LcrPosition.valueOf(offsetContext.getLcrPosition());
+            if (lcrPosition.compareTo(offsetLcrPosition) <= 0) {
+                if (LOGGER.isDebugEnabled()) {
+                    final LcrPosition recPosition = offsetLcrPosition;
+                    LOGGER.debug(
+                            "Ignoring change event with already processed SCN/LCR Position {}/{}, last recorded {}/{}",
+                            lcrPosition,
+                            lcrPosition.getScn(),
+                            recPosition != null ? recPosition : "none",
+                            recPosition != null ? recPosition.getScn() : "none");
+                }
+                return;
+            }
+
+            offsetContext.setScn(lcrPosition.getScn());
+            offsetContext.setEventScn(lcrPosition.getScn());
+            offsetContext.setLcrPosition(lcrPosition.toString());
+            offsetContext.setTransactionId(lcr.getTransactionId());
+            offsetContext.tableEvent(
+                    new TableId(
+                            lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName()),
+                    lcr.getSourceTime().timestampValue().toInstant());
+
+            if (lcr instanceof RowLCR) {
+                processRowLCR((RowLCR) lcr);
+            } else if (lcr instanceof DDLLCR) {
+                dispatchSchemaChangeEvent((DDLLCR) lcr);
+            }
+        }
+        // nothing to be done here if interrupted; the event loop will be stopped in the streaming
+        // source
+        catch (InterruptedException e) {
+            Thread.interrupted();
+            LOGGER.info("Received signal to stop, event loop will halt");
+        }
+        // XStream's receiveLCRCallback() doesn't reliably propagate exceptions, so we do that
+        // ourselves here
+        catch (Exception e) {
+            errorHandler.setProducerThrowable(e);
+        }
+    }
+
+    private void processRowLCR(RowLCR row) throws InterruptedException {
+        if (row.getCommandType().equals(RowLCR.LOB_ERASE)) {
+            LOGGER.warn(
+                    "LOB_ERASE for table '{}' is not supported, "
+                            + "use DML operations to manipulate LOB columns only.",
+                    row.getObjectName());
+            return;
+        }
+
+        if (row.hasChunkData()) {
+            // If the row has chunk data, the RowLCR cannot be immediately dispatched.
+            // The handler needs to cache the current row and wait for the chunks to be delivered
+            // before
+            // the event can be safely dispatched. See processChunk below.
+            currentRow = row;
+        } else {
+            // Since the row has no chunk data, it can be dispatched immediately.
+            dispatchDataChangeEvent(row, null);
+        }
+    }
+
+    private void dispatchDataChangeEvent(RowLCR lcr, Map<String, Object> chunkValues)
+            throws InterruptedException {
+        LOGGER.debug("Processing DML event {}", lcr);
+
+        if (RowLCR.COMMIT.equals(lcr.getCommandType())) {
+            dispatcher.dispatchTransactionCommittedEvent(partition, offsetContext);
+            return;
+        }
+
+        if (eventSource.shouldSkipDataEvent(offsetContext)) {
+            return;
+        }
+
+        TableId tableId = getTableId(lcr);
+
+        Table table = schema.tableFor(tableId);
+        if (table == null) {
+            if (!connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
+                LOGGER.trace("Table {} is new but excluded, schema change skipped.", tableId);
+                return;
+            }
+
+            final String tableDdl;
+            try {
+                tableDdl = getTableMetadataDdl(tableId);
+            } catch (NonRelationalTableException e) {
+                LOGGER.warn("Table {} is not a relational table and will be skipped.", tableId);
+                streamingMetrics.incrementWarningCount();
+                return;
+            }
+
+            LOGGER.info("Table {} will be captured.", tableId);
+            dispatcher.dispatchSchemaChangeEvent(
+                    partition,
+                    tableId,
+                    new OracleSchemaChangeEventEmitter(
+                            connectorConfig,
+                            partition,
+                            offsetContext,
+                            tableId,
+                            tableId.catalog(),
+                            tableId.schema(),
+                            tableDdl,
+                            schema,
+                            Instant.now(),
+                            streamingMetrics,
+                            null));
+
+            table = schema.tableFor(tableId);
+            if (table == null) {
+                return;
+            }
+        }
+
+        // Xstream does not provide any before state for LOB columns and so this map will be
+        // populated here by column name with the OracleValueConverters.UNAVAILABLE_VALUE.
+        Map<String, Object> oldChunkValues = new HashMap<>(0);
+
+        if (chunkValues == null) {
+            // Happens when dispatching an LCR without any chunk data.
+            chunkValues = new HashMap<>(0);
+        }
+
+        // LCR events may arrive both with and without chunk data.
+        //
+        // For example a DELETE by a primary key on a table with LOB columns will not supply any
+        // LOB chunk data. In other scenarios such as an UPDATE where a LOB column is modified,
+        // the updated LOB value will be provided but the prior value will not be.
+        //
+        // So in either case, the values need to be serialized here such that any LOB column that
+        // is not explicitly provided in the map is initialized with the unavailable value
+        // marker object so its transformed correctly by the value converters.
+
+        for (Column column : schema.getLobColumnsForTable(table.id())) {
+            // again Xstream doesn't supply before state for LOB values; explicitly use unavailable
+            // value
+            oldChunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
+            if (!chunkValues.containsKey(column.name())) {
+                // Column not supplied, initialize with unavailable value marker
+                LOGGER.trace(
+                        "\tColumn '{}' not supplied, initialized with unavailable value",
+                        column.name());
+                chunkValues.put(column.name(), OracleValueConverters.UNAVAILABLE_VALUE);
+            }
+        }
+
+        dispatcher.dispatchDataChangeEvent(
+                partition,
+                tableId,
+                new XStreamChangeRecordEmitter(
+                        connectorConfig,
+                        partition,
+                        offsetContext,
+                        lcr,
+                        oldChunkValues,
+                        chunkValues,
+                        schema.tableFor(tableId),
+                        schema,
+                        clock));
+    }
+
+    private void dispatchSchemaChangeEvent(DDLLCR ddlLcr) throws InterruptedException {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Processing DDL event {}", ddlLcr.getDDLText());
+        }
+
+        TableId tableId = getTableId(ddlLcr);
+
+        dispatcher.dispatchSchemaChangeEvent(
+                partition,
+                tableId,
+                new OracleSchemaChangeEventEmitter(
+                        connectorConfig,
+                        partition,
+                        offsetContext,
+                        tableId,
+                        ddlLcr.getSourceDatabaseName(),
+                        ddlLcr.getObjectOwner(),
+                        ddlLcr.getDDLText(),
+                        schema,
+                        ddlLcr.getSourceTime().timestampValue().toInstant(),
+                        streamingMetrics,
+                        () -> processTruncateEvent(ddlLcr)));
+    }
+
+    private void processTruncateEvent(DDLLCR ddlLcr) {
+        LOGGER.debug("Handling truncate event");
+        DefaultRowLCR rowLCR =
+                new DefaultRowLCR(
+                        ddlLcr.getSourceDatabaseName(),
+                        ddlLcr.getCommandType(),
+                        ddlLcr.getObjectOwner(),
+                        ddlLcr.getObjectName(),
+                        ddlLcr.getTransactionId(),
+                        ddlLcr.getTag(),
+                        ddlLcr.getPosition(),
+                        ddlLcr.getSourceTime());
+        try {
+            dispatchDataChangeEvent(rowLCR, null);
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted", e);
+        }
+    }
+
+    private TableId getTableId(LCR lcr) {
+        if (!this.tablenameCaseInsensitive) {
+            return new TableId(
+                    lcr.getSourceDatabaseName(), lcr.getObjectOwner(), lcr.getObjectName());
+        } else {
+            return new TableId(
+                    lcr.getSourceDatabaseName(),
+                    lcr.getObjectOwner(),
+                    lcr.getObjectName().toLowerCase());
+        }
+    }
+
+    private String getTableMetadataDdl(TableId tableId) throws NonRelationalTableException {
+        LOGGER.info("Getting database metadata for table '{}'", tableId);
+        final String pdbName = connectorConfig.getPdbName();
+        // A separate connection must be used for this out-of-bands query while processing the
+        // Xstream callback.
+        // This should have negligible overhead as this should happen rarely.
+        try (OracleConnection connection =
+                new OracleConnection(
+                        connectorConfig.getJdbcConfig(),
+                        () -> getClass().getClassLoader(),
+                        false)) {
+            if (!Strings.isNullOrBlank(pdbName)) {
+                connection.setSessionToPdb(pdbName);
+            }
+            connection.setAutoCommit(false);
+            return connection.getTableMetadataDdl(tableId);
+        } catch (SQLException e) {
+            throw new DebeziumException("Failed to get table DDL metadata for: " + tableId, e);
+        }
+    }
+
+    private void setWatermark() {
+        if (eventSource.getXsOut() == null) {
+            return;
+        }
+        try {
+            final PositionAndScn message = eventSource.receivePublishedPosition();
+            if (message == null) {
+                return;
+            }
+            LOGGER.debug("Recording offsets to Oracle");
+            if (message.position != null) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Recording position {}", message.position);
+                }
+                eventSource
+                        .getXsOut()
+                        .setProcessedLowWatermark(
+                                message.position.getRawPosition(), XStreamOut.DEFAULT_MODE);
+            } else if (message.scn != null) {
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Recording position with SCN {}", message.scn);
+                }
+                eventSource
+                        .getXsOut()
+                        .setProcessedLowWatermark(message.scn, XStreamOut.DEFAULT_MODE);
+            } else {
+                LOGGER.warn("Nothing in offsets could be recorded to Oracle");
+                return;
+            }
+            LOGGER.trace("Offsets recorded to Oracle");
+        } catch (StreamsException e) {
+            throw new DebeziumException("Couldn't set processed low watermark", e);
+        }
+    }
+
+    @Override
+    public void processChunk(ChunkColumnValue chunk) throws StreamsException {
+        columnChunks
+                .computeIfAbsent(chunk.getColumnName(), v -> new ChunkColumnValues())
+                .add(chunk);
+        if (chunk.isEndOfRow()) {
+            resolveAndDispatchCurrentChunkedRow();
+        }
+    }
+
+    @Override
+    public LCR createLCR() throws StreamsException {
+        throw new UnsupportedOperationException("Should never be called");
+    }
+
+    @Override
+    public ChunkColumnValue createChunk() throws StreamsException {
+        throw new UnsupportedOperationException("Should never be called");
+    }
+
+    private void resolveAndDispatchCurrentChunkedRow() {
+        try {
+            // Map of resolved chunk values
+            Map<String, Object> resolvedChunkValues = new HashMap<>();
+
+            // All chunks have been dispatched to the event handler, combine the chunks now.
+            for (Map.Entry<String, ChunkColumnValues> entry : columnChunks.entrySet()) {
+                final String columnName = entry.getKey();
+                final ChunkColumnValues chunkValues = entry.getValue();
+
+                if (chunkValues.isEmpty()) {
+                    LOGGER.trace("Column '{}' has no chunk values.", columnName);
+                    continue;
+                }
+
+                final int type = chunkValues.getChunkType();
+                switch (type) {
+                    case ChunkColumnValue.CLOB:
+                    case ChunkColumnValue.NCLOB:
+                        resolvedChunkValues.put(columnName, chunkValues.getStringValue());
+                        break;
+
+                    case ChunkColumnValue.BLOB:
+                        resolvedChunkValues.put(columnName, chunkValues.getByteArray());
+                        break;
+
+                    default:
+                        LOGGER.trace(
+                                "Received an unsupported chunk type '{}' for column '{}', ignored.",
+                                type,
+                                columnName);
+                        break;
+                }
+            }
+
+            columnChunks.clear();
+            dispatchDataChangeEvent(currentRow, resolvedChunkValues);
+        } catch (InterruptedException e) {
+            Thread.interrupted();
+            LOGGER.info("Received signal to stop, event loop will halt");
+        } catch (SQLException e) {
+            throw new DebeziumException("Failed to process chunk data", e);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSource.java
@@ -1,0 +1,489 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.connector.oracle.xstream;
+
+import io.debezium.connector.oracle.OracleConnection;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.OracleDatabaseSchema;
+import io.debezium.connector.oracle.OracleDatabaseVersion;
+import io.debezium.connector.oracle.OracleOffsetContext;
+import io.debezium.connector.oracle.OraclePartition;
+import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
+import io.debezium.connector.oracle.Scn;
+import io.debezium.connector.oracle.SourceInfo;
+import io.debezium.connector.oracle.StreamingAdapter.TableNameCaseSensitivity;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+import io.debezium.util.Strings;
+import oracle.sql.NUMBER;
+import oracle.streams.StreamsException;
+import oracle.streams.XStreamOut;
+import oracle.streams.XStreamUtility;
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Local override of Debezium's {@code XstreamStreamingChangeEventSource}.
+ *
+ * <p>Enhancement:
+ *
+ * <ul>
+ *   <li>For each receive loop, we additionally inspect {@code XStreamOut#getFetchLowWatermark()}
+ *       and advance {@code offsetContext} when possible. This lets bounded split logic evaluate
+ *       ending offset even when no user-level DML/DDL event is emitted for captured tables.
+ * </ul>
+ */
+public class XstreamStreamingChangeEventSource
+        implements StreamingChangeEventSource<OraclePartition, OracleOffsetContext> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(XstreamStreamingChangeEventSource.class);
+    static final int XSTREAM_ATTACH_MAX_RETRIES = 3;
+    static final long XSTREAM_ATTACH_BASE_DELAY_MILLIS = 10000L;
+    static final long XSTREAM_ATTACH_MAX_DELAY_MILLIS = 30000L;
+    static final long XSTREAM_ATTACH_TOTAL_RETRY_WINDOW_MILLIS = 60000L;
+    private static final String ACTIVE_XSTREAM_SESSION_ERROR_CODE = "ORA-26812";
+
+    private final OracleConnectorConfig connectorConfig;
+    private final OracleConnection jdbcConnection;
+    private final EventDispatcher<OraclePartition, TableId> dispatcher;
+    private final ErrorHandler errorHandler;
+    private final Clock clock;
+    private final OracleDatabaseSchema schema;
+    private final OracleStreamingChangeEventSourceMetrics streamingMetrics;
+    private final String xStreamServerName;
+    private final Object xsOutLock = new Object();
+    private volatile XStreamOut xsOut;
+    private final int posVersion;
+    private final Long startupTimestampMillis;
+    private boolean reachedStartupTimestamp;
+    private long startupFilteredCount;
+    private boolean startupSeekStarted;
+
+    /**
+     * A message box between thread that is informed about committed offsets and the XStream thread.
+     * When the last offset is committed its value is passed to the XStream thread and a watermark
+     * is set to signal which events were safely processed.
+     *
+     * <p>This is important as setting watermark in a concurrent thread can lead to a deadlock due
+     * to an internal Oracle code locking.
+     */
+    private final AtomicReference<PositionAndScn> lcrMessage = new AtomicReference<>();
+
+    public XstreamStreamingChangeEventSource(
+            OracleConnectorConfig connectorConfig,
+            OracleConnection jdbcConnection,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            ErrorHandler errorHandler,
+            Clock clock,
+            OracleDatabaseSchema schema,
+            OracleStreamingChangeEventSourceMetrics streamingMetrics) {
+        this(
+                connectorConfig,
+                jdbcConnection,
+                dispatcher,
+                errorHandler,
+                clock,
+                schema,
+                streamingMetrics,
+                null);
+    }
+
+    public XstreamStreamingChangeEventSource(
+            OracleConnectorConfig connectorConfig,
+            OracleConnection jdbcConnection,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            ErrorHandler errorHandler,
+            Clock clock,
+            OracleDatabaseSchema schema,
+            OracleStreamingChangeEventSourceMetrics streamingMetrics,
+            Long startupTimestampMillis) {
+        this(
+                connectorConfig,
+                jdbcConnection,
+                dispatcher,
+                errorHandler,
+                clock,
+                schema,
+                streamingMetrics,
+                startupTimestampMillis,
+                resolvePosVersion(jdbcConnection, connectorConfig));
+    }
+
+    XstreamStreamingChangeEventSource(
+            OracleConnectorConfig connectorConfig,
+            OracleConnection jdbcConnection,
+            EventDispatcher<OraclePartition, TableId> dispatcher,
+            ErrorHandler errorHandler,
+            Clock clock,
+            OracleDatabaseSchema schema,
+            OracleStreamingChangeEventSourceMetrics streamingMetrics,
+            Long startupTimestampMillis,
+            int posVersion) {
+        this.connectorConfig = connectorConfig;
+        this.jdbcConnection = jdbcConnection;
+        this.dispatcher = dispatcher;
+        this.errorHandler = errorHandler;
+        this.clock = clock;
+        this.schema = schema;
+        this.streamingMetrics = streamingMetrics;
+        this.xStreamServerName = connectorConfig.getXoutServerName();
+        this.posVersion = posVersion;
+        this.startupTimestampMillis = startupTimestampMillis;
+    }
+
+    @Override
+    public void execute(
+            ChangeEventSourceContext context,
+            OraclePartition partition,
+            OracleOffsetContext offsetContext)
+            throws InterruptedException {
+
+        LcrEventHandler eventHandler =
+                new LcrEventHandler(
+                        connectorConfig,
+                        errorHandler,
+                        dispatcher,
+                        clock,
+                        schema,
+                        partition,
+                        offsetContext,
+                        TableNameCaseSensitivity.INSENSITIVE.equals(
+                                connectorConfig
+                                        .getAdapter()
+                                        .getTableNameCaseSensitivity(jdbcConnection)),
+                        this,
+                        streamingMetrics);
+
+        try (OracleConnection xsConnection =
+                new OracleConnection(jdbcConnection.config(), () -> getClass().getClassLoader())) {
+            try {
+                // 1. connect
+                final byte[] startPosition;
+                String lcrPosition = offsetContext.getLcrPosition();
+                if (lcrPosition != null) {
+                    startPosition = LcrPosition.valueOf(lcrPosition).getRawPosition();
+                } else {
+                    startPosition = convertScnToPosition(offsetContext.getScn());
+                }
+
+                XStreamOut attachedXStream =
+                        retryWhenSessionBusy(
+                                context,
+                                xStreamServerName,
+                                () -> attachXStream(xsConnection, startPosition),
+                                this::pauseBetweenAttachRetries,
+                                getAttachBusyRetryTimes());
+                if (attachedXStream == null) {
+                    LOGGER.info(
+                            "Skip attaching XStream outbound server {} because source is stopping.",
+                            xStreamServerName);
+                    return;
+                }
+                setXsOut(attachedXStream);
+
+                // 2. receive events while running
+                while (context.isRunning()) {
+                    LOGGER.trace("Receiving LCR");
+                    xsOut.receiveLCRCallback(eventHandler, XStreamOut.DEFAULT_MODE);
+                    advanceOffsetByFetchLowWatermark(offsetContext);
+                    onAfterReceive(context, partition, offsetContext);
+                }
+            } finally {
+                // 3. disconnect
+                detachXStreamSession();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (!context.isRunning()) {
+                LOGGER.info(
+                        "Ignore XStream interruption while stopping outbound server {}.",
+                        xStreamServerName);
+                return;
+            }
+            errorHandler.setProducerThrowable(e);
+        } catch (Throwable e) {
+            if (!context.isRunning()) {
+                LOGGER.info(
+                        "Ignore XStream exception while stopping outbound server {}.",
+                        xStreamServerName,
+                        e);
+                return;
+            }
+            errorHandler.setProducerThrowable(e);
+        }
+    }
+
+    @Override
+    public void commitOffset(Map<String, ?> offset) {
+        if (xsOut != null) {
+            LOGGER.debug("Sending message to request recording of offsets to Oracle");
+            final LcrPosition lcrPosition =
+                    LcrPosition.valueOf((String) offset.get(SourceInfo.LCR_POSITION_KEY));
+            final Scn scn =
+                    OracleOffsetContext.getScnFromOffsetMapByKey(offset, SourceInfo.SCN_KEY);
+            // We can safely overwrite the message even if it was not processed. The watermarked
+            // will be set to the highest (last) delivered value in a single step instead of
+            // incrementally.
+            sendPublishedPosition(lcrPosition, scn);
+        }
+    }
+
+    private void advanceOffsetByFetchLowWatermark(OracleOffsetContext offsetContext) {
+        if (xsOut == null) {
+            return;
+        }
+        final byte[] fetchLowWatermark = xsOut.getFetchLowWatermark();
+        if (fetchLowWatermark == null || fetchLowWatermark.length == 0) {
+            return;
+        }
+        try {
+            final LcrPosition fetchPosition = new LcrPosition(fetchLowWatermark);
+            final LcrPosition currentPosition = LcrPosition.valueOf(offsetContext.getLcrPosition());
+            if (currentPosition != null && fetchPosition.compareTo(currentPosition) <= 0) {
+                return;
+            }
+            offsetContext.setScn(fetchPosition.getScn());
+            offsetContext.setEventScn(fetchPosition.getScn());
+            offsetContext.setLcrPosition(fetchPosition.toString());
+            LOGGER.debug(
+                    "Advanced XStream offset by fetch low watermark to {}", fetchPosition.getScn());
+        } catch (RuntimeException e) {
+            // Keep original behaviour (continue receiving). Bounded split fallback still relies on
+            // event-driven SCN update path in LcrEventHandler.
+            LOGGER.warn(
+                    "Failed to parse XStream fetch low watermark, skip proactive offset update.",
+                    e);
+        }
+    }
+
+    protected void onAfterReceive(
+            ChangeEventSourceContext context,
+            OraclePartition partition,
+            OracleOffsetContext offsetContext)
+            throws InterruptedException {
+        dispatcher.dispatchHeartbeatEvent(partition, offsetContext);
+    }
+
+    private byte[] convertScnToPosition(Scn scn) {
+        try {
+            return XStreamUtility.convertSCNToPosition(
+                    new NUMBER(scn.toString(), 0), this.posVersion);
+        } catch (SQLException | StreamsException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class PositionAndScn {
+        public final LcrPosition position;
+        public final byte[] scn;
+
+        public PositionAndScn(LcrPosition position, byte[] scn) {
+            this.position = position;
+            this.scn = scn;
+        }
+    }
+
+    XStreamOut getXsOut() {
+        return xsOut;
+    }
+
+    public void closeXStreamSession() {
+        detachXStreamSession();
+    }
+
+    private void sendPublishedPosition(final LcrPosition lcrPosition, final Scn scn) {
+        lcrMessage.set(
+                new PositionAndScn(lcrPosition, (scn != null) ? convertScnToPosition(scn) : null));
+    }
+
+    PositionAndScn receivePublishedPosition() {
+        return lcrMessage.getAndSet(null);
+    }
+
+    boolean shouldSkipDataEvent(OracleOffsetContext offsetContext) {
+        if (startupTimestampMillis == null || reachedStartupTimestamp) {
+            return false;
+        }
+        if (!startupSeekStarted) {
+            startupSeekStarted = true;
+            LOGGER.info(
+                    "Begin to seek Oracle xstream to startup timestamp {}.",
+                    startupTimestampMillis);
+        }
+        Struct sourceInfo = offsetContext.getSourceInfo();
+        Long eventTimestamp =
+                sourceInfo == null ? null : sourceInfo.getInt64(SourceInfo.TIMESTAMP_KEY);
+        if (eventTimestamp != null && eventTimestamp >= startupTimestampMillis) {
+            reachedStartupTimestamp = true;
+            LOGGER.info(
+                    "Successfully seek Oracle xstream to startup timestamp {} with filtered {} change events.",
+                    startupTimestampMillis,
+                    startupFilteredCount);
+            return false;
+        }
+        startupFilteredCount++;
+        if (startupFilteredCount % 10000 == 0) {
+            LOGGER.info(
+                    "Seeking Oracle xstream to startup timestamp {} with filtered {} change events.",
+                    startupTimestampMillis,
+                    startupFilteredCount);
+        }
+        return true;
+    }
+
+    private static int resolvePosVersion(
+            OracleConnection connection, OracleConnectorConfig connectorConfig) {
+        // Option 'internal.database.oracle.version' takes precedence
+        final String oracleVersion = connectorConfig.getOracleVersion();
+        if (!Strings.isNullOrEmpty(oracleVersion)) {
+            if ("11".equals(oracleVersion)) {
+                return XStreamUtility.POS_VERSION_V1;
+            }
+            return XStreamUtility.POS_VERSION_V2;
+        }
+
+        // As fallback, resolve this based on the OracleDatabaseVersion
+        final OracleDatabaseVersion databaseVersion = connection.getOracleVersion();
+        if (databaseVersion.getMajor() == 11
+                || (databaseVersion.getMajor() == 12 && databaseVersion.getMaintenance() < 2)) {
+            return XStreamUtility.POS_VERSION_V1;
+        }
+        return XStreamUtility.POS_VERSION_V2;
+    }
+
+    protected XStreamOut attachXStream(OracleConnection xsConnection, byte[] startPosition)
+            throws StreamsException {
+        try {
+            return XStreamOut.attach(
+                    (oracle.jdbc.OracleConnection) xsConnection.connection(),
+                    xStreamServerName,
+                    startPosition,
+                    1,
+                    1,
+                    XStreamOut.DEFAULT_MODE);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void pauseBetweenAttachRetries(long delayMillis) throws InterruptedException {
+        Thread.sleep(delayMillis);
+    }
+
+    protected int getAttachBusyRetryTimes() {
+        return XSTREAM_ATTACH_MAX_RETRIES;
+    }
+
+    private void setXsOut(XStreamOut xsOut) {
+        synchronized (xsOutLock) {
+            this.xsOut = xsOut;
+        }
+    }
+
+    private void detachXStreamSession() {
+        XStreamOut currentXsOut;
+        synchronized (xsOutLock) {
+            currentXsOut = xsOut;
+            xsOut = null;
+        }
+        if (currentXsOut == null) {
+            return;
+        }
+        try {
+            currentXsOut.detach(XStreamOut.DEFAULT_MODE);
+        } catch (StreamsException e) {
+            LOGGER.error("Couldn't detach from XStream outbound server " + xStreamServerName, e);
+        }
+    }
+
+    static <T> T retryWhenSessionBusy(
+            ChangeEventSourceContext context,
+            String xStreamServerName,
+            XStreamAttachOperation<T> attachOperation,
+            RetrySleeper retrySleeper,
+            int maxRetries)
+            throws StreamsException, InterruptedException {
+        int retryAttempt = 0;
+        while (true) {
+            if (!context.isRunning()) {
+                return null;
+            }
+            try {
+                return attachOperation.attach();
+            } catch (StreamsException e) {
+                if (!isActiveSessionAttachedError(e)) {
+                    throw e;
+                }
+                if (retryAttempt >= maxRetries) {
+                    throw sessionBusyTimeoutException(xStreamServerName, maxRetries, e);
+                }
+                retryAttempt++;
+                long delayMillis = getAttachRetryDelayMillis(retryAttempt);
+                LOGGER.warn(
+                        "XStream outbound server {} is still occupied by an active session ({}), retrying attach attempt {}/{} after {} ms.",
+                        xStreamServerName,
+                        ACTIVE_XSTREAM_SESSION_ERROR_CODE,
+                        retryAttempt,
+                        maxRetries,
+                        delayMillis);
+                retrySleeper.sleep(delayMillis);
+            }
+        }
+    }
+
+    static long getAttachRetryDelayMillis(int attempt) {
+        long exponentialDelay = XSTREAM_ATTACH_BASE_DELAY_MILLIS << Math.max(0, attempt - 1);
+        return Math.min(exponentialDelay, XSTREAM_ATTACH_MAX_DELAY_MILLIS);
+    }
+
+    private static StreamsException sessionBusyTimeoutException(
+            String xStreamServerName, int maxRetries, StreamsException cause) {
+        String detailMessage =
+                maxRetries > 0
+                        ? String.format(
+                                "XStream outbound server \"%s\" is still occupied by an active session after %d retries (~%d ms). Please clean the residual session and retry.",
+                                xStreamServerName,
+                                maxRetries,
+                                XSTREAM_ATTACH_TOTAL_RETRY_WINDOW_MILLIS)
+                        : String.format(
+                                "XStream outbound server \"%s\" is still occupied by an active session and retry is disabled for this path. Please clean the residual session and retry.",
+                                xStreamServerName);
+        StreamsException wrapped = new StreamsException(detailMessage);
+        wrapped.initCause(cause);
+        return wrapped;
+    }
+
+    static boolean isActiveSessionAttachedError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current.getMessage() != null
+                    && current.getMessage().contains(ACTIVE_XSTREAM_SESSION_ERROR_CODE)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    @FunctionalInterface
+    interface XStreamAttachOperation<T> {
+        T attach() throws StreamsException;
+    }
+
+    @FunctionalInterface
+    interface RetrySleeper {
+        void sleep(long delayMillis) throws InterruptedException;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleDialect.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleDialect.java
@@ -41,6 +41,8 @@ import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.relational.history.TableChanges.TableChange;
 
+import javax.annotation.Nullable;
+
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
@@ -57,6 +59,7 @@ public class OracleDialect implements JdbcDataSourceDialect {
     private transient OracleSchema oracleSchema;
 
     private transient Tables.TableFilter filters;
+    @Nullable private transient OracleStreamFetchTask streamFetchTask;
 
     @Override
     public String getName() {
@@ -153,7 +156,8 @@ public class OracleDialect implements JdbcDataSourceDialect {
         if (sourceSplitBase.isSnapshotSplit()) {
             return new OracleScanFetchTask(sourceSplitBase.asSnapshotSplit());
         } else {
-            return new OracleStreamFetchTask(sourceSplitBase.asStreamSplit());
+            this.streamFetchTask = new OracleStreamFetchTask(sourceSplitBase.asStreamSplit());
+            return this.streamFetchTask;
         }
     }
 
@@ -164,5 +168,12 @@ public class OracleDialect implements JdbcDataSourceDialect {
         }
 
         return filters.isIncluded(tableId);
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId, Offset offset) throws Exception {
+        if (streamFetchTask != null) {
+            streamFetchTask.commitCurrentOffset(offset);
+        }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleSourceBuilder.java
@@ -17,18 +17,29 @@
 
 package org.apache.flink.cdc.connectors.oracle.source;
 
+import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
 import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.base.source.jdbc.JdbcIncrementalSource;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceRecords;
+import org.apache.flink.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReaderContext;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
 import org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfigFactory;
 import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffsetFactory;
+import org.apache.flink.cdc.connectors.oracle.source.reader.OracleSourceReader;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
 import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -281,6 +292,37 @@ public class OracleSourceBuilder<T> {
                 RedoLogOffsetFactory offsetFactory,
                 OracleDialect dataSourceDialect) {
             super(configFactory, deserializationSchema, offsetFactory, dataSourceDialect);
+        }
+
+        @Override
+        public IncrementalSourceReader<T, JdbcSourceConfig> createReader(
+                SourceReaderContext readerContext) throws Exception {
+            JdbcSourceConfig sourceConfig = configFactory.create(readerContext.getIndexOfSubtask());
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue =
+                    new FutureCompletingBlockingQueue<>();
+
+            final SourceReaderMetrics sourceReaderMetrics =
+                    new SourceReaderMetrics(readerContext.metricGroup());
+
+            IncrementalSourceReaderContext incrementalSourceReaderContext =
+                    new IncrementalSourceReaderContext(readerContext);
+            Supplier<IncrementalSourceSplitReader<JdbcSourceConfig>> splitReaderSupplier =
+                    () ->
+                            new IncrementalSourceSplitReader<>(
+                                    readerContext.getIndexOfSubtask(),
+                                    dataSourceDialect,
+                                    sourceConfig,
+                                    incrementalSourceReaderContext,
+                                    snapshotHooks);
+            return new OracleSourceReader(
+                    elementsQueue,
+                    splitReaderSupplier,
+                    createRecordEmitter(sourceConfig, sourceReaderMetrics),
+                    readerContext.getConfiguration(),
+                    incrementalSourceReaderContext,
+                    sourceConfig,
+                    sourceSplitSerializer,
+                    dataSourceDialect);
         }
 
         public static <T> OracleSourceBuilder<T> builder() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactory.java
@@ -18,6 +18,7 @@
 package org.apache.flink.cdc.connectors.oracle.source.config;
 
 import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfigFactory;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 import org.apache.flink.cdc.connectors.base.source.EmbeddedFlinkDatabaseHistory;
 
 import io.debezium.config.Configuration;
@@ -136,5 +137,23 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
                 skipSnapshotBackfill,
                 scanNewlyAddedTableEnabled,
                 assignUnboundedChunkFirst);
+    }
+
+    @Override
+    public JdbcSourceConfigFactory startupOptions(StartupOptions startupOptions) {
+        switch (startupOptions.startupMode) {
+            case INITIAL:
+            case SNAPSHOT:
+            case LATEST_OFFSET:
+            case SPECIFIC_OFFSETS:
+            case COMMITTED_OFFSETS:
+            case TIMESTAMP:
+                break;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported startup mode: " + startupOptions.startupMode);
+        }
+        this.startupOptions = startupOptions;
+        return this;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffset.java
@@ -35,6 +35,7 @@ public class RedoLogOffset extends Offset {
     public static final String SCN_KEY = "scn";
     public static final String COMMIT_SCN_KEY = "commit_scn";
     public static final String LCR_POSITION_KEY = "lcr_position";
+    public static final String STARTUP_TIMESTAMP_MILLIS_KEY = "startup_timestamp_millis";
 
     public static final RedoLogOffset INITIAL_OFFSET = new RedoLogOffset(0L);
     public static final RedoLogOffset NO_STOPPING_OFFSET = new RedoLogOffset(Long.MIN_VALUE);
@@ -44,14 +45,25 @@ public class RedoLogOffset extends Offset {
     }
 
     public RedoLogOffset(Long scn) {
-        this(scn, 0L, null);
+        this(scn, 0L, null, null);
     }
 
     public RedoLogOffset(Long scn, Long commitScn, @Nullable String lcrPosition) {
+        this(scn, commitScn, lcrPosition, null);
+    }
+
+    public RedoLogOffset(
+            Long scn,
+            Long commitScn,
+            @Nullable String lcrPosition,
+            @Nullable Long startupTimestampMillis) {
         Map<String, String> offsetMap = new HashMap<>();
         offsetMap.put(SCN_KEY, String.valueOf(scn));
         offsetMap.put(COMMIT_SCN_KEY, String.valueOf(commitScn));
         offsetMap.put(LCR_POSITION_KEY, lcrPosition);
+        if (startupTimestampMillis != null) {
+            offsetMap.put(STARTUP_TIMESTAMP_MILLIS_KEY, String.valueOf(startupTimestampMillis));
+        }
         this.offset = offsetMap;
     }
 
@@ -65,6 +77,12 @@ public class RedoLogOffset extends Offset {
 
     public String getLcrPosition() {
         return offset.get(LCR_POSITION_KEY);
+    }
+
+    @Nullable
+    public Long getStartupTimestampMillis() {
+        String timestampMillis = offset.get(STARTUP_TIMESTAMP_MILLIS_KEY);
+        return timestampMillis == null ? null : Long.valueOf(timestampMillis);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffset.java
@@ -111,7 +111,22 @@ public class RedoLogOffset extends Offset {
         } else if (StringUtils.isNotEmpty(scnStr)) {
             return 1;
         }
+
+        String lcrPosition = this.getLcrPosition();
+        String targetLcrPosition = that.getLcrPosition();
+        if (isValidOffsetValue(targetLcrPosition)) {
+            if (isValidOffsetValue(lcrPosition)) {
+                return lcrPosition.compareTo(targetLcrPosition);
+            }
+            return -1;
+        } else if (isValidOffsetValue(lcrPosition)) {
+            return 1;
+        }
         return 0;
+    }
+
+    private static boolean isValidOffsetValue(String value) {
+        return StringUtils.isNotEmpty(value) && !"null".equalsIgnoreCase(value);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffsetFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffsetFactory.java
@@ -48,8 +48,7 @@ public class RedoLogOffsetFactory extends OffsetFactory {
 
     @Override
     public Offset createTimestampOffset(long timestampMillis) {
-        throw new UnsupportedOperationException(
-                "Do not support to create RedoLogOffset by timestamp.");
+        return new RedoLogOffset(0L, 0L, null, timestampMillis);
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/OracleSourceReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/OracleSourceReader.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader;
+
+import org.apache.flink.cdc.common.annotation.Experimental;
+import org.apache.flink.cdc.connectors.base.config.SourceConfig;
+import org.apache.flink.cdc.connectors.base.dialect.DataSourceDialect;
+import org.apache.flink.cdc.connectors.base.source.meta.events.LatestFinishedSplitsNumberEvent;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitSerializer;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReaderContext;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReaderWithCommit;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Oracle source reader that only externalizes stream offsets after the stream split is safe to
+ * commit.
+ *
+ * <p>When newly added table scanning is enabled, the stream split can be suspended and later
+ * recreated with a reset start offset after new snapshot metadata is collected. Offsets observed
+ * before that reset must not be committed to Oracle XStream processed low watermark.
+ */
+@Experimental
+public class OracleSourceReader extends IncrementalSourceReaderWithCommit {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OracleSourceReader.class);
+
+    private volatile boolean isCommitOffset;
+
+    public OracleSourceReader(
+            FutureCompletingBlockingQueue elementQueue,
+            Supplier supplier,
+            RecordEmitter recordEmitter,
+            Configuration config,
+            IncrementalSourceReaderContext incrementalSourceReaderContext,
+            SourceConfig sourceConfig,
+            SourceSplitSerializer sourceSplitSerializer,
+            DataSourceDialect dialect) {
+        super(
+                elementQueue,
+                supplier,
+                recordEmitter,
+                config,
+                incrementalSourceReaderContext,
+                sourceConfig,
+                sourceSplitSerializer,
+                dialect);
+        this.isCommitOffset = false;
+    }
+
+    @Override
+    protected void updateStreamSplitFinishedSplitsSize(
+            LatestFinishedSplitsNumberEvent sourceEvent) {
+        super.updateStreamSplitFinishedSplitsSize(sourceEvent);
+        isCommitOffset = true;
+    }
+
+    @Override
+    public List<SourceSplitBase> snapshotState(long checkpointId) {
+        List<SourceSplitBase> sourceSplitBases = super.snapshotState(checkpointId);
+        if (!isCommitOffset()) {
+            LOG.debug("Close Oracle XStream offset commit for checkpoint {}", checkpointId);
+            lastCheckpointOffsets.remove(checkpointId);
+        }
+        return sourceSplitBases;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (isCommitOffset()) {
+            super.notifyCheckpointComplete(checkpointId);
+        } else {
+            LOG.debug("Skip Oracle XStream offset commit for checkpoint {}", checkpointId);
+        }
+    }
+
+    private boolean isCommitOffset() {
+        return !sourceConfig.isScanNewlyAddedTableEnabled() || isCommitOffset;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/EventProcessorFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/EventProcessorFactory.java
@@ -30,6 +30,7 @@ import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
+import io.debezium.connector.oracle.logminer.events.EventType;
 import io.debezium.connector.oracle.logminer.events.LogMinerEventRow;
 import io.debezium.connector.oracle.logminer.processor.LogMinerEventProcessor;
 import io.debezium.connector.oracle.logminer.processor.infinispan.EmbeddedInfinispanLogMinerEventProcessor;
@@ -65,7 +66,8 @@ public class EventProcessorFactory {
             OracleDatabaseSchema schema,
             OracleStreamingChangeEventSourceMetrics metrics,
             ErrorHandler errorHandler,
-            StreamSplit redoLogSplit) {
+            StreamSplit redoLogSplit,
+            Long startupTimestampMillis) {
         final OracleConnectorConfig.LogMiningBufferType bufferType =
                 connectorConfig.getLogMiningBufferType();
         if (bufferType.equals(OracleConnectorConfig.LogMiningBufferType.MEMORY)) {
@@ -80,7 +82,8 @@ public class EventProcessorFactory {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         } else if (bufferType.equals(
                 OracleConnectorConfig.LogMiningBufferType.INFINISPAN_EMBEDDED)) {
             return new CDCEmbeddedInfinispanLogMinerEventProcessor(
@@ -94,7 +97,8 @@ public class EventProcessorFactory {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         } else if (bufferType.equals(OracleConnectorConfig.LogMiningBufferType.INFINISPAN_REMOTE)) {
             return new CDCRemoteInfinispanLogMinerEventProcessor(
                     context,
@@ -107,7 +111,8 @@ public class EventProcessorFactory {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         } else {
             throw new IllegalArgumentException(
                     "not support this type of bufferType: " + bufferType);
@@ -124,6 +129,7 @@ public class EventProcessorFactory {
 
         private ChangeEventSource.ChangeEventSourceContext context;
         private final WatermarkDispatcher watermarkDispatcher;
+        private final StartupTimestampFilter startupTimestampFilter;
 
         public CDCMemoryLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
@@ -136,7 +142,8 @@ public class EventProcessorFactory {
                 OracleDatabaseSchema schema,
                 OracleStreamingChangeEventSourceMetrics metrics,
                 ErrorHandler errorHandler,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     context,
                     connectorConfig,
@@ -150,6 +157,7 @@ public class EventProcessorFactory {
             this.errorHandler = errorHandler;
             this.context = context;
             this.watermarkDispatcher = watermarkDispatcher;
+            this.startupTimestampFilter = new StartupTimestampFilter(startupTimestampMillis);
         }
 
         @Override
@@ -157,6 +165,9 @@ public class EventProcessorFactory {
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
                     partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
+                return;
+            }
+            if (startupTimestampFilter.shouldSkip(row)) {
                 return;
             }
             super.processRow(partition, row);
@@ -174,6 +185,7 @@ public class EventProcessorFactory {
 
         private ChangeEventSource.ChangeEventSourceContext context;
         private final WatermarkDispatcher watermarkDispatcher;
+        private final StartupTimestampFilter startupTimestampFilter;
 
         public CDCEmbeddedInfinispanLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
@@ -186,7 +198,8 @@ public class EventProcessorFactory {
                 OracleDatabaseSchema schema,
                 OracleStreamingChangeEventSourceMetrics metrics,
                 ErrorHandler errorHandler,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     context,
                     connectorConfig,
@@ -200,6 +213,7 @@ public class EventProcessorFactory {
             this.errorHandler = errorHandler;
             this.context = context;
             this.watermarkDispatcher = watermarkDispatcher;
+            this.startupTimestampFilter = new StartupTimestampFilter(startupTimestampMillis);
         }
 
         @Override
@@ -207,6 +221,9 @@ public class EventProcessorFactory {
                 throws SQLException, InterruptedException {
             if (reachEndingOffset(
                     partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
+                return;
+            }
+            if (startupTimestampFilter.shouldSkip(row)) {
                 return;
             }
             super.processRow(partition, row);
@@ -224,6 +241,7 @@ public class EventProcessorFactory {
 
         private ChangeEventSource.ChangeEventSourceContext context;
         private final WatermarkDispatcher watermarkDispatcher;
+        private final StartupTimestampFilter startupTimestampFilter;
 
         public CDCRemoteInfinispanLogMinerEventProcessor(
                 ChangeEventSource.ChangeEventSourceContext context,
@@ -236,7 +254,8 @@ public class EventProcessorFactory {
                 OracleDatabaseSchema schema,
                 OracleStreamingChangeEventSourceMetrics metrics,
                 ErrorHandler errorHandler,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     context,
                     connectorConfig,
@@ -250,6 +269,7 @@ public class EventProcessorFactory {
             this.errorHandler = errorHandler;
             this.context = context;
             this.watermarkDispatcher = watermarkDispatcher;
+            this.startupTimestampFilter = new StartupTimestampFilter(startupTimestampMillis);
         }
 
         @Override
@@ -259,8 +279,63 @@ public class EventProcessorFactory {
                     partition, row, redoLogSplit, errorHandler, watermarkDispatcher, context)) {
                 return;
             }
+            if (startupTimestampFilter.shouldSkip(row)) {
+                return;
+            }
             super.processRow(partition, row);
         }
+    }
+
+    private static class StartupTimestampFilter {
+        private final Long startupTimestampMillis;
+        private boolean reachedTimestamp;
+        private long filtered;
+        private boolean seekStarted;
+
+        private StartupTimestampFilter(Long startupTimestampMillis) {
+            this.startupTimestampMillis = startupTimestampMillis;
+        }
+
+        private boolean shouldSkip(LogMinerEventRow row) {
+            if (startupTimestampMillis == null
+                    || reachedTimestamp
+                    || !isRowMutation(row.getEventType())) {
+                return false;
+            }
+            if (!seekStarted) {
+                seekStarted = true;
+                LOG.info(
+                        "Begin to seek Oracle redo log to startup timestamp {}.",
+                        startupTimestampMillis);
+            }
+            if (row.getChangeTime() != null
+                    && row.getChangeTime().toEpochMilli() >= startupTimestampMillis) {
+                reachedTimestamp = true;
+                LOG.info(
+                        "Successfully seek Oracle redo log to startup timestamp {} with filtered {} change events.",
+                        startupTimestampMillis,
+                        filtered);
+                return false;
+            }
+            filtered++;
+            if (filtered % 10000 == 0) {
+                LOG.info(
+                        "Seeking Oracle redo log to startup timestamp {} with filtered {} change events.",
+                        startupTimestampMillis,
+                        filtered);
+            }
+            return true;
+        }
+    }
+
+    private static boolean isRowMutation(EventType eventType) {
+        return EventType.INSERT.equals(eventType)
+                || EventType.UPDATE.equals(eventType)
+                || EventType.DELETE.equals(eventType)
+                || EventType.SELECT_LOB_LOCATOR.equals(eventType)
+                || EventType.LOB_WRITE.equals(eventType)
+                || EventType.LOB_ERASE.equals(eventType)
+                || EventType.LOB_TRIM.equals(eventType);
     }
 
     public static boolean reachEndingOffset(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -141,7 +141,8 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                 context.getDatabaseSchema(),
                 context.getSourceConfig().getOriginDbzConnectorConfig(),
                 context.getStreamingChangeEventSourceMetrics(),
-                backfillRedoLogSplit);
+                backfillRedoLogSplit,
+                null);
     }
 
     /** A wrapped task to fetch snapshot split of table. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -28,7 +28,6 @@ import io.debezium.connector.oracle.OracleConnectorConfig;
 import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleOffsetContext;
 import io.debezium.connector.oracle.OraclePartition;
-import io.debezium.connector.oracle.logminer.LogMinerOracleOffsetContextLoader;
 import io.debezium.heartbeat.Heartbeat;
 import io.debezium.pipeline.EventDispatcher;
 import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
@@ -53,6 +52,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 
 import static org.apache.flink.cdc.connectors.oracle.source.reader.fetch.OracleStreamFetchTask.RedoLogSplitReadTask;
+import static org.apache.flink.cdc.connectors.oracle.source.reader.fetch.OracleStreamFetchTask.XStreamSplitReadTask;
 import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleUtils.buildSplitScanQuery;
 import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleUtils.readTableSplitDataStatement;
 
@@ -94,46 +94,51 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
             throws Exception {
         OracleSourceFetchTaskContext sourceFetchContext = (OracleSourceFetchTaskContext) context;
 
-        final RedoLogSplitReadTask backfillRedoLogReadTask =
-                createBackfillRedoLogReadTask(backfillStreamSplit, sourceFetchContext);
+        OracleConnectorConfig backfillConnectorConfig =
+                createBackfillConnectorConfig(sourceFetchContext);
+        OracleStreamFetchTask.validateAdapterSupportsSplit(
+                backfillConnectorConfig, backfillStreamSplit);
 
-        final LogMinerOracleOffsetContextLoader loader =
-                new LogMinerOracleOffsetContextLoader(
-                        ((OracleSourceFetchTaskContext) context).getDbzConnectorConfig());
         final OracleOffsetContext oracleOffsetContext =
-                loader.load(backfillStreamSplit.getStartingOffset().getOffset());
-        backfillRedoLogReadTask.execute(
-                new StoppableChangeEventSourceContext(),
-                sourceFetchContext.getPartition(),
-                oracleOffsetContext);
+                OracleSourceFetchTaskContext.createOffsetContextLoader(backfillConnectorConfig)
+                        .load(backfillStreamSplit.getStartingOffset().getOffset());
+
+        if (OracleSourceFetchTaskContext.isLogMinerAdapter(backfillConnectorConfig)) {
+            final RedoLogSplitReadTask backfillRedoLogReadTask =
+                    createBackfillRedoLogReadTask(
+                            backfillConnectorConfig, backfillStreamSplit, sourceFetchContext);
+            backfillRedoLogReadTask.execute(
+                    new StoppableChangeEventSourceContext(),
+                    sourceFetchContext.getPartition(),
+                    oracleOffsetContext);
+            return;
+        }
+
+        if (OracleSourceFetchTaskContext.isXStreamAdapter(backfillConnectorConfig)) {
+            StoppableChangeEventSourceContext changeEventSourceContext =
+                    new StoppableChangeEventSourceContext();
+            XStreamSplitReadTask backfillXstreamSplitReadTask =
+                    createBackfillXstreamReadTask(
+                            backfillConnectorConfig, backfillStreamSplit, sourceFetchContext);
+            backfillXstreamSplitReadTask.execute(
+                    changeEventSourceContext,
+                    sourceFetchContext.getPartition(),
+                    oracleOffsetContext);
+            return;
+        }
+
+        throw new UnsupportedOperationException(
+                String.format(
+                        "Oracle adapter %s does not support backfill task yet",
+                        backfillConnectorConfig.getAdapter().getType()));
     }
 
     private RedoLogSplitReadTask createBackfillRedoLogReadTask(
-            StreamSplit backfillRedoLogSplit, OracleSourceFetchTaskContext context) {
-        // we should only capture events for the current table,
-        // otherwise, we may can't find corresponding schema
-        Configuration dezConf =
-                context.getSourceConfig()
-                        .getDbzConfiguration()
-                        .edit()
-                        // It will cause data loss before.
-                        // Because the table name contains the database
-                        // prefix when logminer queries the redo log, but in fact the
-                        // logminer content does not contain the database prefix,
-                        // this will cause the back fill tofail,
-                        // thereby affecting data consistency.
-                        .with(
-                                "table.include.list",
-                                String.format(
-                                        "%s.%s",
-                                        snapshotSplit.getTableId().schema(),
-                                        snapshotSplit.getTableId().table()))
-                        // Disable heartbeat event in snapshot split fetcher
-                        .with(Heartbeat.HEARTBEAT_INTERVAL, 0)
-                        .build();
-        // task to read redo log and backfill for current split
+            OracleConnectorConfig backfillConnectorConfig,
+            StreamSplit backfillRedoLogSplit,
+            OracleSourceFetchTaskContext context) {
         return new RedoLogSplitReadTask(
-                new OracleConnectorConfig(dezConf),
+                backfillConnectorConfig,
                 context.getConnection(),
                 context.getEventDispatcher(),
                 context.getWaterMarkDispatcher(),
@@ -143,6 +148,32 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                 context.getStreamingChangeEventSourceMetrics(),
                 backfillRedoLogSplit,
                 null);
+    }
+
+    private XStreamSplitReadTask createBackfillXstreamReadTask(
+            OracleConnectorConfig backfillConnectorConfig,
+            StreamSplit backfillStreamSplit,
+            OracleSourceFetchTaskContext context) {
+        return XStreamSplitReadTask.createTask(
+                backfillConnectorConfig, context, backfillStreamSplit, null);
+    }
+
+    private OracleConnectorConfig createBackfillConnectorConfig(
+            OracleSourceFetchTaskContext context) {
+        Configuration dezConf =
+                context.getSourceConfig()
+                        .getDbzConfiguration()
+                        .edit()
+                        .with(
+                                "table.include.list",
+                                String.format(
+                                        "%s.%s",
+                                        snapshotSplit.getTableId().schema(),
+                                        snapshotSplit.getTableId().table()))
+                        // Disable heartbeat event in snapshot split fetcher
+                        .with(Heartbeat.HEARTBEAT_INTERVAL, 0)
+                        .build();
+        return new OracleConnectorConfig(dezConf);
     }
 
     /** A wrapped task to fetch snapshot split of table. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
@@ -70,8 +70,10 @@ import org.slf4j.LoggerFactory;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.Map;
+import java.util.function.Function;
 
 import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleConnectionUtils.createOracleConnection;
+import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleConnectionUtils.resolveRedoLogOffsetByTimestamp;
 import static org.apache.flink.cdc.connectors.oracle.util.ChunkUtils.getChunkKeyColumn;
 
 /** The context for fetch task that fetching data of snapshot split from Oracle data source. */
@@ -86,6 +88,7 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     private OracleTaskContext taskContext;
     private OracleOffsetContext offsetContext;
     private OraclePartition partition;
+    private Long startupTimestampMillis;
 
     private SnapshotChangeEventSourceMetrics<OraclePartition> snapshotChangeEventSourceMetrics;
     private OracleStreamingChangeEventSourceMetrics streamingChangeEventSourceMetrics;
@@ -272,12 +275,54 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
     /** Loads the connector's persistent offset (if present) via the given loader. */
     private OracleOffsetContext loadStartingOffsetState(
             OffsetContext.Loader<OracleOffsetContext> loader, SourceSplitBase oracleSplit) {
-        Offset offset =
-                oracleSplit.isSnapshotSplit()
-                        ? RedoLogOffset.INITIAL_OFFSET
-                        : oracleSplit.asStreamSplit().getStartingOffset();
+        StartingOffsetResolution resolution =
+                resolveStartingOffset(
+                        oracleSplit,
+                        timestampMillis ->
+                                resolveRedoLogOffsetByTimestamp(connection, timestampMillis));
+        startupTimestampMillis = resolution.startupTimestampMillis;
+        return loader.load(resolution.offset.getOffset());
+    }
 
-        return loader.load(offset.getOffset());
+    public Long getStartupTimestampMillis() {
+        return startupTimestampMillis;
+    }
+
+    static StartingOffsetResolution resolveStartingOffset(
+            SourceSplitBase oracleSplit, Function<Long, Offset> timestampOffsetResolver) {
+        Offset offset = RedoLogOffset.INITIAL_OFFSET;
+        Long resolvedStartupTimestampMillis = null;
+        if (!oracleSplit.isSnapshotSplit()) {
+            offset = oracleSplit.asStreamSplit().getStartingOffset();
+            if (offset instanceof RedoLogOffset) {
+                final Long splitStartupTimestampMillis =
+                        ((RedoLogOffset) offset).getStartupTimestampMillis();
+                if (splitStartupTimestampMillis != null) {
+                    resolvedStartupTimestampMillis = splitStartupTimestampMillis;
+                    offset = timestampOffsetResolver.apply(splitStartupTimestampMillis);
+                }
+            }
+        }
+
+        return new StartingOffsetResolution(offset, resolvedStartupTimestampMillis);
+    }
+
+    static class StartingOffsetResolution {
+        private final Offset offset;
+        private final Long startupTimestampMillis;
+
+        private StartingOffsetResolution(Offset offset, Long startupTimestampMillis) {
+            this.offset = offset;
+            this.startupTimestampMillis = startupTimestampMillis;
+        }
+
+        Offset getOffset() {
+            return offset;
+        }
+
+        Long getStartupTimestampMillis() {
+            return startupTimestampMillis;
+        }
     }
 
     private void validateAndLoadDatabaseHistory(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
@@ -46,7 +46,6 @@ import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.OracleTaskContext;
 import io.debezium.connector.oracle.OracleTopicSelector;
 import io.debezium.connector.oracle.SourceInfo;
-import io.debezium.connector.oracle.logminer.LogMinerOracleOffsetContextLoader;
 import io.debezium.data.Envelope;
 import io.debezium.pipeline.DataChangeEvent;
 import io.debezium.pipeline.ErrorHandler;
@@ -62,7 +61,8 @@ import io.debezium.schema.TopicSelector;
 import io.debezium.util.Collect;
 import oracle.sql.ROWID;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,10 +115,9 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                         .getString(EmbeddedFlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME),
                 sourceSplitBase.getTableSchemas().values());
         this.databaseSchema = OracleUtils.createOracleDatabaseSchema(connectorConfig, connection);
-        // todo logMiner or xStream
         this.offsetContext =
                 loadStartingOffsetState(
-                        new LogMinerOracleOffsetContextLoader(connectorConfig), sourceSplitBase);
+                        createOffsetContextLoader(connectorConfig), sourceSplitBase);
         this.partition = new OraclePartition(connectorConfig.getLogicalName());
         validateAndLoadDatabaseHistory(offsetContext, databaseSchema);
 
@@ -217,20 +216,52 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
 
         // RowId is chunk key column by default, compare RowId
         if (splitKeyType.getFieldNames().contains(ROWID.class.getSimpleName())) {
-            ConnectHeaders headers = (ConnectHeaders) record.headers();
-            ROWID rowId = null;
-            try {
-                rowId = new ROWID(headers.iterator().next().value().toString());
-            } catch (SQLException e) {
-                LOG.error("{} can not convert to RowId", record);
-            }
-            Object[] rowIds = new ROWID[] {rowId};
+            TableId tableId = SourceRecordUtils.getTableId(record);
+            ROWID rowId = parseRowIdFromHeaders(record.headers(), tableId);
+            Object[] rowIds = new Object[] {rowId};
             return SplitKeyUtils.splitKeyRangeContains(rowIds, splitStart, splitEnd);
         } else {
             // config chunk key column compare
             Object[] key = SplitKeyUtils.getSplitKey(splitKeyType, record, getSchemaNameAdjuster());
             return SplitKeyUtils.splitKeyRangeContains(key, splitStart, splitEnd);
         }
+    }
+
+    static ROWID parseRowIdFromHeaders(Headers headers, TableId tableId) {
+        for (Header header : headers) {
+            if (!ROWID.class.getSimpleName().equals(header.key()) || header.value() == null) {
+                continue;
+            }
+            Object value = header.value();
+            if (value instanceof ROWID) {
+                return (ROWID) value;
+            }
+            if (!(value instanceof String)) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Invalid ROWID header type %s for table %s. Configure "
+                                        + "'scan.incremental.snapshot.chunk.key-column' to a stable primary key "
+                                        + "or enable 'scan.incremental.snapshot.backfill.skip=true'.",
+                                value.getClass().getName(), tableId));
+            }
+            try {
+                return new ROWID((String) value);
+            } catch (SQLException e) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Invalid ROWID header for table %s. Configure "
+                                        + "'scan.incremental.snapshot.chunk.key-column' to a stable primary key "
+                                        + "or enable 'scan.incremental.snapshot.backfill.skip=true'.",
+                                tableId),
+                        e);
+            }
+        }
+        throw new IllegalStateException(
+                String.format(
+                        "Missing ROWID header for table %s while using default ROWID split key. "
+                                + "Configure 'scan.incremental.snapshot.chunk.key-column' to a stable primary key "
+                                + "or enable 'scan.incremental.snapshot.backfill.skip=true'.",
+                        tableId));
     }
 
     @Override
@@ -286,6 +317,23 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
 
     public Long getStartupTimestampMillis() {
         return startupTimestampMillis;
+    }
+
+    public OracleTaskContext getTaskContext() {
+        return taskContext;
+    }
+
+    static OffsetContext.Loader<OracleOffsetContext> createOffsetContextLoader(
+            OracleConnectorConfig connectorConfig) {
+        return connectorConfig.getAdapter().getOffsetContextLoader();
+    }
+
+    static boolean isLogMinerAdapter(OracleConnectorConfig connectorConfig) {
+        return "logminer".equalsIgnoreCase(connectorConfig.getAdapter().getType());
+    }
+
+    static boolean isXStreamAdapter(OracleConnectorConfig connectorConfig) {
+        return "xstream".equalsIgnoreCase(connectorConfig.getAdapter().getType());
     }
 
     static StartingOffsetResolution resolveStartingOffset(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
@@ -64,7 +64,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                         sourceFetchContext.getDatabaseSchema(),
                         sourceFetchContext.getSourceConfig().getOriginDbzConnectorConfig(),
                         sourceFetchContext.getStreamingChangeEventSourceMetrics(),
-                        split);
+                        split,
+                        sourceFetchContext.getStartupTimestampMillis());
         StoppableChangeEventSourceContext changeEventSourceContext =
                 new StoppableChangeEventSourceContext();
         redoLogSplitReadTask.execute(
@@ -105,6 +106,7 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
         private final OracleDatabaseSchema schema;
 
         private final OracleStreamingChangeEventSourceMetrics metrics;
+        private final Long startupTimestampMillis;
 
         public RedoLogSplitReadTask(
                 OracleConnectorConfig connectorConfig,
@@ -115,7 +117,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                 OracleDatabaseSchema schema,
                 Configuration jdbcConfig,
                 OracleStreamingChangeEventSourceMetrics metrics,
-                StreamSplit redoLogSplit) {
+                StreamSplit redoLogSplit,
+                Long startupTimestampMillis) {
             super(
                     connectorConfig,
                     connection,
@@ -133,6 +136,7 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
             this.connection = connection;
             this.metrics = metrics;
             this.schema = schema;
+            this.startupTimestampMillis = startupTimestampMillis;
         }
 
         @Override
@@ -163,7 +167,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                     schema,
                     metrics,
                     errorHandler,
-                    redoLogSplit);
+                    redoLogSplit,
+                    startupTimestampMillis);
         }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTask.java
@@ -18,11 +18,16 @@
 package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
 
 import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
 import org.apache.flink.cdc.connectors.base.WatermarkDispatcher;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
 import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitBase;
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.base.source.meta.wartermark.WatermarkKind;
 import org.apache.flink.cdc.connectors.base.source.reader.external.FetchTask;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
 
+import io.debezium.DebeziumException;
 import io.debezium.config.Configuration;
 import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.OracleConnectorConfig;
@@ -32,19 +37,30 @@ import io.debezium.connector.oracle.OraclePartition;
 import io.debezium.connector.oracle.OracleStreamingChangeEventSourceMetrics;
 import io.debezium.connector.oracle.logminer.LogMinerStreamingChangeEventSource;
 import io.debezium.connector.oracle.logminer.processor.LogMinerEventProcessor;
+import io.debezium.connector.oracle.xstream.XstreamStreamingChangeEventSource;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 /** The task to work for fetching data of Oracle table stream split. */
 @Internal
 public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(OracleStreamFetchTask.class);
+    private static final String XSTREAM_COMMIT_PROCESSED_LOW_WATERMARK_ENABLED =
+            "xstream.commit.processed.low.watermark.enabled";
+
     private final StreamSplit split;
     private volatile boolean taskRunning = false;
+    private volatile RunningChangeEventSource runningChangeEventSource;
+    @Nullable private volatile Offset lastCommittedOffset;
 
     public OracleStreamFetchTask(StreamSplit split) {
         this.split = split;
@@ -54,9 +70,27 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
     public void execute(Context context) throws Exception {
         OracleSourceFetchTaskContext sourceFetchContext = (OracleSourceFetchTaskContext) context;
         taskRunning = true;
+        final OracleConnectorConfig connectorConfig = sourceFetchContext.getDbzConnectorConfig();
+        validateAdapterSupportsSplit(connectorConfig, split);
+
+        if (OracleSourceFetchTaskContext.isLogMinerAdapter(connectorConfig)) {
+            executeLogMinerTask(sourceFetchContext, connectorConfig);
+            return;
+        }
+        if (OracleSourceFetchTaskContext.isXStreamAdapter(connectorConfig)) {
+            executeXStreamTask(sourceFetchContext, connectorConfig);
+            return;
+        }
+
+        executeWithAdapter(sourceFetchContext, connectorConfig);
+    }
+
+    private void executeLogMinerTask(
+            OracleSourceFetchTaskContext sourceFetchContext,
+            OracleConnectorConfig connectorConfig) {
         RedoLogSplitReadTask redoLogSplitReadTask =
                 new RedoLogSplitReadTask(
-                        sourceFetchContext.getDbzConnectorConfig(),
+                        connectorConfig,
                         sourceFetchContext.getConnection(),
                         sourceFetchContext.getEventDispatcher(),
                         sourceFetchContext.getWaterMarkDispatcher(),
@@ -68,10 +102,93 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                         sourceFetchContext.getStartupTimestampMillis());
         StoppableChangeEventSourceContext changeEventSourceContext =
                 new StoppableChangeEventSourceContext();
-        redoLogSplitReadTask.execute(
-                changeEventSourceContext,
-                sourceFetchContext.getPartition(),
-                sourceFetchContext.getOffsetContext());
+        RunningChangeEventSource runningChangeEventSource =
+                registerRunningChangeEventSource(changeEventSourceContext, null);
+        try {
+            redoLogSplitReadTask.execute(
+                    changeEventSourceContext,
+                    sourceFetchContext.getPartition(),
+                    sourceFetchContext.getOffsetContext());
+        } finally {
+            clearRunningChangeEventSource(runningChangeEventSource);
+        }
+    }
+
+    private void executeWithAdapter(
+            OracleSourceFetchTaskContext sourceFetchContext, OracleConnectorConfig connectorConfig)
+            throws InterruptedException {
+        StreamingChangeEventSource<OraclePartition, OracleOffsetContext> streamingSource =
+                connectorConfig
+                        .getAdapter()
+                        .getSource(
+                                sourceFetchContext.getConnection(),
+                                sourceFetchContext.getEventDispatcher(),
+                                sourceFetchContext.getErrorHandler(),
+                                Clock.SYSTEM,
+                                sourceFetchContext.getDatabaseSchema(),
+                                sourceFetchContext.getTaskContext(),
+                                sourceFetchContext.getSourceConfig().getOriginDbzConnectorConfig(),
+                                sourceFetchContext.getStreamingChangeEventSourceMetrics());
+
+        StoppableChangeEventSourceContext changeEventSourceContext =
+                new StoppableChangeEventSourceContext();
+        XstreamStreamingChangeEventSource xstreamStreamingSource =
+                streamingSource instanceof XstreamStreamingChangeEventSource
+                        ? (XstreamStreamingChangeEventSource) streamingSource
+                        : null;
+        RunningChangeEventSource runningChangeEventSource =
+                registerRunningChangeEventSource(
+                        changeEventSourceContext,
+                        xstreamStreamingSource,
+                        isXStreamCommitProcessedLowWatermarkEnabled(sourceFetchContext));
+        try {
+            streamingSource.execute(
+                    changeEventSourceContext,
+                    sourceFetchContext.getPartition(),
+                    sourceFetchContext.getOffsetContext());
+        } finally {
+            clearRunningChangeEventSource(runningChangeEventSource);
+        }
+    }
+
+    private void executeXStreamTask(
+            OracleSourceFetchTaskContext sourceFetchContext, OracleConnectorConfig connectorConfig)
+            throws InterruptedException {
+        StoppableChangeEventSourceContext changeEventSourceContext =
+                new StoppableChangeEventSourceContext();
+        XStreamSplitReadTask xstreamFetchTask =
+                XStreamSplitReadTask.createTask(
+                        connectorConfig,
+                        sourceFetchContext,
+                        split,
+                        sourceFetchContext.getStartupTimestampMillis());
+        RunningChangeEventSource runningChangeEventSource =
+                registerRunningChangeEventSource(
+                        changeEventSourceContext,
+                        xstreamFetchTask,
+                        isXStreamCommitProcessedLowWatermarkEnabled(sourceFetchContext));
+        try {
+            xstreamFetchTask.execute(
+                    changeEventSourceContext,
+                    sourceFetchContext.getPartition(),
+                    sourceFetchContext.getOffsetContext());
+        } finally {
+            clearRunningChangeEventSource(runningChangeEventSource);
+        }
+    }
+
+    static void validateAdapterSupportsSplit(
+            OracleConnectorConfig connectorConfig, StreamSplit streamSplit) {
+        if (RedoLogOffset.NO_STOPPING_OFFSET.equals(streamSplit.getEndingOffset())) {
+            return;
+        }
+        if (OracleSourceFetchTaskContext.isLogMinerAdapter(connectorConfig)) {
+            return;
+        }
+        throw new DebeziumException(
+                String.format(
+                        "Oracle adapter '%s' does not support bounded stream split backfill yet.",
+                        connectorConfig.getAdapter().getType()));
     }
 
     @Override
@@ -87,6 +204,118 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
     @Override
     public void close() {
         taskRunning = false;
+        RunningChangeEventSource runningChangeEventSource = this.runningChangeEventSource;
+        if (runningChangeEventSource != null) {
+            runningChangeEventSource.stop();
+        }
+    }
+
+    RunningChangeEventSource registerRunningChangeEventSource(
+            StoppableChangeEventSourceContext changeEventSourceContext,
+            XstreamStreamingChangeEventSource xstreamStreamingSource) {
+        return registerRunningChangeEventSource(
+                changeEventSourceContext, xstreamStreamingSource, false);
+    }
+
+    RunningChangeEventSource registerRunningChangeEventSource(
+            StoppableChangeEventSourceContext changeEventSourceContext,
+            XstreamStreamingChangeEventSource xstreamStreamingSource,
+            boolean commitProcessedLowWatermarkEnabled) {
+        RunningChangeEventSource runningChangeEventSource =
+                new ActiveChangeEventSource(
+                        changeEventSourceContext,
+                        xstreamStreamingSource,
+                        commitProcessedLowWatermarkEnabled);
+        this.runningChangeEventSource = runningChangeEventSource;
+        return runningChangeEventSource;
+    }
+
+    void clearRunningChangeEventSource(RunningChangeEventSource runningChangeEventSource) {
+        if (this.runningChangeEventSource == runningChangeEventSource) {
+            this.runningChangeEventSource = null;
+        }
+    }
+
+    public void commitCurrentOffset(@Nullable Offset offsetToCommit) {
+        if (offsetToCommit == null) {
+            return;
+        }
+        if (lastCommittedOffset != null && offsetToCommit.compareTo(lastCommittedOffset) <= 0) {
+            return;
+        }
+
+        RunningChangeEventSource current = this.runningChangeEventSource;
+        if (current != null && current.commitOffset(offsetToCommit)) {
+            lastCommittedOffset = offsetToCommit;
+            LOG.info("Committed Oracle stream offset {} for {}", offsetToCommit, split);
+        }
+    }
+
+    private boolean isXStreamCommitProcessedLowWatermarkEnabled(
+            OracleSourceFetchTaskContext sourceFetchContext) {
+        return Boolean.parseBoolean(
+                sourceFetchContext
+                        .getSourceConfig()
+                        .getOriginDbzConnectorConfig()
+                        .getString(XSTREAM_COMMIT_PROCESSED_LOW_WATERMARK_ENABLED, "false"));
+    }
+
+    @VisibleForTesting
+    void setRunningChangeEventSource(RunningChangeEventSource runningChangeEventSource) {
+        this.runningChangeEventSource = runningChangeEventSource;
+    }
+
+    interface RunningChangeEventSource {
+        void stop();
+
+        default boolean commitOffset(Offset offset) {
+            return false;
+        }
+    }
+
+    private static final class ActiveChangeEventSource implements RunningChangeEventSource {
+
+        private final StoppableChangeEventSourceContext changeEventSourceContext;
+        private final XstreamStreamingChangeEventSource xstreamStreamingSource;
+        private final boolean commitProcessedLowWatermarkEnabled;
+
+        private ActiveChangeEventSource(
+                StoppableChangeEventSourceContext changeEventSourceContext,
+                XstreamStreamingChangeEventSource xstreamStreamingSource,
+                boolean commitProcessedLowWatermarkEnabled) {
+            this.changeEventSourceContext = changeEventSourceContext;
+            this.xstreamStreamingSource = xstreamStreamingSource;
+            this.commitProcessedLowWatermarkEnabled = commitProcessedLowWatermarkEnabled;
+        }
+
+        @Override
+        public void stop() {
+            changeEventSourceContext.stopChangeEventSource();
+            if (xstreamStreamingSource != null) {
+                xstreamStreamingSource.closeXStreamSession();
+            }
+        }
+
+        @Override
+        public boolean commitOffset(Offset offset) {
+            if (xstreamStreamingSource == null) {
+                return false;
+            }
+            if (!commitProcessedLowWatermarkEnabled) {
+                LOG.debug(
+                        "Skip committing Oracle XStream offset because {} is disabled: {}",
+                        XSTREAM_COMMIT_PROCESSED_LOW_WATERMARK_ENABLED,
+                        offset);
+                return false;
+            }
+            String lcrPosition = offset.getOffset().get(RedoLogOffset.LCR_POSITION_KEY);
+            if (lcrPosition == null || "null".equalsIgnoreCase(lcrPosition)) {
+                LOG.debug("Skip committing Oracle XStream offset without LCR position: {}", offset);
+                return false;
+            }
+            xstreamStreamingSource.commitOffset(offset.getOffset());
+            return true;
+        }
     }
 
     /**
@@ -168,6 +397,98 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                     metrics,
                     errorHandler,
                     redoLogSplit,
+                    startupTimestampMillis);
+        }
+    }
+
+    /** Task to read XStream events and stop when reaching split ending watermark. */
+    public static class XStreamSplitReadTask extends XstreamStreamingChangeEventSource {
+
+        private final WatermarkDispatcher watermarkDispatcher;
+        private final StreamSplit streamSplit;
+        private boolean endWatermarkDispatched;
+
+        public XStreamSplitReadTask(
+                OracleConnectorConfig connectorConfig,
+                OracleConnection connection,
+                EventDispatcher<OraclePartition, TableId> eventDispatcher,
+                ErrorHandler errorHandler,
+                OracleDatabaseSchema schema,
+                OracleStreamingChangeEventSourceMetrics metrics,
+                WatermarkDispatcher watermarkDispatcher,
+                StreamSplit streamSplit,
+                Long startupTimestampMillis) {
+            super(
+                    connectorConfig,
+                    connection,
+                    eventDispatcher,
+                    errorHandler,
+                    Clock.SYSTEM,
+                    schema,
+                    metrics,
+                    startupTimestampMillis);
+            this.watermarkDispatcher = watermarkDispatcher;
+            this.streamSplit = streamSplit;
+        }
+
+        @Override
+        protected void onAfterReceive(
+                ChangeEventSource.ChangeEventSourceContext context,
+                OraclePartition partition,
+                OracleOffsetContext offsetContext)
+                throws InterruptedException {
+            if (reachEndingOffset(context, partition, offsetContext)) {
+                return;
+            }
+            super.onAfterReceive(context, partition, offsetContext);
+        }
+
+        @Override
+        protected int getAttachBusyRetryTimes() {
+            return 0;
+        }
+
+        private boolean reachEndingOffset(
+                ChangeEventSource.ChangeEventSourceContext sourceContext,
+                OraclePartition partition,
+                OracleOffsetContext offsetContext)
+                throws InterruptedException {
+            if (endWatermarkDispatched
+                    || RedoLogOffset.NO_STOPPING_OFFSET.equals(streamSplit.getEndingOffset())) {
+                return false;
+            }
+            if (offsetContext.getScn() == null) {
+                return false;
+            }
+
+            RedoLogOffset currentOffset = new RedoLogOffset(offsetContext.getScn().longValue());
+            if (!currentOffset.isAtOrAfter(streamSplit.getEndingOffset())) {
+                return false;
+            }
+
+            watermarkDispatcher.dispatchWatermarkEvent(
+                    partition.getSourcePartition(), streamSplit, currentOffset, WatermarkKind.END);
+            endWatermarkDispatched = true;
+            if (sourceContext instanceof StoppableChangeEventSourceContext) {
+                ((StoppableChangeEventSourceContext) sourceContext).stopChangeEventSource();
+            }
+            return true;
+        }
+
+        static XStreamSplitReadTask createTask(
+                OracleConnectorConfig connectorConfig,
+                OracleSourceFetchTaskContext sourceFetchContext,
+                StreamSplit streamSplit,
+                Long startupTimestampMillis) {
+            return new XStreamSplitReadTask(
+                    connectorConfig,
+                    sourceFetchContext.getConnection(),
+                    sourceFetchContext.getEventDispatcher(),
+                    sourceFetchContext.getErrorHandler(),
+                    sourceFetchContext.getDatabaseSchema(),
+                    sourceFetchContext.getStreamingChangeEventSourceMetrics(),
+                    sourceFetchContext.getWaterMarkDispatcher(),
+                    streamSplit,
                     startupTimestampMillis);
         }
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtils.java
@@ -22,6 +22,7 @@ import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
 import org.apache.flink.util.FlinkRuntimeException;
 
 import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnection;
 import io.debezium.connector.oracle.Scn;
 import io.debezium.jdbc.JdbcConfiguration;
 import io.debezium.jdbc.JdbcConnection;
@@ -31,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -46,8 +49,19 @@ public class OracleConnectionUtils {
     /** Returned by column metadata in Oracle if no scale is set. */
     private static final int ORACLE_UNSET_SCALE = -127;
 
+    private static final int ORA_TIMESTAMP_TO_SCN_OUT_OF_RANGE = 8181;
+    private static final int ORA_TIMESTAMP_TO_SCN_INVALID_TIMESTAMP = 8186;
+
     /** show current scn sql in oracle. */
     private static final String SHOW_CURRENT_SCN = "SELECT CURRENT_SCN FROM V$DATABASE";
+
+    private static final String SHOW_SCN_BY_TIMESTAMP = "SELECT timestamp_to_scn(?) FROM DUAL";
+    private static final String SHOW_OLDEST_AVAILABLE_SCN =
+            "SELECT MIN(FIRST_CHANGE#) FROM ("
+                    + "SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$LOG "
+                    + "UNION "
+                    + "SELECT MIN(FIRST_CHANGE#) AS FIRST_CHANGE# FROM V$ARCHIVED_LOG WHERE STATUS='A'"
+                    + ")";
 
     /** Creates a new {@link OracleSourceConnection}, but not open the connection. */
     public static OracleSourceConnection createOracleConnection(Configuration configuration) {
@@ -86,6 +100,103 @@ public class OracleConnectionUtils {
                             + "'. Make sure your server is correctly configured",
                     e);
         }
+    }
+
+    @FunctionalInterface
+    interface ScnSupplier {
+        Scn get() throws SQLException;
+    }
+
+    /** Resolve the startup timestamp to a readable redo-log offset. */
+    public static RedoLogOffset resolveRedoLogOffsetByTimestamp(
+            OracleConnection connection, long startupTimestampMillis) {
+        return resolveRedoLogOffsetByTimestamp(
+                startupTimestampMillis,
+                () ->
+                        connection.prepareQueryAndMap(
+                                SHOW_SCN_BY_TIMESTAMP,
+                                statement ->
+                                        statement.setTimestamp(
+                                                1,
+                                                Timestamp.from(
+                                                        Instant.ofEpochMilli(
+                                                                startupTimestampMillis))),
+                                rs -> {
+                                    if (rs.next()) {
+                                        final String value = rs.getString(1);
+                                        return value == null ? null : Scn.valueOf(value);
+                                    }
+                                    return null;
+                                }),
+                () ->
+                        connection.queryAndMap(
+                                SHOW_OLDEST_AVAILABLE_SCN,
+                                rs -> {
+                                    if (rs.next()) {
+                                        final String value = rs.getString(1);
+                                        return value == null ? Scn.NULL : Scn.valueOf(value);
+                                    }
+                                    return Scn.NULL;
+                                }));
+    }
+
+    static RedoLogOffset resolveRedoLogOffsetByTimestamp(
+            long startupTimestampMillis,
+            ScnSupplier timestampScnSupplier,
+            ScnSupplier oldestScnSupplier) {
+        try {
+            final Scn timestampScn = timestampScnSupplier.get();
+
+            if (timestampScn != null && !timestampScn.isNull()) {
+                LOG.info(
+                        "Resolved startup timestamp {} to Oracle SCN {}.",
+                        startupTimestampMillis,
+                        timestampScn);
+                return new RedoLogOffset(timestampScn.subtract(Scn.ONE).longValue());
+            }
+        } catch (SQLException e) {
+            if (isTimestampToScnFallbackError(e)) {
+                LOG.warn(
+                        "Cannot resolve startup timestamp {} to SCN due to {}, fallback to oldest available SCN.",
+                        startupTimestampMillis,
+                        e.getMessage());
+            } else {
+                throw new FlinkRuntimeException(
+                        "Cannot resolve startup timestamp "
+                                + startupTimestampMillis
+                                + " to Oracle SCN.",
+                        e);
+            }
+        }
+
+        try {
+            final Scn oldestScn = oldestScnSupplier.get();
+            if (oldestScn == null || oldestScn.isNull()) {
+                throw new FlinkRuntimeException(
+                        "Cannot resolve oldest available Oracle SCN for startup timestamp "
+                                + startupTimestampMillis);
+            }
+            LOG.warn(
+                    "Fallback startup timestamp {} to oldest available Oracle SCN {}.",
+                    startupTimestampMillis,
+                    oldestScn);
+            return new RedoLogOffset(oldestScn.subtract(Scn.ONE).longValue());
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException(
+                    "Cannot query oldest available Oracle SCN for startup timestamp "
+                            + startupTimestampMillis,
+                    e);
+        }
+    }
+
+    private static boolean isTimestampToScnFallbackError(SQLException e) {
+        if (e.getErrorCode() == ORA_TIMESTAMP_TO_SCN_OUT_OF_RANGE
+                || e.getErrorCode() == ORA_TIMESTAMP_TO_SCN_INVALID_TIMESTAMP) {
+            return true;
+        }
+        String message = e.getMessage();
+        return message != null
+                && (message.startsWith("ORA-08181") || message.startsWith("ORA-08186"));
     }
 
     public static List<TableId> listTables(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleTypeUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleTypeUtils.java
@@ -66,7 +66,9 @@ public class OracleTypeUtils {
                 return DataTypes.DOUBLE();
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return DataTypes.DECIMAL(column.length(), column.scale().orElse(0));
+                int precision = normalizeDecimalPrecision(column.length());
+                int scale = normalizeDecimalScale(column.scale().orElse(0), precision);
+                return DataTypes.DECIMAL(precision, scale);
             case Types.DATE:
                 return DataTypes.DATE();
             case Types.TIMESTAMP:
@@ -88,5 +90,19 @@ public class OracleTypeUtils {
                                 "Don't support Oracle type '%s' yet, jdbcType:'%s'.",
                                 column.typeName(), column.jdbcType()));
         }
+    }
+
+    private static int normalizeDecimalPrecision(int precision) {
+        if (precision <= 0) {
+            return 38;
+        }
+        return Math.min(precision, 38);
+    }
+
+    private static int normalizeDecimalScale(int scale, int precision) {
+        if (scale < 0) {
+            return 0;
+        }
+        return Math.min(scale, precision);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleUtils.java
@@ -27,11 +27,14 @@ import io.debezium.connector.oracle.OracleDatabaseSchema;
 import io.debezium.connector.oracle.OracleDefaultValueConverter;
 import io.debezium.connector.oracle.OracleTopicSelector;
 import io.debezium.connector.oracle.OracleValueConverters;
+import io.debezium.connector.oracle.SourceInfo;
 import io.debezium.connector.oracle.StreamingAdapter;
+import io.debezium.data.Envelope;
 import io.debezium.jdbc.JdbcConnection;
 import io.debezium.relational.TableId;
 import io.debezium.schema.TopicSelector;
 import io.debezium.util.SchemaNameAdjuster;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import java.sql.Connection;
@@ -219,16 +222,35 @@ public class OracleUtils {
     }
 
     public static RedoLogOffset getRedoLogPosition(SourceRecord dataRecord) {
-        return getRedoLogPosition(dataRecord.sourceOffset());
+        Map<String, String> offsetStrMap = toStringOffsetMap(dataRecord.sourceOffset());
+        if (offsetStrMap.get(RedoLogOffset.SCN_KEY) == null) {
+            Struct value = (Struct) dataRecord.value();
+            if (value != null && value.schema() != null) {
+                Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                if (source != null
+                        && source.schema() != null
+                        && source.schema().field(SourceInfo.SCN_KEY) != null) {
+                    Object scn = source.get(SourceInfo.SCN_KEY);
+                    if (scn != null) {
+                        offsetStrMap.put(RedoLogOffset.SCN_KEY, scn.toString());
+                    }
+                }
+            }
+        }
+        return new RedoLogOffset(offsetStrMap);
     }
 
     public static RedoLogOffset getRedoLogPosition(Map<String, ?> offset) {
+        return new RedoLogOffset(toStringOffsetMap(offset));
+    }
+
+    private static Map<String, String> toStringOffsetMap(Map<String, ?> offset) {
         Map<String, String> offsetStrMap = new HashMap<>();
         for (Map.Entry<String, ?> entry : offset.entrySet()) {
             offsetStrMap.put(
                     entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
         }
-        return new RedoLogOffset(offsetStrMap);
+        return offsetStrMap;
     }
 
     public static String quote(String dbOrTableName) {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -53,6 +53,7 @@ import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_IN
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_STARTUP_MODE;
+import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SCAN_STARTUP_TIMESTAMP_MILLIS;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
 import static org.apache.flink.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND;
 import static org.apache.flink.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
@@ -195,6 +196,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP);
         options.add(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        options.add(SCAN_STARTUP_TIMESTAMP_MILLIS);
         return options;
     }
 
@@ -204,6 +206,7 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
     private static final String SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS = "specific-offset";
     private static final String SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS_PREFIX =
             "scan.startup.specific-offset.";
+    private static final String SCAN_STARTUP_MODE_VALUE_TIMESTAMP = "timestamp";
 
     private static StartupOptions getStartupOptions(
             ReadableConfig config, Map<String, String> options) {
@@ -219,14 +222,17 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
             case SCAN_STARTUP_MODE_VALUE_SPECIFIC_OFFSETS:
                 Map<String, String> offsetMap = getSpecificOffsetMap(options);
                 return StartupOptions.specificOffset(offsetMap);
+            case SCAN_STARTUP_MODE_VALUE_TIMESTAMP:
+                return StartupOptions.timestamp(config.get(SCAN_STARTUP_TIMESTAMP_MILLIS));
             default:
                 throw new ValidationException(
                         String.format(
-                                "Invalid value for option '%s'. Supported values are [%s, %s, %s], but was: %s",
+                                "Invalid value for option '%s'. Supported values are [%s, %s, %s, %s], but was: %s",
                                 SCAN_STARTUP_MODE.key(),
                                 SCAN_STARTUP_MODE_VALUE_INITIAL,
                                 SCAN_STARTUP_MODE_VALUE_SNAPSHOT,
                                 SCAN_STARTUP_MODE_VALUE_LATEST,
+                                SCAN_STARTUP_MODE_VALUE_TIMESTAMP,
                                 modeString));
         }
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactory.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.factories.FactoryUtil;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -68,6 +69,13 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class OracleTableSourceFactory implements DynamicTableSourceFactory {
 
     private static final String IDENTIFIER = "oracle-cdc";
+    private static final String DEBEZIUM_DATABASE_CONNECTION_ADAPTER =
+            "debezium.database.connection.adapter";
+    private static final String ADAPTER_XSTREAM = "xstream";
+    private static final String XSTREAM_BACKFILL_VALIDATION_MESSAGE =
+            "Oracle XStream does not support bounded backfill. Set "
+                    + "'scan.incremental.snapshot.backfill.skip' = 'true' when using "
+                    + "'debezium.database.connection.adapter' = 'xstream'.";
 
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
@@ -118,6 +126,9 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         boolean scanNewlyAddedTableEnabled = config.get(SCAN_NEWLY_ADDED_TABLE_ENABLED);
         boolean assignUnboundedChunkFirst =
                 config.get(SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED);
+        validateXStreamBackfillCompatibility(
+                context.getCatalogTable().getOptions().get(DEBEZIUM_DATABASE_CONNECTION_ADAPTER),
+                skipSnapshotBackfill);
 
         if (enableParallelRead) {
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
@@ -283,5 +294,12 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
                         0.0d,
                         1.0d,
                         distributionFactorLower));
+    }
+
+    static void validateXStreamBackfillCompatibility(String adapter, boolean skipSnapshotBackfill) {
+        String normalizedAdapter = adapter == null ? "" : adapter.trim().toLowerCase(Locale.ROOT);
+        if (ADAPTER_XSTREAM.equals(normalizedAdapter) && !skipSnapshotBackfill) {
+            throw new ValidationException(XSTREAM_BACKFILL_VALIDATION_MESSAGE);
+        }
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/util/ChunkUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/util/ChunkUtils.java
@@ -58,7 +58,7 @@ public class ChunkUtils {
         if (chunkKeyColumn != null) {
             Optional<Column> targetPkColumn =
                     searchColumns.stream()
-                            .filter(col -> chunkKeyColumn.equals(col.name()))
+                            .filter(col -> chunkKeyColumn.equalsIgnoreCase(col.name()))
                             .findFirst();
             if (targetPkColumn.isPresent()) {
                 return targetPkColumn.get();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/OracleConnectionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for Oracle SCN timestamp compatibility helpers. */
+class OracleConnectionTest {
+
+    @Test
+    void testReadScnTimestampUsesTimestampMapping() throws Exception {
+        Timestamp timestamp = Timestamp.valueOf("2026-04-08 13:49:08");
+        ResultSet rs = resultSet(timestamp);
+
+        Instant actual = OracleConnection.readScnTimestamp(rs, 1);
+
+        assertThat(actual).isEqualTo(timestamp.toInstant());
+    }
+
+    @Test
+    void testReadScnTimestampAllowsNullTimestamp() throws Exception {
+        ResultSet rs = resultSet(null);
+
+        Instant actual = OracleConnection.readScnTimestamp(rs, 1);
+
+        assertThat(actual).isNull();
+    }
+
+    private static ResultSet resultSet(Timestamp timestamp) {
+        InvocationHandler handler =
+                (proxy, method, args) -> {
+                    String name = method.getName();
+                    if ("getTimestamp".equals(name)) {
+                        return timestamp;
+                    }
+                    if ("getObject".equals(name) && args != null && args.length == 2) {
+                        throw new SQLException("OffsetDateTime path should not be used");
+                    }
+                    if ("wasNull".equals(name)) {
+                        return timestamp == null;
+                    }
+                    if ("unwrap".equals(name)) {
+                        return null;
+                    }
+                    if ("isWrapperFor".equals(name)) {
+                        return false;
+                    }
+                    throw new UnsupportedOperationException("Unexpected method: " + name);
+                };
+        return (ResultSet)
+                Proxy.newProxyInstance(
+                        OracleConnectionTest.class.getClassLoader(),
+                        new Class[] {ResultSet.class},
+                        handler);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategyTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/logminer/logwriter/RacCommitLogWriterFlushStrategyTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle.logminer.logwriter;
+
+import io.debezium.jdbc.JdbcConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for RAC LGWR flush JDBC URL rewriting. */
+class RacCommitLogWriterFlushStrategyTest {
+
+    @Test
+    void testRewriteServiceNameJdbcUrl() {
+        assertThat(
+                        RacCommitLogWriterFlushStrategy.rewriteJdbcUrl(
+                                "jdbc:oracle:thin:@//scan-host:1521/ORCL19", "127.0.0.1", 15210))
+                .isEqualTo("jdbc:oracle:thin:@//127.0.0.1:15210/ORCL19");
+    }
+
+    @Test
+    void testRewriteSidJdbcUrl() {
+        assertThat(
+                        RacCommitLogWriterFlushStrategy.rewriteJdbcUrl(
+                                "jdbc:oracle:thin:@scan-host:1521:ORCL19", "127.0.0.1", 15210))
+                .isEqualTo("jdbc:oracle:thin:@127.0.0.1:15210:ORCL19");
+    }
+
+    @Test
+    void testResolveJdbcUrlFallsBackToServiceNameWhenRawUrlMissing() {
+        JdbcConfiguration jdbcConfiguration =
+                JdbcConfiguration.adapt(
+                        JdbcConfiguration.create()
+                                .with(JdbcConfiguration.HOSTNAME, "scan-host")
+                                .with(JdbcConfiguration.PORT, 1521)
+                                .with(JdbcConfiguration.DATABASE, "ORCL19")
+                                .build());
+
+        assertThat(
+                        RacCommitLogWriterFlushStrategy.resolveJdbcUrl(
+                                jdbcConfiguration, "127.0.0.1", 15210))
+                .isEqualTo("jdbc:oracle:thin:@//127.0.0.1:15210/ORCL19");
+    }
+
+    @Test
+    void testBuildHostJdbcConfigurationOverridesHostPortAndUrlTogether() {
+        JdbcConfiguration jdbcConfiguration =
+                JdbcConfiguration.adapt(
+                        JdbcConfiguration.create()
+                                .with(JdbcConfiguration.HOSTNAME, "scan-host")
+                                .with(JdbcConfiguration.PORT, 1521)
+                                .with(JdbcConfiguration.DATABASE, "ORCL19")
+                                .with("url", "jdbc:oracle:thin:@//scan-host:1521/ORCL19")
+                                .build());
+
+        JdbcConfiguration hostConfig =
+                RacCommitLogWriterFlushStrategy.buildHostJdbcConfiguration(
+                        jdbcConfiguration, "127.0.0.1", 15210);
+
+        assertThat(hostConfig.getHostname()).isEqualTo("127.0.0.1");
+        assertThat(hostConfig.getPort()).isEqualTo(15210);
+        assertThat(hostConfig.getString("url"))
+                .isEqualTo("jdbc:oracle:thin:@//127.0.0.1:15210/ORCL19");
+    }
+
+    @Test
+    void testBuildHostJdbcConfigurationRestoresCredentialsWhenRuntimeConfigMissesThem() {
+        JdbcConfiguration runtimeJdbcConfiguration =
+                JdbcConfiguration.adapt(
+                        JdbcConfiguration.create()
+                                .with(JdbcConfiguration.HOSTNAME, "scan-host")
+                                .with(JdbcConfiguration.PORT, 1521)
+                                .build());
+
+        JdbcConfiguration hostConfig =
+                RacCommitLogWriterFlushStrategy.buildHostJdbcConfiguration(
+                        runtimeJdbcConfiguration,
+                        "jdbc:oracle:thin:@//scan-host:1521/ORCL19",
+                        "ORCL19",
+                        "flinkuser",
+                        "flinkpw",
+                        "127.0.0.1",
+                        15210);
+
+        assertThat(hostConfig.getUser()).isEqualTo("flinkuser");
+        assertThat(hostConfig.getPassword()).isEqualTo("flinkpw");
+        assertThat(hostConfig.getString("url"))
+                .isEqualTo("jdbc:oracle:thin:@//127.0.0.1:15210/ORCL19");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSourceTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/io/debezium/connector/oracle/xstream/XstreamStreamingChangeEventSourceTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.oracle.xstream;
+
+import org.apache.flink.cdc.connectors.oracle.source.reader.fetch.StoppableChangeEventSourceContext;
+
+import oracle.streams.StreamsException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for XStream attach retry lifecycle helpers. */
+class XstreamStreamingChangeEventSourceTest {
+
+    @Test
+    void testRetryWhenSessionBusyEventuallySucceeds() throws Exception {
+        StoppableChangeEventSourceContext context = new StoppableChangeEventSourceContext();
+        AtomicInteger attempts = new AtomicInteger();
+        AtomicInteger sleeps = new AtomicInteger();
+
+        String result =
+                XstreamStreamingChangeEventSource.retryWhenSessionBusy(
+                        context,
+                        "DBZXOUT",
+                        () -> {
+                            if (attempts.incrementAndGet() < 3) {
+                                throw new StreamsException(
+                                        "ORA-26812: An active session currently attached to XStream server \"DBZXOUT\"");
+                            }
+                            return "attached";
+                        },
+                        delayMillis -> sleeps.incrementAndGet(),
+                        XstreamStreamingChangeEventSource.XSTREAM_ATTACH_MAX_RETRIES);
+
+        assertThat(result).isEqualTo("attached");
+        assertThat(attempts).hasValue(3);
+        assertThat(sleeps).hasValue(2);
+    }
+
+    @Test
+    void testRetryWhenSessionBusyStopsWhenContextClosed() throws Exception {
+        StoppableChangeEventSourceContext context = new StoppableChangeEventSourceContext();
+        AtomicInteger attempts = new AtomicInteger();
+        AtomicInteger sleeps = new AtomicInteger();
+
+        String result =
+                XstreamStreamingChangeEventSource.retryWhenSessionBusy(
+                        context,
+                        "DBZXOUT",
+                        () -> {
+                            attempts.incrementAndGet();
+                            throw new StreamsException(
+                                    "ORA-26812: An active session currently attached to XStream server \"DBZXOUT\"");
+                        },
+                        delayMillis -> {
+                            sleeps.incrementAndGet();
+                            context.stopChangeEventSource();
+                        },
+                        XstreamStreamingChangeEventSource.XSTREAM_ATTACH_MAX_RETRIES);
+
+        assertThat(result).isNull();
+        assertThat(attempts).hasValue(1);
+        assertThat(sleeps).hasValue(1);
+    }
+
+    @Test
+    void testRetryWhenSessionBusyDoesNotRetryOtherErrors() {
+        StoppableChangeEventSourceContext context = new StoppableChangeEventSourceContext();
+        AtomicInteger attempts = new AtomicInteger();
+
+        assertThatThrownBy(
+                        () ->
+                                XstreamStreamingChangeEventSource.retryWhenSessionBusy(
+                                        context,
+                                        "DBZXOUT",
+                                        () -> {
+                                            attempts.incrementAndGet();
+                                            throw new StreamsException(
+                                                    "ORA-00001: unique constraint");
+                                        },
+                                        delayMillis -> {},
+                                        XstreamStreamingChangeEventSource
+                                                .XSTREAM_ATTACH_MAX_RETRIES))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("ORA-00001");
+        assertThat(attempts).hasValue(1);
+    }
+
+    @Test
+    void testRetryWhenSessionBusyExhaustedThrowsClearException() {
+        StoppableChangeEventSourceContext context = new StoppableChangeEventSourceContext();
+        AtomicInteger attempts = new AtomicInteger();
+        AtomicInteger sleeps = new AtomicInteger();
+
+        assertThatThrownBy(
+                        () ->
+                                XstreamStreamingChangeEventSource.retryWhenSessionBusy(
+                                        context,
+                                        "DBZXOUT",
+                                        () -> {
+                                            attempts.incrementAndGet();
+                                            throw new StreamsException(
+                                                    "ORA-26812: An active session currently attached to XStream server \"DBZXOUT\"");
+                                        },
+                                        delayMillis -> sleeps.incrementAndGet(),
+                                        XstreamStreamingChangeEventSource
+                                                .XSTREAM_ATTACH_MAX_RETRIES))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("Please clean the residual session and retry");
+        assertThat(attempts)
+                .hasValue(XstreamStreamingChangeEventSource.XSTREAM_ATTACH_MAX_RETRIES + 1);
+        assertThat(sleeps).hasValue(XstreamStreamingChangeEventSource.XSTREAM_ATTACH_MAX_RETRIES);
+    }
+
+    @Test
+    void testRetryWhenSessionBusyDisabledThrowsImmediately() {
+        StoppableChangeEventSourceContext context = new StoppableChangeEventSourceContext();
+        AtomicInteger attempts = new AtomicInteger();
+        AtomicInteger sleeps = new AtomicInteger();
+
+        assertThatThrownBy(
+                        () ->
+                                XstreamStreamingChangeEventSource.retryWhenSessionBusy(
+                                        context,
+                                        "DBZXOUT",
+                                        () -> {
+                                            attempts.incrementAndGet();
+                                            throw new StreamsException(
+                                                    "ORA-26812: An active session currently attached to XStream server \"DBZXOUT\"");
+                                        },
+                                        delayMillis -> sleeps.incrementAndGet(),
+                                        0))
+                .isInstanceOf(StreamsException.class)
+                .hasMessageContaining("Please clean the residual session and retry");
+        assertThat(attempts).hasValue(1);
+        assertThat(sleeps).hasValue(0);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/config/OracleSourceConfigFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.config;
+
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link OracleSourceConfigFactory#startupOptions(StartupOptions)}. */
+class OracleSourceConfigFactoryTest {
+
+    @Test
+    void testAcceptTimestampStartupMode() {
+        OracleSourceConfigFactory factory = new OracleSourceConfigFactory();
+
+        assertThatCode(() -> factory.startupOptions(StartupOptions.timestamp(1700000000000L)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testAcceptSpecificOffsetsStartupMode() {
+        OracleSourceConfigFactory factory = new OracleSourceConfigFactory();
+
+        assertThatCode(
+                        () ->
+                                factory.startupOptions(
+                                        StartupOptions.specificOffset(
+                                                Collections.singletonMap("scn", "123456"))))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectUnsupportedStartupMode() {
+        OracleSourceConfigFactory factory = new OracleSourceConfigFactory();
+
+        assertThatThrownBy(() -> factory.startupOptions(StartupOptions.earliest()))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Unsupported startup mode");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffsetTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/meta/offset/RedoLogOffsetTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.meta.offset;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link RedoLogOffset}. */
+class RedoLogOffsetTest {
+
+    @Test
+    void testCompareByLcrPositionWhenScnIsAbsent() {
+        RedoLogOffset earlier = lcrOffset("0000000008352fb60000000100000001");
+        RedoLogOffset later = lcrOffset("0000000008363a3a0000000100000001");
+
+        assertThat(later).isGreaterThan(earlier);
+        assertThat(earlier).isLessThan(later);
+    }
+
+    @Test
+    void testNullStringLcrPositionIsNotTreatedAsProgress() {
+        RedoLogOffset empty = lcrOffset("null");
+        RedoLogOffset later = lcrOffset("0000000008363a3a0000000100000001");
+
+        assertThat(later).isGreaterThan(empty);
+        assertThat(empty).isLessThan(later);
+    }
+
+    private static RedoLogOffset lcrOffset(String lcrPosition) {
+        Map<String, String> offset = new HashMap<>();
+        offset.put(RedoLogOffset.LCR_POSITION_KEY, lcrPosition);
+        offset.put("snapshot_scn", "null");
+        offset.put("transaction_id", "null");
+        return new RedoLogOffset(offset);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/OracleSourceReaderCommitTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/OracleSourceReaderCommitTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.cdc.connectors.base.config.JdbcSourceConfig;
+import org.apache.flink.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.cdc.connectors.base.source.meta.events.LatestFinishedSplitsNumberEvent;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceRecords;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitSerializer;
+import org.apache.flink.cdc.connectors.base.source.meta.split.SourceSplitState;
+import org.apache.flink.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceReaderContext;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceRecordEmitter;
+import org.apache.flink.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
+import org.apache.flink.cdc.connectors.base.source.utils.hooks.SnapshotPhaseHooks;
+import org.apache.flink.cdc.connectors.oracle.source.OracleDialect;
+import org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfig;
+import org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfigFactory;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffsetFactory;
+import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.util.Collector;
+
+import org.apache.kafka.connect.source.SourceRecord;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OracleSourceReaderCommitTest {
+
+    @Test
+    void testCommitOffsetImmediatelyWhenNewlyAddedTableScanIsDisabled() throws Exception {
+        RecordingOracleDialect dialect = new RecordingOracleDialect();
+        TestOracleSourceReader reader = createReader(false, dialect);
+        RedoLogOffset offset = lcrOffset("0000000008352fb60000000100000001");
+
+        reader.rememberCheckpointOffset(1L, offset);
+        reader.notifyCheckpointComplete(1L);
+
+        assertThat(dialect.committedOffsets).containsExactly(offset);
+    }
+
+    @Test
+    void testDelayCommitOffsetUntilStreamSplitMetadataUpdatedForNewlyAddedTableScan()
+            throws Exception {
+        RecordingOracleDialect dialect = new RecordingOracleDialect();
+        TestOracleSourceReader reader = createReader(true, dialect);
+        RedoLogOffset blockedOffset = lcrOffset("0000000008352fb60000000100000001");
+        RedoLogOffset allowedOffset = lcrOffset("0000000008363a3a0000000100000001");
+
+        reader.rememberCheckpointOffset(1L, blockedOffset);
+        reader.notifyCheckpointComplete(1L);
+        assertThat(dialect.committedOffsets).isEmpty();
+
+        reader.markStreamSplitMetadataUpdated();
+        reader.rememberCheckpointOffset(2L, allowedOffset);
+        reader.notifyCheckpointComplete(2L);
+
+        assertThat(dialect.committedOffsets).containsExactly(allowedOffset);
+    }
+
+    private static TestOracleSourceReader createReader(
+            boolean scanNewlyAddedTableEnabled, RecordingOracleDialect dialect) {
+        TestingReaderContext readerContext = new TestingReaderContext();
+        OracleSourceConfig sourceConfig = createSourceConfig(scanNewlyAddedTableEnabled);
+        RedoLogOffsetFactory offsetFactory = new RedoLogOffsetFactory();
+        SourceReaderMetrics sourceReaderMetrics =
+                new SourceReaderMetrics(readerContext.metricGroup());
+        RecordEmitter<SourceRecords, SourceRecord, SourceSplitState> recordEmitter =
+                new IncrementalSourceRecordEmitter<>(
+                        new ForwardDeserializeSchema(),
+                        sourceReaderMetrics,
+                        sourceConfig.isIncludeSchemaChanges(),
+                        offsetFactory);
+        IncrementalSourceReaderContext incrementalSourceReaderContext =
+                new IncrementalSourceReaderContext(readerContext);
+        Supplier<IncrementalSourceSplitReader<JdbcSourceConfig>> splitReaderSupplier =
+                () ->
+                        new IncrementalSourceSplitReader<>(
+                                readerContext.getIndexOfSubtask(),
+                                dialect,
+                                sourceConfig,
+                                incrementalSourceReaderContext,
+                                SnapshotPhaseHooks.empty());
+        return new TestOracleSourceReader(
+                new FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>>(),
+                splitReaderSupplier,
+                recordEmitter,
+                readerContext.getConfiguration(),
+                incrementalSourceReaderContext,
+                sourceConfig,
+                new SourceSplitSerializer() {
+                    @Override
+                    public OffsetFactory getOffsetFactory() {
+                        return offsetFactory;
+                    }
+                },
+                dialect);
+    }
+
+    private static OracleSourceConfig createSourceConfig(boolean scanNewlyAddedTableEnabled) {
+        return (OracleSourceConfig)
+                new OracleSourceConfigFactory()
+                        .startupOptions(StartupOptions.initial())
+                        .databaseList("ORCLCDB")
+                        .tableList("DEBEZIUM.PRODUCTS")
+                        .includeSchemaChanges(false)
+                        .hostname("127.0.0.1")
+                        .port(1521)
+                        .username("flinkuser")
+                        .password("flinkpw")
+                        .serverTimeZone(ZoneId.of("UTC").toString())
+                        .scanNewlyAddedTableEnabled(scanNewlyAddedTableEnabled)
+                        .create(0);
+    }
+
+    private static RedoLogOffset lcrOffset(String lcrPosition) {
+        HashMap<String, String> offset = new HashMap<>();
+        offset.put(RedoLogOffset.LCR_POSITION_KEY, lcrPosition);
+        offset.put("snapshot_scn", "null");
+        offset.put("transaction_id", "null");
+        return new RedoLogOffset(offset);
+    }
+
+    private static class TestOracleSourceReader extends OracleSourceReader {
+
+        private TestOracleSourceReader(
+                FutureCompletingBlockingQueue elementQueue,
+                Supplier supplier,
+                RecordEmitter recordEmitter,
+                org.apache.flink.configuration.Configuration config,
+                IncrementalSourceReaderContext incrementalSourceReaderContext,
+                JdbcSourceConfig sourceConfig,
+                SourceSplitSerializer sourceSplitSerializer,
+                OracleDialect dialect) {
+            super(
+                    elementQueue,
+                    supplier,
+                    recordEmitter,
+                    config,
+                    incrementalSourceReaderContext,
+                    sourceConfig,
+                    sourceSplitSerializer,
+                    dialect);
+        }
+
+        private void rememberCheckpointOffset(long checkpointId, Offset offset) {
+            lastCheckpointOffsets.put(checkpointId, offset);
+        }
+
+        private void markStreamSplitMetadataUpdated() {
+            updateStreamSplitFinishedSplitsSize(new LatestFinishedSplitsNumberEvent(0));
+        }
+    }
+
+    private static class RecordingOracleDialect extends OracleDialect {
+
+        private final List<Offset> committedOffsets = new ArrayList<>();
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId, Offset offset) {
+            committedOffsets.add(offset);
+        }
+    }
+
+    private static class ForwardDeserializeSchema
+            implements DebeziumDeserializationSchema<SourceRecord> {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void deserialize(SourceRecord record, Collector<SourceRecord> out) {
+            out.collect(record);
+        }
+
+        @Override
+        public TypeInformation<SourceRecord> getProducedType() {
+            return TypeInformation.of(SourceRecord.class);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/RedoLogOffsetFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/RedoLogOffsetFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader;
+
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffsetFactory;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link RedoLogOffsetFactory}. */
+class RedoLogOffsetFactoryTest {
+
+    @Test
+    void testCreateTimestampOffset() {
+        long startupTimestampMillis = 1700000000000L;
+        RedoLogOffsetFactory offsetFactory = new RedoLogOffsetFactory();
+        RedoLogOffset offset =
+                (RedoLogOffset) offsetFactory.createTimestampOffset(startupTimestampMillis);
+
+        assertThat(offset.getScn()).isEqualTo("0");
+        assertThat(offset.getStartupTimestampMillis()).isEqualTo(startupTimestampMillis);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContextTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContextTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
+
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for startup-offset resolution in {@link OracleSourceFetchTaskContext}. */
+class OracleSourceFetchTaskContextTest {
+
+    @Test
+    void testDoNotResolveTimestampAgainWhenRestoredFromSpecificScnOffset() {
+        StreamSplit restoredSplit =
+                new StreamSplit(
+                        StreamSplit.STREAM_SPLIT_ID,
+                        new RedoLogOffset(123L),
+                        RedoLogOffset.NO_STOPPING_OFFSET,
+                        new ArrayList<>(),
+                        new HashMap<>(),
+                        0);
+        AtomicInteger resolveCalls = new AtomicInteger();
+
+        OracleSourceFetchTaskContext.StartingOffsetResolution resolution =
+                OracleSourceFetchTaskContext.resolveStartingOffset(
+                        restoredSplit,
+                        timestampMillis -> {
+                            resolveCalls.incrementAndGet();
+                            return new RedoLogOffset(999L);
+                        });
+
+        assertThat(resolveCalls.get()).isZero();
+        assertThat(resolution.getStartupTimestampMillis()).isNull();
+        assertThat(((RedoLogOffset) resolution.getOffset()).getScn()).isEqualTo("123");
+    }
+
+    @Test
+    void testResolveTimestampOffsetForStreamSplitWhenTimestampMarkerExists() {
+        long startupTimestampMillis = 1700000000000L;
+        StreamSplit timestampSplit =
+                new StreamSplit(
+                        StreamSplit.STREAM_SPLIT_ID,
+                        new RedoLogOffset(0L, 0L, null, startupTimestampMillis),
+                        RedoLogOffset.NO_STOPPING_OFFSET,
+                        new ArrayList<>(),
+                        new HashMap<>(),
+                        0);
+        AtomicInteger resolveCalls = new AtomicInteger();
+        AtomicLong observedTimestamp = new AtomicLong(-1L);
+
+        OracleSourceFetchTaskContext.StartingOffsetResolution resolution =
+                OracleSourceFetchTaskContext.resolveStartingOffset(
+                        timestampSplit,
+                        timestampMillis -> {
+                            resolveCalls.incrementAndGet();
+                            observedTimestamp.set(timestampMillis);
+                            return new RedoLogOffset(456L);
+                        });
+
+        assertThat(resolveCalls.get()).isEqualTo(1);
+        assertThat(observedTimestamp.get()).isEqualTo(startupTimestampMillis);
+        assertThat(resolution.getStartupTimestampMillis()).isEqualTo(startupTimestampMillis);
+        assertThat(((RedoLogOffset) resolution.getOffset()).getScn()).isEqualTo("456");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContextTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleSourceFetchTaskContextTest.java
@@ -20,6 +20,13 @@ package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
 import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
 import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
 
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import io.debezium.connector.oracle.logminer.LogMinerOracleOffsetContextLoader;
+import io.debezium.connector.oracle.xstream.XStreamOracleOffsetContextLoader;
+import io.debezium.relational.TableId;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -28,6 +35,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit tests for startup-offset resolution in {@link OracleSourceFetchTaskContext}. */
 class OracleSourceFetchTaskContextTest {
@@ -84,5 +92,94 @@ class OracleSourceFetchTaskContextTest {
         assertThat(observedTimestamp.get()).isEqualTo(startupTimestampMillis);
         assertThat(resolution.getStartupTimestampMillis()).isEqualTo(startupTimestampMillis);
         assertThat(((RedoLogOffset) resolution.getOffset()).getScn()).isEqualTo("456");
+    }
+
+    @Test
+    void testResolveOffsetContextLoaderByAdapter() {
+        assertThat(
+                        OracleSourceFetchTaskContext.createOffsetContextLoader(
+                                connectorConfig("logminer")))
+                .isInstanceOf(LogMinerOracleOffsetContextLoader.class);
+        assertThat(
+                        OracleSourceFetchTaskContext.createOffsetContextLoader(
+                                connectorConfig("xstream")))
+                .isInstanceOf(XStreamOracleOffsetContextLoader.class);
+    }
+
+    @Test
+    void testIsLogMinerAdapter() {
+        assertThat(OracleSourceFetchTaskContext.isLogMinerAdapter(connectorConfig("logminer")))
+                .isTrue();
+        assertThat(OracleSourceFetchTaskContext.isLogMinerAdapter(connectorConfig("xstream")))
+                .isFalse();
+    }
+
+    @Test
+    void testDefaultAdapterFallsBackToLogMiner() {
+        OracleConnectorConfig defaultConfig = connectorConfig(null);
+        assertThat(OracleSourceFetchTaskContext.isLogMinerAdapter(defaultConfig)).isTrue();
+        assertThat(OracleSourceFetchTaskContext.createOffsetContextLoader(defaultConfig))
+                .isInstanceOf(LogMinerOracleOffsetContextLoader.class);
+    }
+
+    @Test
+    void testIsXStreamAdapter() {
+        assertThat(OracleSourceFetchTaskContext.isXStreamAdapter(connectorConfig("xstream")))
+                .isTrue();
+        assertThat(OracleSourceFetchTaskContext.isXStreamAdapter(connectorConfig("logminer")))
+                .isFalse();
+    }
+
+    @Test
+    void testParseRowIdFromHeadersReturnsRowId() throws Exception {
+        String rowIdValue = "AAAzIdACKAAABWCAAA";
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.add("ROWID", new SchemaAndValue(null, rowIdValue));
+        TableId tableId = new TableId("ORCL19", "TESTUSER", "ORDERS");
+
+        assertThat(OracleSourceFetchTaskContext.parseRowIdFromHeaders(headers, tableId))
+                .isEqualTo(new oracle.sql.ROWID(rowIdValue));
+    }
+
+    @Test
+    void testParseRowIdFromHeadersThrowsClearErrorWhenHeaderMissing() {
+        ConnectHeaders headers = new ConnectHeaders();
+        TableId tableId = new TableId("ORCL19", "TESTUSER", "ORDERS");
+
+        assertThatThrownBy(
+                        () -> OracleSourceFetchTaskContext.parseRowIdFromHeaders(headers, tableId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Missing ROWID header")
+                .hasMessageContaining("scan.incremental.snapshot.chunk.key-column")
+                .hasMessageContaining("scan.incremental.snapshot.backfill.skip=true");
+    }
+
+    @Test
+    void testParseRowIdFromHeadersThrowsClearErrorWhenHeaderInvalid() {
+        ConnectHeaders headers = new ConnectHeaders();
+        headers.add("ROWID", new SchemaAndValue(null, 1L));
+        TableId tableId = new TableId("ORCL19", "TESTUSER", "ORDERS");
+
+        assertThatThrownBy(
+                        () -> OracleSourceFetchTaskContext.parseRowIdFromHeaders(headers, tableId))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Invalid ROWID header type")
+                .hasMessageContaining("scan.incremental.snapshot.chunk.key-column")
+                .hasMessageContaining("scan.incremental.snapshot.backfill.skip=true");
+    }
+
+    private static OracleConnectorConfig connectorConfig(String adapter) {
+        Configuration.Builder builder =
+                Configuration.create()
+                        .with("database.server.name", "test")
+                        .with("database.dbname", "ORCLCDB")
+                        .with("database.hostname", "127.0.0.1")
+                        .with("database.port", 1521)
+                        .with("database.user", "flinkuser")
+                        .with("database.password", "flinkpw");
+        if (adapter != null) {
+            builder.with("database.connection.adapter", adapter);
+        }
+        return new OracleConnectorConfig(builder.build());
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleStreamFetchTaskTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.reader.fetch;
+
+import org.apache.flink.cdc.connectors.base.source.meta.offset.Offset;
+import org.apache.flink.cdc.connectors.base.source.meta.split.StreamSplit;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+
+import io.debezium.config.Configuration;
+import io.debezium.connector.oracle.OracleConnectorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for adapter split capability checks in {@link OracleStreamFetchTask}. */
+class OracleStreamFetchTaskTest {
+
+    @Test
+    void testAllowUnboundedSplitForXstreamAdapter() {
+        assertThatCode(
+                        () ->
+                                OracleStreamFetchTask.validateAdapterSupportsSplit(
+                                        connectorConfig("xstream"),
+                                        streamSplit(
+                                                new RedoLogOffset(1L),
+                                                RedoLogOffset.NO_STOPPING_OFFSET)))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testAllowBoundedSplitForLogMinerAdapter() {
+        assertThatCode(
+                        () ->
+                                OracleStreamFetchTask.validateAdapterSupportsSplit(
+                                        connectorConfig("logminer"),
+                                        streamSplit(new RedoLogOffset(1L), new RedoLogOffset(2L))))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testRejectBoundedSplitForXstreamAdapter() {
+        assertThatThrownBy(
+                        () ->
+                                OracleStreamFetchTask.validateAdapterSupportsSplit(
+                                        connectorConfig("xstream"),
+                                        streamSplit(new RedoLogOffset(1L), new RedoLogOffset(2L))))
+                .hasMessageContaining("xstream")
+                .hasMessageContaining("bounded stream split backfill");
+    }
+
+    @Test
+    void testAllowBoundedSplitForDefaultAdapter() {
+        assertThatCode(
+                        () ->
+                                OracleStreamFetchTask.validateAdapterSupportsSplit(
+                                        connectorConfig(null),
+                                        streamSplit(new RedoLogOffset(1L), new RedoLogOffset(2L))))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void testCloseStopsRunningChangeEventSourceContext() {
+        OracleStreamFetchTask fetchTask =
+                new OracleStreamFetchTask(
+                        streamSplit(new RedoLogOffset(1L), RedoLogOffset.NO_STOPPING_OFFSET));
+        StoppableChangeEventSourceContext changeEventSourceContext =
+                new StoppableChangeEventSourceContext();
+        fetchTask.registerRunningChangeEventSource(changeEventSourceContext, null);
+
+        fetchTask.close();
+
+        assertThat(changeEventSourceContext.isRunning()).isFalse();
+        assertThat(fetchTask.isRunning()).isFalse();
+    }
+
+    @Test
+    void testCommitCurrentOffsetSuppressesDuplicateAndRollbackLcrPositions() {
+        OracleStreamFetchTask fetchTask =
+                new OracleStreamFetchTask(
+                        streamSplit(new RedoLogOffset(1L), RedoLogOffset.NO_STOPPING_OFFSET));
+        RecordingChangeEventSource runningChangeEventSource = new RecordingChangeEventSource();
+        fetchTask.setRunningChangeEventSource(runningChangeEventSource);
+        RedoLogOffset earlier = lcrOffset("0000000008352fb60000000100000001");
+        RedoLogOffset later = lcrOffset("0000000008363a3a0000000100000001");
+
+        fetchTask.commitCurrentOffset(earlier);
+        fetchTask.commitCurrentOffset(earlier);
+        fetchTask.commitCurrentOffset(later);
+        fetchTask.commitCurrentOffset(earlier);
+
+        assertThat(runningChangeEventSource.committedOffsets).containsExactly(earlier, later);
+    }
+
+    private static StreamSplit streamSplit(RedoLogOffset start, RedoLogOffset end) {
+        return new StreamSplit(
+                StreamSplit.STREAM_SPLIT_ID, start, end, new ArrayList<>(), new HashMap<>(), 0);
+    }
+
+    private static RedoLogOffset lcrOffset(String lcrPosition) {
+        HashMap<String, String> offset = new HashMap<>();
+        offset.put(RedoLogOffset.LCR_POSITION_KEY, lcrPosition);
+        offset.put("snapshot_scn", "null");
+        offset.put("transaction_id", "null");
+        return new RedoLogOffset(offset);
+    }
+
+    private static OracleConnectorConfig connectorConfig(String adapter) {
+        Configuration.Builder builder =
+                Configuration.create()
+                        .with("database.server.name", "test")
+                        .with("database.dbname", "ORCLCDB")
+                        .with("database.hostname", "127.0.0.1")
+                        .with("database.port", 1521)
+                        .with("database.user", "flinkuser")
+                        .with("database.password", "flinkpw");
+        if (adapter != null) {
+            builder.with("database.connection.adapter", adapter);
+        }
+        return new OracleConnectorConfig(builder.build());
+    }
+
+    private static class RecordingChangeEventSource
+            implements OracleStreamFetchTask.RunningChangeEventSource {
+
+        private final List<Offset> committedOffsets = new ArrayList<>();
+
+        @Override
+        public void stop() {}
+
+        @Override
+        public boolean commitOffset(Offset offset) {
+            committedOffsets.add(offset);
+            return true;
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleConnectionUtilsTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.utils;
+
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import io.debezium.connector.oracle.Scn;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link OracleConnectionUtils}. */
+class OracleConnectionUtilsTest {
+
+    @Test
+    void testResolveTimestampScnAsExclusiveLowerBound() {
+        long startupTimestampMillis = 1700000000000L;
+
+        RedoLogOffset offset =
+                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                        startupTimestampMillis, () -> Scn.valueOf("456"), () -> Scn.valueOf("1"));
+
+        assertThat(offset.getScn()).isEqualTo("455");
+    }
+
+    @Test
+    void testFallbackToOldestAvailableScnWhenTimestampCannotBeMapped() {
+        long startupTimestampMillis = 1700000000000L;
+
+        RedoLogOffset offset =
+                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                        startupTimestampMillis,
+                        () -> {
+                            throw new SQLException(
+                                    "ORA-08181: specified number is not a valid system change number");
+                        },
+                        () -> Scn.valueOf("123456"));
+
+        assertThat(offset.getScn()).isEqualTo("123455");
+    }
+
+    @Test
+    void testFallbackToOldestAvailableScnWhenTimestampIsInvalid() {
+        long startupTimestampMillis = 1700000000000L;
+
+        RedoLogOffset offset =
+                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                        startupTimestampMillis,
+                        () -> {
+                            throw new SQLException(
+                                    "ORA-08186: invalid timestamp specified", "72000", 8186);
+                        },
+                        () -> Scn.valueOf("223344"));
+
+        assertThat(offset.getScn()).isEqualTo("223343");
+    }
+
+    @Test
+    void testThrowWhenTimestampQueryFailedWithUnexpectedSQLException() {
+        long startupTimestampMillis = 1700000000000L;
+
+        assertThatThrownBy(
+                        () ->
+                                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                                        startupTimestampMillis,
+                                        () -> {
+                                            throw new SQLException(
+                                                    "ORA-01017: invalid username/password");
+                                        },
+                                        () -> Scn.valueOf("123456")))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining("Cannot resolve startup timestamp");
+    }
+
+    @Test
+    void testThrowWhenFallbackOldestScnIsUnavailable() {
+        long startupTimestampMillis = 1700000000000L;
+
+        assertThatThrownBy(
+                        () ->
+                                OracleConnectionUtils.resolveRedoLogOffsetByTimestamp(
+                                        startupTimestampMillis, () -> null, () -> Scn.NULL))
+                .isInstanceOf(FlinkRuntimeException.class)
+                .hasMessageContaining("Cannot resolve oldest available Oracle SCN");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleTypeUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/source/utils/OracleTypeUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.source.utils;
+
+import org.apache.flink.table.types.logical.DecimalType;
+
+import io.debezium.relational.Column;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link OracleTypeUtils}. */
+class OracleTypeUtilsTest {
+
+    @Test
+    void testNormalizeDecimalPrecisionAndScale() {
+        DecimalType precisionUnset =
+                (DecimalType) OracleTypeUtils.fromDbzColumn(decimalColumn(0, 0)).getLogicalType();
+        assertThat(precisionUnset.getPrecision()).isEqualTo(38);
+        assertThat(precisionUnset.getScale()).isEqualTo(0);
+
+        DecimalType precisionTooLarge =
+                (DecimalType) OracleTypeUtils.fromDbzColumn(decimalColumn(50, 0)).getLogicalType();
+        assertThat(precisionTooLarge.getPrecision()).isEqualTo(38);
+        assertThat(precisionTooLarge.getScale()).isEqualTo(0);
+
+        DecimalType negativeScale =
+                (DecimalType)
+                        OracleTypeUtils.fromDbzColumn(decimalColumn(20, -127)).getLogicalType();
+        assertThat(negativeScale.getPrecision()).isEqualTo(20);
+        assertThat(negativeScale.getScale()).isEqualTo(0);
+
+        DecimalType scaleGreaterThanPrecision =
+                (DecimalType) OracleTypeUtils.fromDbzColumn(decimalColumn(10, 20)).getLogicalType();
+        assertThat(scaleGreaterThanPrecision.getPrecision()).isEqualTo(10);
+        assertThat(scaleGreaterThanPrecision.getScale()).isEqualTo(10);
+    }
+
+    private static Column decimalColumn(int precision, int scale) {
+        return Column.editor()
+                .name("ID")
+                .jdbcType(Types.DECIMAL)
+                .length(precision)
+                .scale(scale)
+                .optional(false)
+                .create();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -357,6 +357,47 @@ class OracleTableSourceFactoryTest {
     }
 
     @Test
+    void testStartupFromTimestamp() {
+        long startupTimestampMillis = 1700000000000L;
+        Map<String, String> properties = getAllRequiredOptionsWithHost();
+        properties.put("scan.startup.mode", "timestamp");
+        properties.put("scan.startup.timestamp-millis", String.valueOf(startupTimestampMillis));
+
+        DynamicTableSource actualSource = createTableSource(properties);
+        OracleTableSource expectedSource =
+                new OracleTableSource(
+                        SCHEMA,
+                        null,
+                        MY_PORT,
+                        MY_LOCALHOST,
+                        MY_DATABASE,
+                        MY_TABLE,
+                        MY_SCHEMA,
+                        MY_USERNAME,
+                        MY_PASSWORD,
+                        PROPERTIES,
+                        StartupOptions.timestamp(startupTimestampMillis),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE.defaultValue(),
+                        SourceOptions.CHUNK_META_GROUP_SIZE.defaultValue(),
+                        SourceOptions.SCAN_SNAPSHOT_FETCH_SIZE.defaultValue(),
+                        JdbcSourceOptions.CONNECT_TIMEOUT.defaultValue(),
+                        JdbcSourceOptions.CONNECT_MAX_RETRIES.defaultValue(),
+                        JdbcSourceOptions.CONNECTION_POOL_SIZE.defaultValue(),
+                        JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND
+                                .defaultValue(),
+                        JdbcSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND
+                                .defaultValue(),
+                        null,
+                        SourceOptions.SCAN_INCREMENTAL_CLOSE_IDLE_READER_ENABLED.defaultValue(),
+                        SourceOptions.SCAN_INCREMENTAL_SNAPSHOT_BACKFILL_SKIP.defaultValue(),
+                        SourceOptions.SCAN_NEWLY_ADDED_TABLE_ENABLED.defaultValue(),
+                        JdbcSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST_ENABLED
+                                .defaultValue());
+        Assertions.assertThat(actualSource).isEqualTo(expectedSource);
+    }
+
+    @Test
     void testMetadataColumns() {
         Map<String, String> properties = getAllRequiredOptions();
 
@@ -444,7 +485,7 @@ class OracleTableSourceFactoryTest {
                         })
                 .hasStackTraceContaining(
                         "Invalid value for option 'scan.startup.mode'. Supported values are "
-                                + "[initial, snapshot, latest-offset], "
+                                + "[initial, snapshot, latest-offset, timestamp], "
                                 + "but was: abc");
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/table/OracleTableSourceFactoryTest.java
@@ -487,6 +487,16 @@ class OracleTableSourceFactoryTest {
                         "Invalid value for option 'scan.startup.mode'. Supported values are "
                                 + "[initial, snapshot, latest-offset, timestamp], "
                                 + "but was: abc");
+
+        Assertions.assertThatThrownBy(
+                        () -> {
+                            Map<String, String> properties = getAllRequiredOptionsWithHost();
+                            properties.put("debezium.database.connection.adapter", "xstream");
+                            properties.put("scan.incremental.snapshot.backfill.skip", "false");
+                            createTableSource(properties);
+                        })
+                .hasStackTraceContaining("scan.incremental.snapshot.backfill.skip")
+                .hasStackTraceContaining("xstream");
     }
 
     private Map<String, String> getAllRequiredOptions() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/util/ChunkUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/test/java/org/apache/flink/cdc/connectors/oracle/util/ChunkUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.oracle.util;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link ChunkUtils}. */
+class ChunkUtilsTest {
+
+    @Test
+    void testGetChunkKeyColumnMatchesCaseInsensitive() {
+        Table table =
+                Table.editor()
+                        .tableId(new TableId("ORCL19", "TESTUSER", "ORDERS"))
+                        .addColumn(Column.editor().name("ID").jdbcType(Types.NUMERIC).create())
+                        .addColumn(
+                                Column.editor().name("PRODUCT_ID").jdbcType(Types.NUMERIC).create())
+                        .setPrimaryKeyNames("ID")
+                        .create();
+
+        Column chunkKeyColumn = ChunkUtils.getChunkKeyColumn(table, "id");
+        assertThat(chunkKeyColumn.name()).isEqualTo("ID");
+    }
+}


### PR DESCRIPTION
This PR adds Oracle CDC streaming support for the XStream adapter.

This PR is stacked on top of #4433 because XStream startup and offset handling rely on Oracle timestamp/SCN resolution. After #4433 is merged, this PR should contain only the XStream-specific commit.

### Changes
- Add Oracle XStream dependency wiring.
- Add local XStream streaming source and LCR event handling for the Debezium version used by Flink CDC.
- Advance XStream offsets by fetch low watermark so bounded split logic can progress even when no captured-table event is emitted.
- Add OracleSourceReader offset commit gating so processed low watermark is committed only after the stream split is safe, especially with newly added table scanning.
- Add unit coverage for XStream streaming behavior, processed offset commit timing, RAC flush strategy, stream fetch task behavior, type conversion, and ROWID chunk handling.

### Tests
- Not run locally: Maven currently gets stuck before the test phase while launching Java (`java --enable-native-access=ALL-UNNAMED -version`).