### PR TITLE
[FLINK-39844][postgres] Filter snapshot table columns by schema name to fix LIKE-wildcard cross-schema column leakage

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -709,8 +709,13 @@ public class PostgresConnection extends JdbcConnection {
         // - When querying 'user_sink', the pattern may also match 'userbsink' (due to '_')
         // - When querying 'user%data' (where % is literal), it may match 'user_test_data' (due to
         // '%')
+        // Both the schema name and table name are passed to DatabaseMetaData#getColumns as LIKE
+        // patterns, so wildcards in either may produce columns from other schemas/tables. Verify
+        // both against the requested TableId (skipping the schema check when no schema is given).
+        final String resultSchemaName = columnMetadata.getString(2);
         final String resultTableName = columnMetadata.getString(3);
-        if (!tableId.table().equals(resultTableName)) {
+        if (!tableId.table().equals(resultTableName)
+                || (tableId.schema() != null && !tableId.schema().equals(resultSchemaName))) {
             return Optional.empty();
         }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/SimilarTableNamesITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/SimilarTableNamesITCase.java
@@ -224,6 +224,55 @@ class SimilarTableNamesITCase extends PostgresTestBase {
         }
     }
 
+    /**
+     * Test that when capturing CDC events for table 'cross_schema_tbl' in schema 'sch_test', we
+     * don't accidentally capture columns/events from the same-named table in schema 'schxtest'. The
+     * schema name is also passed to {@code DatabaseMetaData#getColumns} as a LIKE pattern, so the
+     * underscore '_' in 'sch_test' matches the 'x' in 'schxtest'. Since both schemas contain a
+     * table named 'cross_schema_tbl', a TABLE_NAME-only filter cannot tell them apart.
+     *
+     * <p>Before adding the schema-name check, this test would fail during the snapshot phase with:
+     * "java.lang.IllegalStateException: Duplicate key Optional.empty".
+     */
+    @Test
+    void testReadTableWithSimilarSchemaNameUnderscore() throws Exception {
+        StreamTableEnvironment tEnv = createTableEnv();
+
+        // Only capture events from 'sch_test.cross_schema_tbl'
+        tEnv.executeSql(createSourceDDL("cross_schema_table", "sch_test", "cross_schema_tbl"));
+
+        TableResult result = tEnv.executeSql("SELECT * FROM cross_schema_table");
+        CloseableIterator<Row> iterator = result.collect();
+
+        try {
+            // Verify snapshot data (3 rows from sch_test.cross_schema_tbl only)
+            List<String> expectedSnapshotData =
+                    Arrays.asList(
+                            "+I[1001, sch_test_1, Shanghai]",
+                            "+I[1002, sch_test_2, Beijing]",
+                            "+I[1003, sch_test_3, Hangzhou]");
+            assertRowsEquals(collectRows(iterator, 3), expectedSnapshotData);
+
+            try (Connection conn =
+                            getJdbcConnection(
+                                    POSTGRES_CONTAINER, similarNamesDatabase.getDatabaseName());
+                    Statement stmt = conn.createStatement()) {
+                // Insert into the look-alike schema - should NOT be captured
+                stmt.execute(
+                        "INSERT INTO schxtest.cross_schema_tbl VALUES (2004, 'schxtest_4', 'Wuhan')");
+                // Insert into the target schema - SHOULD be captured
+                stmt.execute(
+                        "INSERT INTO sch_test.cross_schema_tbl VALUES (1004, 'sch_test_4', 'Suzhou')");
+            }
+
+            // Should only see the insert from sch_test, not schxtest
+            List<String> expectedStreamData = Arrays.asList("+I[1004, sch_test_4, Suzhou]");
+            assertRowsEquals(collectRows(iterator, 1), expectedStreamData);
+        } finally {
+            closeResourcesAndWaitForJobTermination(iterator, result);
+        }
+    }
+
     // ==================== Helper Methods ====================
 
     /** Creates and configures the StreamTableEnvironment. */
@@ -234,8 +283,14 @@ class SimilarTableNamesITCase extends PostgresTestBase {
         return StreamTableEnvironment.create(env);
     }
 
-    /** Creates the source DDL for the given table name pattern. */
+    /** Creates the source DDL for the given table name pattern in the default schema. */
     private String createSourceDDL(String flinkTableName, String pgTablePattern) {
+        return createSourceDDL(flinkTableName, SCHEMA_NAME, pgTablePattern);
+    }
+
+    /** Creates the source DDL for the given schema name and table name pattern. */
+    private String createSourceDDL(
+            String flinkTableName, String pgSchemaName, String pgTablePattern) {
         return format(
                 "CREATE TABLE %s ("
                         + " id INT NOT NULL,"
@@ -264,7 +319,7 @@ class SimilarTableNamesITCase extends PostgresTestBase {
                 similarNamesDatabase.getUsername(),
                 similarNamesDatabase.getPassword(),
                 similarNamesDatabase.getDatabaseName(),
-                SCHEMA_NAME,
+                pgSchemaName,
                 pgTablePattern,
                 slotName);
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/similar_names.sql
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/resources/ddl/similar_names.sql
@@ -82,3 +82,39 @@ INSERT INTO user_test_data
 VALUES (301, 'test_1', 'Harbin'),
        (302, 'test_2', 'Changchun'),
        (303, 'test_3', 'Shenyang');
+
+-- Cross-schema variant: the schema name is also passed to getColumns as a LIKE pattern,
+-- so a wildcard in the schema name matches other schemas too. 'sch_test' (where '_' matches any
+-- single character) also matches 'schxtest'. Both schemas contain a table with the SAME name, so
+-- a TABLE_NAME-only filter cannot tell them apart and the snapshot would mix in columns from the
+-- look-alike schema. The schema name must be checked as well.
+DROP SCHEMA IF EXISTS sch_test CASCADE;
+CREATE SCHEMA sch_test;
+DROP SCHEMA IF EXISTS schxtest CASCADE;
+CREATE SCHEMA schxtest;
+
+-- Target schema: sch_test.cross_schema_tbl
+CREATE TABLE sch_test.cross_schema_tbl (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  address VARCHAR(1024)
+);
+ALTER TABLE sch_test.cross_schema_tbl REPLICA IDENTITY FULL;
+
+INSERT INTO sch_test.cross_schema_tbl
+VALUES (1001, 'sch_test_1', 'Shanghai'),
+       (1002, 'sch_test_2', 'Beijing'),
+       (1003, 'sch_test_3', 'Hangzhou');
+
+-- Look-alike schema: schxtest.cross_schema_tbl (matches 'sch_test' because '_' matches 'x')
+CREATE TABLE schxtest.cross_schema_tbl (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  address VARCHAR(1024)
+);
+ALTER TABLE schxtest.cross_schema_tbl REPLICA IDENTITY FULL;
+
+INSERT INTO schxtest.cross_schema_tbl
+VALUES (2001, 'schxtest_1', 'Guangzhou'),
+       (2002, 'schxtest_2', 'Shenzhen'),
+       (2003, 'schxtest_3', 'Chengdu');


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-39844

## What is the purpose of the change

During the snapshot phase, the PostgreSQL connector reads column structure via JDBC `DatabaseMetaData#getColumns(catalog, schemaPattern, tableNamePattern, columnNamePattern)`. Per the JDBC spec, **both** `schemaPattern` and `tableNamePattern` are LIKE patterns, where `_` matches any single character and `%` matches any sequence of characters. Both are legal identifier characters in PostgreSQL, so `getColumns` can return columns from other schemas/tables that were never meant to match.

An exact filter on the **table name** already exists, but the **schema name was never validated**. When two schemas have names that are wildcard matches of each other (e.g. `sch_test` and `schxtest`, where `_` matches `x`) and both contain a same-named table, capturing `sch_test.<table>` also pulls in the look-alike schema's columns. The table-name filter cannot tell them apart, so the snapshot fails with `IllegalStateException: Duplicate key Optional.empty` (or, when columns differ, silently merges columns from the wrong schema).

## Brief change log

- `PostgresConnection#doReadTableColumn`: also compare the result-set `TABLE_SCHEM` (column 2) against `TableId.schema()`, in addition to the existing `TABLE_NAME` check. The schema check is skipped when the requested schema is `null`, so columns are not dropped when no schema is specified. This is a pure after-the-fact filter; it does not change the metadata query and does not affect normal (non-wildcard) schemas/tables.
- `SimilarTableNamesITCase` / `similar_names.sql`: add a cross-schema case with two schemas (`sch_test` / `schxtest`) that are wildcard matches of each other, each holding a same-named table, verifying that only the target schema's snapshot and incremental data are captured.

## Verifying this change

This change added tests and can be verified as follows:

- Added `SimilarTableNamesITCase#testReadTableWithSimilarSchemaNameUnderscore`, which fails (snapshot `IllegalStateException: Duplicate key Optional.empty`) without the fix and passes with it.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The connector code base: yes (postgres-cdc snapshot column reading)

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
