### PR TITLE
[FLINK-40331][cdc-connect][fluss] Support forward shuffle in fluss sink.

### DIFF
--- a/docs/content.zh/docs/connectors/pipeline-connectors/fluss.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/fluss.md
@@ -100,6 +100,13 @@ Pipeline Connector Options
       <td>用于建立与 Fluss 集群初始连接的主机/端口对列表。 </td>
     </tr>
     <tr>
+      <td>sink.partitioning.strategy</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">DEFAULT</td>
+      <td>String</td>
+      <td>DataChangeEvent 路由使用的分区策略。可选值为 <code>DEFAULT</code> 和 <code>FORWARD</code>。<code>DEFAULT</code> 对主键表按主键 hash，对 log 表采用 round-robin。<code>FORWARD</code> 将数据事件发送到与上游 subtask 索引相同的下游 subtask，用于 Fluss 到 Fluss 的数据同步。上游数据分布必须与 Fluss 表的分桶策略保持一致，否则可能出现数据正确性问题。</td>
+    </tr>
+    <tr>
       <td>bucket.key</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content.zh/docs/connectors/pipeline-connectors/fluss.md
+++ b/docs/content.zh/docs/connectors/pipeline-connectors/fluss.md
@@ -104,7 +104,7 @@ Pipeline Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">DEFAULT</td>
       <td>String</td>
-      <td>DataChangeEvent 路由使用的分区策略。可选值为 <code>DEFAULT</code> 和 <code>FORWARD</code>。<code>DEFAULT</code> 对主键表按主键 hash，对 log 表采用 round-robin。<code>FORWARD</code> 将数据事件发送到与上游 subtask 索引相同的下游 subtask，用于 Fluss 到 Fluss 的数据同步。上游数据分布必须与 Fluss 表的分桶策略保持一致，否则可能出现数据正确性问题。</td>
+      <td>DataChangeEvent 路由使用的分区策略。可选值为 <code>DEFAULT</code> 和 <code>FORWARD</code>。<code>DEFAULT</code> 对主键表按主键进行哈希分区，对日志表采用随机分发，将事件分散到各下游 subtask 以实现负载均衡。<code>FORWARD</code> 将数据事件发送到与上游 subtask 索引相同的下游 subtask，用于 Fluss 到 Fluss 的数据同步。上游数据分布必须与 Fluss 表的分桶策略保持一致，否则可能出现数据正确性问题。</td>
     </tr>
     <tr>
       <td>bucket.key</td>

--- a/docs/content/docs/connectors/pipeline-connectors/fluss.md
+++ b/docs/content/docs/connectors/pipeline-connectors/fluss.md
@@ -101,6 +101,13 @@ Pipeline Connector Options
       <td>The bootstrap servers for the Fluss sink connection. </td>
     </tr>
     <tr>
+      <td>sink.partitioning.strategy</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">DEFAULT</td>
+      <td>String</td>
+      <td>The partitioning strategy for DataChangeEvent routing. Available values are <code>DEFAULT</code> and <code>FORWARD</code>. <code>DEFAULT</code> hashes primary key tables by primary keys and routes log tables in round-robin mode. <code>FORWARD</code> routes data events to downstream subtasks with the same indices as upstream and is intended for Fluss-to-Fluss data synchronization. The upstream data distribution must match the Fluss table bucket distribution; otherwise, data correctness issues may occur.</td>
+    </tr>
+    <tr>
       <td>bucket.key</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content/docs/connectors/pipeline-connectors/fluss.md
+++ b/docs/content/docs/connectors/pipeline-connectors/fluss.md
@@ -105,7 +105,7 @@ Pipeline Connector Options
       <td>optional</td>
       <td style="word-wrap: break-word;">DEFAULT</td>
       <td>String</td>
