### PR TITLE
[FLINK-39916][mysql] Fix MySQL batch startup option validation error

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -139,7 +139,7 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
                 && !StartupOptions.snapshot().equals(startupOptions)) {
             throw new IllegalArgumentException(
                     String.format(
-                            "Only \"snapshot\" of MySQLDataSource StartupOption is supported in BATCH pipeline, but actual MySQLDataSource StartupOption is {}.",
+                            "Only \"snapshot\" of MySQLDataSource StartupOption is supported in BATCH pipeline, but actual MySQLDataSource StartupOption is %s.",
                             startupOptions.startupMode));
         }
         boolean includeSchemaChanges = config.get(SCHEMA_CHANGE_ENABLED);

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/factory/MySqlDataSourceFactory.java
@@ -513,8 +513,6 @@ public class MySqlDataSourceFactory implements DataSourceFactory {
                         distributionFactorLower));
     }
 
-    private static final String DOT_PLACEHOLDER = "_$dot_placeholder$_";
-
     /** Replaces the default timezone placeholder with session timezone, if applicable. */
     private static ZoneId getServerTimeZone(Configuration config) {
         final String serverTimeZone = config.get(SERVER_TIME_ZONE);


### PR DESCRIPTION
## What is the purpose of the change
This PR fixes an incorrect placeholder used in the MySQL Pipeline Connector batch startup option validation error.

## JIRA
[FLINK-39916](https://issues.apache.org/jira/browse/FLINK-39916)

## Change log
- Replace the SLF4J-style `{}` placeholder with the Java `String.format` placeholder `%s` in `MySqlDataSourceFactory.java`, so the actual startup option can be rendered correctly in the thrown `IllegalArgumentException`.

- Additional Cleanup: Remove an unused `DOT_PLACEHOLDER` constant from `MySqlDataSourceFactory.java`.

## Verifying this change
This is a small validation error output fix with no test coverage added.

## Why are the changes needed?
- This avoids showing an unresolved `{}` placeholder when an unsupported MySQL startup option is used in BATCH pipeline mode.

## How was this patch tested?
- Ran the related unit test locally.