### PR TITLE
[hotfix][runtime] Return UNKNOWN for null regex LIKE predicates

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/impl/StringFunctions.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/functions/impl/StringFunctions.java
@@ -66,7 +66,10 @@ public class StringFunctions {
         return String.join("", str);
     }
 
-    public static boolean like(String str, String regex) {
+    public static Boolean like(String str, String regex) {
+        if (str == null || regex == null) {
+            return null;
+        }
         return Pattern.compile(regex).matcher(str).find();
     }
 
@@ -77,8 +80,8 @@ public class StringFunctions {
         return SqlFunctions.like(str, pattern, escape);
     }
 
-    public static boolean notLike(String str, String regex) {
-        return !like(str, regex);
+    public static Boolean notLike(String str, String regex) {
+        return LogicalFunctions.not(like(str, regex));
     }
 
     public static Boolean notLike(String str, String pattern, String escape) {

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/functions/impl/StringFunctionsTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/functions/impl/StringFunctionsTest.java
@@ -45,6 +45,14 @@ class StringFunctionsTest {
     }
 
     @Test
+    void testLegacyLikeNullReturnsUnknown() {
+        assertThat(StringFunctions.like(null, "A.*")).isNull();
+        assertThat(StringFunctions.like("Alice", null)).isNull();
+        assertThat(StringFunctions.notLike(null, "A.*")).isNull();
+        assertThat(StringFunctions.notLike("Alice", null)).isNull();
+    }
+
+    @Test
     void testSimilarTo() {
         assertThat(StringFunctions.similarTo("Alice", "(A|B)%")).isTrue();
         assertThat(StringFunctions.similarTo("Carol", "(A|B)%")).isFalse();

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/JaninoCompilerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/JaninoCompilerTest.java
@@ -288,6 +288,25 @@ class JaninoCompilerTest {
     }
 
     @Test
+    void testTranslatedLikePredicateReturnsUnknownForNullOperand()
+            throws InvocationTargetException {
+        List<Column> columns = List.of(Column.physicalColumn("name", DataTypes.STRING()));
+        Map<String, String> columnNameMap = Map.of("name", "$0");
+        List<String> columnNames = List.of("$0");
+        List<Class<?>> columnTypes = List.of(String.class);
+
+        ExpressionEvaluator likeEvaluator =
+                compileTranslatedFilterExpression(
+                        "name like 'A.*'", columns, columnNameMap, columnNames, columnTypes);
+        Assertions.assertThat(likeEvaluator.evaluate(new Object[] {null})).isNull();
+
+        ExpressionEvaluator notLikeEvaluator =
+                compileTranslatedFilterExpression(
+                        "name not like 'A.*'", columns, columnNameMap, columnNames, columnTypes);
+        Assertions.assertThat(notLikeEvaluator.evaluate(new Object[] {null})).isNull();
+    }
+
+    @Test
     void testLargeNumericLiterals() {
         // Test parsing integer literals
         Stream.of(


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR fixes nullable transform `LIKE` / `NOT LIKE` predicates that are translated to the two-argument regex helpers.

The three-argument SQL `LIKE` helper already returns SQL UNKNOWN (`null`) when any operand is null. The regex-style two-argument helper instead called `Pattern.matcher(...)` directly and threw an NPE when the input string was null. This caused nullable transform predicates such as `name like 'A.*'` to fail during evaluation instead of producing UNKNOWN.

## Brief change log

- Return `Boolean` from the two-argument regex `like` / `notLike` helpers.
- Return `null` when the input string or regex pattern is null.
- Use `LogicalFunctions.not(...)` for nullable `notLike` semantics.
- Add function-level and Janino-translated predicate regression coverage.

---

## Verifying this change

This change added tests and can be verified as follows:

- Added unit coverage in `StringFunctionsTest` for nullable two-argument regex `LIKE` / `NOT LIKE` operands.
- Added regression coverage in `JaninoCompilerTest` for translated nullable `LIKE` / `NOT LIKE` predicates.
- Verified RED before the fix:
  - `mvn -U -pl flink-cdc-runtime -am -Dtest=JaninoCompilerTest#testTranslatedLikePredicateReturnsUnknownForNullOperand -DfailIfNoTests=false -Dspotless.check.skip=true -Dcheckstyle.skip=true test`
  - Failed with `NullPointerException` from `StringFunctions.like(StringFunctions.java:70)`.
- Verified after the fix with Java 17:
  - `mvn -pl flink-cdc-runtime -am -Dtest=JaninoCompilerTest#testTranslatedLikePredicateReturnsUnknownForNullOperand -DfailIfNoTests=false -Dspotless.check.skip=true -Dcheckstyle.skip=true test`
  - `mvn -pl flink-cdc-runtime -am -Dtest=StringFunctionsTest,JaninoCompilerTest -DfailIfNoTests=false -Dspotless.check.skip=true -Dcheckstyle.skip=true test`
  - `mvn -pl flink-cdc-runtime -am -DfailIfNoTests=false -Dspotless.check.skip=true -Dcheckstyle.skip=true test`
  - `mvn -pl flink-cdc-runtime -am -DskipTests test`

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: OpenAI Codex
