### PR TITLE
[FLINK-40040][cdc-runtime] Wrap coordinator failure in SerializedThrowable across the RPC boundary

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/ValuesDatabase.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/ValuesDatabase.java
@@ -40,6 +40,7 @@ import org.apache.flink.cdc.common.source.MetadataAccessor;
 import org.apache.flink.cdc.common.utils.Preconditions;
 import org.apache.flink.cdc.common.utils.SchemaUtils;
 import org.apache.flink.cdc.connectors.values.sink.ValuesDataSink;
+import org.apache.flink.cdc.connectors.values.sink.ValuesDataSinkOptions;
 import org.apache.flink.cdc.connectors.values.source.ValuesDataSource;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.Sets;
@@ -129,10 +130,22 @@ public class ValuesDatabase {
      * changes occur.
      */
     public static class ErrorOnChangeMetadataApplier implements MetadataApplier {
+
+        public static final String SIMULATED_CAUSE_MESSAGE =
+                "Simulated cause for rejected schema change events.";
+
         private Set<SchemaChangeEventType> enabledSchemaEvolutionTypes;
 
+        /** {@link ValuesDataSinkOptions#ERROR_ON_SCHEMA_CHANGE_EXCEPTION_CLASS}. */
+        private final @Nullable String rejectionCauseClass;
+
         public ErrorOnChangeMetadataApplier() {
+            this(null);
+        }
+
+        public ErrorOnChangeMetadataApplier(@Nullable String rejectionCauseClass) {
             enabledSchemaEvolutionTypes = getSupportedSchemaEvolutionTypes();
+            this.rejectionCauseClass = rejectionCauseClass;
         }
 
         @Override
@@ -167,7 +180,27 @@ public class ValuesDatabase {
                 throw new UnsupportedSchemaChangeEventException(
                         schemaChangeEvent,
                         "Rejected schema change event since error.on.schema.change is enabled.",
-                        null);
+                        createRejectionCause());
+            }
+        }
+
+        /**
+         * Reflectively instantiates the configured rejection cause on the coordinator, so that the
+         * cause class only needs to be present on the JobManager classpath.
+         */
+        @Nullable
+        private Throwable createRejectionCause() {
+            if (rejectionCauseClass == null) {
+                return null;
+            }
+            try {
+                return (Throwable)
+                        Class.forName(rejectionCauseClass, true, getClass().getClassLoader())
+                                .getConstructor(String.class)
+                                .newInstance(SIMULATED_CAUSE_MESSAGE);
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException(
+                        "Unable to instantiate rejection cause class " + rejectionCauseClass, e);
             }
         }
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/factory/ValuesDataFactory.java
@@ -89,8 +89,9 @@ public class ValuesDataFactory implements DataSourceFactory, DataSinkFactory {
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.MATERIALIZED_IN_MEMORY),
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.PRINT_ENABLED),
                 context.getFactoryConfiguration().get(ValuesDataSinkOptions.SINK_API),
+                context.getFactoryConfiguration().get(ValuesDataSinkOptions.ERROR_ON_SCHEMA_CHANGE),
                 context.getFactoryConfiguration()
-                        .get(ValuesDataSinkOptions.ERROR_ON_SCHEMA_CHANGE));
+                        .get(ValuesDataSinkOptions.ERROR_ON_SCHEMA_CHANGE_EXCEPTION_CLASS));
     }
 
     @Override
