### PR TITLE
[FLINK-40051][pipeline-connector/hudi] Fix schema operator UID with operator UID prefix

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi/src/main/java/org/apache/flink/cdc/connectors/hudi/sink/HudiDataSinkFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi/src/main/java/org/apache/flink/cdc/connectors/hudi/sink/HudiDataSinkFactory.java
@@ -42,6 +42,7 @@ public class HudiDataSinkFactory implements DataSinkFactory {
     private static final Logger LOG = LoggerFactory.getLogger(HudiDataSinkFactory.class);
 
     public static final String IDENTIFIER = "hudi";
+    private static final String SCHEMA_OPERATOR_UID_SUFFIX = "schema-operator";
 
     @Override
     public String identifier() {
@@ -70,9 +71,7 @@ public class HudiDataSinkFactory implements DataSinkFactory {
         }
         config.set(HudiConfig.INDEX_TYPE, HoodieIndex.IndexType.BUCKET.name());
 
-        String schemaOperatorUid =
-                context.getPipelineConfiguration()
-                        .get(PipelineOptions.PIPELINE_SCHEMA_OPERATOR_UID);
+        String schemaOperatorUid = getSchemaOperatorUid(context.getPipelineConfiguration());
 
         return new HudiDataSink(config, schemaOperatorUid);
     }
@@ -90,5 +89,15 @@ public class HudiDataSinkFactory implements DataSinkFactory {
         options.add(HudiConfig.TABLE_TYPE);
         options.add(HudiConfig.INDEX_TYPE);
         return options;
+    }
+
+    private static String getSchemaOperatorUid(Configuration pipelineConfig) {
+        if (pipelineConfig.contains(PipelineOptions.PIPELINE_OPERATOR_UID_PREFIX)) {
+            return String.format(
+                    "%s-%s",
+                    pipelineConfig.get(PipelineOptions.PIPELINE_OPERATOR_UID_PREFIX),
+                    SCHEMA_OPERATOR_UID_SUFFIX);
+        }
+        return pipelineConfig.get(PipelineOptions.PIPELINE_SCHEMA_OPERATOR_UID);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi/src/test/java/org/apache/flink/cdc/connectors/hudi/sink/HudiDataSinkFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi/src/test/java/org/apache/flink/cdc/connectors/hudi/sink/HudiDataSinkFactoryTest.java
@@ -21,8 +21,11 @@ import org.apache.flink.cdc.common.configuration.ConfigOption;
 import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.factories.DataSinkFactory;
 import org.apache.flink.cdc.common.factories.FactoryHelper;
+import org.apache.flink.cdc.common.pipeline.PipelineOptions;
 import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
 import org.apache.flink.cdc.composer.utils.FactoryDiscoveryUtils;
+import org.apache.flink.cdc.connectors.hudi.sink.v2.HudiSink;
 import org.apache.flink.table.api.ValidationException;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
@@ -31,6 +34,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +61,34 @@ class HudiDataSinkFactoryTest {
                         new FactoryHelper.DefaultContext(
                                 conf, conf, Thread.currentThread().getContextClassLoader()));
         Assertions.assertThat(dataSink).isInstanceOf(HudiDataSink.class);
+    }
+
+    @Test
+    void testSchemaOperatorUidFollowsOperatorUidPrefix() throws Exception {
+        DataSinkFactory sinkFactory =
+                FactoryDiscoveryUtils.getFactoryByIdentifier("hudi", DataSinkFactory.class);
+        Assertions.assertThat(sinkFactory).isInstanceOf(HudiDataSinkFactory.class);
+
+        Configuration sinkConfig =
+                Configuration.fromMap(
+                        ImmutableMap.<String, String>builder()
+                                .put(HudiConfig.PATH.key(), temporaryFolder.toString())
+                                .build());
+        Configuration pipelineConfig = new Configuration();
+        pipelineConfig.set(
+                PipelineOptions.PIPELINE_OPERATOR_UID_PREFIX, "mysql_hudi_user_behavior");
+
+        DataSink dataSink =
+                sinkFactory.createDataSink(
+                        new FactoryHelper.DefaultContext(
+                                sinkConfig,
+                                pipelineConfig,
+                                Thread.currentThread().getContextClassLoader()));
+        FlinkSinkProvider sinkProvider = (FlinkSinkProvider) dataSink.getEventSinkProvider();
+        HudiSink hudiSink = (HudiSink) sinkProvider.getSink();
+
+        Assertions.assertThat(getSchemaOperatorUid(hudiSink))
+                .isEqualTo("mysql_hudi_user_behavior-schema-operator");
     }
 
     @Test
@@ -140,5 +172,11 @@ class HudiDataSinkFactoryTest {
                         new FactoryHelper.DefaultContext(
                                 conf, conf, Thread.currentThread().getContextClassLoader()));
         Assertions.assertThat(dataSink).isInstanceOf(HudiDataSink.class);
+    }
+
+    private static String getSchemaOperatorUid(HudiSink hudiSink) throws Exception {
+        Field field = HudiSink.class.getDeclaredField("schemaOperatorUid");
+        field.setAccessible(true);
+        return (String) field.get(hudiSink);
     }
 }


### PR DESCRIPTION
## Summary

- Fix Hudi pipeline sink schema coordinator lookup when `pipeline.operator.uid.prefix` is configured.
- Add a regression test covering prefix-derived schema operator UID propagation into the Hudi sink.

## Root Cause

`FlinkPipelineComposer` derives the schema operator UID from `pipeline.operator.uid.prefix` (for example, `<prefix>-schema-operator`) when the prefix option is set. However, `HudiDataSinkFactory` still passed `pipeline.schema.operator.uid` directly to `HudiDataSink`, so the Hudi sink used the deprecated default schema operator UID instead of the actual prefix-derived schema operator UID. This mismatch can make Hudi coordinator requests fail with `No coordinator registered for operator`.

## Fix

- Make `HudiDataSinkFactory` derive the schema operator UID from `pipeline.operator.uid.prefix` when that option is explicitly configured.
- Preserve the existing `pipeline.schema.operator.uid` behavior when the prefix option is not set.
- Add `HudiDataSinkFactoryTest#testSchemaOperatorUidFollowsOperatorUidPrefix`.

## Validation

- `mvn -B -ntp -pl flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi -am -Dtest=HudiDataSinkFactoryTest#testSchemaOperatorUidFollowsOperatorUidPrefix -DfailIfNoTests=false test`
- `mvn -B -ntp -pl flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi -am -DfailIfNoTests=false test`
- `git diff --check`

## Jira

- https://issues.apache.org/jira/browse/FLINK-40051

## Reviewers

Could @cshuo or @voonhous please review when convenient?

## AI assistance

This PR was prepared with AI assistance. The focused regression test and Hudi module tests listed above were run locally.
