### PR TITLE
[FLINK-39613][runtime] Unquote schema metadata keys

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/SchemaMetadataTransform.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/operators/transform/SchemaMetadataTransform.java
@@ -50,14 +50,14 @@ public class SchemaMetadataTransform implements Serializable {
         if (!StringUtils.isNullOrWhitespaceOnly(primaryKeyString)) {
             String[] primaryKeyArr = primaryKeyString.split(",");
             for (int i = 0; i < primaryKeyArr.length; i++) {
-                primaryKeyArr[i] = primaryKeyArr[i].trim();
+                primaryKeyArr[i] = normalizeColumnReference(primaryKeyArr[i]);
             }
             primaryKeys = Arrays.asList(primaryKeyArr);
         }
         if (!StringUtils.isNullOrWhitespaceOnly(partitionKeyString)) {
             String[] partitionKeyArr = partitionKeyString.split(",");
             for (int i = 0; i < partitionKeyArr.length; i++) {
-                partitionKeyArr[i] = partitionKeyArr[i].trim();
+                partitionKeyArr[i] = normalizeColumnReference(partitionKeyArr[i]);
             }
             partitionKeys = Arrays.asList(partitionKeyArr);
         }
@@ -84,6 +84,14 @@ public class SchemaMetadataTransform implements Serializable {
                 }
             }
         }
+    }
+
+    private String normalizeColumnReference(String columnReference) {
+        String trimmed = columnReference.trim();
+        if (trimmed.length() >= 2 && trimmed.startsWith("`") && trimmed.endsWith("`")) {
+            return trimmed.substring(1, trimmed.length() - 1).replace("``", "`");
+        }
+        return trimmed;
     }
 
     public List<String> getPrimaryKeys() {

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/SchemaMetadataTransformTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/operators/transform/SchemaMetadataTransformTest.java
@@ -25,6 +25,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SchemaMetadataTransformTest {
 
     @Test
+    void testPrimaryAndPartitionKeysStripBackticks() {
+        SchemaMetadataTransform transform =
+                new SchemaMetadataTransform(
+                        "id, `order-id`, `customer``name`", "region, `order-id`", null, null);
+
+        assertThat(transform.getPrimaryKeys()).containsExactly("id", "order-id", "customer`name");
+        assertThat(transform.getPartitionKeys()).containsExactly("region", "order-id");
+    }
+
+    @Test
     void testTableOptionsWithCommaDelimiter() {
         SchemaMetadataTransform transform =
                 new SchemaMetadataTransform(null, null, "key1=value1,key2=value2", null);


### PR DESCRIPTION
## Summary
- Normalize `primary-keys` and `partition-keys` entries in `SchemaMetadataTransform` by stripping MySQL-style outer backticks.
- Preserve existing unquoted key behavior and unescape doubled backticks inside quoted identifiers.
- Add a focused regression test for backtick-quoted primary/partition key entries.

## Root Cause
`projection` is parsed through Calcite with the MySQL dialect and therefore resolves backtick-quoted identifiers to their unquoted column names. In contrast, `primary-keys` and `partition-keys` were parsed with plain comma splitting and trimming, so entries like `` `order-id` `` were kept verbatim and did not match the schema column name `order-id`.

## Fix
- Apply a small normalization step to primary/partition key entries after trimming.
- If an entry is enclosed in backticks, remove the outer backticks and decode doubled backticks (` `` ` -> ` `).

## Validation
- RED: `mvn -pl flink-cdc-runtime -am -Dtest=org.apache.flink.cdc.runtime.operators.transform.SchemaMetadataTransformTest#testPrimaryAndPartitionKeysStripBackticks -DfailIfNoTests=false -DskipITs -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true test`
- GREEN: same focused test after the fix.
- `mvn -pl flink-cdc-runtime -am -Dtest=org.apache.flink.cdc.runtime.operators.transform.SchemaMetadataTransformTest -DfailIfNoTests=false -DskipITs -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true test`
- `mvn -pl flink-cdc-runtime -am -Dtest=org.apache.flink.cdc.runtime.operators.transform.PreTransformOperatorTest -DfailIfNoTests=false -DskipITs -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.check.skip=true test`
- `mvn -pl flink-cdc-runtime -am -DskipTests -DskipITs -Drat.skip=true -Dcheckstyle.skip=true spotless:check`
- `mvn -pl flink-cdc-runtime -am -DskipTests -DskipITs -Drat.skip=true -Dspotless.check.skip=true test-compile`

## Jira
- https://issues.apache.org/jira/browse/FLINK-39613

## Review
cc @yuxiqian @leonardBang, could you please take a look when you have time?

## AI Assistance
This PR was prepared with AI assistance and manually verified with the commands above.
