### PR TITLE
[FLINK-40274][cdc-cli] Remove unsupported kubernetes-session from target option help message

### DIFF
--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontendOptions.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontendOptions.java
@@ -51,8 +51,12 @@ public class CliFrontendOptions {
                     .longOpt("target")
                     .hasArg()
                     .desc(
-                            "The deployment target for the execution. This can take one of the following values "
-                                    + "local/remote/yarn-session/yarn-application/kubernetes-application")
+                            "The deployment target for the execution. This can take one of the following values:\n"
+                                    + "- local\n"
+                                    + "- remote\n"
+                                    + "- yarn-session\n"
+                                    + "- yarn-application\n"
+                                    + "- kubernetes-application")
                     .build();
 
     public static final Option USE_MINI_CLUSTER =

--- a/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontendOptions.java
+++ b/flink-cdc-cli/src/main/java/org/apache/flink/cdc/cli/CliFrontendOptions.java
@@ -52,8 +52,7 @@ public class CliFrontendOptions {
                     .hasArg()
                     .desc(
                             "The deployment target for the execution. This can take one of the following values "
-                                    + "local/remote/yarn-session/yarn-application/kubernetes-session/kubernetes"
-                                    + "-application")
+                                    + "local/remote/yarn-session/yarn-application/kubernetes-application")
                     .build();
 
     public static final Option USE_MINI_CLUSTER =

--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/CliFrontendTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/CliFrontendTest.java
@@ -281,10 +281,12 @@ class CliFrontendTest {
                     + "                                                hdfs:///flink/savepoint-1537\n"
                     + "    -t,--target <arg>                           The deployment target for the\n"
                     + "                                                execution. This can take one of\n"
-                    + "                                                the following values\n"
-                    + "                                                local/remote/yarn-session/yarn-a\n"
-                    + "                                                pplication/kubernetes-applicatio\n"
-                    + "                                                n\n"
+                    + "                                                the following values:\n"
+                    + "                                                - local\n"
+                    + "                                                - remote\n"
+                    + "                                                - yarn-session\n"
+                    + "                                                - yarn-application\n"
+                    + "                                                - kubernetes-application\n"
                     + "       --use-mini-cluster                       Use Flink MiniCluster to run the\n"
                     + "                                                pipeline\n";
 

--- a/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/CliFrontendTest.java
+++ b/flink-cdc-cli/src/test/java/org/apache/flink/cdc/cli/CliFrontendTest.java
@@ -283,8 +283,8 @@ class CliFrontendTest {
                     + "                                                execution. This can take one of\n"
                     + "                                                the following values\n"
                     + "                                                local/remote/yarn-session/yarn-a\n"
-                    + "                                                pplication/kubernetes-session/ku\n"
-                    + "                                                bernetes-application\n"
+                    + "                                                pplication/kubernetes-applicatio\n"
+                    + "                                                n\n"
                     + "       --use-mini-cluster                       Use Flink MiniCluster to run the\n"
                     + "                                                pipeline\n";
 


### PR DESCRIPTION
## What is the purpose of this pull request?

This PR corrects the Flink CDC CLI help text for the `--target` option.

The help message listed `kubernetes-session` as a supported deployment target, but
Flink CDC currently supports `kubernetes-application` only for Kubernetes-specific
submission. Kubernetes session clusters can still be used by starting the Flink
session cluster separately and submitting through the existing `remote` target.

## Brief change log

- Removed the unsupported `kubernetes-session` value from the `--target` help text.
- Kept the help message aligned with the deployment targets defined by `ComposeDeployment`.

---

## Verifying this change

This change can be verified as follows:

- Run `mvn --batch-mode --no-transfer-progress -pl flink-cdc-cli -am test`
- Check `flink-cdc.sh --help` and confirm that the `--target` option no longer lists `kubernetes-session`.

## Documentation

- Does this pull request introduce a new feature? no
- If yes, how is the feature documented? not applicable

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (OpenAI Codex)

Generated-by: OpenAI Codex