@@ -113,6 +114,7 @@ public class ValuesDataFactory implements DataSourceFactory, DataSinkFactory {
         options.add(ValuesDataSinkOptions.PRINT_ENABLED);
         options.add(ValuesDataSinkOptions.SINK_API);
         options.add(ValuesDataSinkOptions.ERROR_ON_SCHEMA_CHANGE);
+        options.add(ValuesDataSinkOptions.ERROR_ON_SCHEMA_CHANGE_EXCEPTION_CLASS);
         return options;
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSink.java
@@ -56,15 +56,20 @@ public class ValuesDataSink implements DataSink, Serializable {
 
     private final boolean errorOnSchemaChange;
 
+    /** {@link ValuesDataSinkOptions#ERROR_ON_SCHEMA_CHANGE_EXCEPTION_CLASS}. */
+    private final String errorOnSchemaChangeExceptionClass;
+
     public ValuesDataSink(
             boolean materializedInMemory,
             boolean print,
             SinkApi sinkApi,
-            boolean errorOnSchemaChange) {
+            boolean errorOnSchemaChange,
+            String errorOnSchemaChangeExceptionClass) {
         this.materializedInMemory = materializedInMemory;
         this.print = print;
         this.sinkApi = sinkApi;
         this.errorOnSchemaChange = errorOnSchemaChange;
+        this.errorOnSchemaChangeExceptionClass = errorOnSchemaChangeExceptionClass;
     }
 
     @Override
@@ -80,7 +85,8 @@ public class ValuesDataSink implements DataSink, Serializable {
     @Override
     public MetadataApplier getMetadataApplier() {
         if (errorOnSchemaChange) {
-            return new ValuesDatabase.ErrorOnChangeMetadataApplier();
+            return new ValuesDatabase.ErrorOnChangeMetadataApplier(
+                    errorOnSchemaChangeExceptionClass);
         } else {
             return new ValuesDatabase.ValuesMetadataApplier(materializedInMemory);
         }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-values/src/main/java/org/apache/flink/cdc/connectors/values/sink/ValuesDataSinkOptions.java
@@ -49,4 +49,16 @@ public class ValuesDataSinkOptions {
                     .defaultValue(false)
                     .withDescription(
                             "True if a runtime error should be thrown when handling schema change events.");
+
+    public static final ConfigOption<String> ERROR_ON_SCHEMA_CHANGE_EXCEPTION_CLASS =
+            ConfigOptions.key("error.on.schema.change.exception.class")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Fully-qualified name of a Throwable class to attach as the cause of the "
+                                    + "error thrown when error.on.schema.change is enabled. The class is "
+                                    + "instantiated reflectively (via its String constructor) on the "
+                                    + "SchemaRegistry coordinator, so it only needs to be present on the "
+                                    + "JobManager classpath. Used for testing failure propagation across "
+                                    + "the operator-coordinator RPC boundary.");
 }

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/CoordinatorFailurePropagationE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/CoordinatorFailurePropagationE2eITCase.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.pipeline.tests;
+
+import org.apache.flink.cdc.connectors.mysql.testutils.UniqueDatabase;
+import org.apache.flink.cdc.pipeline.tests.utils.JobManagerOnlyException;
+import org.apache.flink.cdc.pipeline.tests.utils.PipelineTestEnvironment;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+/**
+ * E2e test for FLINK-40040: a failure raised on the SchemaRegistry coordinator must survive the
+ * operator-coordinator RPC boundary even if the receiving side cannot load its exception class.
+ *
+ * <p>To reproduce the classpath asymmetry seen in production (e.g. a JDBC driver installed in the
+ * JobManager's {@code lib/} directory but absent from the TaskManager), the test packages {@link
+ * JobManagerOnlyException} into a jar that is copied into the JobManager container only. The values
+ * sink's metadata applier then raises it on the coordinator as the cause of a rejected schema
+ * change.
+ *
+ * <p>Without wrapping the failure into a {@code SerializedThrowable}, the exceptionally completed
+ * coordination response cannot be deserialized by the TaskManager's RPC layer (which cannot load
+ * user classes). The deserialization failure tears down the whole JobManager <-> TaskManager Pekko
+ * association ("Association with remote system ... has failed, address is now gated"), so
+ * cancellation stalls for a full RPC timeout cycle (around a minute) before the job manages to
+ * reach FAILED, and the original cause never surfaces on the TaskManager — with a restart strategy
+ * configured, every restart attempt repeats this stall, turning a transient coordinator error into
+ * a restart loop with only misleading timeout errors.
+ */
+class CoordinatorFailurePropagationE2eITCase extends PipelineTestEnvironment {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(CoordinatorFailurePropagationE2eITCase.class);
+
+    private static final String JM_ONLY_EXCEPTION_CLASS = JobManagerOnlyException.class.getName();
+
+    private static final String JM_ONLY_EXCEPTION_JAR = "jm-only-exception.jar";
+
+    // Keep in sync with ValuesDatabase.ErrorOnChangeMetadataApplier#SIMULATED_CAUSE_MESSAGE.
+    private static final String SIMULATED_CAUSE_MESSAGE =
+            "Simulated cause for rejected schema change events.";
+
+    protected final UniqueDatabase schemaEvolveDatabase =
+            new UniqueDatabase(MYSQL, "schema_evolve", MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+
+    @Override
+    protected List<String> copyJarToFlinkLib() {
+        // Installs the jar into the JobManager container's /opt/flink/lib only; the TaskManager
+        // container never gets a copy, and the jar is not submitted with the pipeline either.
+        generateJobManagerOnlyExceptionJar();
+        return Collections.singletonList(JM_ONLY_EXCEPTION_JAR);
+    }
+
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+        schemaEvolveDatabase.createAndInitialize();
+    }
+
+    @AfterEach
+    public void after() {
+        super.after();
+        schemaEvolveDatabase.dropDatabase();
+    }
+
+    @Test
+    void testCoordinatorFailureWithJobManagerOnlyClassReachesTaskManager() throws Exception {
+        String dbName = schemaEvolveDatabase.getDatabaseName();
+
+        String pipelineJob =
+                String.format(
+                        "source:\n"
+                                + "  type: mysql\n"
+                                + "  hostname: %s\n"
+                                + "  port: 3306\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "  tables: %s.members\n"
+                                + "  server-id: 5400-5404\n"
+                                + "  server-time-zone: UTC\n"
+                                + "\n"
+                                + "sink:\n"
+                                + "  type: values\n"
+                                + "  error.on.schema.change: true\n"
+                                + "  error.on.schema.change.exception.class: %s\n"
+                                + "\n"
+                                + "pipeline:\n"
+                                + "  schema.change.behavior: evolve\n"
+                                + "  parallelism: %d",
+                        INTER_CONTAINER_MYSQL_ALIAS,
+                        MYSQL_TEST_USER,
+                        MYSQL_TEST_PASSWORD,
+                        dbName,
+                        JM_ONLY_EXCEPTION_CLASS,
+                        parallelism);
+        submitPipelineJob(pipelineJob);
+        waitUntilJobRunning(Duration.ofSeconds(30));
+        LOG.info("Pipeline job is running");
+        validateSnapshotData(dbName);
+
+        LOG.info("Triggering a schema change to make the coordinator fail");
+        String mysqlJdbcUrl =
+                String.format(
+                        "jdbc:mysql://%s:%s/%s", MYSQL.getHost(), MYSQL.getDatabasePort(), dbName);
+
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                mysqlJdbcUrl, MYSQL_TEST_USER, MYSQL_TEST_PASSWORD);
+                Statement stmt = conn.createStatement()) {
+            waitForIncrementalStage(dbName, stmt);
+
+            // Triggers an AddColumnEvent, which the error.on.schema.change applier rejects on the
+            // coordinator with a JobManagerOnlyException cause.
+            stmt.execute("ALTER TABLE members ADD COLUMN gender TINYINT AFTER age;");
+        }
+
+        // The coordinator loads JobManagerOnlyException from the JobManager's lib directory and
+        // fails the job with it.
+        waitUntilLogContains(
+                jobManagerConsumer,
+                "An exception was triggered from Schema change applying task. Job will fail now.");
+        waitUntilLogContains(
+                jobManagerConsumer, JM_ONLY_EXCEPTION_CLASS + ": " + SIMULATED_CAUSE_MESSAGE);
+        waitUntilLogContains(
+                jobManagerConsumer,
+                "org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy");
+
+        // The job must fail cleanly: terminal state reached on the JobManager and all tasks
+        // reporting a final execution state on the TaskManager. Without the SerializedThrowable
+        // wrapping this takes a full RPC timeout cycle instead of a few seconds, because the
+        // undeliverable failure tears down the JobManager <-> TaskManager Pekko association and
+        // cancellation stalls until it recovers.
+        waitUntilLogContains(jobManagerConsumer, "reached terminal state FAILED");
+        waitUntilLogContains(
+                taskManagerConsumer, "Un-registering task and sending final execution state");
+
+        // The regression assertion: the TaskManager's RPC layer must never choke on the
+        // coordinator failure. Without the SerializedThrowable wrapping, deserializing the
+        // exceptionally completed coordination response fails on the TaskManager and Pekko logs
+        // "Association with remote system [...] has failed, address is now gated ...
+        // Reason: [org.apache.flink.cdc...Exception]" here.
+        Assertions.assertThat(taskManagerConsumer.toUtf8String())
+                .doesNotContain("has failed, address is now gated");
+    }
+
+    private void validateSnapshotData(String dbName) throws Exception {
+        validateResult(
+                s -> String.format(s, dbName),
+                "CreateTableEvent{tableId=%s.members, schema=columns={`id` INT NOT NULL,`name` VARCHAR(17),`age` INT}, primaryKeys=id, options=()}",
+                "DataChangeEvent{tableId=%s.members, before=[], after=[1008, Alice, 21], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.members, before=[], after=[1009, Bob, 20], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.members, before=[], after=[1010, Carol, 19], op=INSERT, meta=()}",
+                "DataChangeEvent{tableId=%s.members, before=[], after=[1011, Derrida, 18], op=INSERT, meta=()}");
+    }
+
+    private void waitForIncrementalStage(String dbName, Statement stmt) throws Exception {
+        stmt.execute("INSERT INTO members VALUES (0, '__fence__', 0);");
+
+        // Ensure we change schema after incremental stage
+        waitUntilSpecificEvent(
+                taskManagerConsumer,
+                String.format(
+                        "DataChangeEvent{tableId=%s.members, before=[], after=[0, __fence__, 0], op=INSERT, meta=()}",
+                        dbName));
+    }
+
+    /**
+     * Packages the compiled {@link JobManagerOnlyException} class from the test classpath into a
+     * standalone jar under the module's {@code target} directory, where {@code
+     * TestUtils#getResource} can find it.
+     */
+    private static void generateJobManagerOnlyExceptionJar() {
+        String classEntry = JM_ONLY_EXCEPTION_CLASS.replace('.', '/') + ".class";
+        Path moduleDir =
+                Paths.get(
+                        System.getProperty("moduleDir", Paths.get("").toAbsolutePath().toString()));
+        Path jarPath =
+                moduleDir
+                        .resolve("target")
+                        .resolve("generated-e2e-jars")
+                        .resolve(JM_ONLY_EXCEPTION_JAR);
+        try {
+            Files.createDirectories(jarPath.getParent());
+            try (InputStream classStream =
+                            CoordinatorFailurePropagationE2eITCase.class
+                                    .getClassLoader()
+                                    .getResourceAsStream(classEntry);
+                    JarOutputStream jarStream =
+                            new JarOutputStream(Files.newOutputStream(jarPath))) {
+                if (classStream == null) {
+                    throw new IllegalStateException(
+                            "Could not find " + classEntry + " on the test classpath.");
+                }
+                jarStream.putNextEntry(new JarEntry(classEntry));
+                byte[] buffer = new byte[4096];
+                int read;
+                while ((read = classStream.read(buffer)) != -1) {
+                    jarStream.write(buffer, 0, read);
+                }
+                jarStream.closeEntry();
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to generate " + JM_ONLY_EXCEPTION_JAR, e);
+        }
+    }
+}

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolveE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolveE2eITCase.java
@@ -100,8 +100,12 @@ class SchemaEvolveE2eITCase extends PipelineTestEnvironment {
                 false,
                 Collections.emptyList(),
                 Arrays.asList(
-                        "Caused by: org.apache.flink.util.FlinkRuntimeException: Failed to apply schema change event.",
-                        "Caused by: org.apache.flink.cdc.common.exceptions.UnsupportedSchemaChangeEventException",
+                        // The coordinator failure crosses the operator-coordinator RPC boundary as
+                        // a SerializedThrowable, so the "Caused by: " rendering of the cause chain
+                        // varies; only assert the class names and messages that appear in every
+                        // representation.
+                        "org.apache.flink.util.FlinkRuntimeException: Failed to apply schema change event.",
+                        "org.apache.flink.cdc.common.exceptions.UnsupportedSchemaChangeEventException",
                         "org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy"));
     }
 

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolvingTransformE2eITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/SchemaEvolvingTransformE2eITCase.java
@@ -101,7 +101,9 @@ class SchemaEvolvingTransformE2eITCase extends PipelineTestEnvironment {
                 Arrays.asList(
                         "An exception was triggered from Schema change applying task. Job will fail now.",
                         "org.apache.flink.util.FlinkRuntimeException: Failed to apply schema change event.",
-                        "Caused by: org.apache.flink.cdc.common.exceptions.UnsupportedSchemaChangeEventException",
+                        // No "Caused by: " prefix: the coordinator failure crosses the RPC boundary
+                        // as a SerializedThrowable, so the cause-chain rendering varies.
+                        "org.apache.flink.cdc.common.exceptions.UnsupportedSchemaChangeEventException",
                         "org.apache.flink.runtime.JobException: Recovery is suppressed by NoRestartBackoffTimeStrategy"));
     }
 

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/utils/JobManagerOnlyException.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/utils/JobManagerOnlyException.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.pipeline.tests.utils;
+
+/**
+ * A {@link RuntimeException} that is deliberately packaged into a jar which is only installed into
+ * the JobManager container's {@code /opt/flink/lib}, and never shipped to the TaskManager container
+ * or submitted with the pipeline jars.
+ *
+ * <p>It emulates the classpath asymmetry seen in production (e.g. a JDBC driver present in the
+ * JobManager's lib directory but absent from the TaskManager), so that a coordinator-side failure
+ * of this class cannot be deserialized on the TaskManager unless it crosses the
+ * operator-coordinator RPC boundary as a {@code SerializedThrowable} (FLINK-40040).
+ */
+public class JobManagerOnlyException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public JobManagerOnlyException(String message) {
+        super(message);
+    }
+}

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaRegistry.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaRegistry.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.function.ThrowingRunnable;
 
 import org.slf4j.Logger;
