### PR TITLE
[FLINK-40337][runtime] Preserve operator precedence in generated Janino expressions

### DIFF
--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -94,6 +94,16 @@ public class JaninoCompiler {
         "Arithmetic", "Casting", "Comparison", "Logical", "String", "Struct", "Temporal"
     };
 
+    private static final Map<String, Integer> BINARY_OPERATOR_PRECEDENCE =
+            Map.of(
+                    "||", 1,
+                    "&&", 2,
+                    "+", 3,
+                    "-", 3,
+                    "*", 4,
+                    "/", 4,
+                    "%", 4);
+
     @VisibleForTesting
     public static final String LOAD_MODULES_EXPRESSION =
             Arrays.stream(BUILTIN_FUNCTION_MODULES)
@@ -484,7 +494,34 @@ public class JaninoCompiler {
                 return new Java.MethodInvocation(Location.NOWHERE, null, handler, atoms);
             }
         }
-        return new Java.BinaryOperation(Location.NOWHERE, atoms[0], operator, atoms[1]);
+        return new Java.BinaryOperation(
+                Location.NOWHERE,
+                parenthesizeIfNeeded(atoms[0], operator, false),
+                operator,
+                parenthesizeIfNeeded(atoms[1], operator, true));
+    }
+
+    private static Java.Rvalue parenthesizeIfNeeded(
+            Java.Rvalue expression, String parentOperator, boolean isRightOperand) {
+        if (!(expression instanceof Java.BinaryOperation)) {
+            return expression;
+        }
+
+        Java.BinaryOperation binaryExpression = (Java.BinaryOperation) expression;
+        int parentPrecedence = getBinaryOperatorPrecedence(parentOperator);
+        int childPrecedence = getBinaryOperatorPrecedence(binaryExpression.operator);
+        // Binary operators are left-associative, so a same-precedence right operand must retain
+        // its grouping.
+        if (childPrecedence < parentPrecedence
+                || (isRightOperand && childPrecedence == parentPrecedence)) {
+            return new Java.ParenthesizedExpression(Location.NOWHERE, expression);
+        }
+        return expression;
+    }
+
+    private static int getBinaryOperatorPrecedence(String operator) {
+        return Preconditions.checkNotNull(
+                BINARY_OPERATOR_PRECEDENCE.get(operator), "Unknown binary operator: %s", operator);
     }
 
     private static Java.Rvalue generateEqualsOperation(

--- a/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
+++ b/flink-cdc-runtime/src/main/java/org/apache/flink/cdc/runtime/parser/JaninoCompiler.java
@@ -46,7 +46,9 @@ import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.commons.compiler.Location;
 import org.codehaus.janino.ExpressionEvaluator;
 import org.codehaus.janino.Java;
+import org.codehaus.janino.Unparser;
 
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -94,16 +96,6 @@ public class JaninoCompiler {
         "Arithmetic", "Casting", "Comparison", "Logical", "String", "Struct", "Temporal"
     };
 
-    private static final Map<String, Integer> BINARY_OPERATOR_PRECEDENCE =
-            Map.of(
-                    "||", 1,
-                    "&&", 2,
-                    "+", 3,
-                    "-", 3,
-                    "*", 4,
-                    "/", 4,
-                    "%", 4);
-
     @VisibleForTesting
     public static final String LOAD_MODULES_EXPRESSION =
             Arrays.stream(BUILTIN_FUNCTION_MODULES)
@@ -141,7 +133,11 @@ public class JaninoCompiler {
     public static String translateSqlNodeToJaninoExpression(Context context, SqlNode transform) {
         Java.Rvalue rvalue = translateSqlNodeToJaninoRvalue(context, transform);
         if (rvalue != null) {
-            return rvalue.toString();
+            StringWriter writer = new StringWriter();
+            Unparser unparser = new Unparser(writer);
+            unparser.unparseAtom(rvalue);
+            unparser.close();
+            return writer.toString();
         }
         return "";
     }
@@ -494,34 +490,7 @@ public class JaninoCompiler {
                 return new Java.MethodInvocation(Location.NOWHERE, null, handler, atoms);
             }
         }
-        return new Java.BinaryOperation(
-                Location.NOWHERE,
-                parenthesizeIfNeeded(atoms[0], operator, false),
-                operator,
-                parenthesizeIfNeeded(atoms[1], operator, true));
-    }
-
-    private static Java.Rvalue parenthesizeIfNeeded(
-            Java.Rvalue expression, String parentOperator, boolean isRightOperand) {
-        if (!(expression instanceof Java.BinaryOperation)) {
-            return expression;
-        }
-
-        Java.BinaryOperation binaryExpression = (Java.BinaryOperation) expression;
-        int parentPrecedence = getBinaryOperatorPrecedence(parentOperator);
-        int childPrecedence = getBinaryOperatorPrecedence(binaryExpression.operator);
-        // Binary operators are left-associative, so a same-precedence right operand must retain
-        // its grouping.
-        if (childPrecedence < parentPrecedence
-                || (isRightOperand && childPrecedence == parentPrecedence)) {
-            return new Java.ParenthesizedExpression(Location.NOWHERE, expression);
-        }
-        return expression;
-    }
-
-    private static int getBinaryOperatorPrecedence(String operator) {
-        return Preconditions.checkNotNull(
-                BINARY_OPERATOR_PRECEDENCE.get(operator), "Unknown binary operator: %s", operator);
+        return new Java.BinaryOperation(Location.NOWHERE, atoms[0], operator, atoms[1]);
     }
 
     private static Java.Rvalue generateEqualsOperation(

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/JaninoCompilerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/JaninoCompilerTest.java
@@ -288,7 +288,7 @@ class JaninoCompilerTest {
     }
 
     @Test
-    void testTranslatedNestedBinaryExpressionPreservesSemantics() throws InvocationTargetException {
+    void testTranslatedNestedExpressionPreservesSemantics() throws InvocationTargetException {
         List<Column> arithmeticColumns =
                 List.of(
                         Column.physicalColumn("a", DataTypes.INT()),
@@ -326,6 +326,26 @@ class JaninoCompilerTest {
                         columnNames,
                         columnTypes);
         Assertions.assertThat(subtractiveRightOperandEvaluator.evaluate(new Object[] {10, 6, 2}))
+                .isEqualTo(true);
+
+        ExpressionEvaluator conditionalLeftOperandEvaluator =
+                compileTranslatedFilterExpression(
+                        "IF(a > b, a, b) + c = 13",
+                        arithmeticColumns,
+                        columnNameMap,
+                        columnNames,
+                        columnTypes);
+        Assertions.assertThat(conditionalLeftOperandEvaluator.evaluate(new Object[] {10, 2, 3}))
+                .isEqualTo(true);
+
+        ExpressionEvaluator conditionalRightOperandEvaluator =
+                compileTranslatedFilterExpression(
+                        "c * IF(a > b, a, b) = 30",
+                        arithmeticColumns,
+                        columnNameMap,
+                        columnNames,
+                        columnTypes);
+        Assertions.assertThat(conditionalRightOperandEvaluator.evaluate(new Object[] {10, 2, 3}))
                 .isEqualTo(true);
 
         List<Column> booleanColumns =

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/JaninoCompilerTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/JaninoCompilerTest.java
@@ -288,6 +288,63 @@ class JaninoCompilerTest {
     }
 
     @Test
+    void testTranslatedNestedBinaryExpressionPreservesSemantics() throws InvocationTargetException {
+        List<Column> arithmeticColumns =
+                List.of(
+                        Column.physicalColumn("a", DataTypes.INT()),
+                        Column.physicalColumn("b", DataTypes.INT()),
+                        Column.physicalColumn("c", DataTypes.INT()));
+        Map<String, String> columnNameMap = Map.of("a", "$0", "b", "$1", "c", "$2");
+        List<String> columnNames = List.of("$0", "$1", "$2");
+        List<Class<?>> columnTypes = List.of(Integer.class, Integer.class, Integer.class);
+
+        ExpressionEvaluator additiveOperandEvaluator =
+                compileTranslatedFilterExpression(
+                        "(a + b) * c = 9",
+                        arithmeticColumns,
+                        columnNameMap,
+                        columnNames,
+                        columnTypes);
+        Assertions.assertThat(additiveOperandEvaluator.evaluate(new Object[] {1, 2, 3}))
+                .isEqualTo(true);
+
+        ExpressionEvaluator multiplicativeRightOperandEvaluator =
+                compileTranslatedFilterExpression(
+                        "a / (b * c) = 2",
+                        arithmeticColumns,
+                        columnNameMap,
+                        columnNames,
+                        columnTypes);
+        Assertions.assertThat(multiplicativeRightOperandEvaluator.evaluate(new Object[] {12, 2, 3}))
+                .isEqualTo(true);
+
+        ExpressionEvaluator subtractiveRightOperandEvaluator =
+                compileTranslatedFilterExpression(
+                        "a - (b - c) = 6",
+                        arithmeticColumns,
+                        columnNameMap,
+                        columnNames,
+                        columnTypes);
+        Assertions.assertThat(subtractiveRightOperandEvaluator.evaluate(new Object[] {10, 6, 2}))
+                .isEqualTo(true);
+
+        List<Column> booleanColumns =
+                List.of(
+                        Column.physicalColumn("a", DataTypes.BOOLEAN().notNull()),
+                        Column.physicalColumn("b", DataTypes.BOOLEAN().notNull()),
+                        Column.physicalColumn("c", DataTypes.BOOLEAN().notNull()));
+        ExpressionEvaluator logicalOperandEvaluator =
+                compileTranslatedFilterExpression(
+                        "(a OR b) AND c",
+                        booleanColumns,
+                        columnNameMap,
+                        columnNames,
+                        List.of(Boolean.class, Boolean.class, Boolean.class));
+        Assertions.assertThat(logicalOperandEvaluator.evaluate(new Object[] {true, false, false}))
+                .isEqualTo(false);
+    }
+
+    @Test
     void testLargeNumericLiterals() {
         // Test parsing integer literals
         Stream.of(

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -452,25 +452,33 @@ class TransformParserTest {
     }
 
     @Test
-    void testTranslateNestedBinaryExpressionPreservesOperatorPrecedence() {
+    void testTranslateNestedExpressionPreservesOperatorPrecedence() {
         List<Column> arithmeticColumns =
                 List.of(
                         Column.physicalColumn("a", DataTypes.INT()),
                         Column.physicalColumn("b", DataTypes.INT()),
                         Column.physicalColumn("c", DataTypes.INT()));
 
-        testFilterExpressionWithColumns("(a + b) * c", "(a + b) * c", arithmeticColumns);
-        testFilterExpressionWithColumns("a / (b * c)", "a / (b * c)", arithmeticColumns);
-        testFilterExpressionWithColumns("a - (b - c)", "a - (b - c)", arithmeticColumns);
+        testFilterExpressionWithColumns("(a + b) * c", "((( a + b ))) * c", arithmeticColumns);
+        testFilterExpressionWithColumns("a / (b * c)", "a / ((( b * c )))", arithmeticColumns);
+        testFilterExpressionWithColumns("a - (b - c)", "a - ((( b - c )))", arithmeticColumns);
         testFilterExpressionWithColumns("a + b * c", "a + b * c", arithmeticColumns);
         testFilterExpressionWithColumns("(a - b) - c", "a - b - c", arithmeticColumns);
+        testFilterExpressionWithColumns(
+                "IF(a > b, a, b) + c",
+                "((( isTrue(greaterThan(a, b)) ? a : b ))) + c",
+                arithmeticColumns);
+        testFilterExpressionWithColumns(
+                "c * IF(a > b, a, b)",
+                "c * ((( isTrue(greaterThan(a, b)) ? a : b )))",
+                arithmeticColumns);
 
         List<Column> booleanColumns =
                 List.of(
                         Column.physicalColumn("a", DataTypes.BOOLEAN().notNull()),
                         Column.physicalColumn("b", DataTypes.BOOLEAN().notNull()),
                         Column.physicalColumn("c", DataTypes.BOOLEAN().notNull()));
-        testFilterExpressionWithColumns("(a OR b) AND c", "(a || b) && c", booleanColumns);
+        testFilterExpressionWithColumns("(a OR b) AND c", "((( a || b ))) && c", booleanColumns);
     }
 
     @Test
@@ -610,7 +618,7 @@ class TransformParserTest {
                         "ProjectionColumn{column=`newCreateTime` TIMESTAMP(3) 'newCreateTime', expression='createTime', scriptExpression='$0', originalColumnNames=[createTime], columnNameMap={createTime=$0}}",
                         "ProjectionColumn{column=`newAddress` VARCHAR(50) 'newAddress', expression='address', scriptExpression='$0', originalColumnNames=[address], columnNameMap={address=$0}}",
                         "ProjectionColumn{column=`deposits` DECIMAL(10, 2) 'deposit', expression='deposit', scriptExpression='$0', originalColumnNames=[deposit], columnNameMap={deposit=$0}}",
-                        "ProjectionColumn{column=`bmi` DOUBLE, expression='`TB`.`weight` / (`TB`.`height` * `TB`.`height`)', scriptExpression='$0 / ($1 * $1)', originalColumnNames=[weight, height, height], columnNameMap={weight=$0, height=$1}}");
+                        "ProjectionColumn{column=`bmi` DOUBLE, expression='`TB`.`weight` / (`TB`.`height` * `TB`.`height`)', scriptExpression='$0 / ((( $1 * $1 )))', originalColumnNames=[weight, height, height], columnNameMap={weight=$0, height=$1}}");
         Assertions.assertThat(result).hasToString("[" + String.join(", ", expected) + "]");
 
         List<ProjectionColumn> regexpResult =

--- a/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
+++ b/flink-cdc-runtime/src/test/java/org/apache/flink/cdc/runtime/parser/TransformParserTest.java
@@ -452,6 +452,28 @@ class TransformParserTest {
     }
 
     @Test
+    void testTranslateNestedBinaryExpressionPreservesOperatorPrecedence() {
+        List<Column> arithmeticColumns =
+                List.of(
+                        Column.physicalColumn("a", DataTypes.INT()),
+                        Column.physicalColumn("b", DataTypes.INT()),
+                        Column.physicalColumn("c", DataTypes.INT()));
+
+        testFilterExpressionWithColumns("(a + b) * c", "(a + b) * c", arithmeticColumns);
+        testFilterExpressionWithColumns("a / (b * c)", "a / (b * c)", arithmeticColumns);
+        testFilterExpressionWithColumns("a - (b - c)", "a - (b - c)", arithmeticColumns);
+        testFilterExpressionWithColumns("a + b * c", "a + b * c", arithmeticColumns);
+        testFilterExpressionWithColumns("(a - b) - c", "a - b - c", arithmeticColumns);
+
+        List<Column> booleanColumns =
+                List.of(
+                        Column.physicalColumn("a", DataTypes.BOOLEAN().notNull()),
+                        Column.physicalColumn("b", DataTypes.BOOLEAN().notNull()),
+                        Column.physicalColumn("c", DataTypes.BOOLEAN().notNull()));
+        testFilterExpressionWithColumns("(a OR b) AND c", "(a || b) && c", booleanColumns);
+    }
+
+    @Test
     public void testTranslateItemAccessToJaninoExpression() {
         // Test collection access functions (ARRAY, MAP) with proper column schema
         List<Column> columns =
@@ -588,7 +610,7 @@ class TransformParserTest {
                         "ProjectionColumn{column=`newCreateTime` TIMESTAMP(3) 'newCreateTime', expression='createTime', scriptExpression='$0', originalColumnNames=[createTime], columnNameMap={createTime=$0}}",
                         "ProjectionColumn{column=`newAddress` VARCHAR(50) 'newAddress', expression='address', scriptExpression='$0', originalColumnNames=[address], columnNameMap={address=$0}}",
                         "ProjectionColumn{column=`deposits` DECIMAL(10, 2) 'deposit', expression='deposit', scriptExpression='$0', originalColumnNames=[deposit], columnNameMap={deposit=$0}}",
-                        "ProjectionColumn{column=`bmi` DOUBLE, expression='`TB`.`weight` / (`TB`.`height` * `TB`.`height`)', scriptExpression='$0 / $1 * $1', originalColumnNames=[weight, height, height], columnNameMap={weight=$0, height=$1}}");
+                        "ProjectionColumn{column=`bmi` DOUBLE, expression='`TB`.`weight` / (`TB`.`height` * `TB`.`height`)', scriptExpression='$0 / ($1 * $1)', originalColumnNames=[weight, height, height], columnNameMap={weight=$0, height=$1}}");
         Assertions.assertThat(result).hasToString("[" + String.join(", ", expected) + "]");
 
         List<ProjectionColumn> regexpResult =


### PR DESCRIPTION
#### Summary

This change preserves operator precedence when generating Janino expressions for Flink CDC pipeline transforms. It uses Janino's AST-aware unparser to retain the grouping and semantics of nested expressions.

#### Key Changes

1. Janino Expression Serialization
- Replaced `Java.Rvalue.toString()` with Janino's `Unparser`.
- Delegates precedence and parenthesis handling to Janino instead of maintaining operator rules manually.
- Supports binary and conditional expressions consistently.

2. Correct Nested Expression Generation
- Preserves expressions such as `(a + b) * c`, `(a OR b) AND c`, and `a / (b * c)`.
- Correctly handles conditional expressions used as arithmetic operands, such as `IF(a > b, a, b) + c`.
- Fixes transform expressions such as `weight / (height * height)` that previously changed semantics during code generation.

3. Test Coverage
- Added coverage for nested arithmetic, logical, and conditional expression generation.
- Added runtime evaluation tests to verify the semantics of generated Janino expressions.
- Verified expressions whose existing precedence already preserves their evaluation order.

#### JIRA Reference

[https://issues.apache.org/jira/browse/FLINK-40337](https://issues.apache.org/jira/browse/FLINK-40337)