### PR TITLE
[FLINK-39950][sqlserver] Fix chunk key column search restricted to primary key columns

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/main/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtils.java
@@ -125,7 +125,7 @@ public class SqlServerUtils {
 
     public static Column getSplitColumn(Table table, @Nullable String chunkKeyColumn) {
         List<Column> primaryKeys = table.primaryKeyColumns();
-        if (primaryKeys.isEmpty()) {
+        if (primaryKeys.isEmpty() && chunkKeyColumn == null) {
             throw new ValidationException(
                     String.format(
                             "Incremental snapshot for tables requires primary key,"
@@ -134,18 +134,19 @@ public class SqlServerUtils {
         }
 
         if (chunkKeyColumn != null) {
-            Optional<Column> targetPkColumn =
-                    primaryKeys.stream()
+            List<Column> columns = table.columns();
+            Optional<Column> targetColumn =
+                    columns.stream()
                             .filter(col -> chunkKeyColumn.equals(col.name()))
                             .findFirst();
-            if (targetPkColumn.isPresent()) {
-                return targetPkColumn.get();
+            if (targetColumn.isPresent()) {
+                return targetColumn.get();
             }
             throw new ValidationException(
                     String.format(
-                            "Chunk key column '%s' doesn't exist in the primary key [%s] of the table %s.",
+                            "Chunk key column '%s' doesn't exist in the columns [%s] of the table %s.",
                             chunkKeyColumn,
-                            primaryKeys.stream().map(Column::name).collect(Collectors.joining(",")),
+                            columns.stream().map(Column::name).collect(Collectors.joining(",")),
                             table.id()));
         }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtilsTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-sqlserver-cdc/src/test/java/org/apache/flink/cdc/connectors/sqlserver/source/utils/SqlServerUtilsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.sqlserver.source.utils;
+
+import org.apache.flink.table.api.ValidationException;
+
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableEditor;
+import io.debezium.relational.TableId;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Types;
+
+/** Unit tests for {@link SqlServerUtils#getSplitColumn}. */
+class SqlServerUtilsTest {
+
+    private static final TableId TABLE_ID = new TableId("testdb", "dbo", "customers");
+
+    // Builds a table with columns: id (PK), name, created_at
+    private static Table buildTable() {
+        Column id =
+                Column.editor()
+                        .name("id")
+                        .jdbcType(Types.INTEGER)
+                        .type("INT", "INT")
+                        .position(1)
+                        .optional(false)
+                        .create();
+        Column name =
+                Column.editor()
+                        .name("name")
+                        .jdbcType(Types.VARCHAR)
+                        .type("VARCHAR", "VARCHAR(255)")
+                        .position(2)
+                        .optional(true)
+                        .create();
+        Column createdAt =
+                Column.editor()
+                        .name("created_at")
+                        .jdbcType(Types.BIGINT)
+                        .type("BIGINT", "BIGINT")
+                        .position(3)
+                        .optional(true)
+                        .create();
+
+        TableEditor editor = Table.editor().tableId(TABLE_ID);
+        editor.addColumn(id);
+        editor.addColumn(name);
+        editor.addColumn(createdAt);
+        editor.setPrimaryKeyNames("id");
+        return editor.create();
+    }
+
+    // Builds a table with no primary key, columns: name, created_at
+    private static Table buildTableWithoutPrimaryKey() {
+        Column name =
+                Column.editor()
+                        .name("name")
+                        .jdbcType(Types.VARCHAR)
+                        .type("VARCHAR", "VARCHAR(255)")
+                        .position(1)
+                        .optional(true)
+                        .create();
+        Column createdAt =
+                Column.editor()
+                        .name("created_at")
+                        .jdbcType(Types.BIGINT)
+                        .type("BIGINT", "BIGINT")
+                        .position(2)
+                        .optional(true)
+                        .create();
+
+        TableEditor editor = Table.editor().tableId(TABLE_ID);
+        editor.addColumn(name);
+        editor.addColumn(createdAt);
+        return editor.create();
+    }
+
+    @Test
+    void testGetSplitColumnDefaultsToPrimaryKey() {
+        Table table = buildTable();
+        Column splitColumn = SqlServerUtils.getSplitColumn(table, null);
+        Assertions.assertThat(splitColumn.name()).isEqualTo("id");
+    }
+
+    @Test
+    void testGetSplitColumnWithPrimaryKeyColumnExplicitlySet() {
+        Table table = buildTable();
+        Column splitColumn = SqlServerUtils.getSplitColumn(table, "id");
+        Assertions.assertThat(splitColumn.name()).isEqualTo("id");
+    }
+
+    @Test
+    void testGetSplitColumnWithNonPrimaryKeyColumn() {
+        Table table = buildTable();
+        // Before the fix, this threw: "Chunk key column 'created_at' doesn't exist in the
+        // primary key [id]"
+        Column splitColumn = SqlServerUtils.getSplitColumn(table, "created_at");
+        Assertions.assertThat(splitColumn.name()).isEqualTo("created_at");
+    }
+
+    @Test
+    void testGetSplitColumnWithNonPrimaryKeyColumnByName() {
+        Table table = buildTable();
+        Column splitColumn = SqlServerUtils.getSplitColumn(table, "name");
+        Assertions.assertThat(splitColumn.name()).isEqualTo("name");
+    }
+
+    @Test
+    void testGetSplitColumnWithChunkKeyOnTableWithoutPrimaryKey() {
+        Table table = buildTableWithoutPrimaryKey();
+        // Before the fix, this threw immediately because primaryKeys.isEmpty() with no chunkKey
+        // guard. Now it should succeed when chunkKeyColumn is provided.
+        Column splitColumn = SqlServerUtils.getSplitColumn(table, "created_at");
+        Assertions.assertThat(splitColumn.name()).isEqualTo("created_at");
+    }
+
+    @Test
+    void testGetSplitColumnThrowsWhenNoPrimaryKeyAndNoChunkKeyColumn() {
+        Table table = buildTableWithoutPrimaryKey();
+        Assertions.assertThatThrownBy(() -> SqlServerUtils.getSplitColumn(table, null))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("doesn't have primary key");
+    }
+
+    @Test
+    void testGetSplitColumnThrowsWhenChunkKeyColumnDoesNotExist() {
+        Table table = buildTable();
+        Assertions.assertThatThrownBy(
+                        () -> SqlServerUtils.getSplitColumn(table, "nonexistent_column"))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("doesn't exist in the columns")
+                .hasMessageContaining("nonexistent_column");
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fixes [FLINK-39950](https://issues.apache.org/jira/browse/FLINK-39950) — `SqlServerUtils.getSplitColumn()` searches only `table.primaryKeyColumns()` when `scan.incremental.snapshot.chunk.key-column` is set, instead of searching all table columns. This makes it impossible to use a non-primary-key column as the chunk key on SQL Server, even though the feature is documented and works correctly in MySQL, Postgres, and Oracle connectors.

As a result, any user who sets `scan.incremental.snapshot.chunk.key-column` to a non-PK column gets a misleading `ValidationException: Chunk key column 'X' doesn't exist in the primary key [...]`. Additionally, tables without a primary key immediately throw before even checking whether a `chunkKeyColumn` was provided, making the no-PK + custom chunk key use case entirely broken.

The fix replaces the `primaryKeys.stream()` search with `table.columns().stream()` in `SqlServerUtils.getSplitColumn()`, and gates the "no primary key" error on `chunkKeyColumn == null`, matching the behavior of the Postgres and Oracle connectors.

## Brief change log
- Fixed `getSplitColumn()` to search all table columns instead of only primary key columns when `chunkKeyColumn` is set
- Updated the "no primary key" guard to allow tables without a PK when a `chunkKeyColumn` is explicitly provided
- Updated error message from "doesn't exist in the primary key" to "doesn't exist in the columns" to accurately reflect what was searched
- Added `SqlServerUtilsTest` with six unit tests covering all cases: default PK, explicit PK column, non-PK column, no-PK table with chunk key, no-PK table without chunk key (should throw), and non-existent column (should throw)

## Verifying this change

This change is covered by new unit tests in `SqlServerUtilsTest`:
- `testGetSplitColumnDefaultsToPrimaryKey()` — verifies the default behavior (no `chunkKeyColumn`) still returns the first PK column
- `testGetSplitColumnWithPrimaryKeyColumnExplicitlySet()` — verifies a PK column can still be explicitly set as the chunk key
- `testGetSplitColumnWithNonPrimaryKeyColumn()` — the core regression test; verifies that a non-PK column (`created_at`) is accepted correctly
- `testGetSplitColumnWithNonPrimaryKeyColumnByName()` — verifies another non-PK column (`name`) works correctly
- `testGetSplitColumnWithChunkKeyOnTableWithoutPrimaryKey()` — verifies a table with no PK can use a chunk key column without throwing
- `testGetSplitColumnThrowsWhenNoPrimaryKeyAndNoChunkKeyColumn()` — verifies the error is still thrown when neither a PK nor a chunk key column is available
- `testGetSplitColumnThrowsWhenChunkKeyColumnDoesNotExist()` — verifies a non-existent column name throws with an accurate error message

## Does this pull request potentially affect one of the following parts
- Dependencies (does it add or upgrade a dependency): **no**
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
- The serializers: **no**
- The runtime per-record code paths (performance sensitive): **no**
- Anything that affects deployment or recovery (JobManager, Checkpointing, Kubernetes/Yarn, ZooKeeper): **no**
- The S3 file system connector: **no**

## Documentation
- Does this pull request introduce a new feature? **no** — it fixes a bug in existing functionality
- If yes, how is the feature documented? not applicable

## Was generative AI tooling used to co-author this PR?
- [x] Yes — Claude Code was used as a pair-programming assistant. All code was written, understood, and verified by the author.
Generated-by: Claude Opus 4.8