### PR TITLE
[hotfix][docs] Fix broken stable docs URL in outdated/unreleased banner

### DIFF
--- a/docs/layouts/partials/docs/inject/content-before.html
+++ b/docs/layouts/partials/docs/inject/content-before.html
@@ -23,14 +23,14 @@ under the License.
 {{ if $.Site.Params.ShowOutDatedWarning }}
 <article class="markdown">
     <blockquote style="border-color:#f66">
-        {{ markdownify "This documentation is for an out-of-date version of Apache Flink CDC. We recommend you use the latest [stable version](https://ci.apache.org/projects/flink/flink-cdc-docs-stable/)."}}
+        {{ markdownify "This documentation is for an out-of-date version of Apache Flink CDC. We recommend you use the latest [stable version](https://nightlies.apache.org/flink/flink-cdc-docs-stable/)."}}
     </blockquote>
 </article>
 {{ end }}
 {{ if (not $.Site.Params.IsStable) }}
 <article class="markdown">
     <blockquote style="border-color:#f66">
-        {{ markdownify "This documentation is for an unreleased version of Apache Flink CDC. We recommend you use the latest [stable version](https://ci.apache.org/projects/flink/flink-cdc-docs-stable/)."}}
+        {{ markdownify "This documentation is for an unreleased version of Apache Flink CDC. We recommend you use the latest [stable version](https://nightlies.apache.org/flink/flink-cdc-docs-stable/)."}}
     </blockquote>
 </article>
 {{ end }}


### PR DESCRIPTION
## What is the purpose of the change

This hotfix updates the broken "stable version" link that appears in the outdated/unreleased documentation banner. The link pointed to the legacy `ci.apache.org` host, which now redirects to `ci2.apache.org` and returns `No Such Resource / File not found`. All other docs references in the repo already use `nightlies.apache.org` — this banner was missed during the original docs infra migration.

Same issue and fix as [apache/flink-kubernetes-operator#1092](https://github.com/apache/flink-kubernetes-operator/pull/1092).

## Brief change log

  - Replace both occurrences of `https://ci.apache.org/projects/flink/flink-cdc-docs-stable/` with `https://nightlies.apache.org/flink/flink-cdc-docs-stable/` in `docs/layouts/partials/docs/inject/content-before.html`.

<img width="1435" height="314" alt="image" src="https://github.com/user-attachments/assets/f41dd082-3395-448a-9181-c26e3a4c4c0e" />
Clicking on the stable version link opens
<img width="1435" height="314" alt="image" src="https://github.com/user-attachments/assets/2ff53374-c190-45e1-884d-e3d470376f55" />

Verified:
```
$ curl -sI -L https://ci.apache.org/projects/flink/flink-cdc-docs-stable/
HTTP/1.1 301 Moved Permanently
Location: https://ci2.apache.org/projects/flink/flink-cdc-docs-stable/
... (then 404 Not Found)

$ curl -sI -L https://nightlies.apache.org/flink/flink-cdc-docs-stable/
HTTP/1.1 200 OK
```

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

## AI Usage Disclosure

- [x] Claude Code