@@ -352,9 +353,10 @@ public abstract class SchemaRegistry implements OperatorCoordinator, Coordinatio
                         // if we have a JVM critical error, promote it immediately, there is a good
                         // chance the logging or job failing will not succeed anymore
                         ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-                        handleUnrecoverableError(
-                                String.format(actionName, actionNameFormatParameters), t);
-                        context.failJob(t);
+                        // Route through failJob so the exception is wrapped into a
+                        // SerializedThrowable before crossing the operator-coordinator RPC
+                        // boundary (see failJob for the rationale).
+                        failJob(String.format(actionName, actionNameFormatParameters), t);
                     }
                 });
     }
@@ -393,8 +395,20 @@ public abstract class SchemaRegistry implements OperatorCoordinator, Coordinatio
     protected <T extends Throwable> void failJob(String taskDescription, T t) {
         ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
         LOG.error("An exception was triggered from {}. Job will fail now.", taskDescription, t);
-        handleUnrecoverableError(taskDescription, t);
-        context.failJob(t);
+        // Wrap into a SerializedThrowable before it crosses the operator-coordinator / failover
+        // RPC boundary. Otherwise an exception whose class only lives in the user classloader
+        // (e.g. com.mysql.cj.exceptions.ConnectionIsClosedException surfaced during table
+        // discovery / schema coordination) fails to deserialize on the receiving side, where
+        // flink-rpc-akka uses an isolated classloader, with ClassNotFoundException. The
+        // coordination response is then never delivered, so the SchemaOperator request stalls
+        // until rpcTimeout and fails with a misleading TimeoutException that hides the real
+        // cause and turns a transient error into a restart loop.
+        SerializedThrowable serialized =
+                (t instanceof SerializedThrowable)
+                        ? (SerializedThrowable) t
+                        : new SerializedThrowable(t);
+        handleUnrecoverableError(taskDescription, serialized);
+        context.failJob(serialized);
     }
 
     // ------------------------

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaRegistryFailJobSerializationTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/common/SchemaRegistryFailJobSerializationTest.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.runtime.operators.schema.common;
+
+import org.apache.flink.cdc.common.event.SchemaChangeEvent;
+import org.apache.flink.cdc.common.pipeline.RouteMode;
+import org.apache.flink.cdc.common.pipeline.SchemaChangeBehavior;
+import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.runtime.operators.schema.common.event.FlushSuccessEvent;
+import org.apache.flink.cdc.runtime.testutils.operators.MockedOperatorCoordinatorContext;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
+import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.util.SerializedThrowable;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Regression test for the operator-coordinator RPC exception-serialization bug.
+ *
+ * <p>When {@link SchemaRegistry#failJob} completes a coordination response exceptionally, the
+ * exception crosses the operator-coordinator RPC boundary and is deserialized by flink-rpc-akka
+ * using an isolated classloader. If the exception's cause chain contains a class that only lives in
+ * the user classloader (e.g. {@code com.mysql.cj.exceptions.ConnectionIsClosedException} raised
+ * during table discovery), plain Java serialization fails on the receiving side with {@link
+ * ClassNotFoundException} and the response is lost, stalling the request until rpcTimeout and
+ * failing with a misleading {@code TimeoutException}. {@code failJob} therefore wraps the exception
+ * into a {@link SerializedThrowable} so it survives that boundary.
+ */
+class SchemaRegistryFailJobSerializationTest {
+
+    /** Stands in for a MySQL driver exception that only lives in the user classloader. */
+    private static final class UserClassloaderOnlyException extends RuntimeException {
+        UserClassloaderOnlyException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    void failJobWrapsExceptionIntoSerializedThrowable() throws Exception {
+        MockedOperatorCoordinatorContext context =
+                new MockedOperatorCoordinatorContext(new OperatorID(), getClass().getClassLoader());
+        try (TestSchemaRegistry registry = new TestSchemaRegistry(context)) {
+            Throwable driverEx =
+                    new UserClassloaderOnlyException("connection was unexpectedly lost");
+            RuntimeException wrapped =
+                    new RuntimeException("Failed to discovery tables to capture", driverEx);
+
+            registry.failJobForTest("table discovery", wrapped);
+
+            assertThat(context.getFailureCause()).isInstanceOf(SerializedThrowable.class);
+        }
+    }
+
+    @Test
+    void wrappedFailureSurvivesIsolatedClassloaderButRawOneDoesNot() throws Exception {
+        Throwable driverEx = new UserClassloaderOnlyException("connection was unexpectedly lost");
+        RuntimeException rawWrapped =
+                new RuntimeException("Failed to discovery tables to capture", driverEx);
+
+        // The isolated classloader (as flink-rpc-akka uses) cannot see the user-jar exception.
+        IsolatedClassLoader isolated =
+                new IsolatedClassLoader(
+                        getClass().getClassLoader(), UserClassloaderOnlyException.class.getName());
+
+        // Before the fix: the raw exception chain fails to deserialize -> response is lost.
+        byte[] rawBytes = serialize(rawWrapped);
+        assertThatThrownBy(() -> deserializeWith(rawBytes, isolated))
+                .isInstanceOf(ClassNotFoundException.class)
+                .hasMessageContaining(UserClassloaderOnlyException.class.getName());
+
+        // After the fix: SerializedThrowable survives and preserves the real cause as text.
+        MockedOperatorCoordinatorContext context =
+                new MockedOperatorCoordinatorContext(new OperatorID(), getClass().getClassLoader());
+        try (TestSchemaRegistry registry = new TestSchemaRegistry(context)) {
+            registry.failJobForTest("table discovery", rawWrapped);
+            SerializedThrowable serialized = (SerializedThrowable) context.getFailureCause();
+
+            byte[] wrappedBytes = serialize(serialized);
+            Object result = deserializeWith(wrappedBytes, isolated);
+
+            assertThat(result).isInstanceOf(SerializedThrowable.class);
+            assertThat(((SerializedThrowable) result).getFullStringifiedStackTrace())
+                    .contains("Failed to discovery tables to capture")
+                    .contains("connection was unexpectedly lost");
+        }
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------------------------------
+
+    /** Minimal concrete {@link SchemaRegistry} that only exposes {@code failJob} for testing. */
+    private static final class TestSchemaRegistry extends SchemaRegistry {
+        private final ExecutorService executor;
+
+        TestSchemaRegistry(OperatorCoordinator.Context context) {
+            this(context, Executors.newSingleThreadExecutor());
+        }
+
+        private TestSchemaRegistry(OperatorCoordinator.Context context, ExecutorService executor) {
+            super(
+                    context,
+                    "test-registry",
+                    executor,
+                    new NoOpMetadataApplier(),
+                    Collections.emptyList(),
+                    RouteMode.ALL_MATCH,
+                    SchemaChangeBehavior.EVOLVE,
+                    Duration.ofSeconds(30));
+            this.executor = executor;
+        }
+
+        void failJobForTest(String taskDescription, Throwable t) {
+            failJob(taskDescription, t);
+        }
+
+        @Override
+        protected void snapshot(CompletableFuture<byte[]> resultFuture) {
+            resultFuture.complete(new byte[0]);
+        }
+
+        @Override
+        protected void restore(byte[] checkpointData) {}
+
+        @Override
+        protected void handleFlushSuccessEvent(FlushSuccessEvent event) {}
+
+        @Override
+        protected void handleCustomCoordinationRequest(
+                CoordinationRequest request,
+                CompletableFuture<CoordinationResponse> responseFuture) {}
+
+        @Override
+        public void close() throws Exception {
+            executor.shutdownNow();
+        }
+    }
+
+    private static final class NoOpMetadataApplier implements MetadataApplier {
+        @Override
+        public void applySchemaChange(SchemaChangeEvent schemaChangeEvent) {}
+    }
+
+    /** Simulates flink-rpc-akka's isolated classloader that cannot see user-jar classes. */
+    private static final class IsolatedClassLoader extends ClassLoader {
+        private final String hiddenClassName;
+
+        IsolatedClassLoader(ClassLoader parent, String hiddenClassName) {
+            super(parent);
+            this.hiddenClassName = hiddenClassName;
+        }
+
+        @Override
+        public Class<?> loadClass(String name) throws ClassNotFoundException {
+            if (name.equals(hiddenClassName)) {
+                throw new ClassNotFoundException(name);
+            }
+            return super.loadClass(name);
+        }
+    }
+
+    private static final class ClassLoaderObjectInputStream extends ObjectInputStream {
+        private final ClassLoader classLoader;
+
+        ClassLoaderObjectInputStream(InputStream in, ClassLoader classLoader) throws IOException {
+            super(in);
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        protected Class<?> resolveClass(ObjectStreamClass desc)
+                throws IOException, ClassNotFoundException {
+            return Class.forName(desc.getName(), false, classLoader);
+        }
+    }
+
+    private static byte[] serialize(Object o) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(o);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static Object deserializeWith(byte[] data, ClassLoader classLoader) throws Exception {
+        try (ClassLoaderObjectInputStream in =
+                new ClassLoaderObjectInputStream(new ByteArrayInputStream(data), classLoader)) {
+            return in.readObject();
+        }
+    }
+}

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaEvolveTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/schema/regular/SchemaEvolveTest.java
@@ -42,7 +42,6 @@ import org.apache.flink.cdc.common.types.RowType;
 import org.apache.flink.cdc.runtime.testutils.operators.RegularEventOperatorTestHarness;
 import org.apache.flink.cdc.runtime.typeutils.BinaryRecordDataGenerator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
 import org.apache.flink.shaded.guava31.com.google.common.collect.Sets;
@@ -56,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 /** Unit tests for the {@link SchemaOperator} to handle evolved schema. */
@@ -702,19 +700,15 @@ class SchemaEvolveTest {
                                             new AddColumnEvent.ColumnWithPosition(
                                                     Column.physicalColumn(
                                                             "height", DOUBLE, "Height data")))));
+            // The coordinator wraps its failure into a SerializedThrowable before completing the
+            // pending coordination response, so it survives the operator-coordinator RPC boundary
+            // (flink-rpc-akka deserializes responses with an isolated classloader that cannot load
+            // user-classloader exception types). The original cause chain is preserved as text, so
+            // assert on stack trace content; the top-level type is not asserted since the failure
+            // may surface via the operator request or the job-failure path depending on timing.
             Assertions.assertThatThrownBy(() -> processEvent(schemaOperator, addColumnEvents))
-                    .isExactlyInstanceOf(IllegalStateException.class)
-                    .cause()
-                    .isExactlyInstanceOf(ExecutionException.class)
-                    .cause()
-                    .isExactlyInstanceOf(FlinkRuntimeException.class)
-                    .hasMessage("Failed to apply schema change event.")
-                    .cause()
-                    .isExactlyInstanceOf(SchemaEvolveException.class)
-                    .extracting("applyingEvent", "exceptionMessage")
-                    .containsExactly(
-                            addColumnEvents.get(0),
-                            "Unexpected schema change events occurred in EXCEPTION mode. Job will fail now.");
+                    .hasStackTraceContaining("Failed to apply schema change event.")
+                    .hasStackTraceContaining(SchemaEvolveException.class.getName());
 
             // No schema change events should be sent to downstream
             Assertions.assertThat(harness.getOutputRecords())
@@ -1097,28 +1091,22 @@ class SchemaEvolveTest {
                                         new AddColumnEvent.ColumnWithPosition(
                                                 Column.physicalColumn(
                                                         "height", DOUBLE, "Height data")))));