-      <td>The partitioning strategy for DataChangeEvent routing. Available values are <code>DEFAULT</code> and <code>FORWARD</code>. <code>DEFAULT</code> hashes primary key tables by primary keys and routes log tables in round-robin mode. <code>FORWARD</code> routes data events to downstream subtasks with the same indices as upstream and is intended for Fluss-to-Fluss data synchronization. The upstream data distribution must match the Fluss table bucket distribution; otherwise, data correctness issues may occur.</td>
+      <td>The partitioning strategy for DataChangeEvent routing. Available values are <code>DEFAULT</code> and <code>FORWARD</code>. <code>DEFAULT</code> hashes primary key tables by primary keys and randomly distributes log table events across downstream subtasks for balanced load. <code>FORWARD</code> routes data events to downstream subtasks with the same indices as upstream and is intended for Fluss-to-Fluss data synchronization. The upstream data distribution must match the Fluss table bucket distribution; otherwise, data correctness issues may occur.</td>
     </tr>
     <tr>
       <td>bucket.key</td>

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/function/DefaultHashContext.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/function/DefaultHashContext.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.function;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.utils.Preconditions;
+
+/** Default implementation of {@link HashFunction.HashContext}. */
+@Internal
+public final class DefaultHashContext implements HashFunction.HashContext {
+
+    private final int sourceSubtaskIndex;
+    private final int downstreamParallelism;
+
+    public DefaultHashContext(int sourceSubtaskIndex, int downstreamParallelism) {
+        Preconditions.checkArgument(
+                sourceSubtaskIndex >= 0,
+                "sourceSubtaskIndex must be greater than or equal to 0, but was %s.",
+                sourceSubtaskIndex);
+        Preconditions.checkArgument(
+                downstreamParallelism > 0,
+                "downstreamParallelism must be greater than 0, but was %s.",
+                downstreamParallelism);
+        this.sourceSubtaskIndex = sourceSubtaskIndex;
+        this.downstreamParallelism = downstreamParallelism;
+    }
+
+    @Override
+    public int getSourceSubtaskIndex() {
+        return sourceSubtaskIndex;
+    }
+
+    @Override
+    public int getDownstreamParallelism() {
+        return downstreamParallelism;
+    }
+}

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/function/HashFunction.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/function/HashFunction.java
@@ -27,15 +27,28 @@ import org.apache.flink.cdc.common.annotation.Internal;
 @Internal
 public interface HashFunction<T> {
 
+    /** Runtime context for calculating an event hash code. */
+    @Internal
+    interface HashContext {
+        int getSourceSubtaskIndex();
+
+        int getDownstreamParallelism();
+    }
+
+    /** Creates a hash context. */
+    static HashContext createContext(int sourceSubtaskIndex, int downstreamParallelism) {
+        return new DefaultHashContext(sourceSubtaskIndex, downstreamParallelism);
+    }
+
     int hashcode(T event);
 
     /**
-     * Calculates the hash code with the upstream source subtask index.
+     * Calculates the hash code with the runtime hash context.
      *
-     * <p>Implementations that do not depend on the source subtask index can continue implementing
-     * {@link #hashcode(Object)} only.
+     * <p>Implementations that do not depend on the context can continue implementing {@link
+     * #hashcode(Object)} only.
      */
-    default int hashcode(int sourceIndex, T event) {
+    default int hashcode(HashContext context, T event) {
         return hashcode(event);
     }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/function/HashFunction.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/function/HashFunction.java
@@ -28,4 +28,14 @@ import org.apache.flink.cdc.common.annotation.Internal;
 public interface HashFunction<T> {
 
     int hashcode(T event);
+
+    /**
+     * Calculates the hash code with the upstream source subtask index.
+     *
+     * <p>Implementations that do not depend on the source subtask index can continue implementing
+     * {@link #hashcode(Object)} only.
+     */
+    default int hashcode(int sourceIndex, T event) {
+        return hashcode(event);
+    }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProvider.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProvider.java
@@ -21,6 +21,7 @@ import org.apache.flink.cdc.common.annotation.Internal;
 import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.function.HashFunction.HashContext;
 import org.apache.flink.cdc.common.function.HashFunctionProvider;
 import org.apache.flink.cdc.common.schema.Schema;
 
@@ -41,12 +42,13 @@ public class ForwardHashFunctionProvider implements HashFunctionProvider<DataCha
 
         @Override
         public int hashcode(DataChangeEvent event) {
-            return 0;
+            throw new UnsupportedOperationException(
+                    "Forward hash function requires a HashContext.");
         }
 
         @Override
-        public int hashcode(int sourceIndex, DataChangeEvent event) {
-            return sourceIndex;
+        public int hashcode(HashContext context, DataChangeEvent event) {
+            return context.getSourceSubtaskIndex();
         }
     }
 }

--- a/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProvider.java
+++ b/flink-cdc-common/src/main/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.sink;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.function.HashFunctionProvider;
+import org.apache.flink.cdc.common.schema.Schema;
+
+import javax.annotation.Nullable;
+
+/** A {@link HashFunctionProvider} that preserves the upstream subtask distribution. */
+@Internal
+public class ForwardHashFunctionProvider implements HashFunctionProvider<DataChangeEvent> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public HashFunction<DataChangeEvent> getHashFunction(@Nullable TableId tableId, Schema schema) {
+        return new ForwardHashFunction();
+    }
+
+    private static class ForwardHashFunction implements HashFunction<DataChangeEvent> {
+
+        @Override
+        public int hashcode(DataChangeEvent event) {
+            return 0;
+        }
+
+        @Override
+        public int hashcode(int sourceIndex, DataChangeEvent event) {
+            return sourceIndex;
+        }
+    }
+}

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/function/HashContextTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/function/HashContextTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.function;
+
+import org.apache.flink.cdc.common.function.HashFunction.HashContext;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link HashContext}. */
+class HashContextTest {
+
+    @Test
+    void testProperties() {
+        HashContext context = HashFunction.createContext(3, 5);
+
+        assertThat(context).isInstanceOf(DefaultHashContext.class);
+        assertThat(context.getSourceSubtaskIndex()).isEqualTo(3);
+        assertThat(context.getDownstreamParallelism()).isEqualTo(5);
+    }
+
+    @Test
+    void testRejectsNegativeSourceSubtaskIndex() {
+        assertThatThrownBy(() -> HashFunction.createContext(-1, 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sourceSubtaskIndex");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void testRejectsNonPositiveDownstreamParallelism(int downstreamParallelism) {
+        assertThatThrownBy(() -> HashFunction.createContext(0, downstreamParallelism))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("downstreamParallelism");
+    }
+}

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProviderTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProviderTest.java
@@ -26,6 +26,7 @@ import org.apache.flink.cdc.common.schema.Schema;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Unit tests for {@link ForwardHashFunctionProvider}. */
 class ForwardHashFunctionProviderTest {
@@ -38,6 +39,19 @@ class ForwardHashFunctionProviderTest {
                 new ForwardHashFunctionProvider()
                         .getHashFunction(event.tableId(), Schema.newBuilder().build());
 
-        assertThat(hashFunction.hashcode(3, event)).isEqualTo(3);
+        assertThat(hashFunction.hashcode(HashFunction.createContext(3, 5), event)).isEqualTo(3);
+    }
+
+    @Test
+    void testHashingWithoutContextFails() {
+        DataChangeEvent event =
+                DataChangeEvent.insertEvent(TableId.tableId("customers"), GenericRecordData.of(1));
+        HashFunction<DataChangeEvent> hashFunction =
+                new ForwardHashFunctionProvider()
+                        .getHashFunction(event.tableId(), Schema.newBuilder().build());
+
+        assertThatThrownBy(() -> hashFunction.hashcode(event))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("HashContext");
     }
 }

--- a/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProviderTest.java
+++ b/flink-cdc-common/src/test/java/org/apache/flink/cdc/common/sink/ForwardHashFunctionProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.common.sink;
+
+import org.apache.flink.cdc.common.data.GenericRecordData;
+import org.apache.flink.cdc.common.event.DataChangeEvent;
+import org.apache.flink.cdc.common.event.TableId;
+import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.schema.Schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link ForwardHashFunctionProvider}. */
+class ForwardHashFunctionProviderTest {
+
+    @Test
+    void testForwardingBySourceIndex() {
+        DataChangeEvent event =
+                DataChangeEvent.insertEvent(TableId.tableId("customers"), GenericRecordData.of(1));
+        HashFunction<DataChangeEvent> hashFunction =
+                new ForwardHashFunctionProvider()
+                        .getHashFunction(event.tableId(), Schema.newBuilder().build());
+
+        assertThat(hashFunction.hashcode(3, event)).isEqualTo(3);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/factory/FlussDataSinkFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/factory/FlussDataSinkFactory.java
@@ -36,6 +36,7 @@ import static org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.BO
 import static org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.BUCKET_KEY;
 import static org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.BUCKET_NUMBER;
 import static org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.CLIENT_PROPERTIES_PREFIX;
+import static org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.SINK_PARTITIONING_STRATEGY;
 import static org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.TABLE_PROPERTIES_PREFIX;
 import static org.apache.flink.cdc.connectors.fluss.utils.FlussConfigUtils.parseBucketKeys;
 import static org.apache.flink.cdc.connectors.fluss.utils.FlussConfigUtils.parseBucketNumber;
@@ -57,7 +58,12 @@ public class FlussDataSinkFactory implements DataSinkFactory {
                 parseBucketKeys(factoryConfiguration.get(BUCKET_KEY));
         Map<String, Integer> bucketNumMap =
                 parseBucketNumber(factoryConfiguration.get(BUCKET_NUMBER));
-        return new FlussDataSink(flussClientConfig, tableProperties, bucketKeysMap, bucketNumMap);
+        return new FlussDataSink(
+                flussClientConfig,
+                tableProperties,
+                bucketKeysMap,
+                bucketNumMap,
+                factoryConfiguration.get(SINK_PARTITIONING_STRATEGY));
     }
 
     @Override
@@ -77,6 +83,7 @@ public class FlussDataSinkFactory implements DataSinkFactory {
         Set<ConfigOption<?>> options = new HashSet<>();
         options.add(BUCKET_KEY);
         options.add(BUCKET_NUMBER);
+        options.add(SINK_PARTITIONING_STRATEGY);
         return options;
     }
 

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussDataSink.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussDataSink.java
@@ -22,7 +22,9 @@ import org.apache.flink.cdc.common.function.HashFunctionProvider;
 import org.apache.flink.cdc.common.sink.DataSink;
 import org.apache.flink.cdc.common.sink.EventSinkProvider;
 import org.apache.flink.cdc.common.sink.FlinkSinkProvider;
+import org.apache.flink.cdc.common.sink.ForwardHashFunctionProvider;
 import org.apache.flink.cdc.common.sink.MetadataApplier;
+import org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.SinkPartitioningStrategy;
 import org.apache.flink.cdc.connectors.fluss.sink.v2.FlussSink;
 
 import org.apache.fluss.config.Configuration;
@@ -37,16 +39,19 @@ public class FlussDataSink implements DataSink {
     private final Map<String, String> tableProperties;
     private final Map<String, List<String>> bucketKeysMap;
     private final Map<String, Integer> bucketNumMap;
+    private final SinkPartitioningStrategy sinkPartitioningStrategy;
 
     public FlussDataSink(
             Configuration flussClientConfig,
             Map<String, String> tableProperties,
             Map<String, List<String>> bucketKeysMap,
-            Map<String, Integer> bucketNumMap) {
+            Map<String, Integer> bucketNumMap,
+            SinkPartitioningStrategy sinkPartitioningStrategy) {
         this.flussClientConfig = flussClientConfig;
         this.tableProperties = tableProperties;
         this.bucketKeysMap = bucketKeysMap;
         this.bucketNumMap = bucketNumMap;
+        this.sinkPartitioningStrategy = sinkPartitioningStrategy;
     }
 
     @Override
@@ -63,6 +68,13 @@ public class FlussDataSink implements DataSink {
 
     @Override
     public HashFunctionProvider<DataChangeEvent> getDataChangeEventHashFunctionProvider() {
-        return new FlussHashFunctionProvider();
+        switch (sinkPartitioningStrategy) {
+            case DEFAULT:
+                return new FlussHashFunctionProvider();
+            case FORWARD:
+                return new ForwardHashFunctionProvider();
+        }
+        throw new IllegalArgumentException(
+                "Unsupported sink partitioning strategy: " + sinkPartitioningStrategy);
     }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussDataSinkOptions.java
@@ -33,6 +33,17 @@ public class FlussDataSinkOptions {
                     .noDefaultValue()
                     .withDescription("The bootstrap servers for the Fluss sink connection.");
 
+    public static final ConfigOption<SinkPartitioningStrategy> SINK_PARTITIONING_STRATEGY =
+            ConfigOptions.key("sink.partitioning.strategy")
+                    .enumType(SinkPartitioningStrategy.class)
+                    .defaultValue(SinkPartitioningStrategy.DEFAULT)
+                    .withDescription(
+                            "Partitioning strategy for DataChangeEvent routing. "
+                                    + "DEFAULT hashes primary key tables by primary keys and routes log tables in round-robin mode. "
+                                    + "FORWARD routes data events to downstream subtasks with the same indices as upstream. "
+                                    + "FORWARD is intended for Fluss-to-Fluss data synchronization. "
+                                    + "The upstream data distribution must match the Fluss table bucket distribution; otherwise, data correctness issues may occur.");
+
     public static final ConfigOption<String> BUCKET_KEY =
             ConfigOptions.key("bucket.key")
                     .stringType()
@@ -54,4 +65,10 @@ public class FlussDataSinkOptions {
                             "The number of buckets of each Fluss table."
                                     + "Tables are separated by ';'. "
                                     + "Format: database1.table1:4;database1.table2:8.");
+
+    /** The shuffle strategy for fluss sink. */
+    public enum SinkPartitioningStrategy {
+        DEFAULT,
+        FORWARD
+    }
 }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussDataSinkOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/main/java/org/apache/flink/cdc/connectors/fluss/sink/FlussDataSinkOptions.java
@@ -39,7 +39,7 @@ public class FlussDataSinkOptions {
                     .defaultValue(SinkPartitioningStrategy.DEFAULT)
                     .withDescription(
                             "Partitioning strategy for DataChangeEvent routing. "
-                                    + "DEFAULT hashes primary key tables by primary keys and routes log tables in round-robin mode. "
+                                    + "DEFAULT hashes primary key tables by primary keys and randomly distributes log table events across downstream subtasks for balanced load. "
                                     + "FORWARD routes data events to downstream subtasks with the same indices as upstream. "
                                     + "FORWARD is intended for Fluss-to-Fluss data synchronization. "
                                     + "The upstream data distribution must match the Fluss table bucket distribution; otherwise, data correctness issues may occur.");

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/test/java/org/apache/flink/cdc/connectors/fluss/factory/FlussDataSinkFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-fluss/src/test/java/org/apache/flink/cdc/connectors/fluss/factory/FlussDataSinkFactoryTest.java
@@ -21,9 +21,12 @@ import org.apache.flink.cdc.common.configuration.Configuration;
 import org.apache.flink.cdc.common.factories.DataSinkFactory;
 import org.apache.flink.cdc.common.factories.FactoryHelper;
 import org.apache.flink.cdc.common.sink.DataSink;
+import org.apache.flink.cdc.common.sink.ForwardHashFunctionProvider;
 import org.apache.flink.cdc.composer.utils.FactoryDiscoveryUtils;
 import org.apache.flink.cdc.connectors.fluss.sink.FlussDataSink;
 import org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions;
+import org.apache.flink.cdc.connectors.fluss.sink.FlussDataSinkOptions.SinkPartitioningStrategy;
+import org.apache.flink.cdc.connectors.fluss.sink.FlussHashFunctionProvider;
 import org.apache.flink.table.api.ValidationException;
 
 import org.apache.flink.shaded.guava31.com.google.common.collect.ImmutableMap;
@@ -47,6 +50,24 @@ public class FlussDataSinkFactoryTest {
                         new FactoryHelper.DefaultContext(
                                 conf, conf, Thread.currentThread().getContextClassLoader()));
         Assertions.assertThat(dataSink).isInstanceOf(FlussDataSink.class);
+        Assertions.assertThat(dataSink.getDataChangeEventHashFunctionProvider())
+                .isInstanceOf(FlussHashFunctionProvider.class);
+    }
+
+    @Test
+    void testCreateDataSinkWithForwardPartitioningStrategy() {
+        DataSinkFactory sinkFactory =
+                FactoryDiscoveryUtils.getFactoryByIdentifier("fluss", DataSinkFactory.class);
+        Configuration conf = createValidConfiguration();
+        conf.set(FlussDataSinkOptions.SINK_PARTITIONING_STRATEGY, SinkPartitioningStrategy.FORWARD);
+
+        DataSink dataSink =
+                sinkFactory.createDataSink(
+                        new FactoryHelper.DefaultContext(
+                                conf, conf, Thread.currentThread().getContextClassLoader()));
+
+        Assertions.assertThat(dataSink.getDataChangeEventHashFunctionProvider())
+                .isInstanceOf(ForwardHashFunctionProvider.class);
     }
 
     @Test

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/BatchRegularPrePartitionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/BatchRegularPrePartitionOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.cdc.common.event.DataChangeEvent;
 import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.function.HashFunction.HashContext;
 import org.apache.flink.cdc.common.function.HashFunctionProvider;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.runtime.operators.AbstractStreamOperatorAdapter;
@@ -56,7 +57,7 @@ public class BatchRegularPrePartitionOperator
 
     private transient Map<TableId, HashFunction<DataChangeEvent>> cachedHashFunctions;
     private transient volatile Map<TableId, Schema> originalSchemaMap;
-    private transient int subTaskId;
+    private transient HashContext hashContext;
 
     public BatchRegularPrePartitionOperator(
             int downstreamParallelism, HashFunctionProvider<DataChangeEvent> hashFunctionProvider) {
@@ -70,7 +71,10 @@ public class BatchRegularPrePartitionOperator
         super.open();
         cachedHashFunctions = new HashMap<>();
         originalSchemaMap = new HashMap<>();
-        subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+        hashContext =
+                HashFunction.createContext(
+                        getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
+                        downstreamParallelism);
     }
 
     @Override
@@ -97,7 +101,7 @@ public class BatchRegularPrePartitionOperator
                                 dataChangeEvent,
                                 cachedHashFunctions
                                                 .get(dataChangeEvent.tableId())
-                                                .hashcode(subTaskId, dataChangeEvent)
+                                                .hashcode(hashContext, dataChangeEvent)
                                         % downstreamParallelism)));
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/BatchRegularPrePartitionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/BatchRegularPrePartitionOperator.java
@@ -56,6 +56,7 @@ public class BatchRegularPrePartitionOperator
 
     private transient Map<TableId, HashFunction<DataChangeEvent>> cachedHashFunctions;
     private transient volatile Map<TableId, Schema> originalSchemaMap;
+    private transient int subTaskId;
 
     public BatchRegularPrePartitionOperator(
             int downstreamParallelism, HashFunctionProvider<DataChangeEvent> hashFunctionProvider) {
@@ -69,6 +70,7 @@ public class BatchRegularPrePartitionOperator
         super.open();
         cachedHashFunctions = new HashMap<>();
         originalSchemaMap = new HashMap<>();
+        subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
     }
 
     @Override
@@ -95,7 +97,7 @@ public class BatchRegularPrePartitionOperator
                                 dataChangeEvent,
                                 cachedHashFunctions
                                                 .get(dataChangeEvent.tableId())
-                                                .hashcode(dataChangeEvent)
+                                                .hashcode(subTaskId, dataChangeEvent)
                                         % downstreamParallelism)));
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/DistributedPrePartitionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/DistributedPrePartitionOperator.java
@@ -105,7 +105,7 @@ public class DistributedPrePartitionOperator
                                 subTaskId,
                                 hashFunctionMap
                                                 .get(dataChangeEvent.tableId())
