### PR TITLE
[FLINK-38647][CDC] Improve error message for null before/after struct in Postgres CDC

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresEventDeserializer.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/PostgresEventDeserializer.java
@@ -84,6 +84,11 @@ public class PostgresEventDeserializer extends DebeziumEventDeserializationSchem
     }
 
     @Override
+    protected String getNullBeforeDataHint() {
+        return "You may need to execute 'ALTER TABLE <table> REPLICA IDENTITY FULL' on the source table. ";
+    }
+
+    @Override
     protected List<SchemaChangeEvent> deserializeSchemaChangeRecord(SourceRecord record) {
         return Collections.emptyList();
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/event/DebeziumEventDeserializationSchema.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-debezium/src/main/java/org/apache/flink/cdc/debezium/event/DebeziumEventDeserializationSchema.java
@@ -144,12 +144,29 @@ public abstract class DebeziumEventDeserializationSchema extends SourceRecordEve
     private RecordData extractBeforeDataRecord(Struct value, Schema valueSchema) throws Exception {
         Schema beforeSchema = fieldSchema(valueSchema, Envelope.FieldName.BEFORE);
         Struct beforeValue = fieldStruct(value, Envelope.FieldName.BEFORE);
+        if (beforeValue == null) {
+            throw new NullPointerException(
+                    "Before data is null for UPDATE/DELETE event. "
+                            + getNullBeforeDataHint()
+                            + "Schema name: "
+                            + valueSchema.name());
+        }
         return extractDataRecord(beforeValue, beforeSchema);
+    }
+
+    protected String getNullBeforeDataHint() {
+        return "";
     }
 
     private RecordData extractAfterDataRecord(Struct value, Schema valueSchema) throws Exception {
         Schema afterSchema = fieldSchema(valueSchema, Envelope.FieldName.AFTER);
         Struct afterValue = fieldStruct(value, Envelope.FieldName.AFTER);
+        if (afterValue == null) {
+            throw new NullPointerException(
+                    "After data is null for CREATE/READ/UPDATE event. "
+                            + "Schema name: "
+                            + valueSchema.name());
+        }
         return extractDataRecord(afterValue, afterSchema);
     }
 


### PR DESCRIPTION
When PostgreSQL table uses default `REPLICA IDENTITY DEFAULT` or `REPLICA IDENTITY PRIMARY KEY`, the logical decoding plugin (pgoutput) may not provide complete `before-data` for UPDATE events. This causes the `before` struct to be null in Debezium events, leading to an unhelpful `NullPointerException`.