+        // See testExceptionEvolveSchema: the coordinator failure crosses the RPC boundary as a
+        // SerializedThrowable, so assert on stack trace content instead of exact exception types.
+        // Depending on which delivery path surfaces the failure, the wrapped cause is printed
+        // either as its fully-qualified class name (nested-cause toString) or via the exception's
+        // custom toString (top-level stringified stack), so only the simple class name -- present
+        // in both representations -- is asserted.
         Assertions.assertThatThrownBy(() -> processEvent(schemaOperator, addColumnEvents))
-                .isExactlyInstanceOf(IllegalStateException.class)
-                .cause()
-                .isExactlyInstanceOf(ExecutionException.class)
-                .cause()
-                .isExactlyInstanceOf(FlinkRuntimeException.class)
-                .hasMessage("Failed to apply schema change event.")
-                .cause()
-                .isExactlyInstanceOf(UnsupportedSchemaChangeEventException.class)
-                .extracting("applyingEvent", "exceptionMessage")
-                .containsExactly(
-                        addColumnEvents.get(0), "Sink doesn't support such schema change event.");
+                .hasStackTraceContaining("Failed to apply schema change event.")
+                .hasStackTraceContaining(
+                        UnsupportedSchemaChangeEventException.class.getSimpleName());
 
         Assertions.assertThat(harness.isJobFailed()).isTrue();
