### PR TITLE
[FLINK-39760] Fix missing JTS core dependency of PostgreSQL YAML connector

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/pom.xml
@@ -188,6 +188,7 @@ limitations under the License.
                                     <include>com.google.guava:*</include>
                                     <include>org.apache.kafka:*</include>
                                     <include>org.postgresql:postgresql</include>
+                                    <include>org.locationtech.jts:jts-core</include>
                                     <include>com.fasterxml.*:*</include>
                                     <!--  Include fixed version 30.1.1-jre-14.0 of flink shaded guava  -->
                                     <include>org.apache.flink:flink-shaded-guava</include>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/pom.xml
@@ -29,6 +29,7 @@ limitations under the License.
     <artifactId>flink-cdc-pipeline-connector-postgres</artifactId>
 
     <properties>
+        <jts.version>1.19.0</jts.version>
     </properties>
 
     <dependencies>
@@ -37,6 +38,12 @@ limitations under the License.
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-postgres-cdc</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>${jts.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Summary
This commit adds the missing JTS core dependency to the PostgreSQL YAML connector, ensuring the connector can be built independently when geometry handling code uses JTS classes.
### Key Changes
**Explicit JTS Core Dependency**

- Added org.locationtech.jts:jts-core to flink-cdc-pipeline-connector-postgres.
- Uses jts.version set to 1.19.0, matching the JTS version already used transitively in the project dependency tree.

**Fix Standalone Connector Build**

- PostgresEventDeserializer imports and uses JTS classes such as Coordinate and WKBReader for geometry value handling.
- Before this change, the PostgreSQL YAML connector did not declare jts-core in its own module dependencies, which could break isolated module builds or packaging workflows.

### JIRA Reference
[https://issues.apache.org/jira/browse/FLINK-39760](url)