### PR TITLE
[hotfix] Bump Mockito for JDK 17 tests

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-hudi/pom.xml
@@ -33,7 +33,7 @@ limitations under the License.
     <properties>
         <hudi.version>1.1.0</hudi.version>
         <hadoop.version>2.10.2</hadoop.version>
-        <mockito.version>3.4.6</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
         <metrics.version>4.1.1</metrics.version>
         <caffeine.version>2.9.1</caffeine.version>
         <jetty.version>9.4.57.v20241219</jetty.version>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/pom.xml
@@ -28,7 +28,7 @@ limitations under the License.
     <artifactId>flink-cdc-base</artifactId>
 
     <properties>
-        <mockito.version>3.4.6</mockito.version>
+        <mockito.version>3.12.4</mockito.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bump Mockito version to fix JDK 17 tests, as older version could not handle JDK 17 bytecodes properly.