+        // The job failure cause is likewise a SerializedThrowable carrying the original chain.
         Assertions.assertThat(harness.getJobFailureCause())
-                .cause()
-                .isExactlyInstanceOf(UnsupportedSchemaChangeEventException.class)
-                .matches(
-                        e ->
-                                ((UnsupportedSchemaChangeEventException) e)
-                                        .getExceptionMessage()
-                                        .equals("Sink doesn't support such schema change event."));
+                .hasStackTraceContaining(
+                        UnsupportedSchemaChangeEventException.class.getSimpleName());
         harness.close();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Schema-evolution coordination responses are dropped when the failure's cause is a class that only lives in the user classloader (e.g. `com.mysql.cj.exceptions.ConnectionIsClosedException`). `flink-rpc-akka` deserializes the coordination response with an isolated classloader and throws `ClassNotFoundException`, so the response never reaches `SchemaOperator`, which then blocks on `responseFuture.get(rpcTimeout)` and fails with a misleading `TimeoutException` -- turning a transient error into a restart loop that only a full job restart recovers from.

Observed in production (Flink CDC 3.6.0 on Flink 1.20.3):

```
ERROR org.apache.pekko.remote.Remoting                             [] - com.mysql.cj.exceptions.ConnectionIsClosedException
java.lang.ClassNotFoundException: com.mysql.cj.exceptions.ConnectionIsClosedException
	at java.base/java.net.URLClassLoader.findClass(Unknown Source) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
	at org.apache.flink.core.classloading.ComponentClassLoader.loadClassFromComponentOnly(ComponentClassLoader.java:150) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.core.classloading.ComponentClassLoader.loadClass(ComponentClassLoader.java:113) ~[flink-dist-1.20.3.jar:1.20.3]
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.resolveClass(Unknown Source) ~[?:?]
	at org.apache.pekko.util.ClassLoaderObjectInputStream.resolveClass(ClassLoaderObjectInputStream.scala:29) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at java.base/java.io.ObjectInputStream.readNonProxyDesc(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readClassDesc(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readObject0(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.defaultReadFields(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.defaultReadObject(Unknown Source) ~[?:?]
	at java.base/java.lang.Throwable.readObject(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectStreamClass.invokeReadObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readSerialData(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readObject0(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.defaultReadFields(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.defaultReadObject(Unknown Source) ~[?:?]
	at java.base/java.lang.Throwable.readObject(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectStreamClass.invokeReadObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readSerialData(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readObject0(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.defaultReadFields(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.defaultReadObject(Unknown Source) ~[?:?]
	at java.base/java.lang.Throwable.readObject(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectStreamClass.invokeReadObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readSerialData(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readObject0(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readObject(Unknown Source) ~[?:?]
	at java.base/java.io.ObjectInputStream.readObject(Unknown Source) ~[?:?]
	at org.apache.pekko.serialization.JavaSerializer.$anonfun$fromBinary$1(Serializer.scala:358) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at scala.util.DynamicVariable.withValue(DynamicVariable.scala:62) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.JavaSerializer.fromBinary(Serializer.scala:358) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.$anonfun$deserializeByteArray$1(Serialization.scala:233) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.deserializeByteArray(Serialization.scala:167) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.$anonfun$deserialize$5(Serialization.scala:218) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at scala.util.Try$.apply(Try.scala:213) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.deserialize(Serialization.scala:209) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.serialization.WrappedPayloadSupport$.deserializePayload(WrappedPayloadSupport.scala:107) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.serialization.WrappedPayloadSupport.deserializePayload(WrappedPayloadSupport.scala:48) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.serialization.MiscMessageSerializer.deserializeStatusFailure(MiscMessageSerializer.scala:478) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.serialization.MiscMessageSerializer.$anonfun$fromBinaryMap$4(MiscMessageSerializer.scala:352) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.serialization.MiscMessageSerializer.fromBinary(MiscMessageSerializer.scala:427) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.$anonfun$deserializeByteArray$1(Serialization.scala:230) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.deserializeByteArray(Serialization.scala:167) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.$anonfun$deserialize$5(Serialization.scala:218) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at scala.util.Try$.apply(Try.scala:213) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.serialization.Serialization.deserialize(Serialization.scala:209) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.MessageSerializer$.deserialize(MessageSerializer.scala:44) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.DefaultMessageDispatcher.payload$lzycompute$1(Endpoint.scala:84) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.DefaultMessageDispatcher.payload$1(Endpoint.scala:84) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.DefaultMessageDispatcher.dispatch(Endpoint.scala:110) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.EndpointReader$$anonfun$receive$2.applyOrElse(Endpoint.scala:1155) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.actor.Actor.aroundReceive(Actor.scala:547) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.actor.Actor.aroundReceive$(Actor.scala:545) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.remote.EndpointActor.aroundReceive(Endpoint.scala:550) ~[flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.actor.ActorCell.receiveMessage(ActorCell.scala:590) [flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.actor.ActorCell.invoke(ActorCell.scala:557) [flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.dispatch.Mailbox.processMailbox(Mailbox.scala:272) [flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.dispatch.Mailbox.run(Mailbox.scala:233) [flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at org.apache.pekko.dispatch.Mailbox.exec(Mailbox.scala:245) [flink-rpc-akka3036b107-8ca6-47fb-81d3-1dc9a83bcb7b.jar:1.20.3]
	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source) [?:?]
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source) [?:?]
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source) [?:?]
```

