### PR TITLE
[FLINK-40161] Log original MySQL DDL events before parsing

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -652,6 +652,24 @@ public class MySqlStreamingChangeEventSource
             LOGGER.warn(
                     "Rollback statements cannot be handled without binlog buffering, the connector will fail. Please check '{}' to see how to enable buffering",
                     MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER.name());
+        } else {
+            // ROLLBACK is not a DDL event and already has a dedicated warning above.
+            EventHeader header = event.getHeader();
+            if (header instanceof EventHeaderV4) {
+                EventHeaderV4 eventHeader = (EventHeaderV4) header;
+                LOGGER.info(
+                        "Received MySQL DDL event at {} [{}-{}], database={}, ddl={}",
+                        offsetContext.getSource().binlogFilename(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        command.getDatabase(),
+                        sql);
+            } else {
+                LOGGER.info(
+                        "Received MySQL DDL event, database={}, ddl={}",
+                        command.getDatabase(),
+                        sql);
+            }
         }
 
         final List<SchemaChangeEvent> schemaChangeEvents =


### PR DESCRIPTION
#### Summary

This commit adds logging for original MySQL DDL events before they are parsed by the Flink CDC MySQL source. When DDL parsing fails, users can now find the original DDL statement together with its binlog coordinates in the logs, making troubleshooting easier.

#### Key Changes

1. Log Original MySQL DDL Events
- Added info-level logging in `MySqlStreamingChangeEventSource` before calling `parseStreamingDdl(...)`.
- Logs the database name and original DDL SQL.
- Logs binlog file name and event start/end positions when the event header provides them.

2. Keep ROLLBACK Handling Separate
- Keeps the existing dedicated warning path for `ROLLBACK`.
- Avoids logging `ROLLBACK` as a DDL event because it is not a schema change.

#### JIRA Reference

[https://issues.apache.org/jira/browse/FLINK-40161](url)