### PR TITLE
[ci] Exclude Flink compatibility modules from Javadoc

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -22,6 +22,8 @@ on:
       - release-*
     paths:
       - 'docs/**'
+      - '.github/workflows/build_docs.yml'
+      - '.github/workflows/docs.sh'
   schedule:
     - cron: '0 0 * * *' # Deploy every day
   workflow_dispatch:

--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -54,7 +54,9 @@ mvn clean install -B -DskipTests -Dfast
 
 # build java/scala docs
 mkdir -p docs/target/api
+# Compatibility modules target different Flink versions and cannot share a Javadoc classpath.
 mvn javadoc:aggregate -B \
+    -pl '!flink-cdc-flink1-compat,!flink-cdc-flink2-compat' \
     -DadditionalJOption="-Xdoclint:none --allow-script-in-comments" \
     -Dmaven.javadoc.failOnError=false \
     -Dcheckstyle.skip=true \


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix Flink CDC JavaDocs building failure.

https://github.com/apache/flink-cdc/actions/runs/29216138198/job/86712319829

## Brief change log

Excludes Flink 1.x / 2.x compatible modules from JavaDoc generation.

---

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable)

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes

Generated-by: Codex with GPT 5.6 Sol