3 minutes later (exactly the schema operator rpcTimeout), the pending request times out:

```
WARN  org.apache.flink.runtime.taskmanager.Task                    [] - Transform:Data -> SchemaOperator -> PrePartition (1/1)#3 (8f7dbf9559420d3b74a342f42d4fe3d4_90bea66de1c231edf33913ecd54406c1_0_3) switched from RUNNING to FAILED with failure cause:
org.apache.flink.cdc.runtime.operators.transform.exceptions.TransformException: Failed to post-transform with
    AddColumnEvent{tableId=a, addedColumns=[ColumnWithPosition{column=`index` DECIMAL(20, 0) NOT NULL '0', position=AFTER, existedColumnName=.}]}
for table
a
from schema
    columns={`id` DECIMAL(20, 0) NOT NULL,...}, primaryKeys=id, options=()
to schema
    columns={`id` DECIMAL(20, 0) NOT NULL,...}, primaryKeys=id, options=().
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElement(PostTransformOperator.java:160) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.streaming.runtime.tasks.OneInputStreamTask$StreamTaskNetworkOutput.emitRecord(OneInputStreamTask.java:238) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.io.AbstractStreamTaskNetworkInput.processElement(AbstractStreamTaskNetworkInput.java:157) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.io.AbstractStreamTaskNetworkInput.emitNext(AbstractStreamTaskNetworkInput.java:114) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.io.StreamOneInputProcessor.processInput(StreamOneInputProcessor.java:65) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.processInput(StreamTask.java:638) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor.runMailboxLoop(MailboxProcessor.java:231) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.runMailboxLoop(StreamTask.java:973) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:917) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:970) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:949) [flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:763) [flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:575) [flink-dist-1.20.3.jar:1.20.3]
	at java.base/java.lang.Thread.run(Unknown Source) [?:?]
Caused by: org.apache.flink.streaming.runtime.tasks.ExceptionInChainedOperatorException: Could not forward element to next operator
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:92) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:50) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:29) ~[flink-dist-1.20.3.jar:1.20.3]
	at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElementInternal(PostTransformOperator.java:194) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElement(PostTransformOperator.java:144) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	... 13 more
Caused by: java.lang.IllegalStateException: Failed to send request to coordinator: SchemaChangeRequest{tableId=a, schemaChangeEvent=AddColumnEvent{tableId=a, addedColumns=[ColumnWithPosition{column=`index` DECIMAL(20, 0) NOT NULL '0', position=AFTER, existedColumnName=.}]}, subTaskId=0}
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.sendRequestToCoordinator(SchemaOperator.java:246) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.requestSchemaChange(SchemaOperator.java:232) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.handleSchemaChangeEvent(SchemaOperator.java:178) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.processElement(SchemaOperator.java:153) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:75) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:50) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:29) ~[flink-dist-1.20.3.jar:1.20.3]
	at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElementInternal(PostTransformOperator.java:194) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElement(PostTransformOperator.java:144) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	... 13 more
Caused by: java.util.concurrent.TimeoutException
	at java.base/java.util.concurrent.CompletableFuture.timedGet(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture.get(Unknown Source) ~[?:?]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.sendRequestToCoordinator(SchemaOperator.java:243) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.requestSchemaChange(SchemaOperator.java:232) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.handleSchemaChangeEvent(SchemaOperator.java:178) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.schema.regular.SchemaOperator.processElement(SchemaOperator.java:153) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.pushToOperator(CopyingChainingOutput.java:75) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:50) ~[flink-dist-1.20.3.jar:1.20.3]
	at org.apache.flink.streaming.runtime.tasks.CopyingChainingOutput.collect(CopyingChainingOutput.java:29) ~[flink-dist-1.20.3.jar:1.20.3]
	at java.base/java.util.Optional.ifPresent(Unknown Source) ~[?:?]
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElementInternal(PostTransformOperator.java:194) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	at org.apache.flink.cdc.runtime.operators.transform.PostTransformOperator.processElement(PostTransformOperator.java:144) ~[flink-cdc-dist-3.6.0-1.20.jar:3.6.0-1.20]
	... 13 more
```

