### PR TITLE
[FLINK-40202] Fix ConcurrentModificationException when initializing enumerator metrics

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/HybridSplitAssigner.java
@@ -136,9 +136,11 @@ public class HybridSplitAssigner<C extends SourceConfig> implements SplitAssigne
             enumeratorMetrics.exitStreamReading();
         }
 
-        snapshotSplitAssigner.open();
-        // init enumerator metrics
+        // Init enumerator metrics before opening the snapshot assigner. Opening the assigner
+        // starts an asynchronous splitting thread that mutates remainingSplits, so metrics must be
+        // initialized first to avoid a ConcurrentModificationException while iterating the splits.
         snapshotSplitAssigner.initEnumeratorMetrics(enumeratorMetrics);
+        snapshotSplitAssigner.open();
     }
 
     @Override

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/assigner/SnapshotSplitAssigner.java
@@ -295,7 +295,10 @@ public class SnapshotSplitAssigner<C extends SourceConfig> implements SplitAssig
         }
     }
 
-    /** This should be invoked after this class's open method. */
+    /**
+     * This must be invoked before this class's {@link #open()} method, because {@code open()}
+     * starts an asynchronous splitting thread that concurrently mutates {@code remainingSplits}.
+     */
     public void initEnumeratorMetrics(SourceEnumeratorMetrics enumeratorMetrics) {
         this.enumeratorMetrics = enumeratorMetrics;
 


### PR DESCRIPTION
This closes FLINK-40202.

`HybridSplitAssigner#open()` initializes enumerator metrics *after* calling `snapshotSplitAssigner.open()`, which has already started an asynchronous splitting thread that mutates `remainingSplits`. `initEnumeratorMetrics()` then iterates that list without synchronization, causing the following exception:

<img width="2510" height="892" alt="image" src="https://github.com/user-attachments/assets/2395e8d9-f505-49ba-9b66-57caf06e1d85" />

The fix initializes the enumerator metrics before opening the snapshot assigner, so metrics are seeded before the background splitting thread starts.