-                                                .hashcode(dataChangeEvent)
+                                                .hashcode(subTaskId, dataChangeEvent)
                                         % downstreamParallelism)));
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/DistributedPrePartitionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/DistributedPrePartitionOperator.java
@@ -23,6 +23,7 @@ import org.apache.flink.cdc.common.event.Event;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.function.HashFunction.HashContext;
 import org.apache.flink.cdc.common.function.HashFunctionProvider;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.utils.SchemaUtils;
@@ -53,7 +54,7 @@ public class DistributedPrePartitionOperator
     private transient Map<TableId, Schema> schemaMap;
     private transient Map<TableId, HashFunction<DataChangeEvent>> hashFunctionMap;
 
-    private transient int subTaskId;
+    private transient HashContext hashContext;
 
     public DistributedPrePartitionOperator(
             int downstreamParallelism, HashFunctionProvider<DataChangeEvent> hashFunctionProvider) {
@@ -65,7 +66,10 @@ public class DistributedPrePartitionOperator
     @Override
     public void open() throws Exception {
         super.open();
-        subTaskId = RuntimeContextAdapter.getIndexOfThisSubtask(getRuntimeContext());
+        hashContext =
+                HashFunction.createContext(
+                        RuntimeContextAdapter.getIndexOfThisSubtask(getRuntimeContext()),
+                        downstreamParallelism);
         schemaMap = new HashMap<>();
         hashFunctionMap = new HashMap<>();
     }
@@ -93,7 +97,9 @@ public class DistributedPrePartitionOperator
             partitionBy((DataChangeEvent) event);
         } else {
             throw new IllegalStateException(
-                    subTaskId + "> PrePartition operator received an unexpected event: " + event);
+                    hashContext.getSourceSubtaskIndex()
+                            + "> PrePartition operator received an unexpected event: "
+                            + event);
         }
     }
 
