### PR TITLE
[cdc-connector][oracle] Support row_id metadata column and fix headers loss in JdbcSourceFetchTaskContext

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-cdc-base/src/main/java/org/apache/flink/cdc/connectors/base/source/reader/external/JdbcSourceFetchTaskContext.java
@@ -105,6 +105,8 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
                     Struct after = value.getStruct(Envelope.FieldName.AFTER);
                     Instant fetchTs =
                             Instant.ofEpochMilli((Long) source.get(Envelope.FieldName.TIMESTAMP));
+                    // Preserve headers (e.g. Oracle ROWID) from the original record so that
+                    // MetadataConverters can read them downstream.
                     SourceRecord record =
                             new SourceRecord(
                                     changeRecord.sourcePartition(),
@@ -114,7 +116,9 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
                                     changeRecord.keySchema(),
                                     changeRecord.key(),
                                     changeRecord.valueSchema(),
-                                    envelope.read(after, source, fetchTs));
+                                    envelope.read(after, source, fetchTs),
+                                    changeRecord.timestamp(),
+                                    changeRecord.headers());
                     outputBuffer.put(key, record);
                     break;
                 case DELETE:
@@ -144,6 +148,8 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
                             Instant fetchTs =
                                     Instant.ofEpochMilli(
                                             value.getInt64(Envelope.FieldName.TIMESTAMP));
+                            // Preserve headers (e.g. Oracle ROWID) from the original record so
+                            // that MetadataConverters can read them downstream.
                             SourceRecord sourceRecord =
                                     new SourceRecord(
                                             record.sourcePartition(),
@@ -153,7 +159,9 @@ public abstract class JdbcSourceFetchTaskContext implements FetchTask.Context {
                                             record.keySchema(),
                                             record.key(),
                                             record.valueSchema(),
-                                            envelope.read(updateAfter, source, fetchTs));
+                                            envelope.read(updateAfter, source, fetchTs),
+                                            record.timestamp(),
+                                            record.headers());
                             return sourceRecord;
                         })
                 .collect(Collectors.toList());

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -43,7 +43,10 @@ import io.debezium.util.Clock;
 import io.debezium.util.ColumnUtils;
 import io.debezium.util.Strings;
 import io.debezium.util.Threads;
+import oracle.jdbc.OracleResultSet;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.header.ConnectHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +54,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.cdc.connectors.oracle.source.reader.fetch.OracleStreamFetchTask.RedoLogSplitReadTask;
 import static org.apache.flink.cdc.connectors.oracle.source.utils.OracleUtils.buildSplitScanQuery;
@@ -269,16 +274,29 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                             snapshotSplit.getSplitKeyType(),
                             snapshotSplit.getSplitStart() == null,
                             snapshotSplit.getSplitEnd() == null);