JIRA: https://issues.apache.org/jira/browse/FLINK-40040

## Brief change log

- `SchemaRegistry.failJob` now wraps the cause into `SerializedThrowable` (idempotent, not re-wrapped if already one) before calling `handleUnrecoverableError` (which completes pending coordination responses exceptionally) and `context.failJob`. `SerializedThrowable` carries the original exception as bytes plus a stringified stack trace, so the receiving side can deserialize it without the original class and still see the real cause.
- `SchemaRegistry.runInEventLoop`'s catch block now routes through `failJob` instead of duplicating the fail path, so every exit shares the wrapping.
- Applies to both the regular and distributed `SchemaCoordinator`, since both complete pending response futures via the shared `failJob` -> `handleUnrecoverableError` path.

## Verifying this change

Added `SchemaRegistryFailJobSerializationTest`:

- `failJobWrapsExceptionIntoSerializedThrowable` asserts the failure delivered to the coordinator context is a `SerializedThrowable`.
- `wrappedFailureSurvivesIsolatedClassloaderButRawOneDoesNot` shows a raw exception whose cause is a classloader-isolated type fails to deserialize (`ClassNotFoundException`), while the `SerializedThrowable`-wrapped one deserializes and preserves the real cause text.

## Does this pull request potentially affect one of the following parts

- Dependencies (does it add or upgrade a dependency): no
- Public API / SDK: no
- Serializers / state: no (wraps only the failure carried over the coordinator RPC channel; no state format change)