@@ -102,10 +108,10 @@ public class DistributedPrePartitionOperator
                 new StreamRecord<>(
                         PartitioningEvent.ofDistributed(
                                 dataChangeEvent,
-                                subTaskId,
+                                hashContext.getSourceSubtaskIndex(),
                                 hashFunctionMap
                                                 .get(dataChangeEvent.tableId())
-                                                .hashcode(subTaskId, dataChangeEvent)
+                                                .hashcode(hashContext, dataChangeEvent)
                                         % downstreamParallelism)));
     }
 
@@ -115,7 +121,9 @@ public class DistributedPrePartitionOperator
             // JVM
             Event copiedEvent = EventSerializer.INSTANCE.copy(toBroadcast);
             output.collect(
-                    new StreamRecord<>(PartitioningEvent.ofDistributed(copiedEvent, subTaskId, i)));
+                    new StreamRecord<>(
+                            PartitioningEvent.ofDistributed(
+                                    copiedEvent, hashContext.getSourceSubtaskIndex(), i)));
         }
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/RegularPrePartitionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/RegularPrePartitionOperator.java
@@ -24,6 +24,7 @@ import org.apache.flink.cdc.common.event.FlushEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.function.HashFunction;
+import org.apache.flink.cdc.common.function.HashFunction.HashContext;
 import org.apache.flink.cdc.common.function.HashFunctionProvider;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.runtime.operators.AbstractStreamOperatorAdapter;
