### PR TITLE
[FLINK-40007][postgres] Fix snapshot fetch size conf does not take effect

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTask.java
@@ -98,6 +98,7 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
 
         PostgresSnapshotSplitReadTask snapshotSplitReadTask =
                 new PostgresSnapshotSplitReadTask(
+                        (PostgresSourceConfig) ctx.getSourceConfig(),
                         ctx.getConnection(),
                         ctx.getDbzConnectorConfig(),
                         ctx.getDatabaseSchema(),
@@ -214,7 +215,7 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
                 LoggerFactory.getLogger(PostgresSnapshotSplitReadTask.class);
 
         private final PostgresConnection jdbcConnection;
-        private final PostgresConnectorConfig connectorConfig;
+        private final PostgresSourceConfig sourceConfig;
         private final PostgresEventDispatcher<TableId> eventDispatcher;
         private final SnapshotSplit snapshotSplit;
         private final PostgresOffsetContext offsetContext;
@@ -223,6 +224,7 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
         private final Clock clock;
 
         public PostgresSnapshotSplitReadTask(
+                PostgresSourceConfig sourceConfig,
                 PostgresConnection jdbcConnection,
                 PostgresConnectorConfig connectorConfig,
                 PostgresSchema databaseSchema,
@@ -232,7 +234,7 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
                 SnapshotSplit snapshotSplit) {
             super(connectorConfig, snapshotProgressListener);
             this.jdbcConnection = jdbcConnection;
-            this.connectorConfig = connectorConfig;
+            this.sourceConfig = sourceConfig;
             this.snapshotProgressListener = snapshotProgressListener;
             this.databaseSchema = databaseSchema;
             this.eventDispatcher = eventDispatcher;
@@ -314,7 +316,7 @@ public class PostgresScanFetchTask extends AbstractScanFetchTask {
                                     snapshotSplit.getSplitStart(),
                                     snapshotSplit.getSplitEnd(),
                                     snapshotSplit.getSplitKeyType().getFieldCount(),
-                                    connectorConfig.getSnapshotFetchSize());
+                                    sourceConfig.getFetchSize());
                     ResultSet rs = selectStatement.executeQuery()) {
 
                 ColumnUtils.ColumnArray columnArray = ColumnUtils.toArray(rs, table);

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -55,7 +55,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresScanFetchTaskTest.java
@@ -300,14 +300,10 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
         PostgresSourceConfigFactory sourceConfigFactory =
                 getMockPostgresSourceConfigFactory(
                         customDatabase, schemaName, tableName, null, 10, true);
-        Properties properties = new Properties();
-        properties.setProperty("snapshot.fetch.size", "2");
-        sourceConfigFactory.debeziumProperties(properties);
+        sourceConfigFactory.fetchSize(2);
         PostgresSourceConfig sourceConfig = sourceConfigFactory.create(0);
         PostgresDialect postgresDialect = new PostgresDialect(sourceConfigFactory.create(0));
         SnapshotSplit snapshotSplit = getSnapshotSplits(sourceConfig, postgresDialect).get(0);
-        PostgresSourceFetchTaskContext postgresSourceFetchTaskContext =
-                new PostgresSourceFetchTaskContext(sourceConfig, postgresDialect);
         final String selectSql =
                 PostgresQueryUtils.buildSplitScanQuery(
                         snapshotSplit.getTableId(),
@@ -326,9 +322,7 @@ class PostgresScanFetchTaskTest extends PostgresTestBase {
                                 snapshotSplit.getSplitStart(),
                                 snapshotSplit.getSplitEnd(),
                                 snapshotSplit.getSplitKeyType().getFieldCount(),
-                                postgresSourceFetchTaskContext
-                                        .getDbzConnectorConfig()
-                                        .getSnapshotFetchSize());
+                                sourceConfig.getFetchSize());
                 ResultSet rs = selectStatement.executeQuery()) {
             assertThat(rs.getFetchSize()).isEqualTo(2);
         }


### PR DESCRIPTION
## What is the purpose of the change
Relate pr: https://github.com/apache/flink-cdc/pull/2766

The Postgres incremental source uses the Debezium connector config's snapshot
fetch size (`connectorConfig.getSnapshotFetchSize()`, default `10240`) for the
snapshot split read, instead of the Flink CDC option `scan.snapshot.fetch.size`
(default `1024`). As a result:

1. `scan.snapshot.fetch.size` has no effect for the Postgres source.
2. When a snapshot chunk's row count is `<=` the fetch size, the JDBC
   server-side cursor returns the whole chunk in a single batch, loading every
   row of the chunk into memory at once. On wide tables (many columns / large
   rows) this can exhaust the heap and OOM.

The MySQL source already reads `sourceConfig.getFetchSize()` for its snapshot
read. This PR makes the Postgres snapshot read task do the same, so that
`scan.snapshot.fetch.size` is honored consistently across connectors.

## Brief change log

- `PostgresSnapshotSplitReadTask` now takes the `PostgresSourceConfig` and uses
  `sourceConfig.getFetchSize()` for the snapshot select statement, instead of
  `connectorConfig.getSnapshotFetchSize()`.

## Verifying this change

This change is covered by existing Postgres source tests; the snapshot fetch
size now follows the `scan.snapshot.fetch.size` option.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable
