### PR TITLE
[hotfix][postgres] generateCreateTableEvent result is skipped 

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresPipelineRecordEmitter.java
@@ -94,7 +94,7 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
         this.createTableEventCache =
                 ((DebeziumEventDeserializationSchema) debeziumDeserializationSchema)
                         .getCreateTableEventCache();
-        generateCreateTableEvent(sourceConfig);
+        this.createTableEventCache.putAll(generateCreateTableEvent(sourceConfig));
         this.isBounded = StartupOptions.snapshot().equals(sourceConfig.getStartupOptions());
     }
 
@@ -217,7 +217,7 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
     private Map<TableId, CreateTableEvent> generateCreateTableEvent(
             PostgresSourceConfig sourceConfig) {
         try (PostgresConnection jdbc = postgresDialect.openJdbcConnection()) {
-            Map<TableId, CreateTableEvent> createTableEventCache = new HashMap<>();
+            Map<TableId, CreateTableEvent> generatedCreateTableEvent = new HashMap<>();
             List<TableId> capturedTableIds =
                     TableDiscoveryUtils.listTables(
                             sourceConfig.getDatabaseList().get(0),
@@ -226,7 +226,7 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
                             sourceConfig.includePartitionedTables());
             for (TableId tableId : capturedTableIds) {
                 Schema schema = PostgresSchemaUtils.getTableSchema(tableId, sourceConfig, jdbc);
-                createTableEventCache.put(
+                generatedCreateTableEvent.put(
                         tableId,
                         new CreateTableEvent(
                                 toCdcTableId(
@@ -235,7 +235,7 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
                                         includeDatabaseInTableId),
                                 schema));
             }
-            return createTableEventCache;
+            return generatedCreateTableEvent;
         } catch (SQLException e) {
             throw new RuntimeException("Cannot start emitter to fetch table schema.", e);
         }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

## What is the purpose of this pull request?

For now, the `PostgresPipelineRecordEmitter` class in the constructor call `generateCreateTableEvent` function and throws away the result of the metadata scan. This pull request fixes it and adds table DDL into the local cache map.

## Brief change log

Changed the name of the inner map inside the function `generateCreateTableEvent` to avoid shadowing of the original class field. Additionally, add all the resulting maps into the cache.

---

## Verifying this change

<!-- Describe how this change can be verified. -->

This change is a trivial rework.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable, because it is a bug

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed.
-->

- [ ] No

<!--
Generated-by: [Tool Name and Version]
-->