@@ -62,7 +63,7 @@ public class RegularPrePartitionOperator extends AbstractStreamOperatorAdapter<P
 
     private transient SchemaEvolutionClient schemaEvolutionClient;
     private transient LoadingCache<TableId, HashFunction<DataChangeEvent>> cachedHashFunctions;
-    private transient int subTaskId;
+    private transient HashContext hashContext;
 
     public RegularPrePartitionOperator(
             OperatorID schemaOperatorId,
@@ -81,7 +82,10 @@ public class RegularPrePartitionOperator extends AbstractStreamOperatorAdapter<P
                 getContainingTask().getEnvironment().getOperatorCoordinatorEventGateway();
         schemaEvolutionClient = new SchemaEvolutionClient(toCoordinator, schemaOperatorId);
         cachedHashFunctions = createCache();
-        subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
+        hashContext =
+                HashFunction.createContext(
+                        getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
+                        downstreamParallelism);
     }
 
     @Override
@@ -109,7 +113,7 @@ public class RegularPrePartitionOperator extends AbstractStreamOperatorAdapter<P
                                 dataChangeEvent,
                                 cachedHashFunctions
                                                 .get(dataChangeEvent.tableId())
-                                                .hashcode(subTaskId, dataChangeEvent)
+                                                .hashcode(hashContext, dataChangeEvent)
                                         % downstreamParallelism)));
     }
 

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/RegularPrePartitionOperator.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/partitioning/RegularPrePartitionOperator.java
@@ -62,6 +62,7 @@ public class RegularPrePartitionOperator extends AbstractStreamOperatorAdapter<P
 
     private transient SchemaEvolutionClient schemaEvolutionClient;
     private transient LoadingCache<TableId, HashFunction<DataChangeEvent>> cachedHashFunctions;
