### PR TITLE
[FLINK-40152][connector/postgres] Make table filtering case-sensitive

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfig.java
@@ -22,12 +22,17 @@ import org.apache.flink.cdc.connectors.base.options.StartupOptions;
 
 import io.debezium.config.Configuration;
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.Tables;
+import io.debezium.util.Strings;
 
 import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import static io.debezium.connector.postgresql.PostgresConnectorConfig.SLOT_NAME;
 
@@ -152,7 +157,31 @@ public class PostgresSourceConfig extends JdbcSourceConfig {
 
     @Override
     public PostgresConnectorConfig getDbzConnectorConfig() {
-        return new PostgresConnectorConfig(getDbzConfiguration());
+        return applyCaseSensitiveTableFilter(new PostgresConnectorConfig(getDbzConfiguration()));
+    }
+
+    /** Applies the case-sensitive Postgres table filter to the connector configuration. */
+    public PostgresConnectorConfig applyCaseSensitiveTableFilter(
+            PostgresConnectorConfig connectorConfig) {
+        String tableIncludeList = connectorConfig.getConfig().getString("table.include.list");
+        if (tableIncludeList != null && !tableIncludeList.trim().isEmpty()) {
+            RelationalTableFilters tableFilters = connectorConfig.getTableFilters();
+            Tables.TableFilter originalTableFilter = tableFilters.dataCollectionFilter();
+            Set<Pattern> tableIncludePatterns = Strings.setOfRegex(tableIncludeList);
+            tableFilters.setDataCollectionFilters(
+                    tableId ->
+                            originalTableFilter.isIncluded(tableId)
+                                    && tableIncludePatterns.stream()
+                                            .anyMatch(
+                                                    pattern ->
+                                                            pattern.matcher(
+                                                                            tableId.schema()
+                                                                                    + "."
+                                                                                    + tableId
+                                                                                            .table())
+                                                                    .matches()));
+        }
+        return connectorConfig;
     }
 
     /** Returns whether to include database in the generated Table ID. */

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/main/java/org/apache/flink/cdc/connectors/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -168,6 +168,7 @@ public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                                     .with(DROP_SLOT_ON_STOP.name(), false)
                                     .build());
         }
+        dbzConfig = ((PostgresSourceConfig) sourceConfig).applyCaseSensitiveTableFilter(dbzConfig);
         setDbzConnectorConfig(dbzConfig);
         PostgresConnectorConfig.SnapshotMode snapshotMode =
                 PostgresConnectorConfig.SnapshotMode.parse(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc/src/test/java/org/apache/flink/cdc/connectors/postgres/source/config/PostgresSourceConfigTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.postgres.source.config;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link PostgresSourceConfig}. */
+class PostgresSourceConfigTest {
+
+    @Test
+    void testTableFilterIsCaseSensitiveAndPreservesRegex() {
+        Tables.TableFilter tableFilter =
+                createSourceConfig().getTableFilters().dataCollectionFilter();
+
+        assertThat(tableFilter.isIncluded(new TableId(null, "public", "t_order"))).isTrue();
+        assertThat(tableFilter.isIncluded(new TableId(null, "public", "T_ORDER"))).isFalse();
+    }
+
+    @Test
+    void testTableFilterCanBeReappliedAfterConnectorConfigReconstruction() {
+        PostgresSourceConfig sourceConfig = createSourceConfig();
+        PostgresConnectorConfig reconstructedConfig =
+                new PostgresConnectorConfig(sourceConfig.getDbzConnectorConfig().getConfig());
+
+        Tables.TableFilter tableFilter =
+                sourceConfig
+                        .applyCaseSensitiveTableFilter(reconstructedConfig)
+                        .getTableFilters()
+                        .dataCollectionFilter();
+
+        assertThat(tableFilter.isIncluded(new TableId(null, "public", "t_order"))).isTrue();
+        assertThat(tableFilter.isIncluded(new TableId(null, "public", "T_ORDER"))).isFalse();
+    }
+
+    private PostgresSourceConfig createSourceConfig() {
+        PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+        configFactory.hostname("localhost");
+        configFactory.port(5432);
+        configFactory.database("postgres");
+        configFactory.schemaList(new String[] {"public"});
+        configFactory.tableList("public\\.t_.*");
+        configFactory.username("user");
+        configFactory.password("password");
+
+        return configFactory.create(0);
+    }
+}


### PR DESCRIPTION
## What is the purpose of this pull request?

Fix [FLINK-40152](https://issues.apache.org/jira/browse/FLINK-40152), where the PostgreSQL CDC connector captures case-variant tables even when only one table is configured. PostgreSQL quoted identifiers are case-sensitive, but the Debezium table include predicate is case-insensitive by default.

## Brief change log

- Preserve the existing Debezium table filter and additionally apply the effective `table.include.list` as case-sensitive full-match regular expressions.
- Reapply the case-sensitive filter after split-specific PostgreSQL connector configurations are rebuilt.
- Add unit coverage for regex matching, case-only sibling exclusion, and connector-config reconstruction.

---

## Verifying this change

This change added tests and can be verified as follows:

- Added `PostgresSourceConfigTest`.
- Ran `mvn -pl flink-cdc-connect/flink-cdc-source-connectors/flink-connector-postgres-cdc -am -Dtest=PostgresSourceConfigTest -Dsurefire.failIfNoSpecifiedTests=false test`.
- Result: 2 tests passed; Spotless, Checkstyle, production compilation, and test compilation passed.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Hermes Agent with OpenAI Codex (GPT-5.6)

Generated-by: Hermes Agent with OpenAI Codex (GPT-5.6)
