### PR TITLE
[FLINK-40315][connect/mariadb] Add MariaDB CDC DataStream source

### DIFF
--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/pom.xml
@@ -67,6 +67,15 @@ limitations under the License.
             <scope>test</scope>
         </dependency>
 
+        <!-- Provides TestValuesTableFactory (the 'values' test sink) used by the recovery IT. -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-runtime</artifactId>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flink-cdc-source-connectors</artifactId>
+        <groupId>org.apache.flink</groupId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flink-connector-mariadb-cdc</artifactId>
+    <name>flink-connector-mariadb-cdc</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <!-- Reuse the entire MySQL CDC read pipeline.-->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.27</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-mysql-cdc</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.testcontainers</groupId>
+                    <artifactId>testcontainers</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- test dependencies on TestContainers -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/io/debezium/connector/mysql/MySqlStreamingChangeEventSource.java
@@ -1,0 +1,1637 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.debezium.connector.mysql;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.BinaryLogClient.LifecycleListener;
+import com.github.shyiko.mysql.binlog.MariadbGtidSet;
+import com.github.shyiko.mysql.binlog.event.DeleteRowsEventData;
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventData;
+import com.github.shyiko.mysql.binlog.event.EventHeader;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.GtidEventData;
+import com.github.shyiko.mysql.binlog.event.MariadbGtidEventData;
+import com.github.shyiko.mysql.binlog.event.QueryEventData;
+import com.github.shyiko.mysql.binlog.event.RotateEventData;
+import com.github.shyiko.mysql.binlog.event.RowsQueryEventData;
+import com.github.shyiko.mysql.binlog.event.TableMapEventData;
+import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
+import com.github.shyiko.mysql.binlog.event.WriteRowsEventData;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDataDeserializationException;
+import com.github.shyiko.mysql.binlog.event.deserialization.EventDeserializer;
+import com.github.shyiko.mysql.binlog.event.deserialization.GtidEventDataDeserializer;
+import com.github.shyiko.mysql.binlog.io.ByteArrayInputStream;
+import com.github.shyiko.mysql.binlog.network.AuthenticationException;
+import com.github.shyiko.mysql.binlog.network.DefaultSSLSocketFactory;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
+import com.github.shyiko.mysql.binlog.network.SSLSocketFactory;
+import com.github.shyiko.mysql.binlog.network.ServerException;
+import io.debezium.DebeziumException;
+import io.debezium.annotation.SingleThreadAccess;
+import io.debezium.config.CommonConnectorConfig.EventProcessingFailureHandlingMode;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig.GtidNewChannelPosition;
+import io.debezium.connector.mysql.MySqlConnectorConfig.SecureConnectionMode;
+import io.debezium.connector.mysql.util.ErrorMessageUtils;
+import io.debezium.data.Envelope.Operation;
+import io.debezium.function.BlockingConsumer;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.spi.StreamingChangeEventSource;
+import io.debezium.relational.TableId;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
+import io.debezium.util.Strings;
+import io.debezium.util.Threads;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+
+import static io.debezium.util.Strings.isNullOrEmpty;
+
+/**
+ * Copied from Debezium project(1.9.8.Final) to fix
+ * https://github.com/ververica/flink-cdc-connectors/issues/1944.
+ *
+ * <p>Line 1432-1443 : Adjust GTID merging logic to support recovering from job which previously
+ * specifying starting offset on start. Uses {@link GtidUtils#fixOldChannelsGtidSet} for shared
+ * EARLIEST/LATEST logic.
+ *
+ * <p>Line 1444-1452 : Fix LATEST mode GTID merging to avoid replaying pre-checkpoint transactions
+ * when checkpoint GTID has non-contiguous ranges. Delegates to {@link
+ * GtidUtils#computeLatestModeGtidSet}. See FLINK-39149.
+ *
+ * <p>Line 1490 : Add more error details for some exceptions.
+ *
+ * <p>Line 951-963 : Use iterator instead of index-based loop to avoid O(n²) complexity when
+ * processing LinkedList rows in handleChange method. See FLINK-38846.
+ *
+ * <p>TODO This is copied from mysql-cdc connector's dist. Remove unused methods
+ */
+public class MySqlStreamingChangeEventSource
+        implements StreamingChangeEventSource<MySqlPartition, MySqlOffsetContext> {
+
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(MySqlStreamingChangeEventSource.class);
+
+    private static final String KEEPALIVE_THREAD_NAME = "blc-keepalive";
+
+    private final EnumMap<EventType, BlockingConsumer<Event>> eventHandlers =
+            new EnumMap<>(EventType.class);
+    private final BinaryLogClient client;
+    private final MySqlStreamingChangeEventSourceMetrics metrics;
+    private final Clock clock;
+    private final EventProcessingFailureHandlingMode eventDeserializationFailureHandlingMode;
+    private final EventProcessingFailureHandlingMode inconsistentSchemaHandlingMode;
+
+    private int startingRowNumber = 0;
+    private long initialEventsToSkip = 0L;
+    private boolean skipEvent = false;
+    private boolean ignoreDmlEventByGtidSource = false;
+    private final Predicate<String> gtidDmlSourceFilter;
+    private final AtomicLong totalRecordCounter = new AtomicLong();
+    private volatile Map<String, ?> lastOffset = null;
+    private com.github.shyiko.mysql.binlog.GtidSet gtidSet;
+    private final float heartbeatIntervalFactor = 0.8f;
+    private final Map<String, Thread> binaryLogClientThreads = new ConcurrentHashMap<>(4);
+    private final MySqlTaskContext taskContext;
+    private final MySqlConnectorConfig connectorConfig;
+    private final MySqlConnection connection;
+    private final EventDispatcher<MySqlPartition, TableId> eventDispatcher;
+    private final ErrorHandler errorHandler;
+
+    @SingleThreadAccess("binlog client thread")
+    private Instant eventTimestamp;
+
+    /** Describe binlog position. */
+    public static class BinlogPosition {
+        final String filename;
+        final long position;
+
+        public BinlogPosition(String filename, long position) {
+            assert filename != null;
+
+            this.filename = filename;
+            this.position = position;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public long getPosition() {
+            return position;
+        }
+
+        @Override
+        public String toString() {
+            return filename + "/" + position;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + filename.hashCode();
+            result = prime * result + (int) (position ^ (position >>> 32));
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            BinlogPosition other = (BinlogPosition) obj;
+            if (!filename.equals(other.filename)) {
+                return false;
+            }
+            if (position != other.position) {
+                return false;
+            }
+            return true;
+        }
+    }
+
+    @FunctionalInterface
+    private interface BinlogChangeEmitter<T> {
+        void emit(TableId tableId, T data) throws InterruptedException;
+    }
+
+    public MySqlStreamingChangeEventSource(
+            MySqlConnectorConfig connectorConfig,
+            MySqlConnection connection,
+            EventDispatcher<MySqlPartition, TableId> dispatcher,
+            ErrorHandler errorHandler,
+            Clock clock,
+            MySqlTaskContext taskContext,
+            MySqlStreamingChangeEventSourceMetrics metrics) {
+
+        this.taskContext = taskContext;
+        this.connectorConfig = connectorConfig;
+        this.connection = connection;
+        this.clock = clock;
+        this.eventDispatcher = dispatcher;
+        this.errorHandler = errorHandler;
+        this.metrics = metrics;
+
+        eventDeserializationFailureHandlingMode =
+                connectorConfig.getEventProcessingFailureHandlingMode();
+        inconsistentSchemaHandlingMode = connectorConfig.inconsistentSchemaFailureHandlingMode();
+
+        // Set up the log reader ...
+        client = taskContext.getBinaryLogClient();
+        // BinaryLogClient will overwrite thread names later
+        client.setThreadFactory(
+                Threads.threadFactory(
+                        MySqlConnector.class,
+                        connectorConfig.getLogicalName(),
+                        "binlog-client",
+                        false,
+                        false,
+                        x -> binaryLogClientThreads.put(x.getName(), x)));
+        client.setServerId(connectorConfig.serverId());
+        client.setSSLMode(sslModeFor(connectorConfig.sslMode()));
+        if (connectorConfig.sslModeEnabled()) {
+            SSLSocketFactory sslSocketFactory =
+                    getBinlogSslSocketFactory(connectorConfig, connection);
+            if (sslSocketFactory != null) {
+                client.setSslSocketFactory(sslSocketFactory);
+            }
+        }
+        Configuration configuration = connectorConfig.getConfig();
+        client.setKeepAlive(configuration.getBoolean(MySqlConnectorConfig.KEEP_ALIVE));
+        final long keepAliveInterval =
+                configuration.getLong(MySqlConnectorConfig.KEEP_ALIVE_INTERVAL_MS);
+        client.setKeepAliveInterval(keepAliveInterval);
+        // Considering heartbeatInterval should be less than keepAliveInterval, we use the
+        // heartbeatIntervalFactor
+        // multiply by keepAliveInterval and set the result value to heartbeatInterval.The default
+        // value of heartbeatIntervalFactor
+        // is 0.8, and we believe the left time (0.2 * keepAliveInterval) is enough to process the
+        // packet received from the MySQL server.
+        client.setHeartbeatInterval((long) (keepAliveInterval * heartbeatIntervalFactor));
+
+        boolean filterDmlEventsByGtidSource =
+                configuration.getBoolean(MySqlConnectorConfig.GTID_SOURCE_FILTER_DML_EVENTS);
+        gtidDmlSourceFilter =
+                filterDmlEventsByGtidSource ? connectorConfig.gtidSourceFilter() : null;
+
+        // Set up the event deserializer with additional type(s) ...
+        final Map<Long, TableMapEventData> tableMapEventByTableId =
+                new HashMap<Long, TableMapEventData>();
+        EventDeserializer eventDeserializer =
+                new EventDeserializer() {
+                    @Override
+                    public Event nextEvent(ByteArrayInputStream inputStream) throws IOException {
+                        try {
+                            // Delegate to the superclass ...
+                            Event event = super.nextEvent(inputStream);
+
+                            // We have to record the most recent TableMapEventData for each table
+                            // number for our custom deserializers ...
+                            if (event.getHeader().getEventType() == EventType.TABLE_MAP) {
+                                TableMapEventData tableMapEvent = event.getData();
+                                tableMapEventByTableId.put(
+                                        tableMapEvent.getTableId(), tableMapEvent);
+                            }
+
+                            // DBZ-5126 Clean cache on rotate event to prevent it from growing
+                            // indefinitely.
+                            if (event.getHeader().getEventType() == EventType.ROTATE
+                                    && event.getHeader().getTimestamp() != 0) {
+                                tableMapEventByTableId.clear();
+                            }
+                            return event;
+                        }
+                        // DBZ-217 In case an event couldn't be read we create a pseudo-event for
+                        // the sake of logging
+                        catch (EventDataDeserializationException edde) {
+                            // DBZ-3095 As of Java 15, when reaching EOF in the binlog stream, the
+                            // polling loop in
+                            // BinaryLogClient#listenForEventPackets() keeps returning values != -1
+                            // from peek();
+                            // this causes the loop to never finish
+                            // Propagating the exception (either EOF or socket closed) causes the
+                            // loop to be aborted
+                            // in this case
+                            if (edde.getCause() instanceof IOException) {
+                                throw edde;
+                            }
+
+                            EventHeaderV4 header = new EventHeaderV4();
+                            header.setEventType(EventType.INCIDENT);
+                            header.setTimestamp(edde.getEventHeader().getTimestamp());
+                            header.setServerId(edde.getEventHeader().getServerId());
+
+                            if (edde.getEventHeader() instanceof EventHeaderV4) {
+                                header.setEventLength(
+                                        ((EventHeaderV4) edde.getEventHeader()).getEventLength());
+                                header.setNextPosition(
+                                        ((EventHeaderV4) edde.getEventHeader()).getNextPosition());
+                                header.setFlags(((EventHeaderV4) edde.getEventHeader()).getFlags());
+                            }
+
+                            EventData data = new EventDataDeserializationExceptionData(edde);
+                            return new Event(header, data);
+                        }
+                    }
+                };
+
+        // Add our custom deserializers ...
+        eventDeserializer.setEventDataDeserializer(EventType.STOP, new StopEventDataDeserializer());
+        eventDeserializer.setEventDataDeserializer(EventType.GTID, new GtidEventDataDeserializer());
+        eventDeserializer.setEventDataDeserializer(
+                EventType.WRITE_ROWS,
+                new RowDeserializers.WriteRowsDeserializer(tableMapEventByTableId));
+        eventDeserializer.setEventDataDeserializer(
+                EventType.UPDATE_ROWS,
+                new RowDeserializers.UpdateRowsDeserializer(tableMapEventByTableId));
+        eventDeserializer.setEventDataDeserializer(
+                EventType.DELETE_ROWS,
+                new RowDeserializers.DeleteRowsDeserializer(tableMapEventByTableId));
+        eventDeserializer.setEventDataDeserializer(
+                EventType.EXT_WRITE_ROWS,
+                new RowDeserializers.WriteRowsDeserializer(tableMapEventByTableId)
+                        .setMayContainExtraInformation(true));
+        eventDeserializer.setEventDataDeserializer(
+                EventType.EXT_UPDATE_ROWS,
+                new RowDeserializers.UpdateRowsDeserializer(tableMapEventByTableId)
+                        .setMayContainExtraInformation(true));
+        eventDeserializer.setEventDataDeserializer(
+                EventType.EXT_DELETE_ROWS,
+                new RowDeserializers.DeleteRowsDeserializer(tableMapEventByTableId)
+                        .setMayContainExtraInformation(true));
+        client.setEventDeserializer(eventDeserializer);
+    }
+
+    protected void onEvent(MySqlOffsetContext offsetContext, Event event) {
+        long ts = 0;
+
+        if (event.getHeader().getEventType() == EventType.HEARTBEAT) {
+            // HEARTBEAT events have no timestamp but are fired only when
+            // there is no traffic on the connection which means we are caught-up
+            // https://dev.mysql.com/doc/internals/en/heartbeat-event.html
+            metrics.setMilliSecondsBehindSource(ts);
+            return;
+        }
+
+        // MySQL has seconds resolution but mysql-binlog-connector-java returns
+        // a value in milliseconds
+        long eventTs = event.getHeader().getTimestamp();
+
+        if (eventTs == 0) {
+            LOGGER.trace("Received unexpected event with 0 timestamp: {}", event);
+            return;
+        }
+
+        ts = clock.currentTimeInMillis() - eventTs;
+        LOGGER.trace("Current milliseconds behind source: {} ms", ts);
+        metrics.setMilliSecondsBehindSource(ts);
+    }
+
+    protected void ignoreEvent(MySqlOffsetContext offsetContext, Event event) {
+        LOGGER.trace("Ignoring event due to missing handler: {}", event);
+    }
+
+    protected void handleEvent(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event) {
+        if (event == null) {
+            return;
+        }
+
+        final EventHeader eventHeader = event.getHeader();
+        // Update the source offset info. Note that the client returns the value in *milliseconds*,
+        // even though the binlog
+        // contains only *seconds* precision ...
+        // HEARTBEAT events have no timestamp; only set the timestamp if the event is not a
+        // HEARTBEAT
+        eventTimestamp =
+                !eventHeader.getEventType().equals(EventType.HEARTBEAT)
+                        ? Instant.ofEpochMilli(eventHeader.getTimestamp())
+                        : null;
+        offsetContext.setBinlogServerId(eventHeader.getServerId());
+
+        final EventType eventType = eventHeader.getEventType();
+        if (eventType == EventType.ROTATE) {
+            EventData eventData = event.getData();
+            RotateEventData rotateEventData;
+            if (eventData instanceof EventDeserializer.EventDataWrapper) {
+                rotateEventData =
+                        (RotateEventData)
+                                ((EventDeserializer.EventDataWrapper) eventData).getInternal();
+            } else {
+                rotateEventData = (RotateEventData) eventData;
+            }
+            offsetContext.setBinlogStartPoint(
+                    rotateEventData.getBinlogFilename(), rotateEventData.getBinlogPosition());
+        } else if (eventHeader instanceof EventHeaderV4) {
+            EventHeaderV4 trackableEventHeader = (EventHeaderV4) eventHeader;
+            offsetContext.setEventPosition(
+                    trackableEventHeader.getPosition(), trackableEventHeader.getEventLength());
+        }
+
+        // If there is a handler for this event, forward the event to it ...
+        try {
+            // Forward the event to the handler ...
+            eventHandlers
+                    .getOrDefault(eventType, (e) -> ignoreEvent(offsetContext, e))
+                    .accept(event);
+
+            // Generate heartbeat message if the time is right
+            eventDispatcher.dispatchHeartbeatEvent(partition, offsetContext);
+
+            // Capture that we've completed another event ...
+            offsetContext.completeEvent();
+
+            // update last offset used for logging
+            lastOffset = offsetContext.getOffset();
+
+            if (skipEvent) {
+                // We're in the mode of skipping events and we just skipped this one, so decrement
+                // our skip count ...
+                --initialEventsToSkip;
+                skipEvent = initialEventsToSkip > 0;
+            }
+        } catch (RuntimeException e) {
+            // There was an error in the event handler, so propagate the failure to Kafka Connect
+            // ...
+            logStreamingSourceState();
+            errorHandler.setProducerThrowable(
+                    new DebeziumException("Error processing binlog event", e));
+            // Do not stop the client, since Kafka Connect should stop the connector on it's own
+            // (and doing it here may cause problems the second time it is stopped).
+            // We can clear the listeners though so that we ignore all future events ...
+            eventHandlers.clear();
+            LOGGER.info(
+                    "Error processing binlog event, and propagating to Kafka Connect so it stops this connector. Future binlog events read before connector is shutdown will be ignored.");
+        } catch (InterruptedException e) {
+            // Most likely because this reader was stopped and our thread was interrupted ...
+            Thread.currentThread().interrupt();
+            eventHandlers.clear();
+            LOGGER.info("Stopped processing binlog events due to thread interruption");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T extends EventData> T unwrapData(Event event) {
+        EventData eventData = event.getData();
+        if (eventData instanceof EventDeserializer.EventDataWrapper) {
+            eventData = ((EventDeserializer.EventDataWrapper) eventData).getInternal();
+        }
+        return (T) eventData;
+    }
+
+    /**
+     * Handle the supplied event that signals that mysqld has stopped.
+     *
+     * @param event the server stopped event to be processed; may not be null
+     */
+    protected void handleServerStop(MySqlOffsetContext offsetContext, Event event) {
+        LOGGER.debug("Server stopped: {}", event);
+    }
+
+    /**
+     * Handle the supplied event that is sent by a primary to a replica to let the replica know that
+     * the primary is still alive. Not written to a binary log.
+     *
+     * @param event the server stopped event to be processed; may not be null
+     */
+    protected void handleServerHeartbeat(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        LOGGER.trace("Server heartbeat: {}", event);
+        eventDispatcher.dispatchServerHeartbeatEvent(partition, offsetContext);
+    }
+
+    /**
+     * Handle the supplied event that signals that an out of the ordinary event that occurred on the
+     * master. It notifies the replica that something happened on the primary that might cause data
+     * to be in an inconsistent state.
+     *
+     * @param event the server stopped event to be processed; may not be null
+     */
+    protected void handleServerIncident(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event) {
+        if (event.getData() instanceof EventDataDeserializationExceptionData) {
+            metrics.onErroneousEvent(partition, "source = " + event);
+            EventDataDeserializationExceptionData data = event.getData();
+
+            EventHeaderV4 eventHeader =
+                    (EventHeaderV4)
+                            data.getCause()
+                                    .getEventHeader(); // safe cast, instantiated that ourselves
+
+            // logging some additional context but not the exception itself, this will happen in
+            // handleEvent()
+            if (eventDeserializationFailureHandlingMode
+                    == EventProcessingFailureHandlingMode.FAIL) {
+                LOGGER.error(
+                        "Error while deserializing binlog event at offset {}.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        offsetContext.getOffset(),
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        offsetContext.getSource().binlogFilename());
+
+                throw new RuntimeException(data.getCause());
+            } else if (eventDeserializationFailureHandlingMode
+                    == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn(
+                        "Error while deserializing binlog event at offset {}.{}"
+                                + "This exception will be ignored and the event be skipped.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        offsetContext.getOffset(),
+                        System.lineSeparator(),
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        offsetContext.getSource().binlogFilename(),
+                        data.getCause());
+            }
+        } else {
+            LOGGER.error("Server incident: {}", event);
+        }
+    }
+
+    /**
+     * Handle the supplied event with a {@link RotateEventData} that signals the logs are being
+     * rotated. This means that either the server was restarted, or the binlog has transitioned to a
+     * new file. In either case, subsequent table numbers will be different than those seen to this
+     * point.
+     *
+     * @param event the database change data event to be processed; may not be null
+     */
+    protected void handleRotateLogsEvent(MySqlOffsetContext offsetContext, Event event) {
+        LOGGER.debug("Rotating logs: {}", event);
+        RotateEventData command = unwrapData(event);
+        assert command != null;
+        taskContext.getSchema().clearTableMappings();
+    }
+
+    /**
+     * Handle the supplied event with a {@link GtidEventData} that signals the beginning of a GTID
+     * transaction. We don't yet know whether this transaction contains any events we're interested
+     * in, but we have to record it so that we know the position of this event and know we've
+     * processed the binlog to this point.
+     *
+     * <p>Note that this captures the current GTID and complete GTID set, regardless of whether the
+     * connector is {@link MySqlTaskContext#gtidSourceFilter() filtering} the GTID set upon
+     * connection. We do this because we actually want to capture all GTID set values found in the
+     * binlog, whether or not we process them. However, only when we connect do we actually want to
+     * pass to MySQL only those GTID ranges that are applicable per the configuration.
+     *
+     * @param event the GTID event to be processed; may not be null
+     */
+    protected void handleGtidEvent(MySqlOffsetContext offsetContext, Event event) {
+        LOGGER.debug("GTID transaction: {}", event);
+        GtidEventData gtidEvent = unwrapData(event);
+        String gtid = gtidEvent.getGtid();
+        gtidSet.add(gtid);
+        offsetContext.startGtid(gtid, gtidSet.toString()); // rather than use the client's GTID set
+        ignoreDmlEventByGtidSource = false;
+        if (gtidDmlSourceFilter != null && gtid != null) {
+            String uuid = gtid.trim().substring(0, gtid.indexOf(":"));
+            if (!gtidDmlSourceFilter.test(uuid)) {
+                ignoreDmlEventByGtidSource = true;
+            }
+        }
+        metrics.onGtidChange(gtid);
+    }
+
+    /**
+     * Handle the supplied event with an {@link RowsQueryEventData} by recording the original SQL
+     * query that generated the event.
+     *
+     * @param event the database change data event to be processed; may not be null
+     */
+    protected void handleRowsQuery(MySqlOffsetContext offsetContext, Event event) {
+        // Unwrap the RowsQueryEvent
+        final RowsQueryEventData lastRowsQueryEventData = unwrapData(event);
+
+        // Set the query on the source
+        offsetContext.setQuery(lastRowsQueryEventData.getQuery());
+    }
+
+    /**
+     * MariaDB connect path: register the MARIADB_GTID handler and resume from the restored GTID set
+     * (server-id agnostic) when present, otherwise from the binlog file/position. Replaces the
+     * MySQL GTID_MODE / SHOW MASTER STATUS logic, which MariaDB does not support.
+     */
+    private void connectMariaDb(MySqlOffsetContext effectiveOffsetContext) {
+        metrics.setIsGtidModeEnabled(true);
+        eventHandlers.put(
+                EventType.MARIADB_GTID,
+                event -> handleMariadbGtidEvent(effectiveOffsetContext, event));
+
+        String restoreGtidStr = effectiveOffsetContext.gtidSet();
+        if (StringUtils.isNotBlank(restoreGtidStr)) {
+            LOGGER.info(
+                    "MariaDB: resuming binlog from restored GTID set {} (binlog file={} pos={})",
+                    restoreGtidStr,
+                    effectiveOffsetContext.getSource().binlogFilename(),
+                    effectiveOffsetContext.getSource().binlogPosition());
+            client.setGtidSet(restoreGtidStr);
+            effectiveOffsetContext.setCompletedGtidSet(restoreGtidStr);
+            gtidSet = new MariadbGtidSet(restoreGtidStr);
+        } else {
+            LOGGER.info(
+                    "MariaDB: no restored GTID, starting from binlog file={} position={}",
+                    effectiveOffsetContext.getSource().binlogFilename(),
+                    effectiveOffsetContext.getSource().binlogPosition());
+            client.setBinlogFilename(effectiveOffsetContext.getSource().binlogFilename());
+            client.setBinlogPosition(effectiveOffsetContext.getSource().binlogPosition());
+            gtidSet = new MariadbGtidSet("");
+        }
+    }
+
+    protected void handleMariadbGtidEvent(MySqlOffsetContext offsetContext, Event event) {
+        String gtid = mariadbGtidOf(event);
+        gtidSet.add(gtid);
+        offsetContext.startGtid(gtid, gtidSet.toString());
+        metrics.onGtidChange(gtid);
+    }
+
+    /**
+     * Build the {@code domain-server-sequence} MariaDB GTID string from a MARIADB_GTID event. The
+     * server id is taken from the event header rather than the payload, matching how MariaDB
+     * records GTIDs and exposes {@code @@gtid_binlog_pos}; using the payload server id would
+     * produce a GTID that does not line up with the server's own set and would break GTID-based
+     * resume.
+     */
+    static String mariadbGtidOf(Event event) {
+        EventData eventData = event.getData();
+        if (eventData instanceof EventDeserializer.EventDataWrapper) {
+            eventData = ((EventDeserializer.EventDataWrapper) eventData).getInternal();
+        }
+
+        MariadbGtidEventData gtidEventData = (MariadbGtidEventData) eventData;
+        EventHeader header = event.getHeader();
+        return gtidEventData.getDomainId()
+                + "-"
+                + header.getServerId()
+                + "-"
+                + gtidEventData.getSequence();
+    }
+
+    /**
+     * Handle the supplied event with an {@link QueryEventData} by possibly recording the DDL
+     * statements as changes in the MySQL schemas.
+     *
+     * @param partition the partition in which the even occurred
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while recording the DDL statements
+     */
+    protected void handleQueryEvent(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        QueryEventData command = unwrapData(event);
+        LOGGER.debug("Received query command: {}", event);
+        String sql = command.getSql().trim();
+        if (sql.equalsIgnoreCase("BEGIN")) {
+            // We are starting a new transaction ...
+            offsetContext.startNextTransaction();
+            eventDispatcher.dispatchTransactionStartedEvent(
+                    partition, offsetContext.getTransactionId(), offsetContext);
+            offsetContext.setBinlogThread(command.getThreadId());
+            if (initialEventsToSkip != 0) {
+                LOGGER.debug(
+                        "Restarting partially-processed transaction; change events will not be created for the first {} events plus {} more rows in the next event",
+                        initialEventsToSkip,
+                        startingRowNumber);
+                // We are restarting, so we need to skip the events in this transaction that we
+                // processed previously...
+                skipEvent = true;
+            }
+            return;
+        }
+        if (sql.equalsIgnoreCase("COMMIT")) {
+            handleTransactionCompletion(partition, offsetContext, event);
+            return;
+        }
+
+        String upperCasedStatementBegin = Strings.getBegin(sql, 7).toUpperCase();
+
+        if (upperCasedStatementBegin.startsWith("XA ")) {
+            // This is an XA transaction, and we currently ignore these and do nothing ...
+            return;
+        }
+        if (connectorConfig.getDdlFilter().test(sql)) {
+            LOGGER.debug("DDL '{}' was filtered out of processing", sql);
+            return;
+        }
+        if (upperCasedStatementBegin.equals("INSERT ")
+                || upperCasedStatementBegin.equals("UPDATE ")
+                || upperCasedStatementBegin.equals("DELETE ")) {
+            LOGGER.warn(
+                    "Received DML '"
+                            + sql
+                            + "' for processing, binlog probably contains events generated with statement or mixed based replication format");
+            return;
+        }
+        if (sql.equalsIgnoreCase("ROLLBACK")) {
+            // We have hit a ROLLBACK which is not supported
+            LOGGER.warn(
+                    "Rollback statements cannot be handled without binlog buffering, the connector will fail. Please check '{}' to see how to enable buffering",
+                    MySqlConnectorConfig.BUFFER_SIZE_FOR_BINLOG_READER.name());
+        } else {
+            // ROLLBACK is not a DDL event and already has a dedicated warning above.
+            EventHeader header = event.getHeader();
+            if (header instanceof EventHeaderV4) {
+                EventHeaderV4 eventHeader = (EventHeaderV4) header;
+                LOGGER.info(
+                        "Received MySQL DDL event at {} [{}-{}], database={}, ddl={}",
+                        offsetContext.getSource().binlogFilename(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        command.getDatabase(),
+                        sql);
+            } else {
+                LOGGER.info(
+                        "Received MySQL DDL event, database={}, ddl={}",
+                        command.getDatabase(),
+                        sql);
+            }
+        }
+
+        final List<SchemaChangeEvent> schemaChangeEvents =
+                taskContext
+                        .getSchema()
+                        .parseStreamingDdl(
+                                partition,
+                                sql,
+                                command.getDatabase(),
+                                offsetContext,
+                                clock.currentTimeAsInstant());
+        try {
+            for (SchemaChangeEvent schemaChangeEvent : schemaChangeEvents) {
+                if (taskContext.getSchema().skipSchemaChangeEvent(schemaChangeEvent)) {
+                    continue;
+                }
+
+                final TableId tableId =
+                        schemaChangeEvent.getTables().isEmpty()
+                                ? null
+                                : schemaChangeEvent.getTables().iterator().next().id();
+                eventDispatcher.dispatchSchemaChangeEvent(
+                        partition,
+                        tableId,
+                        (receiver) -> {
+                            try {
+                                receiver.schemaChangeEvent(schemaChangeEvent);
+                            } catch (Exception e) {
+                                throw new DebeziumException(e);
+                            }
+                        });
+            }
+        } catch (InterruptedException e) {
+            LOGGER.info("Processing interrupted");
+        }
+    }
+
+    private void handleTransactionCompletion(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        // We are completing the transaction ...
+        eventDispatcher.dispatchTransactionCommittedEvent(partition, offsetContext);
+        offsetContext.commitTransaction();
+        offsetContext.setBinlogThread(-1L);
+        skipEvent = false;
+        ignoreDmlEventByGtidSource = false;
+    }
+
+    /**
+     * Handle a change in the table metadata.
+     *
+     * <p>This method should be called whenever we consume a TABLE_MAP event, and every transaction
+     * in the log should include one of these for each table affected by the transaction. Each table
+     * map event includes a monotonically-increasing numeric identifier, and this identifier is used
+     * within subsequent events within the same transaction. This table identifier can change when:
+     *
+     * <ol>
+     *   <li>the table structure is modified (e.g., via an {@code ALTER TABLE ...} command); or
+     *   <li>MySQL rotates to a new binary log file, even if the table structure does not change.
+     * </ol>
+     *
+     * @param event the update event; never null
+     */
+    protected void handleUpdateTableMetadata(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        TableMapEventData metadata = unwrapData(event);
+        long tableNumber = metadata.getTableId();
+        String databaseName = metadata.getDatabase();
+        String tableName = metadata.getTable();
+        TableId tableId = new TableId(databaseName, null, tableName);
+        if (taskContext.getSchema().assignTableNumber(tableNumber, tableId)) {
+            LOGGER.debug("Received update table metadata event: {}", event);
+        } else {
+            informAboutUnknownTableIfRequired(partition, offsetContext, event, tableId);
+        }
+    }
+
+    /**
+     * If we receive an event for a table that is monitored but whose metadata we don't know, either
+     * ignore that event or raise a warning or error as per the {@link
+     * MySqlConnectorConfig#INCONSISTENT_SCHEMA_HANDLING_MODE} configuration.
+     */
+    private void informAboutUnknownTableIfRequired(
+            MySqlPartition partition,
+            MySqlOffsetContext offsetContext,
+            Event event,
+            TableId tableId,
+            Operation operation)
+            throws InterruptedException {
+        if (tableId != null
+                && connectorConfig.getTableFilters().dataCollectionFilter().isIncluded(tableId)) {
+            metrics.onErroneousEvent(
+                    partition, "source = " + tableId + ", event " + event, operation);
+            EventHeaderV4 eventHeader = event.getHeader();
+
+            if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.FAIL) {
+                LOGGER.error(
+                        "Encountered change event '{}' at offset {} for table {} whose schema isn't known to this connector. One possible cause is an incomplete database history topic. Take a new snapshot in this case.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        event,
+                        offsetContext.getOffset(),
+                        tableId,
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        offsetContext.getSource().binlogFilename());
+                throw new DebeziumException(
+                        "Encountered change event for table "
+                                + tableId
+                                + " whose schema isn't known to this connector");
+            } else if (inconsistentSchemaHandlingMode == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn(
+                        "Encountered change event '{}' at offset {} for table {} whose schema isn't known to this connector. One possible cause is an incomplete database history topic. Take a new snapshot in this case.{}"
+                                + "The event will be ignored.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        event,
+                        offsetContext.getOffset(),
+                        tableId,
+                        System.lineSeparator(),
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        offsetContext.getSource().binlogFilename());
+            } else {
+                LOGGER.debug(
+                        "Encountered change event '{}' at offset {} for table {} whose schema isn't known to this connector. One possible cause is an incomplete database history topic. Take a new snapshot in this case.{}"
+                                + "The event will be ignored.{}"
+                                + "Use the mysqlbinlog tool to view the problematic event: mysqlbinlog --start-position={} --stop-position={} --verbose {}",
+                        event,
+                        offsetContext.getOffset(),
+                        tableId,
+                        System.lineSeparator(),
+                        System.lineSeparator(),
+                        eventHeader.getPosition(),
+                        eventHeader.getNextPosition(),
+                        offsetContext.getSource().binlogFilename());
+            }
+        } else {
+            if (tableId == null) {
+                EventData eventData = unwrapData(event);
+                if (eventData instanceof WriteRowsEventData) {
+                    tableId =
+                            taskContext
+                                    .getSchema()
+                                    .getExcludeTableId(
+                                            ((WriteRowsEventData) eventData).getTableId());
+                } else if (eventData instanceof UpdateRowsEventData) {
+                    tableId =
+                            taskContext
+                                    .getSchema()
+                                    .getExcludeTableId(
+                                            ((UpdateRowsEventData) eventData).getTableId());
+                } else if (eventData instanceof DeleteRowsEventData) {
+                    tableId =
+                            taskContext
+                                    .getSchema()
+                                    .getExcludeTableId(
+                                            ((DeleteRowsEventData) eventData).getTableId());
+                }
+            }
+            LOGGER.trace("Filtered {} event for {}", event.getHeader().getEventType(), tableId);
+            metrics.onFilteredEvent(partition, "source = " + tableId, operation);
+            eventDispatcher.dispatchFilteredEvent(partition, offsetContext);
+        }
+    }
+
+    private void informAboutUnknownTableIfRequired(
+            MySqlPartition partition,
+            MySqlOffsetContext offsetContext,
+            Event event,
+            TableId tableId)
+            throws InterruptedException {
+        informAboutUnknownTableIfRequired(partition, offsetContext, event, tableId, null);
+    }
+
+    /**
+     * Generate source records for the supplied event with an {@link WriteRowsEventData}.
+     *
+     * @param partition the partition in which the even occurred
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void handleInsert(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        handleChange(
+                partition,
+                offsetContext,
+                event,
+                Operation.CREATE,
+                WriteRowsEventData.class,
+                x -> taskContext.getSchema().getTableId(x.getTableId()),
+                WriteRowsEventData::getRows,
+                (tableId, row) ->
+                        eventDispatcher.dispatchDataChangeEvent(
+                                partition,
+                                tableId,
+                                new MySqlChangeRecordEmitter(
+                                        partition,
+                                        offsetContext,
+                                        clock,
+                                        Operation.CREATE,
+                                        null,
+                                        row)));
+    }
+
+    /**
+     * Generate source records for the supplied event with an {@link UpdateRowsEventData}.
+     *
+     * @param partition the partition in which the even occurred
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void handleUpdate(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        handleChange(
+                partition,
+                offsetContext,
+                event,
+                Operation.UPDATE,
+                UpdateRowsEventData.class,
+                x -> taskContext.getSchema().getTableId(x.getTableId()),
+                UpdateRowsEventData::getRows,
+                (tableId, row) ->
+                        eventDispatcher.dispatchDataChangeEvent(
+                                partition,
+                                tableId,
+                                new MySqlChangeRecordEmitter(
+                                        partition,
+                                        offsetContext,
+                                        clock,
+                                        Operation.UPDATE,
+                                        row.getKey(),
+                                        row.getValue())));
+    }
+
+    /**
+     * Generate source records for the supplied event with an {@link DeleteRowsEventData}.
+     *
+     * @param partition the partition in which the even occurred
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void handleDelete(
+            MySqlPartition partition, MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        handleChange(
+                partition,
+                offsetContext,
+                event,
+                Operation.DELETE,
+                DeleteRowsEventData.class,
+                x -> taskContext.getSchema().getTableId(x.getTableId()),
+                DeleteRowsEventData::getRows,
+                (tableId, row) ->
+                        eventDispatcher.dispatchDataChangeEvent(
+                                partition,
+                                tableId,
+                                new MySqlChangeRecordEmitter(
+                                        partition,
+                                        offsetContext,
+                                        clock,
+                                        Operation.DELETE,
+                                        row,
+                                        null)));
+    }
+
+    private <T extends EventData, U> void handleChange(
+            MySqlPartition partition,
+            MySqlOffsetContext offsetContext,
+            Event event,
+            Operation operation,
+            Class<T> eventDataClass,
+            TableIdProvider<T> tableIdProvider,
+            RowsProvider<T, U> rowsProvider,
+            BinlogChangeEmitter<U> changeEmitter)
+            throws InterruptedException {
+        if (skipEvent) {
+            // We can skip this because we should already be at least this far ...
+            LOGGER.info("Skipping previously processed row event: {}", event);
+            return;
+        }
+        if (ignoreDmlEventByGtidSource) {
+            LOGGER.debug("Skipping DML event because this GTID source is filtered: {}", event);
+            return;
+        }
+        final T data = unwrapData(event);
+        final TableId tableId = tableIdProvider.getTableId(data);
+        final List<U> rows = rowsProvider.getRows(data);
+        String changeType = operation.name();
+
+        if (tableId != null && taskContext.getSchema().schemaFor(tableId) != null) {
+            int count = 0;
+            int numRows = rows.size();
+            if (startingRowNumber < numRows) {
+                // Use iterator to avoid O(n²) complexity when rows is a LinkedList
+                // (mysql-binlog-connector-java uses LinkedList in WriteRowsEventDataDeserializer
+                // and DeleteRowsEventDataDeserializer)
+                int rowIndex = 0;
+                for (U rowData : rows) {
+                    if (rowIndex >= startingRowNumber) {
+                        offsetContext.setRowNumber(rowIndex, numRows);
+                        offsetContext.event(tableId, eventTimestamp);
+                        changeEmitter.emit(tableId, rowData);
+                        count++;
+                    }
+                    rowIndex++;
+                }
+                if (LOGGER.isDebugEnabled()) {
+                    if (startingRowNumber != 0) {
+                        LOGGER.debug(
+                                "Emitted {} {} record(s) for last {} row(s) in event: {}",
+                                count,
+                                changeType,
+                                numRows - startingRowNumber,
+                                event);
+                    } else {
+                        LOGGER.debug(
+                                "Emitted {} {} record(s) for event: {}", count, changeType, event);
+                    }
+                }
+                offsetContext.changeEventCompleted();
+            } else {
+                // All rows were previously processed ...
+                LOGGER.debug("Skipping previously processed {} event: {}", changeType, event);
+            }
+        } else {
+            informAboutUnknownTableIfRequired(partition, offsetContext, event, tableId, operation);
+        }
+        startingRowNumber = 0;
+    }
+
+    /**
+     * Handle a {@link EventType#VIEW_CHANGE} event.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void viewChange(MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        LOGGER.debug("View Change event: {}", event);
+        // do nothing
+    }
+
+    /**
+     * Handle a {@link EventType#XA_PREPARE} event.
+     *
+     * @param event the database change data event to be processed; may not be null
+     * @throws InterruptedException if this thread is interrupted while blocking
+     */
+    protected void prepareTransaction(MySqlOffsetContext offsetContext, Event event)
+            throws InterruptedException {
+        LOGGER.debug("XA Prepare event: {}", event);
+        // do nothing
+    }
+
+    private SSLMode sslModeFor(SecureConnectionMode mode) {
+        switch (mode) {
+            case DISABLED:
+                return SSLMode.DISABLED;
+            case PREFERRED:
+                return SSLMode.PREFERRED;
+            case REQUIRED:
+                return SSLMode.REQUIRED;
+            case VERIFY_CA:
+                return SSLMode.VERIFY_CA;
+            case VERIFY_IDENTITY:
+                return SSLMode.VERIFY_IDENTITY;
+        }
+        return null;
+    }
+
+    @Override
+    public void execute(
+            ChangeEventSourceContext context,
+            MySqlPartition partition,
+            MySqlOffsetContext offsetContext)
+            throws InterruptedException {
+        if (!connectorConfig.getSnapshotMode().shouldStream()) {
+            LOGGER.info(
+                    "Streaming is disabled for snapshot mode {}",
+                    connectorConfig.getSnapshotMode());
+            return;
+        }
+        if (connectorConfig.getSnapshotMode() != MySqlConnectorConfig.SnapshotMode.NEVER) {
+            taskContext.getSchema().assureNonEmptySchema();
+        }
+        final Set<Operation> skippedOperations = connectorConfig.getSkippedOperations();
+
+        final MySqlOffsetContext effectiveOffsetContext =
+                offsetContext != null ? offsetContext : MySqlOffsetContext.initial(connectorConfig);
+
+        // Register our event handlers ...
+        eventHandlers.put(
+                EventType.STOP, (event) -> handleServerStop(effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.HEARTBEAT,
+                (event) -> handleServerHeartbeat(partition, effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.INCIDENT,
+                (event) -> handleServerIncident(partition, effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.ROTATE, (event) -> handleRotateLogsEvent(effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.TABLE_MAP,
+                (event) -> handleUpdateTableMetadata(partition, effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.QUERY,
+                (event) -> handleQueryEvent(partition, effectiveOffsetContext, event));
+
+        if (!skippedOperations.contains(Operation.CREATE)) {
+            eventHandlers.put(
+                    EventType.WRITE_ROWS,
+                    (event) -> handleInsert(partition, effectiveOffsetContext, event));
+            eventHandlers.put(
+                    EventType.EXT_WRITE_ROWS,
+                    (event) -> handleInsert(partition, effectiveOffsetContext, event));
+        }
+
+        if (!skippedOperations.contains(Operation.UPDATE)) {
+            eventHandlers.put(
+                    EventType.UPDATE_ROWS,
+                    (event) -> handleUpdate(partition, effectiveOffsetContext, event));
+            eventHandlers.put(
+                    EventType.EXT_UPDATE_ROWS,
+                    (event) -> handleUpdate(partition, effectiveOffsetContext, event));
+        }
+
+        if (!skippedOperations.contains(Operation.DELETE)) {
+            eventHandlers.put(
+                    EventType.DELETE_ROWS,
+                    (event) -> handleDelete(partition, effectiveOffsetContext, event));
+            eventHandlers.put(
+                    EventType.EXT_DELETE_ROWS,
+                    (event) -> handleDelete(partition, effectiveOffsetContext, event));
+        }
+
+        eventHandlers.put(
+                EventType.VIEW_CHANGE, (event) -> viewChange(effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.XA_PREPARE, (event) -> prepareTransaction(effectiveOffsetContext, event));
+        eventHandlers.put(
+                EventType.XID,
+                (event) -> handleTransactionCompletion(partition, effectiveOffsetContext, event));
+
+        // Conditionally register ROWS_QUERY handler to parse SQL statements.
+        if (connectorConfig.includeSqlQuery()) {
+            eventHandlers.put(
+                    EventType.ROWS_QUERY,
+                    (event) -> handleRowsQuery(effectiveOffsetContext, event));
+        }
+
+        BinaryLogClient.EventListener listener;
+        if (connectorConfig.bufferSizeForStreamingChangeEventSource() == 0) {
+            listener = (event) -> handleEvent(partition, effectiveOffsetContext, event);
+        } else {
+            EventBuffer buffer =
+                    new EventBuffer(
+                            connectorConfig.bufferSizeForStreamingChangeEventSource(),
+                            this,
+                            context);
+            listener = (event) -> buffer.add(partition, effectiveOffsetContext, event);
+        }
+        client.registerEventListener(listener);
+
+        client.registerLifecycleListener(new ReaderThreadLifecycleListener(effectiveOffsetContext));
+        client.registerEventListener((event) -> onEvent(effectiveOffsetContext, event));
+        if (LOGGER.isDebugEnabled()) {
+            client.registerEventListener((event) -> logEvent(effectiveOffsetContext, event));
+        }
+
+        // MariaDB has no GTID_MODE and no GTID column in SHOW MASTER STATUS; resume is driven by
+        // the shyiko client's native MariaDB GTID support and per-transaction MARIADB_GTID events.
+        connectMariaDb(effectiveOffsetContext);
+
+        // We may be restarting in the middle of a transaction, so see how far into the transaction
+        // we have already processed...
+        initialEventsToSkip = effectiveOffsetContext.eventsToSkipUponRestart();
+        LOGGER.info("Skip {} events on streaming start", initialEventsToSkip);
+
+        // Set the starting row number, which is the next row number to be read ...
+        startingRowNumber = effectiveOffsetContext.rowsToSkipUponRestart();
+        LOGGER.info("Skip {} rows on streaming start", startingRowNumber);
+
+        // Only when we reach the first BEGIN event will we start to skip events ...
+        skipEvent = false;
+
+        try {
+            // Start the log reader, which starts background threads ...
+            if (context.isRunning()) {
+                long timeout = connectorConfig.getConnectionTimeout().toMillis();
+                long started = clock.currentTimeInMillis();
+                try {
+                    LOGGER.debug(
+                            "Attempting to establish binlog reader connection with timeout of {} ms",
+                            timeout);
+                    client.connect(timeout);
+                    // Need to wait for keepalive thread to be running, otherwise it can be left
+                    // orphaned
+                    // The problem is with timing. When the close is called too early after connect
+                    // then
+                    // the keepalive thread is not terminated
+                    if (client.isKeepAlive()) {
+                        LOGGER.info("Waiting for keepalive thread to start");
+                        final Metronome metronome = Metronome.parker(Duration.ofMillis(100), clock);
+                        int waitAttempts = 50;
+                        boolean keepAliveThreadRunning = false;
+                        while (!keepAliveThreadRunning && waitAttempts-- > 0) {
+                            for (Thread t : binaryLogClientThreads.values()) {
+                                if (t.getName().startsWith(KEEPALIVE_THREAD_NAME) && t.isAlive()) {
+                                    LOGGER.info("Keepalive thread is running");
+                                    keepAliveThreadRunning = true;
+                                }
+                            }
+                            metronome.pause();
+                        }
+                    }
+                } catch (TimeoutException e) {
+                    // If the client thread is interrupted *before* the client could connect, the
+                    // client throws a timeout exception
+                    // The only way we can distinguish this is if we get the timeout exception
+                    // before the specified timeout has
+                    // elapsed, so we simply check this (within 10%) ...
+                    long duration = clock.currentTimeInMillis() - started;
+                    if (duration > (0.9 * timeout)) {
+                        double actualSeconds = TimeUnit.MILLISECONDS.toSeconds(duration);
+                        throw new DebeziumException(
+                                "Timed out after "
+                                        + actualSeconds
+                                        + " seconds while waiting to connect to MySQL at "
+                                        + connectorConfig.hostname()
+                                        + ":"
+                                        + connectorConfig.port()
+                                        + " with user '"
+                                        + connectorConfig.username()
+                                        + "'",
+                                e);
+                    }
+                    // Otherwise, we were told to shutdown, so we don't care about the timeout
+                    // exception
+                } catch (AuthenticationException e) {
+                    throw new DebeziumException(
+                            "Failed to authenticate to the MySQL database at "
+                                    + connectorConfig.hostname()
+                                    + ":"
+                                    + connectorConfig.port()
+                                    + " with user '"
+                                    + connectorConfig.username()
+                                    + "'",
+                            e);
+                } catch (Throwable e) {
+                    throw new DebeziumException(
+                            "Unable to connect to the MySQL database at "
+                                    + connectorConfig.hostname()
+                                    + ":"
+                                    + connectorConfig.port()
+                                    + " with user '"
+                                    + connectorConfig.username()
+                                    + "': "
+                                    + e.getMessage(),
+                            e);
+                }
+            }
+            while (context.isRunning()) {
+                Thread.sleep(100);
+            }
+        } finally {
+            try {
+                client.disconnect();
+            } catch (Exception e) {
+                LOGGER.info("Exception while stopping binary log client", e);
+            }
+        }
+    }
+
+    private SSLSocketFactory getBinlogSslSocketFactory(
+            MySqlConnectorConfig connectorConfig, MySqlConnection connection) {
+        String acceptedTlsVersion = connection.getSessionVariableForSslVersion();
+        if (!isNullOrEmpty(acceptedTlsVersion)) {
+            SSLMode sslMode = sslModeFor(connectorConfig.sslMode());
+            LOGGER.info(
+                    "Enable ssl "
+                            + sslMode
+                            + " mode for connector "
+                            + connectorConfig.getLogicalName());
+
+            final char[] keyPasswordArray = connection.connectionConfig().sslKeyStorePassword();
+            final String keyFilename = connection.connectionConfig().sslKeyStore();
+            final char[] trustPasswordArray = connection.connectionConfig().sslTrustStorePassword();
+            final String trustFilename = connection.connectionConfig().sslTrustStore();
+            KeyManager[] keyManagers = null;
+            if (keyFilename != null) {
+                try {
+                    KeyStore ks = connection.loadKeyStore(keyFilename, keyPasswordArray);
+
+                    KeyManagerFactory kmf = KeyManagerFactory.getInstance("NewSunX509");
+                    kmf.init(ks, keyPasswordArray);
+
+                    keyManagers = kmf.getKeyManagers();
+                } catch (KeyStoreException
+                        | NoSuchAlgorithmException
+                        | UnrecoverableKeyException e) {
+                    throw new DebeziumException("Could not load keystore", e);
+                }
+            }
+            TrustManager[] trustManagers;
+            try {
+                KeyStore ks = null;
+                if (trustFilename != null) {
+                    ks = connection.loadKeyStore(trustFilename, trustPasswordArray);
+                }
+
+                if (ks == null && (sslMode == SSLMode.PREFERRED || sslMode == SSLMode.REQUIRED)) {
+                    trustManagers =
+                            new TrustManager[] {
+                                new X509TrustManager() {
+
+                                    @Override
+                                    public void checkClientTrusted(
+                                            X509Certificate[] x509Certificates, String s)
+                                            throws CertificateException {}
+
+                                    @Override
+                                    public void checkServerTrusted(
+                                            X509Certificate[] x509Certificates, String s)
+                                            throws CertificateException {}
+
+                                    @Override
+                                    public X509Certificate[] getAcceptedIssuers() {
+                                        return new X509Certificate[0];
+                                    }
+                                }
+                            };
+                } else {
+                    TrustManagerFactory tmf =
+                            TrustManagerFactory.getInstance(
+                                    TrustManagerFactory.getDefaultAlgorithm());
+                    tmf.init(ks);
+                    trustManagers = tmf.getTrustManagers();
+                }
+            } catch (KeyStoreException | NoSuchAlgorithmException e) {
+                throw new DebeziumException("Could not load truststore", e);
+            }
+            // DBZ-1208 Resembles the logic from the upstream BinaryLogClient, only that
+            // the accepted TLS version is passed to the constructed factory
+            final KeyManager[] finalKMS = keyManagers;
+            return new DefaultSSLSocketFactory(acceptedTlsVersion) {
+
+                @Override
+                protected void initSSLContext(SSLContext sc) throws GeneralSecurityException {
+                    sc.init(finalKMS, trustManagers, null);
+                }
+            };
+        }
+
+        return null;
+    }
+
+    private void logStreamingSourceState() {
+        logStreamingSourceState(Level.ERROR);
+    }
+
+    protected void logEvent(MySqlOffsetContext offsetContext, Event event) {
+        LOGGER.trace("Received event: {}", event);
+    }
+
+    private void logStreamingSourceState(Level severity) {
+        final Object position =
+                client == null
+                        ? "N/A"
+                        : client.getBinlogFilename() + "/" + client.getBinlogPosition();
+        final String message =
+                "Error during binlog processing. Last offset stored = {}, binlog reader near position = {}";
+        switch (severity) {
+            case WARN:
+                LOGGER.warn(message, lastOffset, position);
+                break;
+            case DEBUG:
+                LOGGER.debug(message, lastOffset, position);
+                break;
+            default:
+                LOGGER.error(message, lastOffset, position);
+        }
+    }
+
+    /**
+     * Apply the include/exclude GTID source filters to the current {@link #source() GTID set} and
+     * merge them onto the currently available GTID set from a MySQL server.
+     *
+     * <p>The merging behavior of this method might seem a bit strange at first. It's required in
+     * order for Debezium to consume a MySQL binlog that has multi-source replication enabled, if a
+     * failover has to occur. In such a case, the server that Debezium is failed over to might have
+     * a different set of sources, but still include the sources required for Debezium to continue
+     * to function. MySQL does not allow downstream replicas to connect if the GTID set does not
+     * contain GTIDs for all channels that the server is replicating from, even if the server does
+     * have the data needed by the client. To get around this, we can have Debezium merge its GTID
+     * set with whatever is on the server, so that MySQL will allow it to connect. See <a
+     * href="https://issues.jboss.org/browse/DBZ-143">DBZ-143</a> for details.
+     *
+     * <p>This method does not mutate any state in the context.
+     *
+     * @param availableServerGtidSet the GTID set currently available in the MySQL server
+     * @param purgedServerGtid the GTID set already purged by the MySQL server
+     * @return A GTID set meant for consuming from a MySQL binlog; may return null if the SourceInfo
+     *     has no GTIDs and therefore none were filtered
+     */
+    public GtidSet filterGtidSet(
+            MySqlOffsetContext offsetContext,
+            GtidSet availableServerGtidSet,
+            GtidSet purgedServerGtid) {
+        String gtidStr = offsetContext.gtidSet();
+        if (gtidStr == null) {
+            return null;
+        }
+        LOGGER.info("Attempting to generate a filtered GTID set");
+        LOGGER.info("GTID set from previous recorded offset: {}", gtidStr);
+        GtidSet filteredGtidSet = new GtidSet(gtidStr);
+        Predicate<String> gtidSourceFilter = connectorConfig.gtidSourceFilter();
+        if (gtidSourceFilter != null) {
+            filteredGtidSet = filteredGtidSet.retainAll(gtidSourceFilter);
+            LOGGER.info(
+                    "GTID set after applying GTID source includes/excludes to previous recorded offset: {}",
+                    filteredGtidSet);
+        }
+        LOGGER.info("GTID set available on server: {}", availableServerGtidSet);
+
+        GtidSet mergedGtidSet;
+
+        if (connectorConfig.gtidNewChannelPosition() == GtidNewChannelPosition.EARLIEST) {
+            LOGGER.info("Using first available positions for new GTID channels");
+            final GtidSet relevantAvailableServerGtidSet =
+                    (gtidSourceFilter != null)
+                            ? availableServerGtidSet.retainAll(gtidSourceFilter)
+                            : availableServerGtidSet;
+            LOGGER.info(
+                    "Relevant GTID set available on server: {}", relevantAvailableServerGtidSet);
+
+            // Since the GTID recorded in the checkpoint represents the CDC-executed records, in
+            // certain scenarios
+            // (such as when the startup mode is earliest/timestamp/binlogfile), the recorded GTID
+            // may not start from
+            // the beginning. For example, A:300-500. However, during job recovery, we usually only
+            // need to focus on
+            // the last consumed point instead of consuming A:1-299. Therefore, some adjustments
+            // need to be made to the
+            // recorded offset in the checkpoint, and the available GTID for other MySQL instances
+            // should be completed.
+            mergedGtidSet =
+                    GtidUtils.fixOldChannelsGtidSet(
+                            relevantAvailableServerGtidSet, purgedServerGtid, filteredGtidSet);
+        } else {
+            LOGGER.info("Using latest positions for new GTID channels");
+            mergedGtidSet =
+                    GtidUtils.computeLatestModeGtidSet(
+                            availableServerGtidSet,
+                            purgedServerGtid,
+                            filteredGtidSet,
+                            gtidSourceFilter);
+        }
+
+        LOGGER.info("Final merged GTID set to use when connecting to MySQL: {}", mergedGtidSet);
+        return mergedGtidSet;
+    }
+
+    MySqlStreamingChangeEventSourceMetrics getMetrics() {
+        return metrics;
+    }
+
+    void rewindBinaryLogClient(ChangeEventSourceContext context, BinlogPosition position) {
+        try {
+            if (context.isRunning()) {
+                LOGGER.debug("Rewinding binlog to position {}", position);
+                client.disconnect();
+                client.setBinlogFilename(position.getFilename());
+                client.setBinlogPosition(position.getPosition());
+                client.connect();
+            }
+        } catch (IOException e) {
+            LOGGER.error("Unexpected error when re-connecting to the MySQL binary log reader", e);
+        }
+    }
+
+    BinlogPosition getCurrentBinlogPosition() {
+        return new BinlogPosition(client.getBinlogFilename(), client.getBinlogPosition());
+    }
+
+    /**
+     * Wraps the specified exception in a {@link DebeziumException}, ensuring that all useful state
+     * is captured inside the new exception's message.
+     *
+     * @param error the exception; may not be null
+     * @return the wrapped Kafka Connect exception
+     */
+    protected DebeziumException wrap(Throwable error) {
+        assert error != null;
+        String msg = error.getMessage();
+        if (error instanceof ServerException) {
+            ServerException e = (ServerException) error;
+            msg = msg + " Error code: " + e.getErrorCode() + "; SQLSTATE: " + e.getSqlState() + ".";
+        } else if (error instanceof SQLException) {
+            SQLException e = (SQLException) error;
+            msg =
+                    e.getMessage()
+                            + " Error code: "
+                            + e.getErrorCode()
+                            + "; SQLSTATE: "
+                            + e.getSQLState()
+                            + ".";
+        }
+        msg = ErrorMessageUtils.optimizeErrorMessage(msg);
+        return new DebeziumException(msg, error);
+    }
+
+    /** LifecycleListener for Reader Thread. */
+    protected final class ReaderThreadLifecycleListener implements LifecycleListener {
+        private final MySqlOffsetContext offsetContext;
+
+        ReaderThreadLifecycleListener(MySqlOffsetContext offsetContext) {
+            this.offsetContext = offsetContext;
+        }
+
+        @Override
+        public void onDisconnect(BinaryLogClient client) {
+            if (LOGGER.isInfoEnabled()) {
+                taskContext.temporaryLoggingContext(
+                        connectorConfig,
+                        "binlog",
+                        () -> {
+                            Map<String, ?> offset = lastOffset;
+                            if (offset != null) {
+                                LOGGER.info(
+                                        "Stopped reading binlog after {} events, last recorded offset: {}",
+                                        totalRecordCounter,
+                                        offset);
+                            } else {
+                                LOGGER.info(
+                                        "Stopped reading binlog after {} events, no new offset was recorded",
+                                        totalRecordCounter);
+                            }
+                        });
+            }
+        }
+
+        @Override
+        public void onConnect(BinaryLogClient client) {
+            // Set up the MDC logging context for this thread ...
+            taskContext.configureLoggingContext("binlog");
+
+            // The event row number will be used when processing the first event ...
+            LOGGER.info(
+                    "Connected to MySQL binlog at {}:{}, starting at {}",
+                    connectorConfig.hostname(),
+                    connectorConfig.port(),
+                    offsetContext);
+        }
+
+        @Override
+        public void onCommunicationFailure(BinaryLogClient client, Exception ex) {
+            LOGGER.debug("A communication failure event arrived", ex);
+            logStreamingSourceState();
+            try {
+                // Stop BinaryLogClient background threads
+                client.disconnect();
+            } catch (final Exception e) {
+                LOGGER.debug("Exception while closing client", e);
+            }
+            errorHandler.setProducerThrowable(wrap(ex));
+        }
+
+        @Override
+        public void onEventDeserializationFailure(BinaryLogClient client, Exception ex) {
+            if (eventDeserializationFailureHandlingMode
+                    == EventProcessingFailureHandlingMode.FAIL) {
+                LOGGER.debug("A deserialization failure event arrived", ex);
+                logStreamingSourceState();
+                errorHandler.setProducerThrowable(wrap(ex));
+            } else if (eventDeserializationFailureHandlingMode
+                    == EventProcessingFailureHandlingMode.WARN) {
+                LOGGER.warn("A deserialization failure event arrived", ex);
+                logStreamingSourceState(Level.WARN);
+            } else {
+                LOGGER.debug("A deserialization failure event arrived", ex);
+                logStreamingSourceState(Level.DEBUG);
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface TableIdProvider<E extends EventData> {
+        TableId getTableId(E data);
+    }
+
+    @FunctionalInterface
+    private interface RowsProvider<E extends EventData, U> {
+        List<U> getRows(E data);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/debezium/MariaDBBinaryLogClient.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/debezium/MariaDBBinaryLogClient.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.debezium;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.network.protocol.command.Command;
+import com.github.shyiko.mysql.binlog.network.protocol.command.DumpBinaryLogCommand;
+import com.github.shyiko.mysql.binlog.network.protocol.command.QueryCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * A {@link BinaryLogClient} for MariaDB that raises {@code @mariadb_slave_capability} from 1 -> 4
+ * before requesting the binlog stream.
+ *
+ * <p>{@code mysql-binlog-connector-java} 0.27.2 hard-codes {@code SET @mariadb_slave_capability=1}
+ * in {@code com.github.shyiko.mysql.binlog.BinaryLogClient#requestBinaryLogStreamMaria(long)}. With
+ * capability 1 the MariaDB server keeps the legacy replication protocol and emits only a single
+ * {@code MARIADB_GTID} event per connection, so the consumed GTID position can never advance (see
+ * MariaDB <a href="https://jira.mariadb.org/browse/MDEV-225">MDEV-225</a>). Capability 4 makes the
+ * server deliver one {@code MARIADB_GTID} event per transaction, which is what lets the CDC
+ * offset's GTID set move forward across checkpoints and failover.
+ *
+ * <p>Only the MariaDB request path is overridden; the MySQL path is inherited unchanged.
+ */
+public class MariaDBBinaryLogClient extends BinaryLogClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MariaDBBinaryLogClient.class);
+
+    public MariaDBBinaryLogClient(String hostname, int port, String username, String password) {
+        super(hostname, port, username, password);
+    }
+
+    @Override
+    protected void requestBinaryLogStreamMaria(long serverId) throws IOException {
+        Command dumpBinaryLogCommand;
+
+        // https://jira.mariadb.org/browse/MDEV-225 - capability 4 (not the stock 1) is required for
+        // the server to send per-txn MARIADB_GTID events, so the consumed GTID can advance.
+        channel.write(new QueryCommand("SET @mariadb_slave_capability=4"));
+        checkError(channel.read());
+
+        synchronized (gtidSetAccessLock) {
+            if (gtidSet != null) {
+                LOG.debug("MariaDB slave_connect_state = {}", gtidSet);
+                channel.write(
+                        new QueryCommand(
+                                "SET @slave_connect_state = '" + gtidSet.toString() + "'"));
+                checkError(channel.read());
+                channel.write(new QueryCommand("SET @slave_gtid_strict_mode = 0"));
+                checkError(channel.read());
+                channel.write(new QueryCommand("SET @slave_gtid_ignore_duplicates = 0"));
+                checkError(channel.read());
+                dumpBinaryLogCommand =
+                        new DumpBinaryLogCommand(serverId, "", 0L, isUseSendAnnotateRowsEvent());
+            } else {
+                dumpBinaryLogCommand =
+                        new DumpBinaryLogCommand(
+                                serverId, getBinlogFilename(), getBinlogPosition());
+            }
+        }
+
+        channel.write(dumpBinaryLogCommand);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/debezium/MariaDbConnections.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/debezium/MariaDbConnections.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.debezium;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import io.debezium.connector.mysql.MySqlConnection;
+
+import java.sql.SQLException;
+
+/**
+ * MariaDB-specific JDBC helpers.
+ *
+ * <p>Keeping these in the MariaDB module avoids shadowing the whole {@code MySqlConnection} class
+ * just to add a single MariaDB query: MariaDB exposes the executed GTID set through
+ * {@code @@gtid_binlog_pos} rather than MySQL's {@code @@global.gtid_executed}.
+ */
+public final class MariaDbConnections {
+
+    private MariaDbConnections() {}
+
+    /**
+     * Reads the GTID set present in the MariaDB server's binary log via {@code @@gtid_binlog_pos}.
+     * Returns an empty string when the server reports none.
+     */
+    public static String gtidExecuted(MySqlConnection jdbc) {
+        try {
+            String value =
+                    jdbc.queryAndMap(
+                            "SELECT @@gtid_binlog_pos", rs -> rs.next() ? rs.getString(1) : null);
+            return value == null ? "" : value;
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException(
+                    "Unexpected error while reading MariaDB @@gtid_binlog_pos", e);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/source/offset/MariaDbGtidComparator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/source/offset/MariaDbGtidComparator.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.source.offset;
+
+import com.github.shyiko.mysql.binlog.MariadbGtidSet;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Domain-keyed comparison for MariaDB "domain-server-sequence" GTIDs.
+ *
+ * <p>Unlike MySQL's "uuid:interval" model, a MariaDB GTID identifies a position by (domain, server,
+ * sequence), where the sequence increases monotonically per domain across servers. On
+ * master/replica failover the server id changes but the same domain keeps advancing the sequence,
+ * so comparison must be keyed on the domain and ignore the server id — otherwise a post-failover
+ * event looks like a different stream and the offset is mishandled (Debezium DBZ-1672, Flink CDC
+ * #2929).
+ *
+ * <p>The underlying {@code com.github.shyiko} binlog library already parses MariaDB GTID text
+ * ({@link MariadbGtidSet#isMariaGtidSet(String)}), but its {@code equals()} and {@code
+ * isContainedWithin()} compare the server id too, so the domain-keyed comparison is implemented
+ * here directly.
+ *
+ * <p>This replaces PR #4468's {@code MariaDbGtidStrategy}: since the standalone MariaDB connector
+ * has no second dialect, the {@code GtidStrategy} abstraction is dropped and the logic is exposed
+ * as plain static methods.
+ */
+public final class MariaDbGtidComparator {
+
+    private MariaDbGtidComparator() {}
+
+    /** Returns whether {@code gtidText} is a MariaDB (domain-server-sequence) GTID set. */
+    public static boolean canParse(String gtidText) {
+        return gtidText != null && MariadbGtidSet.isMariaGtidSet(gtidText.trim());
+    }
+
+    /** Returns whether two MariaDB GTID sets describe the same per-domain sequence positions. */
+    public static boolean isEqual(String a, String b) {
+        return toDomainSequence(a).equals(toDomainSequence(b));
+    }
+
+    /**
+     * Returns whether {@code sub} is contained within {@code sup}, compared by "domain + sequence"
+     * while deliberately ignoring the server id. For example, "1-100-500" is contained within
+     * "1-101-520", but "1-100-521" is not. If a domain present in {@code sub} is absent from {@code
+     * sup}, containment is false.
+     */
+    public static boolean isContainedWithin(String sub, String sup) {
+        Map<Long, Long> supSequence = toDomainSequence(sup);
+        return toDomainSequence(sub).entrySet().stream()
+                .allMatch(
+                        entry -> supSequence.getOrDefault(entry.getKey(), -1L) >= entry.getValue());
+    }
+
+    /** Converts GTID text into the highest observed sequence for each replication domain. */
+    private static Map<Long, Long> toDomainSequence(String gtidText) {
+        if (StringUtils.isBlank(gtidText)) {
+            return new HashMap<>();
+        }
+
+        Map<Long, Long> domainToSeq = new HashMap<>();
+        for (String tuple : gtidText.split(",")) {
+            String trimmedTuple = tuple.trim();
+            if (StringUtils.isBlank(trimmedTuple)) {
+                continue;
+            }
+
+            String[] parts = trimmedTuple.split("-");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException("Invalid MariaDB gtid format: " + trimmedTuple);
+            }
+
+            Long domain = Long.parseLong(parts[0].trim());
+            Long sequence = Long.parseLong(parts[2].trim());
+            domainToSeq.merge(domain, sequence, Math::max);
+        }
+        return domainToSeq;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/table/MariaDbTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/table/MariaDbTableSourceFactory.java
@@ -30,8 +30,8 @@ import org.apache.flink.cdc.connectors.mysql.table.MySqlTableSourceFactory;
  *
  * <ul>
  *   <li>Identified by factory identifier "mariadb-cdc"
- *   <li>Reuses all MySQL CDC connector options (startup mode, "server-id", incremental
- *       snapshot, etc.);
+ *   <li>Reuses all MySQL CDC connector options (startup mode, "server-id", incremental snapshot,
+ *       etc.);
  * </ul>
  *
  * @see org.apache.flink.cdc.connectors.mysql.table.MySqlTableSourceFactory base MySQL

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/table/MariaDbTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mariadb/table/MariaDbTableSourceFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.table;
+
+import org.apache.flink.cdc.connectors.mysql.table.MySqlTableSourceFactory;
+
+/**
+ * Factory for creating table sources that capture change data from MariaDB.
+ *
+ * <p>This factory extends {@link MySqlTableSourceFactory} to reuse the entire MySQL CDC connector
+ * read pipeline. MariaDB and MySQL share the same wire protocol and binary-log-based CDC mechanism,
+ * so snapshot and streaming are reused as-is.
+ *
+ * <p>Key characteristics:
+ *
+ * <ul>
+ *   <li>Identified by factory identifier "mariadb-cdc"
+ *   <li>Reuses all MySQL CDC connector options (startup mode, "server-id", incremental
+ *       snapshot, etc.);
+ * </ul>
+ *
+ * @see org.apache.flink.cdc.connectors.mysql.table.MySqlTableSourceFactory base MySQL
+ *     implementation
+ */
+public class MariaDbTableSourceFactory extends MySqlTableSourceFactory {
+
+    private static final String IDENTIFIER = "mariadb-cdc";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/DebeziumUtils.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/DebeziumUtils.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.debezium;
+
+import org.apache.flink.cdc.connectors.mariadb.debezium.MariaDBBinaryLogClient;
+import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import org.apache.flink.cdc.connectors.mysql.source.connection.JdbcConnectionFactory;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffsetBuilder;
+import org.apache.flink.cdc.connectors.mysql.source.utils.TableDiscoveryUtils;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.event.EventData;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.RotateEventData;
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnection;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlDatabaseSchema;
+import io.debezium.connector.mysql.MySqlSystemVariables;
+import io.debezium.connector.mysql.MySqlTopicSelector;
+import io.debezium.connector.mysql.MySqlValueConverters;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.jdbc.JdbcValueConverters;
+import io.debezium.jdbc.TemporalPrecisionMode;
+import io.debezium.relational.Selectors;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.SchemaNameAdjuster;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.function.Predicate;
+
+/** Utilities related to Debezium. */
+public class DebeziumUtils {
+    private static final String QUOTED_CHARACTER = "`";
+
+    private static final Logger LOG = LoggerFactory.getLogger(DebeziumUtils.class);
+
+    /** Creates and opens a new {@link JdbcConnection} backing connection pool. */
+    public static JdbcConnection openJdbcConnection(MySqlSourceConfig sourceConfig) {
+        JdbcConnection jdbc =
+                new JdbcConnection(
+                        JdbcConfiguration.adapt(sourceConfig.getDbzConfiguration()),
+                        new JdbcConnectionFactory(sourceConfig),
+                        QUOTED_CHARACTER,
+                        QUOTED_CHARACTER);
+        try {
+            jdbc.connect();
+        } catch (Exception e) {
+            LOG.error("Failed to open MySQL connection", e);
+            throw new FlinkRuntimeException(e);
+        }
+        return jdbc;
+    }
+
+    /** Creates a new {@link MySqlConnection}, but not open the connection. */
+    public static MySqlConnection createMySqlConnection(MySqlSourceConfig sourceConfig) {
+        return createMySqlConnection(
+                sourceConfig.getDbzConfiguration(), sourceConfig.getJdbcProperties());
+    }
+
+    /** Creates a new {@link MySqlConnection}, but not open the connection. */
+    public static MySqlConnection createMySqlConnection(
+            Configuration dbzConfiguration, Properties jdbcProperties) {
+        return new MySqlConnection(
+                new MySqlConnection.MySqlConnectionConfiguration(dbzConfiguration, jdbcProperties));
+    }
+
+    /** Creates a new {@link BinaryLogClient} for consuming mysql binlog. */
+    public static BinaryLogClient createBinaryClient(Configuration dbzConfiguration) {
+        final MySqlConnectorConfig connectorConfig = new MySqlConnectorConfig(dbzConfiguration);
+        // MariaDB requires @mariadb_slave_capability=4 to advance the consumed GTID position;
+        // MariaDBBinaryLogClient overrides only the MariaDB request path for that.
+        return new MariaDBBinaryLogClient(
+                connectorConfig.hostname(),
+                connectorConfig.port(),
+                connectorConfig.username(),
+                connectorConfig.password());
+    }
+
+    /** Creates a new {@link MySqlDatabaseSchema} to monitor the latest MySql database schemas. */
+    public static MySqlDatabaseSchema createMySqlDatabaseSchema(
+            MySqlConnectorConfig dbzMySqlConfig, boolean isTableIdCaseSensitive) {
+        TopicSelector<TableId> topicSelector = MySqlTopicSelector.defaultSelector(dbzMySqlConfig);
+        SchemaNameAdjuster schemaNameAdjuster = SchemaNameAdjuster.create();
+        MySqlValueConverters valueConverters = getValueConverters(dbzMySqlConfig);
+        return new MySqlDatabaseSchema(
+                dbzMySqlConfig,
+                valueConverters,
+                topicSelector,
+                schemaNameAdjuster,
+                isTableIdCaseSensitive);
+    }
+
+    /** Fetch current binlog offsets in MySql Server. */
+    /**
+     * Fetch the current MariaDB binlog offset. MariaDB has no GTID column in {@code SHOW MASTER
+     * STATUS}; the executed GTID set is read separately from {@code @@gtid_binlog_pos}.
+     */
+    public static BinlogOffset currentBinlogOffset(MySqlConnection jdbc) {
+        final String showMasterStmt = "SHOW MASTER STATUS";
+        try {
+            BinlogOffsetBuilder builder =
+                    jdbc.queryAndMap(
+                            showMasterStmt,
+                            rs -> {
+                                if (rs.next()) {
+                                    return BinlogOffset.builder()
+                                            .setBinlogFilePosition(rs.getString(1), rs.getLong(2));
+                                }
+                                throw new FlinkRuntimeException(
+                                        "Cannot read MariaDB binlog filename/position via '"
+                                                + showMasterStmt
+                                                + "'. Make sure your server is correctly configured.");
+                            });
+            String gtidSet =
+                    jdbc.queryAndMap(
+                            "SELECT @@gtid_binlog_pos", rs -> rs.next() ? rs.getString(1) : null);
+            if (StringUtils.isNotBlank(gtidSet)) {
+                builder.setGtidSet(gtidSet);
+            }
+            return builder.build();
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException(
+                    "Cannot read MariaDB binlog offset via '" + showMasterStmt + "'.", e);
+        }
+    }
+
+    /** Create a TableFilter by database name and table name. */
+    public static Tables.TableFilter createTableFilter(String database, String table) {
+        final Selectors.TableSelectionPredicateBuilder eligibleTables =
+                Selectors.tableSelector().includeDatabases(database);
+
+        Predicate<TableId> tablePredicate = eligibleTables.includeTables(table).build();
+
+        Predicate<TableId> finalTablePredicate =
+                tablePredicate.and(
+                        Tables.TableFilter.fromPredicate(MySqlConnectorConfig::isNotBuiltInTable)
+                                ::isIncluded);
+        return finalTablePredicate::test;
+    }
+
+    // --------------------------------------------------------------------------------------------
+
+    private static MySqlValueConverters getValueConverters(MySqlConnectorConfig dbzMySqlConfig) {
+        TemporalPrecisionMode timePrecisionMode = dbzMySqlConfig.getTemporalPrecisionMode();
+        JdbcValueConverters.DecimalMode decimalMode = dbzMySqlConfig.getDecimalMode();
+        String bigIntUnsignedHandlingModeStr =
+                dbzMySqlConfig
+                        .getConfig()
+                        .getString(MySqlConnectorConfig.BIGINT_UNSIGNED_HANDLING_MODE);
+        MySqlConnectorConfig.BigIntUnsignedHandlingMode bigIntUnsignedHandlingMode =
+                MySqlConnectorConfig.BigIntUnsignedHandlingMode.parse(
+                        bigIntUnsignedHandlingModeStr);
+        JdbcValueConverters.BigIntUnsignedMode bigIntUnsignedMode =
+                bigIntUnsignedHandlingMode.asBigIntUnsignedMode();
+
+        boolean timeAdjusterEnabled =
+                dbzMySqlConfig.getConfig().getBoolean(MySqlConnectorConfig.ENABLE_TIME_ADJUSTER);
+        return new MySqlValueConverters(
+                decimalMode,
+                timePrecisionMode,
+                bigIntUnsignedMode,
+                dbzMySqlConfig.binaryHandlingMode(),
+                timeAdjusterEnabled ? MySqlValueConverters::adjustTemporal : x -> x,
+                MySqlValueConverters::defaultParsingErrorHandler);
+    }
+
+    public static List<TableId> discoverCapturedTables(
+            JdbcConnection jdbc, MySqlSourceConfig sourceConfig) {
+
+        final List<TableId> capturedTableIds;
+        try {
+            capturedTableIds =
+                    TableDiscoveryUtils.listTables(
+                            jdbc, sourceConfig.getDatabaseFilter(), sourceConfig.getTableFilter());
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException("Failed to discover captured tables", e);
+        }
+        if (capturedTableIds.isEmpty()) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "No matched tables found. Please verify:\n1) The configured database(s) [%s] and table(s) [%s] exist;\n2) The MySQL user has sufficient permissions to access them.",
+                            sourceConfig.getDatabaseList(), sourceConfig.getTableList()));
+        }
+        return capturedTableIds;
+    }
+
+    public static boolean isTableIdCaseSensitive(JdbcConnection connection) {
+        return !"0"
+                .equals(
+                        readMySqlSystemVariables(connection)
+                                .get(MySqlSystemVariables.LOWER_CASE_TABLE_NAMES));
+    }
+
+    public static Map<String, String> readMySqlSystemVariables(JdbcConnection connection) {
+        // Read the system variables from the MySQL instance and get the current database name ...
+        return querySystemVariables(connection, "SHOW VARIABLES");
+    }
+
+    private static Map<String, String> querySystemVariables(
+            JdbcConnection connection, String statement) {
+        final Map<String, String> variables = new HashMap<>();
+        try {
+            connection.query(
+                    statement,
+                    rs -> {
+                        while (rs.next()) {
+                            String varName = rs.getString(1);
+                            String value = rs.getString(2);
+                            if (varName != null && value != null) {
+                                variables.put(varName, value);
+                            }
+                        }
+                    });
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException("Error reading MySQL variables: " + e.getMessage(), e);
+        }
+
+        return variables;
+    }
+
+    public static BinlogOffset findBinlogOffset(
+            long targetMs, MySqlConnection connection, MySqlSourceConfig mySqlSourceConfig) {
+        MySqlConnection.MySqlConnectionConfiguration config = connection.connectionConfig();
+        BinaryLogClient client =
+                new BinaryLogClient(
+                        config.hostname(), config.port(), config.username(), config.password());
+        if (mySqlSourceConfig.getServerIdRange() != null) {
+            client.setServerId(mySqlSourceConfig.getServerIdRange().getStartServerId());
+        }
+        List<String> binlogFiles = new ArrayList<>();
+        JdbcConnection.ResultSetConsumer rsc =
+                rs -> {
+                    while (rs.next()) {
+                        String fileName = rs.getString(1);
+                        long fileSize = rs.getLong(2);
+                        if (fileSize > 0) {
+                            binlogFiles.add(fileName);
+                        }
+                    }
+                };
+
+        try {
+            connection.query("SHOW BINARY LOGS", rsc);
+            LOG.info("Total search binlog: {}", binlogFiles);
+
+            if (binlogFiles.isEmpty()) {
+                return BinlogOffset.ofBinlogFilePosition("", 0);
+            }
+
+            String binlogName = searchBinlogName(client, targetMs, binlogFiles);
+            return BinlogOffset.ofBinlogFilePosition(binlogName, 0);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+    }
+
+    private static String searchBinlogName(
+            BinaryLogClient client, long targetMs, List<String> binlogFiles)
+            throws IOException, InterruptedException {
+        int startIdx = 0;
+        int endIdx = binlogFiles.size() - 1;
+
+        while (startIdx <= endIdx) {
+            int mid = startIdx + (endIdx - startIdx) / 2;
+            long midTs = getBinlogTimestamp(client, binlogFiles.get(mid));
+            if (midTs < targetMs) {
+                startIdx = mid + 1;
+            } else if (targetMs < midTs) {
+                endIdx = mid - 1;
+            } else {
+                return binlogFiles.get(mid);
+            }
+        }
+
+        return endIdx < 0 ? binlogFiles.get(0) : binlogFiles.get(endIdx);
+    }
+
+    private static long getBinlogTimestamp(BinaryLogClient client, String binlogFile)
+            throws IOException, InterruptedException {
+
+        ArrayBlockingQueue<Long> binlogTimestamps = new ArrayBlockingQueue<>(1);
+        BinaryLogClient.EventListener eventListener =
+                event -> {
+                    EventData data = event.getData();
+                    if (data instanceof RotateEventData) {
+                        // We skip RotateEventData because it does not contain the timestamp we are
+                        // interested in.
+                        return;
+                    }
+
+                    EventHeaderV4 header = event.getHeader();
+                    long timestamp = header.getTimestamp();
+                    if (timestamp > 0) {
+                        binlogTimestamps.offer(timestamp);
+                        try {
+                            client.disconnect();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                };
+
+        try {
+            client.registerEventListener(eventListener);
+            client.setBinlogFilename(binlogFile);
+            client.setBinlogPosition(0);
+
+            LOG.info("begin parse binlog: {}", binlogFile);
+            client.connect();
+        } finally {
+            client.unregisterEventListener(eventListener);
+        }
+        return binlogTimestamps.take();
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/task/context/StatefulTaskContext.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.debezium.task.context;
+
+import org.apache.flink.cdc.connectors.mariadb.debezium.MariaDbConnections;
+import org.apache.flink.cdc.connectors.mariadb.source.offset.MariaDbGtidComparator;
+import org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils;
+import org.apache.flink.cdc.connectors.mysql.debezium.EmbeddedFlinkDatabaseHistory;
+import org.apache.flink.cdc.connectors.mysql.debezium.dispatcher.EventDispatcherImpl;
+import org.apache.flink.cdc.connectors.mysql.debezium.dispatcher.SignalEventDispatcher;
+import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
+import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.mysql.MySqlChangeEventSourceMetricsFactory;
+import io.debezium.connector.mysql.MySqlConnection;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.connector.mysql.MySqlDatabaseSchema;
+import io.debezium.connector.mysql.MySqlOffsetContext;
+import io.debezium.connector.mysql.MySqlPartition;
+import io.debezium.connector.mysql.MySqlStreamingChangeEventSourceMetrics;
+import io.debezium.connector.mysql.MySqlTopicSelector;
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.Offsets;
+import io.debezium.relational.TableId;
+import io.debezium.schema.DataCollectionId;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.Clock;
+import io.debezium.util.Collect;
+import io.debezium.util.SchemaNameAdjuster;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset.BINLOG_FILENAME_OFFSET_KEY;
+import static org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffsetUtils.initializeEffectiveOffset;
+
+/**
+ * A stateful task context that contains entries the debezium mysql connector task required.
+ *
+ * <p>The offset change and schema change should record to MySqlSplitState when emit the record,
+ * thus the Flink's state mechanism can help to store/restore when failover happens.
+ */
+public class StatefulTaskContext implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StatefulTaskContext.class);
+    private static final int DEFAULT_BINLOG_QUEUE_SIZE_IN_SNAPSHOT_SCAN = 1024;
+    private static final Clock clock = Clock.SYSTEM;
+
+    private final MySqlSourceConfig sourceConfig;
+    private final MySqlConnectorConfig connectorConfig;
+    private final MySqlEventMetadataProvider metadataProvider;
+    private final SchemaNameAdjuster schemaNameAdjuster;
+    private final MySqlConnection connection;
+    private final BinaryLogClient binaryLogClient;
+
+    private MySqlDatabaseSchema databaseSchema;
+    private MySqlTaskContextImpl taskContext;
+    private MySqlOffsetContext offsetContext;
+    private MySqlPartition mySqlPartition;
+    private TopicSelector<TableId> topicSelector;
+    private SnapshotChangeEventSourceMetrics<MySqlPartition> snapshotChangeEventSourceMetrics;
+    private StreamingChangeEventSourceMetrics<MySqlPartition> streamingChangeEventSourceMetrics;
+    private EventDispatcherImpl<TableId> dispatcher;
+    private EventDispatcher.SnapshotReceiver<MySqlPartition> snapshotReceiver;
+    private SignalEventDispatcher signalEventDispatcher;
+    private ChangeEventQueue<DataChangeEvent> queue;
+    private ErrorHandler errorHandler;
+
+    public StatefulTaskContext(
+            MySqlSourceConfig sourceConfig,
+            BinaryLogClient binaryLogClient,
+            MySqlConnection connection) {
+        this.sourceConfig = sourceConfig;
+        this.connectorConfig = sourceConfig.getMySqlConnectorConfig();
+        this.schemaNameAdjuster = SchemaNameAdjuster.create();
+        this.metadataProvider = new MySqlEventMetadataProvider();
+        this.binaryLogClient = binaryLogClient;
+        this.connection = connection;
+    }
+
+    public void configure(MySqlSplit mySqlSplit) {
+        // initial stateful objects
+        final boolean tableIdCaseInsensitive = connection.isTableIdCaseSensitive();
+        this.topicSelector = MySqlTopicSelector.defaultSelector(connectorConfig);
+        EmbeddedFlinkDatabaseHistory.registerHistory(
+                sourceConfig
+                        .getDbzConfiguration()
+                        .getString(EmbeddedFlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME),
+                mySqlSplit.getTableSchemas().values());
+
+        Optional.ofNullable(databaseSchema).ifPresent(MySqlDatabaseSchema::close);
+        this.databaseSchema =
+                DebeziumUtils.createMySqlDatabaseSchema(connectorConfig, tableIdCaseInsensitive);
+
+        this.mySqlPartition = new MySqlPartition(connectorConfig.getLogicalName());
+
+        this.offsetContext =
+                loadStartingOffsetState(new MySqlOffsetContext.Loader(connectorConfig), mySqlSplit);
+        validateAndLoadDatabaseHistory(offsetContext, databaseSchema);
+
+        this.taskContext =
+                new MySqlTaskContextImpl(connectorConfig, databaseSchema, binaryLogClient);
+
+        final int queueSize =
+                mySqlSplit.isSnapshotSplit()
+                        ? sourceConfig.getSplitSize() + DEFAULT_BINLOG_QUEUE_SIZE_IN_SNAPSHOT_SCAN
+                        : connectorConfig.getMaxQueueSize();
+        this.queue =
+                new ChangeEventQueue.Builder<DataChangeEvent>()
+                        .pollInterval(connectorConfig.getPollInterval())
+                        .maxBatchSize(connectorConfig.getMaxBatchSize())
+                        .maxQueueSize(queueSize)
+                        .maxQueueSizeInBytes(connectorConfig.getMaxQueueSizeInBytes())
+                        .loggingContextSupplier(
+                                () ->
+                                        taskContext.configureLoggingContext(
+                                                "mysql-cdc-connector-task"))
+                        // do not buffer any element, we use signal event
+                        // .buffering()
+                        .build();
+        this.dispatcher =
+                new EventDispatcherImpl<>(
+                        connectorConfig,
+                        topicSelector,
+                        databaseSchema,
+                        queue,
+                        connectorConfig.getTableFilters().dataCollectionFilter(),
+                        DataChangeEvent::new,
+                        metadataProvider,
+                        schemaNameAdjuster);
+
+        this.snapshotReceiver = dispatcher.getSnapshotChangeEventReceiver();
+
+        this.signalEventDispatcher =
+                new SignalEventDispatcher(
+                        offsetContext.getOffset(), topicSelector.getPrimaryTopic(), queue);
+
+        final MySqlChangeEventSourceMetricsFactory changeEventSourceMetricsFactory =
+                new MySqlChangeEventSourceMetricsFactory(
+                        new MySqlStreamingChangeEventSourceMetrics(
+                                taskContext, queue, metadataProvider));
+        this.snapshotChangeEventSourceMetrics =
+                changeEventSourceMetricsFactory.getSnapshotMetrics(
+                        taskContext, queue, metadataProvider);
+        this.streamingChangeEventSourceMetrics =
+                changeEventSourceMetricsFactory.getStreamingMetrics(
+                        taskContext, queue, metadataProvider);
+        this.errorHandler =
+                new MySqlErrorHandler(connectorConfig, queue, taskContext, sourceConfig);
+    }
+
+    private void validateAndLoadDatabaseHistory(
+            MySqlOffsetContext offset, MySqlDatabaseSchema schema) {
+        schema.initializeStorage();
+        schema.recover(Offsets.of(mySqlPartition, offset));
+    }
+
+    /** Loads the connector's persistent offset (if present) via the given loader. */
+    protected MySqlOffsetContext loadStartingOffsetState(
+            OffsetContext.Loader<MySqlOffsetContext> loader, MySqlSplit mySqlSplit) {
+        BinlogOffset offset =
+                mySqlSplit.isSnapshotSplit()
+                        ? BinlogOffset.ofEarliest()
+                        : initializeEffectiveOffset(
+                                mySqlSplit.asBinlogSplit().getStartingOffset(),
+                                connection,
+                                sourceConfig);
+
+        LOG.info("Starting offset is initialized to {}", offset);
+
+        MySqlOffsetContext mySqlOffsetContext = loader.load(offset.getOffset());
+
+        if (!isBinlogAvailable(mySqlOffsetContext)) {
+            throw new IllegalStateException(
+                    "The connector is trying to read binlog starting at "
+                            + mySqlOffsetContext.getSourceInfo()
+                            + ", but this is no longer "
+                            + "available on the server. Reconfigure the connector to use a snapshot when needed.");
+        }
+        return mySqlOffsetContext;
+    }
+
+    private boolean isBinlogAvailable(MySqlOffsetContext offset) {
+        String gtidStr = offset.gtidSet();
+        if (gtidStr != null) {
+            return checkGtidSet(offset);
+        }
+
+        return checkBinlogFilename(offset);
+    }
+
+    private boolean checkGtidSet(MySqlOffsetContext offset) {
+        String gtidStr = offset.gtidSet();
+
+        if (gtidStr.trim().isEmpty()) {
+            return true; // start at beginning ...
+        }
+
+        return checkMariadbGtidSet(gtidStr);
+    }
+
+    /**
+     * MariaDB recovery check: the restored GTID set must be contained within the target server's
+     * {@code @@gtid_binlog_pos}, compared by domain+sequence (ignoring server id) so that a replica
+     * with a different server id but the same replicated history is accepted. When the checkpoint
+     * is ahead of the server (a lagging replica), containment fails and the task fails fast;
+     * Flink's restart strategy then reconnects, expecting the proxy to route to a caught-up node.
+     */
+    private boolean checkMariadbGtidSet(String restoredGtid) {
+        if (!MariaDbGtidComparator.canParse(restoredGtid)) {
+            throw new FlinkRuntimeException(
+                    String.format(
+                            "The GTID set '%s' is not in MariaDB 'domain-server-sequence' format "
+                                    + "(for example '0-1-100'). The MariaDB CDC connector cannot resume from a "
+                                    + "MySQL-style 'uuid:interval' GTID set. If you configured "
+                                    + "'scan.startup.mode' = 'specific-offset', supply a MariaDB GTID set; "
+                                    + "state taken from the mysql-cdc connector cannot be restored here.",
+                            restoredGtid));
+        }
+
+        String available = MariaDbConnections.gtidExecuted(connection);
+        if (StringUtils.isBlank(available)) {
+            LOG.warn(
+                    "Connector used MariaDB GTID previously, but the server reports no @@gtid_binlog_pos");
+            return false;
+        }
+
+        boolean contained = MariaDbGtidComparator.isContainedWithin(restoredGtid, available);
+        if (!contained) {
+            LOG.info(
+                    "MariaDB restored GTID set {} is not contained within server set {}",
+                    restoredGtid,
+                    available);
+        }
+        return contained;
+    }
+
+    private boolean checkBinlogFilename(MySqlOffsetContext offset) {
+        String binlogFilename = offset.getSourceInfo().getString(BINLOG_FILENAME_OFFSET_KEY);
+        if (binlogFilename == null) {
+            return true; // start at current position
+        }
+        if (binlogFilename.equals("")) {
+            return true; // start at beginning
+        }
+
+        // Accumulate the available binlog filenames ...
+        List<String> logNames = connection.availableBinlogFiles();
+
+        // And compare with the one we're supposed to use ...
+        boolean found = logNames.stream().anyMatch(binlogFilename::equals);
+        if (!found) {
+            LOG.info(
+                    "Connector requires binlog file '{}', but MySQL only has {}",
+                    binlogFilename,
+                    String.join(", ", logNames));
+        } else {
+            LOG.info("MySQL has the binlog file '{}' required by the connector", binlogFilename);
+        }
+        return found;
+    }
+
+    @Override
+    public void close() throws Exception {
+        // BinaryLogClient still tries to enqueue records, if this queue is full, it will
+        // lead to deadlock.
+        if (queue != null) {
+            queue.poll();
+        }
+        if (connection != null) {
+            connection.close();
+        }
+        if (binaryLogClient != null) {
+            binaryLogClient.disconnect();
+        }
+        if (databaseSchema != null) {
+            databaseSchema.close();
+        }
+        if (dispatcher != null) {
+            dispatcher.close();
+        }
+    }
+
+    /** Copied from debezium for accessing here. */
+    public static class MySqlEventMetadataProvider implements EventMetadataProvider {
+        public static final String SERVER_ID_KEY = "server_id";
+
+        public static final String GTID_KEY = "gtid";
+        public static final String BINLOG_FILENAME_OFFSET_KEY = "file";
+        public static final String BINLOG_POSITION_OFFSET_KEY = "pos";
+        public static final String BINLOG_ROW_IN_EVENT_OFFSET_KEY = "row";
+        public static final String THREAD_KEY = "thread";
+        public static final String QUERY_KEY = "query";
+
+        @Override
+        public Instant getEventTimestamp(
+                DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            if (value == null) {
+                return null;
+            }
+            final Struct sourceInfo = value.getStruct(Envelope.FieldName.SOURCE);
+            if (source == null) {
+                return null;
+            }
+            final Long timestamp = sourceInfo.getInt64(AbstractSourceInfo.TIMESTAMP_KEY);
+            return timestamp == null ? null : Instant.ofEpochMilli(timestamp);
+        }
+
+        @Override
+        public Map<String, String> getEventSourcePosition(
+                DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            if (value == null) {
+                return null;
+            }
+            final Struct sourceInfo = value.getStruct(Envelope.FieldName.SOURCE);
+            if (source == null) {
+                return null;
+            }
+            return Collect.hashMapOf(
+                    BINLOG_FILENAME_OFFSET_KEY,
+                    sourceInfo.getString(BINLOG_FILENAME_OFFSET_KEY),
+                    BINLOG_POSITION_OFFSET_KEY,
+                    Long.toString(sourceInfo.getInt64(BINLOG_POSITION_OFFSET_KEY)),
+                    BINLOG_ROW_IN_EVENT_OFFSET_KEY,
+                    Integer.toString(sourceInfo.getInt32(BINLOG_ROW_IN_EVENT_OFFSET_KEY)));
+        }
+
+        @Override
+        public String getTransactionId(
+                DataCollectionId source, OffsetContext offset, Object key, Struct value) {
+            return ((MySqlOffsetContext) offset).getTransactionId();
+        }
+    }
+
+    public static Clock getClock() {
+        return clock;
+    }
+
+    public MySqlSourceConfig getSourceConfig() {
+        return sourceConfig;
+    }
+
+    public MySqlConnectorConfig getConnectorConfig() {
+        return connectorConfig;
+    }
+
+    public MySqlConnection getConnection() {
+        return connection;
+    }
+
+    public BinaryLogClient getBinaryLogClient() {
+        return binaryLogClient;
+    }
+
+    public MySqlDatabaseSchema getDatabaseSchema() {
+        return databaseSchema;
+    }
+
+    public MySqlTaskContextImpl getTaskContext() {
+        return taskContext;
+    }
+
+    public EventDispatcherImpl<TableId> getDispatcher() {
+        return dispatcher;
+    }
+
+    public EventDispatcher.SnapshotReceiver<MySqlPartition> getSnapshotReceiver() {
+        return snapshotReceiver;
+    }
+
+    public SignalEventDispatcher getSignalEventDispatcher() {
+        return signalEventDispatcher;
+    }
+
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return queue;
+    }
+
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+    public MySqlOffsetContext getOffsetContext() {
+        return offsetContext;
+    }
+
+    public MySqlPartition getMySqlPartition() {
+        return mySqlPartition;
+    }
+
+    public TopicSelector<TableId> getTopicSelector() {
+        return topicSelector;
+    }
+
+    public SnapshotChangeEventSourceMetrics<MySqlPartition> getSnapshotChangeEventSourceMetrics() {
+        return snapshotChangeEventSourceMetrics;
+    }
+
+    public StreamingChangeEventSourceMetrics<MySqlPartition>
+            getStreamingChangeEventSourceMetrics() {
+        return streamingChangeEventSourceMetrics;
+    }
+
+    public SchemaNameAdjuster getSchemaNameAdjuster() {
+        return schemaNameAdjuster;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffset.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffset.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.offset;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.annotation.PublicEvolving;
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.connectors.mariadb.source.offset.MariaDbGtidComparator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * A structure describes a fine grained offset in a binlog event including binlog position and gtid
+ * set etc.
+ *
+ * <p>This structure can also be used to deal the binlog event in transaction, a transaction may
+ * contain multiple change events, and each change event may contain multiple rows. When restart
+ * from a specific {@link BinlogOffset}, we need to skip the processed change events and the
+ * processed rows.
+ */
+@PublicEvolving
+public class BinlogOffset implements Comparable<BinlogOffset>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String BINLOG_FILENAME_OFFSET_KEY = "file";
+    public static final String BINLOG_POSITION_OFFSET_KEY = "pos";
+    public static final String EVENTS_TO_SKIP_OFFSET_KEY = "event";
+    public static final String ROWS_TO_SKIP_OFFSET_KEY = "row";
+    public static final String GTID_SET_KEY = "gtids";
+    public static final String TIMESTAMP_KEY = "ts_sec";
+    public static final String SERVER_ID_KEY = "server_id";
+    public static final String OFFSET_KIND_KEY = "kind";
+
+    private final Map<String, String> offset;
+
+    // ------------------------------- Builders --------------------------------
+
+    public static BinlogOffsetBuilder builder() {
+        return new BinlogOffsetBuilder();
+    }
+
+    /** Create offset from binlog filename and position. */
+    public static BinlogOffset ofBinlogFilePosition(String filename, long position) {
+        return builder().setBinlogFilePosition(filename, position).build();
+    }
+
+    /** Create offset from GTID set. */
+    public static BinlogOffset ofGtidSet(String gtidSet) {
+        return builder().setBinlogFilePosition("", 0).setGtidSet(gtidSet).build();
+    }
+
+    /** Create offset which represents the earliest accessible binlog offset. */
+    public static BinlogOffset ofEarliest() {
+        return builder().setOffsetKind(BinlogOffsetKind.EARLIEST).build();
+    }
+
+    /** Create offset which represents the latest offset at the point of access. */
+    public static BinlogOffset ofLatest() {
+        return builder().setOffsetKind(BinlogOffsetKind.LATEST).build();
+    }
+
+    /** Create offset specified by a timestamp in second. */
+    public static BinlogOffset ofTimestampSec(long timestampSec) {
+        return builder()
+                .setOffsetKind(BinlogOffsetKind.TIMESTAMP)
+                .setTimestampSec(timestampSec)
+                .build();
+    }
+
+    @Internal
+    public static BinlogOffset ofNonStopping() {
+        return builder().setOffsetKind(BinlogOffsetKind.NON_STOPPING).build();
+    }
+
+    @VisibleForTesting
+    public BinlogOffset(Map<String, String> offset) {
+        this.offset = offset;
+    }
+
+    // ------------------------------ Field getters -----------------------------
+
+    public Map<String, String> getOffset() {
+        return offset;
+    }
+
+    public String getFilename() {
+        return offset.get(BINLOG_FILENAME_OFFSET_KEY);
+    }
+
+    public long getPosition() {
+        return longOffsetValue(offset, BINLOG_POSITION_OFFSET_KEY);
+    }
+
+    public long getRestartSkipEvents() {
+        return longOffsetValue(offset, EVENTS_TO_SKIP_OFFSET_KEY);
+    }
+
+    public long getRestartSkipRows() {
+        return longOffsetValue(offset, ROWS_TO_SKIP_OFFSET_KEY);
+    }
+
+    public String getGtidSet() {
+        return offset.get(GTID_SET_KEY);
+    }
+
+    public long getTimestampSec() {
+        return longOffsetValue(offset, TIMESTAMP_KEY);
+    }
+
+    public Long getServerId() {
+        return longOffsetValue(offset, SERVER_ID_KEY);
+    }
+
+    @Nullable
+    public BinlogOffsetKind getOffsetKind() {
+        if (offset.get(OFFSET_KIND_KEY) == null) {
+            return null;
+        }
+        return BinlogOffsetKind.valueOf(offset.get(OFFSET_KIND_KEY));
+    }
+
+    private long longOffsetValue(Map<String, ?> values, String key) {
+        Object obj = values.get(key);
+        if (obj == null) {
+            return 0L;
+        }
+        if (obj instanceof Number) {
+            return ((Number) obj).longValue();
+        }
+        try {
+            return Long.parseLong(obj.toString());
+        } catch (NumberFormatException e) {
+            throw new ConnectException(
+                    "Source offset '"
+                            + key
+                            + "' parameter value "
+                            + obj
+                            + " could not be converted to a long");
+        }
+    }
+
+    // ---------------------- Comparing BinlogOffset ----------------------
+
+    /**
+     * This method is inspired by {@link io.debezium.relational.history.HistoryRecordComparator}.
+     */
+    @Override
+    public int compareTo(BinlogOffset that) {
+        // the NON_STOPPING is the max offset
+        if (that.getOffsetKind() == BinlogOffsetKind.NON_STOPPING
+                && this.getOffsetKind() == BinlogOffsetKind.NON_STOPPING) {
+            return 0;
+        }
+        if (this.getOffsetKind() == BinlogOffsetKind.NON_STOPPING) {
+            return 1;
+        }
+        if (that.getOffsetKind() == BinlogOffsetKind.NON_STOPPING) {
+            return -1;
+        }
+
+        String gtidSetStr = this.getGtidSet();
+        String targetGtidSetStr = that.getGtidSet();
+        if (StringUtils.isNotEmpty(targetGtidSetStr)) {
+            // The target offset uses GTIDs, so we ideally compare using GTIDs ...
+            if (StringUtils.isNotEmpty(gtidSetStr)) {
+                // Both have GTIDs, so base the comparison entirely on the GTID sets.
+                // MariaDB (domain-server-sequence) GTID sets compare with server-id-ignoring
+                // semantics; see MariaDbGtidComparator.
+                if (MariaDbGtidComparator.isEqual(gtidSetStr, targetGtidSetStr)) {
+                    long restartSkipEvents = this.getRestartSkipEvents();
+                    long targetRestartSkipEvents = that.getRestartSkipEvents();
+                    if (restartSkipEvents != targetRestartSkipEvents) {
+                        return Long.compare(restartSkipEvents, targetRestartSkipEvents);
+                    }
+                    // The completed events are the same, so compare the row number ...
+                    return Long.compare(this.getRestartSkipRows(), that.getRestartSkipRows());
+                }
+                // The GTIDs are not an exact match, so figure out if this is a subset of the target
+                // offset
+                // ...
+                return MariaDbGtidComparator.isContainedWithin(gtidSetStr, targetGtidSetStr)
+                        ? -1
+                        : 1;
+            }
+            // The target offset did use GTIDs while this did not use GTIDs. So, we assume
+            // that this offset is older since GTIDs are often enabled but rarely disabled.
+            // And if they are disabled,
+            // it is likely that this offset would not include GTIDs as we would be trying
+            // to read the binlog of a
+            // server that no longer has GTIDs. And if they are enabled, disabled, and re-enabled,
+            // per
+            // https://dev.mysql.com/doc/refman/5.7/en/replication-gtids-failover.html all properly
+            // configured slaves that
+            // use GTIDs should always have the complete set of GTIDs copied from the master, in
+            // which case
+            // again we know that this offset not having GTIDs is before the target offset ...
+            return -1;
+        } else if (StringUtils.isNotEmpty(gtidSetStr)) {
+            // This offset has a GTID but the target offset does not, so per the previous paragraph
+            // we
+            // assume that previous
+            // is not at or before ...
+            return 1;
+        }
+
+        // Both offsets are missing GTIDs. Look at the servers ...
+        long serverId = this.getServerId();
+        long targetServerId = that.getServerId();
+
+        if (serverId != targetServerId) {
+            // These are from different servers, and their binlog coordinates are not related. So
+            // the only thing we can do
+            // is compare timestamps, and we have to assume that the server timestamps can be
+            // compared ...
+            long timestamp = this.getTimestampSec();
+            long targetTimestamp = that.getTimestampSec();
+            if (timestamp != 0 && targetTimestamp != 0) {
+                return Long.compare(timestamp, targetTimestamp);
+            }
+        }
+
+        // First compare the MySQL binlog filenames
+        if (this.getFilename() != null
+                && that.getFilename() != null
+                && this.getFilename().compareToIgnoreCase(that.getFilename()) != 0) {
+            if (this.getFilename().length() != that.getFilename().length()) {
+                return Integer.compare(this.getFilename().length(), that.getFilename().length());
+            }
+            return this.getFilename().compareToIgnoreCase(that.getFilename());
+        }
+
+        // The filenames are the same, so compare the positions
+        if (this.getPosition() != that.getPosition()) {
+            return Long.compare(this.getPosition(), that.getPosition());
+        }
+
+        // The positions are the same, so compare the completed events in the transaction ...
+        if (this.getRestartSkipEvents() != that.getRestartSkipEvents()) {
+            return Long.compare(this.getRestartSkipEvents(), that.getRestartSkipEvents());
+        }
+
+        // The completed events are the same, so compare the row number ...
+        return Long.compare(this.getRestartSkipRows(), that.getRestartSkipRows());
+    }
+
+    public boolean isAtOrBefore(BinlogOffset that) {
+        return this.compareTo(that) <= 0;
+    }
+
+    public boolean isBefore(BinlogOffset that) {
+        return this.compareTo(that) < 0;
+    }
+
+    public boolean isAtOrAfter(BinlogOffset that) {
+        return this.compareTo(that) >= 0;
+    }
+
+    public boolean isAfter(BinlogOffset that) {
+        return this.compareTo(that) > 0;
+    }
+
+    @Override
+    public String toString() {
+        return offset.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BinlogOffset)) {
+            return false;
+        }
+        BinlogOffset that = (BinlogOffset) o;
+        return offset.equals(that.offset);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(offset);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.cdc.connectors.mariadb.table.MariaDbTableSourceFactory

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/io/debezium/connector/mysql/MariaDbGtidEventTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/io/debezium/connector/mysql/MariaDbGtidEventTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.mysql;
+
+import com.github.shyiko.mysql.binlog.event.Event;
+import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.MariadbGtidEventData;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link MySqlStreamingChangeEventSource#mariadbGtidOf(Event)}, the MariaDB GTID
+ * formatting used to advance the consumed GTID position while streaming binlog events.
+ *
+ * <p>Lives in {@code io.debezium.connector.mysql} because {@code mariadbGtidOf} is package-private
+ * on the shadowed {@code MySqlStreamingChangeEventSource}.
+ */
+class MariaDbGtidEventTest {
+
+    /**
+     * The formatted GTID must be {@code domain-serverId-sequence} where the server id is taken from
+     * the binlog event header, not the payload. MariaDB records GTIDs against the header server id
+     * and exposes them through {@code @@gtid_binlog_pos}; using the payload server id would produce
+     * a GTID that does not line up with the server's own set and would break GTID-based resume.
+     */
+    @Test
+    void mariadbGtidUsesHeaderServerIdNotPayloadServerId() {
+        MariadbGtidEventData data = new MariadbGtidEventData();
+        data.setDomainId(1);
+        // payload server id: deliberately different from the header
+        data.setServerId(99);
+        data.setSequence(42);
+
+        EventHeaderV4 header = new EventHeaderV4();
+        header.setEventType(EventType.MARIADB_GTID);
+        // header server id: this is the one that must win
+        header.setServerId(7);
+
+        Event event = new Event(header, data);
+
+        assertThat(MySqlStreamingChangeEventSource.mariadbGtidOf(event)).isEqualTo("1-7-42");
+    }
+
+    /** A GTID from a different domain formats independently of any other domain. */
+    @Test
+    void mariadbGtidFormatsDomainSequenceFromPayload() {
+        MariadbGtidEventData data = new MariadbGtidEventData();
+        data.setDomainId(5);
+        data.setServerId(7);
+        data.setSequence(1000);
+
+        EventHeaderV4 header = new EventHeaderV4();
+        header.setEventType(EventType.MARIADB_GTID);
+        header.setServerId(7);
+
+        Event event = new Event(header, data);
+
+        assertThat(MySqlStreamingChangeEventSource.mariadbGtidOf(event)).isEqualTo("5-7-1000");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/source/MariaDbGtidRecoveryITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/source/MariaDbGtidRecoveryITCase.java
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.source;
+
+import org.apache.flink.cdc.connectors.mariadb.testutils.MariaDbContainer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateRecoveryOptions;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.core.execution.SavepointFormatType;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.util.RestartStrategyUtils;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.lifecycle.Startables;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * IT case proving the standalone {@code mariadb-cdc} connector resumes binlog streaming from a
+ * MariaDB GTID offset that was serialized into a savepoint, and that the resume is driven by the
+ * GTID itself rather than merely by within-transaction event/row skipping.
+ *
+ * <p>The delicate part is <em>which</em> GTID the savepoint captures. Debezium only advances the
+ * restartable GTID set once a transaction commits, and MariaDB emits the commit as a trailing
+ * {@code XID} event; because Flink CDC does not surface {@code XID} events to the reader, a
+ * transaction's completed GTID only reaches the Flink split state when the <em>next</em> emitted
+ * record carries it. So a savepoint taken right after transaction A's row still holds the GTID from
+ * <em>before</em> A. To move the committed GTID strictly past A, this test drives a second captured
+ * transaction A' and waits for its row to arrive. That row carries the restart offset from before
+ * A''s own commit is surfaced to the reader, so the split state's restartable GTID set then
+ * includes A but not yet A' (even though A' has already autocommitted on the server). The scenario:
+ *
+ * <ol>
+ *   <li>Consume the two snapshot rows (source enters the binlog phase).
+ *   <li>Insert transaction A (id=100) and wait for its row.
+ *   <li>Insert transaction A' (id=101) and wait for its row; the split state's committed GTID is
+ *       now past A.
+ *   <li>Take a savepoint (serializing that GTID) and cancel the job.
+ *   <li>Restart from the savepoint. On restore the connector reconnects from a GTID set that
+ *       already contains A ({@code checkMariadbGtidSet} + {@code connectMariaDb} with {@code
+ *       @mariadb_slave_capability=4}), so the server never re-sends A.
+ *   <li>Insert transaction B (id=200) and assert the sink ends up with exactly {@code {1, 2, 100,
+ *       101, 200}} — A is not replayed (proving GTID-based resume), and A' is de-duplicated by the
+ *       offset's event/row skip.
+ * </ol>
+ *
+ * <p>This exercises the PR-2 code paths end to end: {@code currentBinlogOffset}, the MariaDB-flavor
+ * {@code BinlogOffset.compareTo}, {@code checkMariadbGtidSet}, {@code connectMariaDb}, and the
+ * {@code MariaDBBinaryLogClient} capability handshake that makes the per-transaction GTID advance.
+ */
+class MariaDbGtidRecoveryITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MariaDbGtidRecoveryITCase.class);
+
+    private static final String TABLE = "gtid_recovery";
+    private static final String SINK = "sink";
+
+    /**
+     * A table the connector does not capture. Writing to it advances the server's GTID position
+     * without producing any change event, which lets a test move {@code @@gtid_binlog_pos} to a
+     * known value at a deterministic point in time.
+     */
+    private static final String MARKER_TABLE = "failover_marker";
+
+    private final MariaDbContainer mariaDb = new MariaDbContainer();
+
+    @BeforeEach
+    void before() throws Exception {
+        LOG.info("Starting MariaDB container...");
+        Startables.deepStart(Stream.of(mariaDb)).join();
+        LOG.info("MariaDB container started.");
+        TestValuesTableFactory.clearAllData();
+        initializeTable();
+    }
+
+    @AfterEach
+    void after() {
+        mariaDb.stop();
+    }
+
+    @Test
+    @Timeout(180)
+    void testGtidRecoveryAfterBinlogSavepoint(@TempDir Path tempDir) throws Exception {
+        final String savepointDirectory = tempDir.toUri().toString();
+
+        // Phase 1: advance the committed GTID past transaction A, then savepoint it.
+        String savepointPath = runJobUntilBinlogAndSavepoint(savepointDirectory);
+
+        // Phase 2: restore, insert transaction B, and prove A is not replayed.
+        runJobFromSavepointAndInsertB(savepointPath);
+
+        // The sink accumulates across both phases; a GTID resume past A appends only transaction B
+        // (A' is de-duplicated by the offset skip), while a wrongful replay would duplicate A here.
+        Assertions.assertThat(TestValuesTableFactory.getRawResultsAsStrings(SINK))
+                .containsExactlyInAnyOrder("+I[1]", "+I[2]", "+I[100]", "+I[101]", "+I[200]");
+    }
+
+    /**
+     * Simulates reconnecting to a different physical node after a failover. The savepoint's GTID
+     * carries the original server id, while the server records subsequent transactions under a new
+     * server id in the same replication domain (MariaDB allows {@code server_id} to change at
+     * runtime). Recovery must still succeed because {@code MariaDbGtidComparator} keys the
+     * containment check on domain + sequence and ignores the server id. A server-id-sensitive
+     * comparison would find no entry for the original server id in the server's GTID set, fail
+     * containment, and the task would fail fast instead of resuming — so this test discriminates
+     * between the two implementations.
+     */
+    @Test
+    @Timeout(180)
+    void testGtidRecoveryAcrossServerIdChange(@TempDir Path tempDir) throws Exception {
+        final String savepointDirectory = tempDir.toUri().toString();
+
+        String savepointPath = runJobUntilBinlogAndSavepoint(savepointDirectory);
+        String gtidBeforeFailover = queryScalar("SELECT @@gtid_binlog_pos");
+        Assertions.assertThat(gtidBeforeFailover).startsWith("0-223344-");
+
+        // The "promoted node" keeps the same domain and history but a different server id.
+        // Changing server_id alone does NOT move @@gtid_binlog_pos — only the next committed
+        // transaction does. Commit one here, into a table the connector does not capture, so the
+        // server's GTID set deterministically carries the NEW server id *before* the restored job
+        // performs its recovery check. Without this the check could race transaction B and still
+        // observe the old server id, which would let a server-id-sensitive comparison pass.
+        executeSql("SET GLOBAL server_id = 654321");
+        executeSql("INSERT INTO " + MARKER_TABLE + " VALUES (1)");
+        String gtidAfterFailover = queryScalar("SELECT @@gtid_binlog_pos");
+        Assertions.assertThat(gtidAfterFailover).startsWith("0-654321-");
+
+        runJobFromSavepointAndInsertB(savepointPath);
+
+        Assertions.assertThat(TestValuesTableFactory.getRawResultsAsStrings(SINK))
+                .containsExactlyInAnyOrder("+I[1]", "+I[2]", "+I[100]", "+I[101]", "+I[200]");
+    }
+
+    /**
+     * A MySQL {@code uuid:interval} GTID set must be rejected with an actionable message rather
+     * than surfacing the comparator's raw {@link IllegalArgumentException} from deep inside the
+     * offset comparison. This covers the guard wired into {@code
+     * StatefulTaskContext#checkMariadbGtidSet}, not just the comparator in isolation.
+     */
+    @Test
+    @Timeout(180)
+    void testMySqlFormatGtidIsRejectedWithActionableError() {
+        StreamExecutionEnvironment env = getExecutionEnvironment(null);
+        // Without this the task would fail, restart, and fail again forever, so the job never
+        // reaches a terminal state and result.await() would hang until the test times out.
+        RestartStrategyUtils.configureNoRestartStrategy(env);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE %s ("
+                                + " id INT NOT NULL,"
+                                + " PRIMARY KEY (id) NOT ENFORCED"
+                                + ") WITH ("
+                                + " 'connector' = 'mariadb-cdc',"
+                                + " 'hostname' = '%s',"
+                                + " 'port' = '%s',"
+                                + " 'username' = '%s',"
+                                + " 'password' = '%s',"
+                                + " 'database-name' = '%s',"
+                                + " 'table-name' = '%s',"
+                                + " 'server-time-zone' = 'UTC',"
+                                + " 'server-id' = '5601-5604',"
+                                + " 'scan.startup.mode' = 'specific-offset',"
+                                // A MySQL-style GTID set, which MariaDB CDC cannot resume from.
+                                + " 'scan.startup.specific-offset.gtid-set' = 'abcd:1-4'"
+                                + ")",
+                        TABLE,
+                        mariaDb.getHost(),
+                        mariaDb.getDatabasePort(),
+                        mariaDb.getUsername(),
+                        mariaDb.getPassword(),
+                        mariaDb.getDatabaseName(),
+                        TABLE));
+        createSinkTable(tEnv);
+
+        TableResult result = tEnv.executeSql("INSERT INTO " + SINK + " SELECT id FROM " + TABLE);
+        Assertions.assertThatThrownBy(() -> result.await())
+                .hasStackTraceContaining("domain-server-sequence")
+                .hasStackTraceContaining("state taken from the mysql-cdc connector");
+    }
+
+    private String runJobUntilBinlogAndSavepoint(String savepointDirectory) throws Exception {
+        StreamExecutionEnvironment env = getExecutionEnvironment(null);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        createCdcTable(tEnv);
+        createSinkTable(tEnv);
+
+        TableResult result = tEnv.executeSql("INSERT INTO " + SINK + " SELECT id FROM " + TABLE);
+        JobClient jobClient = result.getJobClient().orElseThrow(IllegalStateException::new);
+        try {
+            // Two snapshot rows must reach the sink before the source enters the binlog phase.
+            waitForSinkSize(2);
+
+            // Transaction A: its row reaches the sink, but the committed GTID is still before A.
+            executeSql("INSERT INTO " + TABLE + " VALUES (100)");
+            waitForSinkSize(3);
+
+            // Transaction A': observing its row proves A has committed, so the split state's
+            // restartable GTID set now includes A (A' is not surfaced to the reader until its own
+            // commit is carried by a later record). The savepoint therefore captures a GTID past A.
+            executeSql("INSERT INTO " + TABLE + " VALUES (101)");
+            waitForSinkSize(4);
+
+            return triggerSavepointWithRetry(jobClient, savepointDirectory);
+        } finally {
+            jobClient.cancel().get();
+        }
+    }
+
+    private void runJobFromSavepointAndInsertB(String savepointPath) throws Exception {
+        StreamExecutionEnvironment env = getExecutionEnvironment(savepointPath);
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        createCdcTable(tEnv);
+        createSinkTable(tEnv);
+
+        TableResult result = tEnv.executeSql("INSERT INTO " + SINK + " SELECT id FROM " + TABLE);
+        JobClient jobClient = result.getJobClient().orElseThrow(IllegalStateException::new);
+        try {
+            // Transaction B: its GTID is past the saved offset, so it must be delivered once.
+            executeSql("INSERT INTO " + TABLE + " VALUES (200)");
+            waitForSinkSize(5);
+        } finally {
+            jobClient.cancel().get();
+        }
+    }
+
+    private StreamExecutionEnvironment getExecutionEnvironment(String savepointPath) {
+        Configuration configuration = new Configuration();
+        if (savepointPath != null) {
+            configuration.set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
+        }
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setParallelism(1);
+        env.enableCheckpointing(200L);
+        return env;
+    }
+
+    private void createCdcTable(StreamTableEnvironment tEnv) {
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE %s ("
+                                + " id INT NOT NULL,"
+                                + " PRIMARY KEY (id) NOT ENFORCED"
+                                + ") WITH ("
+                                + " 'connector' = 'mariadb-cdc',"
+                                + " 'hostname' = '%s',"
+                                + " 'port' = '%s',"
+                                + " 'username' = '%s',"
+                                + " 'password' = '%s',"
+                                + " 'database-name' = '%s',"
+                                + " 'table-name' = '%s',"
+                                + " 'server-time-zone' = 'UTC',"
+                                + " 'server-id' = '5501-5504',"
+                                + " 'scan.startup.mode' = 'initial'"
+                                + ")",
+                        TABLE,
+                        mariaDb.getHost(),
+                        mariaDb.getDatabasePort(),
+                        mariaDb.getUsername(),
+                        mariaDb.getPassword(),
+                        mariaDb.getDatabaseName(),
+                        TABLE));
+    }
+
+    private void createSinkTable(StreamTableEnvironment tEnv) {
+        tEnv.executeSql(
+                "CREATE TABLE "
+                        + SINK
+                        + " ("
+                        + " id INT NOT NULL,"
+                        + " PRIMARY KEY (id) NOT ENFORCED"
+                        + ") WITH ("
+                        + " 'connector' = 'values',"
+                        + " 'sink-insert-only' = 'false'"
+                        + ")");
+    }
+
+    private static void waitForSinkSize(int expectedSize) throws InterruptedException {
+        while (sinkSize() < expectedSize) {
+            Thread.sleep(100);
+        }
+    }
+
+    private static int sinkSize() {
+        synchronized (TestValuesTableFactory.class) {
+            try {
+                return TestValuesTableFactory.getRawResultsAsStrings(SINK).size();
+            } catch (IllegalArgumentException e) {
+                // The job is not started yet.
+                return 0;
+            }
+        }
+    }
+
+    private String triggerSavepointWithRetry(JobClient jobClient, String savepointDirectory)
+            throws Exception {
+        int retryTimes = 0;
+        while (retryTimes < 600) {
+            try {
+                return jobClient
+                        .triggerSavepoint(savepointDirectory, SavepointFormatType.DEFAULT)
+                        .get();
+            } catch (Exception e) {
+                Optional<CheckpointException> checkpointException =
+                        ExceptionUtils.findThrowable(e, CheckpointException.class);
+                if (checkpointException.isPresent()
+                        && checkpointException
+                                .get()
+                                .getMessage()
+                                .contains("Checkpoint triggering task")) {
+                    Thread.sleep(100);
+                    retryTimes++;
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw new RuntimeException("Failed to trigger savepoint after " + retryTimes + " retries");
+    }
+
+    private void initializeTable() throws Exception {
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                mariaDb.getJdbcUrl(),
+                                mariaDb.getUsername(),
+                                mariaDb.getPassword());
+                Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE TABLE " + TABLE + " (id INT NOT NULL PRIMARY KEY)");
+            stmt.execute("INSERT INTO " + TABLE + " VALUES (1), (2)");
+            // Created up front so the failover test never issues DDL while the source is streaming.
+            stmt.execute("CREATE TABLE " + MARKER_TABLE + " (id INT NOT NULL PRIMARY KEY)");
+        }
+    }
+
+    private String queryScalar(String sql) throws Exception {
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                mariaDb.getJdbcUrl(),
+                                mariaDb.getUsername(),
+                                mariaDb.getPassword());
+                Statement stmt = conn.createStatement();
+                ResultSet rs = stmt.executeQuery(sql)) {
+            return rs.next() ? rs.getString(1) : null;
+        }
+    }
+
+    private void executeSql(String sql) throws Exception {
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                mariaDb.getJdbcUrl(),
+                                mariaDb.getUsername(),
+                                mariaDb.getPassword());
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/source/MariaDbSnapshotITCase.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/source/MariaDbSnapshotITCase.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.source;
+
+import org.apache.flink.cdc.connectors.mariadb.testutils.MariaDbContainer;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.lifecycle.Startables;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * IT case proving the standalone {@code mariadb-cdc} connector performs an initial snapshot and
+ * continues consuming binlog changes from a real MariaDB server. MariaDB GTID recovery is covered
+ * by a later change.
+ */
+class MariaDbSnapshotITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MariaDbSnapshotITCase.class);
+
+    private final MariaDbContainer mariaDb = new MariaDbContainer();
+
+    private final StreamExecutionEnvironment env =
+            StreamExecutionEnvironment.getExecutionEnvironment();
+    private final StreamTableEnvironment tEnv =
+            StreamTableEnvironment.create(
+                    env, EnvironmentSettings.newInstance().inStreamingMode().build());
+
+    @BeforeEach
+    void before() {
+        LOG.info("Starting MariaDB container...");
+        Startables.deepStart(Stream.of(mariaDb)).join();
+        LOG.info("MariaDB container started.");
+        env.setParallelism(1);
+    }
+
+    @AfterEach
+    void after() {
+        mariaDb.stop();
+    }
+
+    @Test
+    void testSnapshotAndStreaming() throws Exception {
+        initializeTable();
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE products ("
+                                + " id INT NOT NULL,"
+                                + " name STRING,"
+                                + " weight DECIMAL(10,3),"
+                                + " PRIMARY KEY (id) NOT ENFORCED"
+                                + ") WITH ("
+                                + " 'connector' = 'mariadb-cdc',"
+                                + " 'hostname' = '%s',"
+                                + " 'port' = '%s',"
+                                + " 'username' = '%s',"
+                                + " 'password' = '%s',"
+                                + " 'database-name' = '%s',"
+                                + " 'table-name' = 'products',"
+                                + " 'server-time-zone' = 'UTC',"
+                                + " 'server-id' = '5401-5404',"
+                                + " 'scan.startup.mode' = 'initial'"
+                                + ")",
+                        mariaDb.getHost(),
+                        mariaDb.getDatabasePort(),
+                        mariaDb.getUsername(),
+                        mariaDb.getPassword(),
+                        mariaDb.getDatabaseName()));
+
+        TableResult result = tEnv.executeSql("SELECT id, name, weight FROM products");
+        JobClient jobClient = result.getJobClient().orElseThrow(IllegalStateException::new);
+        try (CloseableIterator<Row> iterator = result.collect()) {
+            List<String> snapshot = fetchRows(iterator, 3);
+            assertThat(snapshot)
+                    .containsExactlyInAnyOrder(
+                            "+I[101, scooter, 3.140]",
+                            "+I[102, car battery, 8.100]",
+                            "+I[103, hammer, 0.750]");
+
+            makeBinlogChanges();
+
+            List<String> binlog = fetchRows(iterator, 4);
+            assertThat(binlog)
+                    .containsExactly(
+                            "+I[104, drill, 1.250]",
+                            "-U[101, scooter, 3.140]",
+                            "+U[101, scooter, 3.500]",
+                            "-D[102, car battery, 8.100]");
+        } finally {
+            jobClient.cancel().get();
+        }
+    }
+
+    private void makeBinlogChanges() throws Exception {
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                mariaDb.getJdbcUrl(),
+                                mariaDb.getUsername(),
+                                mariaDb.getPassword());
+                Statement stmt = conn.createStatement()) {
+            stmt.execute("INSERT INTO products VALUES (104, 'drill', 1.25)");
+            stmt.execute("UPDATE products SET weight = 3.5 WHERE id = 101");
+            stmt.execute("DELETE FROM products WHERE id = 102");
+        }
+    }
+
+    private void initializeTable() throws Exception {
+        try (Connection conn =
+                        DriverManager.getConnection(
+                                mariaDb.getJdbcUrl(),
+                                mariaDb.getUsername(),
+                                mariaDb.getPassword());
+                Statement stmt = conn.createStatement()) {
+            stmt.execute(
+                    "CREATE TABLE products ("
+                            + " id INTEGER NOT NULL PRIMARY KEY,"
+                            + " name VARCHAR(255) NOT NULL,"
+                            + " weight DECIMAL(10,3))");
+            stmt.execute(
+                    "INSERT INTO products VALUES"
+                            + " (101, 'scooter', 3.14),"
+                            + " (102, 'car battery', 8.1),"
+                            + " (103, 'hammer', 0.75)");
+        }
+    }
+
+    private static List<String> fetchRows(CloseableIterator<Row> iter, int size) {
+        List<String> rows = new ArrayList<>(size);
+        while (size > 0 && iter.hasNext()) {
+            rows.add(iter.next().toString());
+            size--;
+        }
+        return rows;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/source/offset/MariaDbGtidComparatorTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/source/offset/MariaDbGtidComparatorTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.source.offset;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link MariaDbGtidComparator}. MariaDB GTIDs are {@code domain-server-sequence}
+ * and the sequence advances per domain across servers, so comparison must key on the domain and
+ * ignore the server id — otherwise a post-failover event (same domain, new server id) looks like a
+ * different stream and the offset is mishandled (Debezium DBZ-1672, Flink CDC #2929).
+ */
+class MariaDbGtidComparatorTest {
+
+    @Test
+    void canParseMariaDbGtid() {
+        assertThat(MariaDbGtidComparator.canParse("0-1-100")).isTrue();
+        assertThat(MariaDbGtidComparator.canParse("0-1-100,1-2-50")).isTrue();
+        // MySQL uuid:interval form MUST NOT be claimed by the MariaDB parser.
+        assertThat(MariaDbGtidComparator.canParse("A:1-100")).isFalse();
+        assertThat(MariaDbGtidComparator.canParse(null)).isFalse();
+    }
+
+    @Test
+    void isEqualIgnoresServerId() {
+        // Same domain + same sequence, different server id (failover) -> equal
+        assertThat(MariaDbGtidComparator.isEqual("0-1-100", "0-2-100")).isTrue();
+        // different sequence
+        assertThat(MariaDbGtidComparator.isEqual("0-1-100", "0-1-101")).isFalse();
+        // different domain
+        assertThat(MariaDbGtidComparator.isEqual("0-1-100", "1-1-100")).isFalse();
+    }
+
+    @Test
+    void isEqualHandlesMultipleDomainsOrderIndependently() {
+        assertThat(MariaDbGtidComparator.isEqual("0-1-100,1-2-50", "1-9-50,0-7-100")).isTrue();
+        assertThat(MariaDbGtidComparator.isEqual("0-1-100,1-2-50", "0-1-100")).isFalse();
+    }
+
+    @Test
+    void isContainedWithinKeysOnDomainAndIgnoresServerId() {
+        // Failover: sub at seq 100 on server 1, sup advanced to seq 102 on server 2 -> contained
+        assertThat(MariaDbGtidComparator.isContainedWithin("0-1-100", "0-2-102")).isTrue();
+        assertThat(MariaDbGtidComparator.isContainedWithin("0-1-100", "0-2-100")).isTrue();
+        // sub ahead of sup -> not contained.
+        assertThat(MariaDbGtidComparator.isContainedWithin("0-1-101", "0-2-100")).isFalse();
+        // domain missing
+        assertThat(MariaDbGtidComparator.isContainedWithin("0-1-100,1-1-1", "0-2-100")).isFalse();
+        // multi-domain
+        assertThat(MariaDbGtidComparator.isContainedWithin("0-1-100,1-1-50", "0-2-100,1-9-60"))
+                .isTrue();
+    }
+
+    @Test
+    void emptyGtidSets() {
+        assertThat(MariaDbGtidComparator.isEqual("", "")).isTrue();
+        assertThat(MariaDbGtidComparator.isContainedWithin("", "0-1-100")).isTrue();
+        assertThat(MariaDbGtidComparator.isContainedWithin("0-1-100", "")).isFalse();
+    }
+
+    /**
+     * The comparison methods reject non-MariaDB GTID text rather than silently mis-comparing it.
+     * Callers that may see untrusted input (a restored offset, a user-supplied specific-offset)
+     * must guard with {@link MariaDbGtidComparator#canParse(String)} first and raise an actionable
+     * error; {@code StatefulTaskContext#checkMariadbGtidSet} does exactly that.
+     */
+    @Test
+    void nonMariaDbGtidTextIsRejected() {
+        assertThatThrownBy(() -> MariaDbGtidComparator.isEqual("abcd:1-4", "0-1-100"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid MariaDB gtid format");
+
+        assertThatThrownBy(() -> MariaDbGtidComparator.isContainedWithin("0-1", "0-1-100"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid MariaDB gtid format");
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/testutils/MariaDbContainer.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mariadb/testutils/MariaDbContainer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mariadb.testutils;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Docker container for MariaDB, used by the MariaDB CDC integration tests. The binary log and ROW
+ * format are enabled through server command-line flags (rather than a mounted my.cnf) so the
+ * container is fully self-contained; MariaDB tracks {@code @@gtid_binlog_pos} automatically once
+ * the binary log is on.
+ */
+@SuppressWarnings("rawtypes")
+public class MariaDbContainer extends JdbcDatabaseContainer {
+
+    public static final String IMAGE = "mariadb";
+    public static final String VERSION = "11.4";
+    public static final int MARIADB_PORT = 3306;
+
+    private final String databaseName = "test";
+    private final String username = "root";
+    private final String password = "test";
+
+    public MariaDbContainer() {
+        this(VERSION);
+    }
+
+    public MariaDbContainer(String version) {
+        super(DockerImageName.parse(IMAGE + ":" + version));
+        addExposedPort(MARIADB_PORT);
+        // Enable the binary log in ROW format.
+        setCommand("--log-bin=mysql-bin", "--binlog-format=ROW", "--server-id=223344");
+    }
+
+    @Override
+    protected Set<Integer> getLivenessCheckPorts() {
+        return Collections.singleton(getMappedPort(MARIADB_PORT));
+    }
+
+    @Override
+    protected void configure() {
+        addEnv("MARIADB_DATABASE", databaseName);
+        addEnv("MARIADB_ROOT_PASSWORD", password);
+        setStartupAttempts(3);
+    }
+
+    @Override
+    public String getDriverClassName() {
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+            return "com.mysql.cj.jdbc.Driver";
+        } catch (ClassNotFoundException e) {
+            return "com.mysql.jdbc.Driver";
+        }
+    }
+
+    public String getJdbcUrl(String databaseName) {
+        return "jdbc:mysql://"
+                + getHost()
+                + ":"
+                + getDatabasePort()
+                + "/"
+                + databaseName
+                + "?useSSL=false&allowPublicKeyRetrieval=true";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return getJdbcUrl(databaseName);
+    }
+
+    public int getDatabasePort() {
+        return getMappedPort(MARIADB_PORT);
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1";
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffsetTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mariadb-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/offset/BinlogOffsetTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.offset;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the MariaDB-flavored {@link BinlogOffset#compareTo(BinlogOffset)}. The shadowed
+ * {@code BinlogOffset} compares GTID sets in MariaDB's {@code domain-server-sequence} format,
+ * keying on {@code domain} and the highest {@code sequence} while ignoring the {@code server id}
+ * (so a master and its replica compare equal for the same replicated history).
+ */
+class BinlogOffsetTest {
+
+    @Test
+    void testEqualIgnoresServerId() {
+        // Same domain and sequence, different server id -> equal.
+        BinlogOffset offset1 = BinlogOffset.builder().setGtidSet("0-1-100").build();
+        BinlogOffset offset2 = BinlogOffset.builder().setGtidSet("0-2-100").build();
+        assertCompareTo(offset1, offset2, 0);
+        assertCompareTo(offset2, offset1, 0);
+    }
+
+    @Test
+    void testEqualIsOrderIndependentAcrossDomains() {
+        BinlogOffset offset1 = BinlogOffset.builder().setGtidSet("0-1-100,1-1-50").build();
+        // Reordered domains and a different server id in each tuple -> still equal.
+        BinlogOffset offset2 = BinlogOffset.builder().setGtidSet("1-2-50,0-3-100").build();
+        assertCompareTo(offset1, offset2, 0);
+        assertCompareTo(offset2, offset1, 0);
+    }
+
+    @Test
+    void testGtidSetTakesPrecedenceOverBinlogPosition() {
+        // When GTID sets are equal, the binlog file/position is ignored for the comparison.
+        BinlogOffset offset1 =
+                BinlogOffset.builder()
+                        .setGtidSet("0-1-100")
+                        .setBinlogFilePosition("mysql-bin.001", 123)
+                        .build();
+        BinlogOffset offset2 =
+                BinlogOffset.builder()
+                        .setGtidSet("0-2-100")
+                        .setBinlogFilePosition("mysql-bin.001", 456)
+                        .build();
+        assertCompareTo(offset1, offset2, 0);
+    }
+
+    @Test
+    void testContainmentKeysOnDomainAndSequence() {
+        // "0-1-100" is contained within "0-1-200" (same domain, lower highest sequence).
+        BinlogOffset sub = BinlogOffset.builder().setGtidSet("0-1-100").build();
+        BinlogOffset sup = BinlogOffset.builder().setGtidSet("0-1-200").build();
+        assertCompareTo(sub, sup, -1);
+        assertCompareTo(sup, sub, 1);
+    }
+
+    @Test
+    void testContainmentIgnoresServerIdOnFailover() {
+        // The replica advanced past the checkpoint under a different server id; the checkpoint's
+        // GTID must still be recognized as contained within the replica's larger set.
+        BinlogOffset restored = BinlogOffset.builder().setGtidSet("0-1-100").build();
+        BinlogOffset serverSet = BinlogOffset.builder().setGtidSet("0-2-150").build();
+        assertCompareTo(restored, serverSet, -1);
+        assertCompareTo(serverSet, restored, 1);
+    }
+
+    @Test
+    void testDisjointDomainsAreNotContainedEitherWay() {
+        BinlogOffset offset1 = BinlogOffset.builder().setGtidSet("0-1-100").build();
+        BinlogOffset offset2 = BinlogOffset.builder().setGtidSet("1-1-100").build();
+        // Neither contains the other, so the result is always 1 (mirrors upstream MySQL behavior).
+        assertCompareTo(offset1, offset2, 1);
+        assertCompareTo(offset2, offset1, 1);
+    }
+
+    @Test
+    void testEqualGtidBreaksTieOnSkipEventsThenRows() {
+        BinlogOffset offset1 =
+                BinlogOffset.builder().setGtidSet("0-1-100").setSkipEvents(5).build();
+        BinlogOffset offset2 =
+                BinlogOffset.builder().setGtidSet("0-2-100").setSkipEvents(10).build();
+        assertCompareTo(offset1, offset2, -1);
+        assertCompareTo(offset2, offset1, 1);
+
+        BinlogOffset offset3 =
+                BinlogOffset.builder()
+                        .setGtidSet("0-1-100")
+                        .setSkipEvents(5)
+                        .setSkipRows(10)
+                        .build();
+        BinlogOffset offset4 =
+                BinlogOffset.builder()
+                        .setGtidSet("0-2-100")
+                        .setSkipEvents(5)
+                        .setSkipRows(20)
+                        .build();
+        assertCompareTo(offset3, offset4, -1);
+        assertCompareTo(offset4, offset3, 1);
+    }
+
+    @Test
+    void testOffsetWithGtidIsAfterOffsetWithout() {
+        BinlogOffset withGtid =
+                BinlogOffset.builder()
+                        .setGtidSet("0-1-100")
+                        .setBinlogFilePosition("mysql-bin.001", 123)
+                        .build();
+        BinlogOffset withoutGtid =
+                BinlogOffset.builder().setBinlogFilePosition("mysql-bin.001", 456).build();
+        assertCompareTo(withGtid, withoutGtid, 1);
+        assertCompareTo(withoutGtid, withGtid, -1);
+    }
+
+    private void assertCompareTo(BinlogOffset offset1, BinlogOffset offset2, int expected) {
+        int actual = offset1.compareTo(offset2);
+        // compareTo does not guarantee returning -1, 0, or 1. Just check the sign.
+        Assertions.assertThat(Integer.signum(actual)).isEqualTo(expected);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
+++ b/flink-cdc-connect/flink-cdc-source-connectors/pom.xml
@@ -33,6 +33,7 @@ limitations under the License.
         <module>flink-connector-db2-cdc</module>
         <module>flink-connector-debezium</module>
         <module>flink-connector-mongodb-cdc</module>
+        <module>flink-connector-mariadb-cdc</module>
         <module>flink-connector-mysql-cdc</module>
         <module>flink-connector-oceanbase-cdc</module>
         <module>flink-connector-oracle-cdc</module>


### PR DESCRIPTION
## What is the purpose of this pull request?

Implements [FLINK-40315](https://issues.apache.org/jira/browse/FLINK-40315), a sub-task of
[FLINK-40314](https://issues.apache.org/jira/browse/FLINK-40314).

The MySQL CDC connector can already reach MariaDB over its MySQL-compatible wire protocol, but it
does not understand MariaDB GTIDs: it parses the MySQL `uuid:interval` form, while MariaDB uses
`domain-server-sequence`. Once a cluster fails over, scales out, or a job restarts and gets routed
to another server in the same GTID domain, that server has a different server id and the
checkpointed position can no longer be compared correctly — recovery either fails or silently
stops advancing.

Rather than adding MariaDB branches to the MySQL read path — the most critical path in Flink CDC —
this introduces a standalone `flink-connector-mariadb-cdc` module, following the `oceanbase-cdc`
precedent: depend on `flink-connector-mysql-cdc`, reuse its entire read pipeline, and inject
MariaDB behaviour.
**No line of `flink-connector-mysql-cdc` is modified.**

Design background: apache/flink-cdc#4468 validated MariaDB GTID support inside mysql-cdc under
FLINK-34807; that PR is not meant to be merged and serves as the reference for this split.

## Brief change log

**Module**

- Add `flink-connector-mariadb-cdc`, registered under `flink-cdc-source-connectors`, depending on
  `flink-connector-mysql-cdc` to reuse the snapshot and binlog read pipeline
- MySQL Connector/J is declared `provided`, so it is neither bundled nor exposed transitively;
  users supply the driver themselves
- Add `MariaDbTableSourceFactory` (extends `MySqlTableSourceFactory`, overriding only the
  identifier to `mariadb-cdc`) plus its `META-INF/services` registration. All MySQL CDC options
  are reused as-is.

**MariaDB binlog and GTID support** 

 three classes are added(MariaDB core):

- `MariaDBBinaryLogClient` — sets `@mariadb_slave_capability=4` so the server emits `MARIADB_GTID`
  events and the consumed GTID actually advances per transaction
- `MariaDbConnections` — reads `@@gtid_binlog_pos` (a lightweight helper, so `MySqlConnection` does
  not have to be overridden for a single query)
- `MariaDbGtidComparator` — domain+sequence containment, ignoring the server id


## Documentation

- Does this pull request introduce a new feature? (yes)
- If yes, how is the feature documented? (docs — tracked separately in
  [FLINK-40328](https://issues.apache.org/jira/browse/FLINK-40328))

---

##### Was generative AI tooling used to co-author this PR?

- [x] Yes (Opus-4.8,GPT5.5-sol)