### PR TITLE
[FLINK-39934][postgres] Fix invalid tables format error message

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/factory/PostgresDataSourceFactory.java
@@ -383,7 +383,7 @@ public class PostgresDataSourceFactory implements DataSourceFactory {
                     tableNameParts.length == 3,
                     String.format(
                             "Tables format must db.schema.table, can not 'tables' = %s",
-                            TABLES.key()));
+                            trimmedTableName));
             String currentDbName = tableNameParts[0];
 
             checkState(


### PR DESCRIPTION
# What is the purpose of the change

  This PR fixes the misleading validation error message in the Postgres pipeline connector when the configured tables value does not match the required db.schema.table format.

  Previously, the error message always printed the option key tables instead of the actual invalid table value, making the configuration issue harder to diagnose.

  Jira: [FLINK-39934](https://issues.apache.org/jira/browse/FLINK-39934)

  # Brief change log

  - Print the actual invalid table pattern in PostgresDataSourceFactory#getValidateDatabaseName
  - Keep the existing table format validation logic unchanged

  No configuration option is added because this only improves the validation error message and does not change connector behavior.

  # Verifying this change

  This change is verified by code inspection and git diff --check.

  Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e. is any changed class annotated with @Public(@PublicEvolving): no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no

  # Documentation

  Does this pull request introduce a new feature? no

  If yes, how is the feature documented? not applicable