+            // Rewrite SQL to append ROWID pseudo-column at the tail, because Oracle's SELECT *
+            // does not include ROWID. Placing ROWID after T0.* keeps the physical column
+            // positions unchanged (starting from 1), so we can manually build a ColumnArray
+            // excluding ROWID to bypass ColumnUtils.toArray strict validation, and read ROWID
+            // separately from the last result-set column.
+            // SELECT * FROM "SCHEMA"."TABLE" ... -> SELECT T0.*, ROWID FROM "SCHEMA"."TABLE" T0 ...
+            final String tableRef =
+                    org.apache.flink.cdc.connectors.oracle.source.utils.OracleUtils
+                            .quoteSchemaAndTable(snapshotSplit.getTableId());
+            final String rowIdSelectSql =
+                    selectSql.replaceFirst(
+                            "SELECT \\* FROM " + Pattern.quote(tableRef),
+                            "SELECT T0.*, ROWID FROM " + tableRef + " T0");
             LOG.info(
                     "For split '{}' of table {} using select statement: '{}'",
                     snapshotSplit.splitId(),
                     table.id(),
-                    selectSql);
+                    rowIdSelectSql);
 
             try (PreparedStatement selectStatement =
                             readTableSplitDataStatement(
                                     jdbcConnection,
-                                    selectSql,
+                                    rowIdSelectSql,
                                     snapshotSplit.getSplitStart() == null,
                                     snapshotSplit.getSplitEnd() == null,
                                     snapshotSplit.getSplitStart(),
@@ -287,7 +305,21 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                                     connectorConfig.getQueryFetchSize());
                     ResultSet rs = selectStatement.executeQuery()) {
 
-                ColumnUtils.ColumnArray columnArray = ColumnUtils.toArray(rs, table);
+                // Manually build ColumnArray from Table columns to bypass ColumnUtils strict
+                // validation on the extra ROWID column at the tail of the ResultSet. Physical
+                // columns still occupy ResultSet positions 1..N (SELECT T0.* preserves their
+                // order), ROWID is at position N+1.
+                final int rowIdColumnIndex = rs.getMetaData().getColumnCount();
+                io.debezium.relational.Column[] tableColumns =
+                        table.columns().toArray(new io.debezium.relational.Column[0]);
+                int greatestPosition = 0;
+                for (io.debezium.relational.Column c : tableColumns) {
+                    if (c.position() > greatestPosition) {
+                        greatestPosition = c.position();
+                    }
+                }
+                ColumnUtils.ColumnArray columnArray =
+                        new ColumnUtils.ColumnArray(tableColumns, greatestPosition);
                 long rows = 0;
                 Threads.Timer logTimer = getTableScanLogTimer();
 
@@ -295,6 +327,20 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                     rows++;
                     final Object[] row =
                             jdbcConnection.rowToArray(table, databaseSchema, rs, columnArray);
+                    // Extract ROWID pseudo-column (last column) from Oracle JDBC ResultSet.
+                    String rowId = null;
+                    try {
+                        oracle.sql.ROWID oracleRowId =
+                                ((OracleResultSet) rs).getROWID(rowIdColumnIndex);
+                        if (oracleRowId != null) {
+                            rowId = oracleRowId.stringValue();
+                        }
+                    } catch (Exception e) {
+                        LOG.debug(
+                                "Failed to extract ROWID from OracleResultSet at column index {}",
+                                rowIdColumnIndex,
+                                e);
+                    }
                     if (logTimer.expired()) {
                         long stop = clock.currentTimeInMillis();
                         LOG.info(
@@ -309,7 +355,7 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
                     eventDispatcher.dispatchSnapshotEvent(
                             snapshotContext.partition,
                             table.id(),
-                            getChangeRecordEmitter(snapshotContext, table.id(), row),
+                            getChangeRecordEmitter(snapshotContext, table.id(), row, rowId),
                             snapshotReceiver);
                 }
                 LOG.info(
@@ -325,10 +371,23 @@ public class OracleScanFetchTask extends AbstractScanFetchTask {
         protected ChangeRecordEmitter<OraclePartition> getChangeRecordEmitter(
                 SnapshotContext<OraclePartition, OracleOffsetContext> snapshotContext,
                 TableId tableId,
-                Object[] row) {
+                Object[] row,
+                String rowId) {
             snapshotContext.offset.event(tableId, clock.currentTime());
-            return new SnapshotChangeRecordEmitter<>(
-                    snapshotContext.partition, snapshotContext.offset, row, clock);
+            return new SnapshotChangeRecordEmitter<OraclePartition>(
+                    snapshotContext.partition, snapshotContext.offset, row, clock) {
+                @Override
+                protected Optional<ConnectHeaders> getEmitConnectHeaders() {
+                    if (rowId != null) {
+                        ConnectHeaders headers = new ConnectHeaders();
+                        headers.add(
+                                oracle.sql.ROWID.class.getSimpleName(),
+                                new SchemaAndValue(null, rowId));
+                        return Optional.of(headers);
+                    }
+                    return Optional.empty();
+                }
+            };
         }
 
         private Threads.Timer getTableScanLogTimer() {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleReadableMetaData.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc/src/main/java/org/apache/flink/cdc/connectors/oracle/table/OracleReadableMetaData.java
@@ -26,6 +26,8 @@ import org.apache.flink.table.types.DataType;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.source.SourceRecord;
 
 /** Defines the supported metadata columns for {@link OracleTableSource}. */
@@ -94,6 +96,32 @@ public enum OracleReadableMetaData {
                     Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
                     return TimestampData.fromEpochMillis(
                             (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
+                }
+            }),
+
+    /**
+     * The ROWID pseudo-column of the Oracle table. For streaming changes, the ROWID is extracted
+     * from LogMiner's V$LOGMNR_CONTENTS.ROW_ID and propagated via record headers. For snapshot
+     * reads, the ROWID is obtained via Oracle JDBC's OracleResultSet.getROWID() and injected into
+     * headers by OracleScanFetchTask.
+     */
+    ROW_ID(
+            "row_id",
+            DataTypes.STRING(),
+            new MetadataConverter() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(SourceRecord record) {
+                    ConnectHeaders headers = (ConnectHeaders) record.headers();
+                    if (headers != null) {
+                        for (Header header : headers) {
+                            if (oracle.sql.ROWID.class.getSimpleName().equals(header.key())) {
+                                return StringData.fromString(header.value().toString());
+                            }
+                        }
+                    }
+                    return null;
                 }
             });
 


### PR DESCRIPTION
## Purpose

Add support for extracting Oracle **ROWID pseudo-column** as a metadata column in Oracle CDC. Users can then access it in Flink SQL via:

```sql
CREATE TABLE oracle_source (
    ID INT,
    NAME STRING,
    row_id STRING METADATA FROM 'row_id' VIRTUAL   -- new
) WITH (
    'connector' = 'oracle-cdc',
    'scan.incremental.snapshot.enabled' = 'true',
    ...
);
```

Typical use cases: data lineage, exact-row identification, idempotent downstream writes, systems that rely on ROWID for reconciliation.

## What is changed

### 1. `OracleReadableMetaData` — new `ROW_ID` enum
Reads the ROWID value from the `SourceRecord` headers (key = `ROWID`).

### 2. `OracleScanFetchTask` (snapshot phase)
Oracle's `SELECT *` does **not** include ROWID. So:
- Rewrite the split-scan SQL: `SELECT * FROM tab` → `SELECT T0.*, ROWID FROM tab T0` (ROWID placed at the tail keeps physical column positions unchanged).
- Manually construct `ColumnArray` from the table's own columns to bypass Debezium's `ColumnUtils.toArray(rs, table)` strict validation, which would otherwise reject the extra ROWID column.
- Extract ROWID via `((OracleResultSet) rs).getROWID(N+1)` and inject it into `SourceRecord` headers by overriding `SnapshotChangeRecordEmitter#getEmitConnectHeaders`.

Streaming phase already carries ROWID in headers through Debezium's `LogMinerChangeRecordEmitter` (from `V$LOGMNR_CONTENTS.ROW_ID`), so no changes are needed there.

### 3. `JdbcSourceFetchTaskContext` — headers-loss bug fix ⭐

While implementing the above, we discovered a **latent bug affecting all JDBC-based CDC connectors** (MySQL, PostgreSQL, SQL Server, Db2, Oracle):

Both `rewriteOutputBuffer()` (used for PK-update path) and `formatMessageTimestamp()` (used for snapshot record normalization) were constructing new `SourceRecord`s using the 8-argument constructor, silently discarding the **timestamp** and **headers** from the original record.

Any header-based metadata — including the new Oracle `row_id`, and any future header-based columns that may be added — would be silently dropped by these two rewrite paths.

Fix: switch both call sites to the 10-argument `SourceRecord` constructor so `timestamp` and `headers` are preserved.

## Verification

Compilation:
```
mvn compile -pl flink-cdc-connect/flink-cdc-source-connectors/flink-connector-oracle-cdc -am -DskipTests
```
✅ BUILD SUCCESS

Runtime (Oracle Database 12c Standard Edition 12.1.0.2.0, back-ported to release-2.4 and verified end-to-end):
```
+I[2, bbb, AABDuHAAGAAAAF3AAA]
+I[3, ccc, AABDuHAAGAAAAF0AAA]
+I[4, ddd, AABDuHAAGAAAAF0AAB]
-D[2, bbb, AABDuHAAGAAAAF3AAA]
```
Both snapshot (READ) and streaming (INSERT/UPDATE/DELETE) rows carry a valid ROWID.

## Data flow

```
Snapshot phase:
  OracleScanFetchTask (rs.getROWID)
    → SnapshotChangeRecordEmitter.getEmitConnectHeaders (inject ROWID)
      → BufferingSnapshotChangeRecordReceiver (new SourceRecord with headers)
        → ChangeEventQueue

Streaming phase (already works):
  LogMinerChangeRecordEmitter.getEmitConnectHeaders (inject ROWID)
    → ChangeEventQueue

Reader side (bug fix here):
  IncrementalSourceScanFetcher.pollSplitRecords
    → JdbcSourceFetchTaskContext.formatMessageTimestamp/rewriteOutputBuffer
      (preserve headers)  ⭐
        → OracleReadableMetaData.ROW_ID.read(record.headers())
```

## User requirements

- `scan.incremental.snapshot.enabled=true` (this PR does not touch Debezium's native snapshot path).
- Table supplemental logging enabled for streaming capture:
  ```
  ALTER TABLE <schema>.<table> ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
  ```

## Compatibility

- No breaking API changes.
- No new configuration options.
- Users who don't declare `row_id` metadata column see zero behavioral change (SQL rewrite still runs but only adds a single pseudo-column to the JDBC query, which is negligible).
- The `JdbcSourceFetchTaskContext` fix is transparent — records that previously had `null`/absent headers still have `null`/absent headers afterwards.