+    private transient int subTaskId;
 
     public RegularPrePartitionOperator(
             OperatorID schemaOperatorId,
@@ -80,6 +81,7 @@ public class RegularPrePartitionOperator extends AbstractStreamOperatorAdapter<P
                 getContainingTask().getEnvironment().getOperatorCoordinatorEventGateway();
         schemaEvolutionClient = new SchemaEvolutionClient(toCoordinator, schemaOperatorId);
         cachedHashFunctions = createCache();
+        subTaskId = getRuntimeContext().getTaskInfo().getIndexOfThisSubtask();
     }
 
     @Override
@@ -107,7 +109,7 @@ public class RegularPrePartitionOperator extends AbstractStreamOperatorAdapter<P
                                 dataChangeEvent,
                                 cachedHashFunctions
                                                 .get(dataChangeEvent.tableId())
-                                                .hashcode(dataChangeEvent)
+                                                .hashcode(subTaskId, dataChangeEvent)
                                         % downstreamParallelism)));
     }
 

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/partitioning/PrePartitionOperatorTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/partitioning/PrePartitionOperatorTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.cdc.common.event.SchemaChangeEventType;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.schema.Schema;
 import org.apache.flink.cdc.common.sink.DefaultDataChangeEventHashFunctionProvider;
+import org.apache.flink.cdc.common.sink.ForwardHashFunctionProvider;
 import org.apache.flink.cdc.common.sink.TableIdHashFunctionProvider;
 import org.apache.flink.cdc.common.types.DataTypes;
 import org.apache.flink.cdc.common.types.RowType;
