### PR TITLE
[FLINK-40043] fix the paimon pipeline job couldn’t increase job parallelism.

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-paimon/src/main/java/org/apache/flink/cdc/connectors/paimon/sink/v2/PaimonSink.java
@@ -98,7 +98,10 @@ public class PaimonSink<InputT>
                 context.getRestoredCheckpointId()
                         .orElse(CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1);
         Preconditions.checkNotNull(paimonWriterStates);
-        String storedCommitUser = paimonWriterStates.iterator().next().getCommitUser();
+        String storedCommitUser =
+                paimonWriterStates.isEmpty()
+                        ? this.commitUser
+                        : paimonWriterStates.iterator().next().getCommitUser();
         return new PaimonWriter<>(
                 catalogOptions,
                 context.metricGroup(),

--- a/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/migration/MySqlToPaimonMigrationITCase.java
+++ b/flink-cdc-e2e-tests/flink-cdc-pipeline-e2e-tests/src/test/java/org/apache/flink/cdc/pipeline/tests/migration/MySqlToPaimonMigrationITCase.java
@@ -262,6 +262,97 @@ class MySqlToPaimonMigrationITCase extends PipelineTestEnvironment {
 
     @ParameterizedTest(name = "{0} -> SNAPSHOT")
     @EnumSource(names = {"SNAPSHOT"})
+    void testStartingJobFromSavepointWithRescaledParallelism(
+            TarballFetcher.CdcVersion migrateFromVersion) throws Exception {
+        TarballFetcher.fetch(jobManager, migrateFromVersion);
+
+        String warehouse = sharedVolume.toString() + "/" + "paimon_" + UUID.randomUUID();
+        String originalContent =
+                String.format(
+                        "source:\n"
+                                + "  type: mysql\n"
+                                + "  hostname: %s\n"
+                                + "  port: %d\n"
+                                + "  username: %s\n"
+                                + "  password: %s\n"
+                                + "  tables: %s.products\n"
+                                + "  server-id: 5400-5404\n"
+                                + "  server-time-zone: UTC\n"
+                                + "\n"
+                                + "sink:\n"
+                                + "  type: paimon\n"
+                                + "  catalog.properties.warehouse: %s\n"
+                                + "  catalog.properties.metastore: filesystem\n"
+                                + "  catalog.properties.cache-enabled: false\n"
+                                + "\n"
+                                + "pipeline:\n"
+                                + "  parallelism: %d\n",
+                        INTER_CONTAINER_MYSQL_ALIAS,
+                        MySqlContainer.MYSQL_PORT,
+                        MYSQL_TEST_USER,
+                        MYSQL_TEST_PASSWORD,
+                        mysqlInventoryDatabase.getDatabaseName(),
+                        warehouse,
+                        /* parallelism */ 2);
+
+        Path paimonCdcConnector = TestUtils.getResource("paimon-cdc-pipeline-connector.jar");
+        Path hadoopJar = TestUtils.getResource("flink-shade-hadoop.jar");
+        JobID jobID = submitPipelineJob(originalContent, paimonCdcConnector, hadoopJar);
+        Assertions.assertThat(jobID).isNotNull();
+
+        // 1) Snapshot + initial incremental events (parallelism = 2)
+        validateSinkResult(
+                warehouse,
+                mysqlInventoryDatabase.getDatabaseName(),
+                "products",
+                Arrays.asList(
+                        "101, scooter, Small 2-wheel scooter, 3.14, red, {\"key1\": \"value1\"}, {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102, car battery, 12V car battery, 8.1, white, {\"key2\": \"value2\"}, {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103, 12-pack drill bits, 12-pack of drill bits with sizes ranging from #40 to #3, 0.8, red, {\"key3\": \"value3\"}, {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104, hammer, 12oz carpenter's hammer, 0.75, white, {\"key4\": \"value4\"}, {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105, hammer, 14oz carpenter's hammer, 0.875, red, {\"k1\": \"v1\", \"k2\": \"v2\"}, {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106, hammer, 16oz carpenter's hammer, 1.0, null, null, null",
+                        "107, rocks, box of assorted rocks, 5.3, null, null, null",
+                        "108, jacket, water resistent black wind breaker, 0.1, null, null, null",
+                        "109, spare tire, 24 inch spare tire, 22.2, null, null, null"));
+
+        generateIncrementalEventsPhaseOne();
+        // (validate phase 1 result ...)
+
+        // 2) Stop with savepoint
+        String savepointPath = stopJobWithSavepoint(jobID);
+        LOG.info("Stopped Job {} and created a savepoint at {}.", jobID, savepointPath);
+
+        // 3) Modify YAML: bump parallelism from 2 to 4
+        String rescaledContent = originalContent.replace("parallelism: 2", "parallelism: 4");
+
+        // 4) Resume from savepoint with higher parallelism  <-- was failing pre-fix
+        JobID newJobID =
+                submitPipelineJob(
+                        rescaledContent, savepointPath, true, paimonCdcConnector, hadoopJar);
+        LOG.info("Reincarnated Job {} has been submitted successfully.", newJobID);
+
+        // 5) Verify state preserved and writes continue correctly under new parallelism
+        generateIncrementalEventsPhaseThree();
+        validateSinkResult(
+                warehouse,
+                mysqlInventoryDatabase.getDatabaseName(),
+                "products",
+                Arrays.asList(
+                        "101, scooter, Small 2-wheel scooter, 3.14, red, {\"key1\": \"value1\"}, {\"coordinates\":[1,1],\"type\":\"Point\",\"srid\":0}",
+                        "102, car battery, 12V car battery, 8.1, white, {\"key2\": \"value2\"}, {\"coordinates\":[2,2],\"type\":\"Point\",\"srid\":0}",
+                        "103, 12-pack drill bits, 12-pack of drill bits with sizes ranging from #40 to #3, 0.8, red, {\"key3\": \"value3\"}, {\"coordinates\":[3,3],\"type\":\"Point\",\"srid\":0}",
+                        "104, hammer, 12oz carpenter's hammer, 0.75, white, {\"key4\": \"value4\"}, {\"coordinates\":[4,4],\"type\":\"Point\",\"srid\":0}",
+                        "105, hammer, 14oz carpenter's hammer, 0.875, red, {\"k1\": \"v1\", \"k2\": \"v2\"}, {\"coordinates\":[5,5],\"type\":\"Point\",\"srid\":0}",
+                        "106, hammer, 18oz carpenter hammer, 1.0, null, null, null",
+                        "107, rocks, box of assorted rocks, 5.1, null, null, null",
+                        "108, jacket, water resistent black wind breaker, 0.1, null, null, null",
+                        "109, spare tire, 24 inch spare tire, 22.2, null, null, null"));
+        cancelJob(newJobID);
+    }
+
+    @ParameterizedTest(name = "{0} -> SNAPSHOT")
+    @EnumSource(names = {"SNAPSHOT"})
     void testStartingJobFromSavepointWithSchemaChange(TarballFetcher.CdcVersion migrateFromVersion)
             throws Exception {
         TarballFetcher.fetch(jobManager, migrateFromVersion);


### PR DESCRIPTION
Fix a NoSuchElementException thrown by PaimonSink.restoreWriter when a CDC pipeline job using the Paimon sink is restored from a savepoint with a higher pipeline.parallelism than the original run.

## Bug Description
Rescaling a pipeline job up via savepoint (stop --withSavepoint → modify pipeline.parallelism → run --fromSavepoint) causes the new sink subtasks to fail to initialize, taking the entire job down at startup. The same operation with the same or lower parallelism works as expected.

## Stack trace:

```
java.util.NoSuchElementException
    at java.util.ArrayList$Itr.next(ArrayList.java:1000)
    at org.apache.flink.cdc.connectors.paimon.sink.v2.PaimonSink.restoreWriter(PaimonSink.java:101)
    at org.apache.flink.streaming.runtime.operators.sink.StatefulSinkWriterStateHandler.createWriter(StatefulSinkWriterStateHandler.java:120)
    at org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperator.initializeState(SinkWriterOperator.java:153)
    at org.apache.flink.cdc.runtime.operators.sink.DataSinkWriterOperator.initializeState(DataSinkWriterOperator.java:132)
    ...
```

## Root Cause Analysis
PaimonSink implements SupportsWriterState<InputT, PaimonWriterState>. Each PaimonWriter snapshots one PaimonWriterState (containing the randomly generated commitUser) in PaimonWriter.snapshotState():

```java
@Override
public List<PaimonWriterState> snapshotState(long checkpointId) {
    return Collections.singletonList(stateCache);
}
```

When restoring, Flink's StatefulSinkWriterStateHandler.createWriter() (a Flink framework class) takes the union of all previously snapshotted states, and re-distributes them across the new parallelism based on its internal channel computer. With P_old < P_new, some of the new subtasks will receive zero PaimonWriterState entries — this is expected behavior of the SupportsWriterState contract.

However, PaimonSink.restoreWriter does not handle the empty-collection case:

```java
@Override
public StatefulSinkWriter<InputT, PaimonWriterState> restoreWriter(
        WriterInitContext context, Collection<PaimonWriterState> paimonWriterStates) {
    long lastCheckpointId = ...;
    Preconditions.checkNotNull(paimonWriterStates);                       // only null check
    String storedCommitUser = paimonWriterStates.iterator().next().getCommitUser();  // <-- NPE on empty
    return new PaimonWriter<>(catalogOptions, context.metricGroup(), storedCommitUser, ...);
}
```

Calling iterator().next() on an empty collection throws NoSuchElementException. This is a contract violation of the SupportsWriterState interface, which explicitly allows empty collections (see Flink's StreamingFileSink and FileSink for correct implementations).

The issue was masked before FLINK-38478 introduced per-writer random commitUsers stored in state — the previous commitUser was a static field on the sink and didn't need to be restored per-subtask.

## Fix
When the restored state collection is empty (i.e., this subtask did not receive any historical state during rescale-out), fall back to the commitUser field on the PaimonSink instance. This is safe because all subtasks of the same job share the same PaimonSink instance (and therefore the same commitUser), and the commitUser is re-generated only on a fresh job startup — not on a state restore.

```java
@Override
public StatefulSinkWriter<InputT, PaimonWriterState> restoreWriter(
        WriterInitContext context, Collection<PaimonWriterState> paimonWriterStates) {
    long lastCheckpointId =
            context.getRestoredCheckpointId()
                    .orElse(CheckpointIDCounter.INITIAL_CHECKPOINT_ID - 1);
    Preconditions.checkNotNull(paimonWriterStates);
    String storedCommitUser =
            paimonWriterStates.isEmpty()
                    ? commitUser
                    : paimonWriterStates.iterator().next().getCommitUser();
    return new PaimonWriter<>(
            catalogOptions,
            context.metricGroup(),
            storedCommitUser,
            serializer,
            lastCheckpointId);
}
```