@@ -39,7 +40,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Unit test for {@link RegularPrePartitionOperator}. */
+/** Unit tests for pre-partition operators. */
 class PrePartitionOperatorTest {
     private static final TableId CUSTOMERS =
             TableId.tableId("my_company", "my_branch", "customers");
@@ -140,6 +141,31 @@ class PrePartitionOperatorTest {
         }
     }
 
+    @Test
+    void testForwardingDataChangeEvent() throws Exception {
+        try (RegularEventOperatorTestHarness<RegularPrePartitionOperator, PartitioningEvent>
+                testHarness = createDataForwardTestHarness()) {
+            testHarness.open();
+            testHarness.registerTableSchema(CUSTOMERS, CUSTOMERS_SCHEMA);
+
+            DataChangeEvent dataChangeEvent = createDataChangeEvent();
+            testHarness.getOperator().processElement(new StreamRecord<>(dataChangeEvent));
+
+            assertThat(testHarness.getOutputRecords())
+                    .containsExactly(
+                            new StreamRecord<>(PartitioningEvent.ofRegular(dataChangeEvent, 0)));
+        }
+    }
+
+    private DataChangeEvent createDataChangeEvent() {
+        BinaryRecordDataGenerator recordDataGenerator =
+                new BinaryRecordDataGenerator(((RowType) CUSTOMERS_SCHEMA.toRowDataType()));
+        return DataChangeEvent.insertEvent(
+                CUSTOMERS,
+                recordDataGenerator.generate(
+                        new Object[] {1, new BinaryStringData("Alice"), 12345678L}));
+    }
+
     private int getPartitioningTarget(Schema schema, DataChangeEvent dataChangeEvent) {
         return new DefaultDataChangeEventHashFunctionProvider()
                         .getHashFunction(null, schema)
@@ -226,6 +252,16 @@ class PrePartitionOperatorTest {
                         TestingSchemaRegistryGateway.SCHEMA_OPERATOR_ID,
                         DOWNSTREAM_PARALLELISM,
                         new DefaultDataChangeEventHashFunctionProvider());
+        return RegularEventOperatorTestHarness.with(operator, DOWNSTREAM_PARALLELISM);
+    }
+
+    private RegularEventOperatorTestHarness<RegularPrePartitionOperator, PartitioningEvent>
+            createDataForwardTestHarness() {
+        RegularPrePartitionOperator operator =
+                new RegularPrePartitionOperator(
+                        TestingSchemaRegistryGateway.SCHEMA_OPERATOR_ID,
+                        DOWNSTREAM_PARALLELISM,
+                        new ForwardHashFunctionProvider());
         return RegularEventOperatorTestHarness.with(operator, DOWNSTREAM_PARALLELISM);
     }
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

## What is the purpose of this pull request?
https://issues.apache.org/jira/browse/FLINK-40331

## Brief change log

Add sink.partitioning.strategy in fluss sink to support FORWARD.

---

## Verifying this change

<!-- Describe how this change can be verified. -->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change added tests and can be verified as follows:

- *Added/Updated unit tests in `...*`*
- *Added/Updated integration tests in `...*`*
- *Manually tested by ...*

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
