### PR TITLE
[FLINK-40397][mysql] Add binlog position lag metrics for MySQL binlog reader

### DIFF
--- a/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content.zh/docs/connectors/flink-sources/mysql-cdc.md
@@ -432,6 +432,19 @@ Flink SQL> SELECT * FROM orders;
       </td>
     </tr>
     <tr>
+      <td>scan.binlog.position-lag.interval.ms</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">-1</td>
+      <td>Long</td>
+      <td>
+        获取 master binlog 状态以计算延迟指标的时间间隔（毫秒）。<br>
+        默认值 -1 表示关闭该功能。设置为正值（如 10000）时，连接器会按此间隔定期执行 SHOW MASTER STATUS 查询，并计算两个延迟指标：<br>
+        <li>currentBinlogTransactionLag：基于 GTID 的事务数延迟（非 GTID 模式下报告 -1）</li>
+        <li>currentBinlogBytePositionLag：基于 binlog 文件和位置的字节位置延迟</li>
+        注意：该指标仅在 binlog 增量读取阶段生效，snapshot 全量阶段不会产出此指标。开启此功能会对 MySQL 服务器产生额外的周期性查询。<br>
+      </td>
+    </tr>
+    <tr>
       <td>scan.incremental.snapshot.backfill.skip</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">false</td>

--- a/docs/content/docs/connectors/flink-sources/mysql-cdc.md
+++ b/docs/content/docs/connectors/flink-sources/mysql-cdc.md
@@ -457,6 +457,19 @@ Only valid for cdc 1.x version. During a snapshot operation, the connector will 
       </td>
     </tr>
     <tr>
+      <td>scan.binlog.position-lag.interval.ms</td>
+      <td>optional</td>
+      <td style="word-wrap: break-word;">-1</td>
+      <td>Long</td>
+      <td>
+        The interval in milliseconds to fetch master binlog status for lag metrics.<br>
+        A value of -1 (default) disables the feature. When set to a positive value (e.g. 10000), the connector periodically executes SHOW MASTER STATUS at this interval to calculate two lag metrics:<br>
+        <li>currentBinlogTransactionLag: GTID-based transaction count lag (reports -1 when GTID is unavailable)</li>
+        <li>currentBinlogBytePositionLag: byte position lag based on binlog file and position</li>
+        Note: this metric is only reported during the binlog (incremental) reading phase; it is not available during the snapshot (full) phase. Enabling this feature adds periodic queries to the MySQL server.<br>
+      </td>
+    </tr>
+    <tr>
       <td>scan.incremental.snapshot.backfill.skip</td>
       <td>optional</td>
       <td style="word-wrap: break-word;">false</td>

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSource.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlDataSource.java
@@ -80,12 +80,13 @@ public class MySqlDataSource implements DataSource {
                 new MySqlSource<>(
                         configFactory,
                         deserializer,
-                        (sourceReaderMetrics, sourceConfig) ->
+                        (sourceReaderMetrics, sourceConfig, latestMasterOffset) ->
                                 new MySqlPipelineRecordEmitter(
                                         deserializer,
                                         sourceReaderMetrics,
                                         sourceConfig,
-                                        isTableIdCaseInsensitive));
+                                        isTableIdCaseInsensitive,
+                                        latestMasterOffset));
 
         return FlinkSourceProvider.of(source);
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-mysql/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlPipelineRecordEmitter.java
@@ -26,6 +26,7 @@ import org.apache.flink.cdc.connectors.mysql.schema.MySqlFieldDefinition;
 import org.apache.flink.cdc.connectors.mysql.schema.MySqlTableDefinition;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import org.apache.flink.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitState;
@@ -59,6 +60,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils.openJdbcConnection;
@@ -92,13 +94,16 @@ public class MySqlPipelineRecordEmitter extends MySqlRecordEmitter<Event> {
             DebeziumDeserializationSchema<Event> debeziumDeserializationSchema,
             MySqlSourceReaderMetrics sourceReaderMetrics,
             MySqlSourceConfig sourceConfig,
-            boolean isTableIdCaseInsensitive) {
+            boolean isTableIdCaseInsensitive,
+            AtomicReference<BinlogOffset> latestMasterOffset) {
         super(
                 debeziumDeserializationSchema,
                 sourceReaderMetrics,
                 sourceConfig.isIncludeSchemaChanges(),
                 false, // Explicitly disable heartbeat events
-                false); // Explicitly disable transaction metadata events
+                false, // Explicitly disable transaction metadata events
+                latestMasterOffset,
+                sourceConfig.getBinlogPositionLagIntervalMs());
         this.debeziumDeserializationSchema = debeziumDeserializationSchema;
         this.sourceConfig = sourceConfig;
         this.alreadySendCreateTableTables = new HashSet<>();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReader.java
@@ -62,10 +62,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
 import static org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils.createBinaryClient;
 import static org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils.createMySqlConnection;
+import static org.apache.flink.cdc.connectors.mysql.debezium.DebeziumUtils.currentBinlogOffset;
 import static org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils.isEndWatermarkEvent;
 
 /**
@@ -97,17 +99,28 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
 
     private static final long READER_CLOSE_TIMEOUT = 30L;
 
-    public BinlogSplitReader(MySqlSourceConfig sourceConfig, int subtaskId) {
+    private long lastFetchMasterStatusTime = 0;
+    private final AtomicReference<BinlogOffset> latestMasterOffset;
+
+    public BinlogSplitReader(
+            MySqlSourceConfig sourceConfig,
+            int subtaskId,
+            AtomicReference<BinlogOffset> latestMasterOffset) {
         this(
                 new StatefulTaskContext(
                         sourceConfig,
                         createBinaryClient(sourceConfig.getDbzConfiguration()),
                         createMySqlConnection(sourceConfig)),
-                subtaskId);
+                subtaskId,
+                latestMasterOffset);
     }
 
-    public BinlogSplitReader(StatefulTaskContext statefulTaskContext, int subtaskId) {
+    public BinlogSplitReader(
+            StatefulTaskContext statefulTaskContext,
+            int subtaskId,
+            AtomicReference<BinlogOffset> latestMasterOffset) {
         this.statefulTaskContext = statefulTaskContext;
+        this.latestMasterOffset = latestMasterOffset;
         ThreadFactory threadFactory =
                 new ThreadFactoryBuilder().setNameFormat("binlog-reader-" + subtaskId).build();
         this.executorService = Executors.newSingleThreadExecutor(threadFactory);
@@ -166,6 +179,7 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
     @Override
     public Iterator<SourceRecords> pollSplitRecords() throws InterruptedException {
         checkReadException();
+
         final List<SourceRecord> sourceRecords = new ArrayList<>();
         if (currentTaskRunning) {
             List<DataChangeEvent> batch = queue.poll();
@@ -219,6 +233,24 @@ public class BinlogSplitReader implements DebeziumReader<SourceRecords, MySqlSpl
                     sourceRecords.add(event.getRecord());
                 }
             }
+
+            // Fetch master offset AFTER polling records, so master reflects the latest
+            // state and is always >= the records we just polled.
+            if (statefulTaskContext.getSourceConfig().isBinlogPositionLagEnabled()) {
+                long now = System.currentTimeMillis();
+                long interval =
+                        statefulTaskContext.getSourceConfig().getBinlogPositionLagIntervalMs();
+                if (now - lastFetchMasterStatusTime > interval) {
+                    lastFetchMasterStatusTime = now;
+                    try {
+                        latestMasterOffset.set(
+                                currentBinlogOffset(statefulTaskContext.getConnection()));
+                    } catch (Exception e) {
+                        LOG.warn("Failed to fetch master binlog offset for lag metric", e);
+                    }
+                }
+            }
+
             List<SourceRecords> sourceRecordsSet = new ArrayList<>();
             sourceRecordsSet.add(new SourceRecords(sourceRecords));
             return sourceRecordsSet.iterator();

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSource.java
@@ -43,6 +43,7 @@ import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.flink.cdc.connectors.mysql.source.enumerator.MySqlSourceEnumerator;
 import org.apache.flink.cdc.connectors.mysql.source.metrics.MySqlSourceReaderMetrics;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlRecordEmitter;
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReader;
 import org.apache.flink.cdc.connectors.mysql.source.reader.MySqlSourceReaderContext;
@@ -61,6 +62,7 @@ import io.debezium.jdbc.JdbcConnection;
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -125,13 +127,15 @@ public class MySqlSource<T>
         this(
                 configFactory,
                 deserializationSchema,
-                (sourceReaderMetrics, sourceConfig) ->
+                (sourceReaderMetrics, sourceConfig, latestMasterOffset) ->
                         new MySqlRecordEmitter<>(
                                 deserializationSchema,
                                 sourceReaderMetrics,
                                 sourceConfig.isIncludeSchemaChanges(),
                                 sourceConfig.isIncludeHeartbeatEvents(),
-                                sourceConfig.isIncludeTransactionMetadataEvents()));
+                                sourceConfig.isIncludeTransactionMetadataEvents(),
+                                latestMasterOffset,
+                                sourceConfig.getBinlogPositionLagIntervalMs()));
     }
 
     MySqlSource(
@@ -171,18 +175,24 @@ public class MySqlSource<T>
         final MySqlSourceReaderMetrics sourceReaderMetrics =
                 new MySqlSourceReaderMetrics(metricGroup);
         sourceReaderMetrics.registerMetrics();
+        if (sourceConfig.isBinlogPositionLagEnabled()) {
+            sourceReaderMetrics.registerBinlogLagMetrics();
+        }
         MySqlSourceReaderContext mySqlSourceReaderContext =
                 new MySqlSourceReaderContext(readerContext);
+        // Shared reference for binlog position lag between SplitReader and RecordEmitter
+        final AtomicReference<BinlogOffset> latestMasterOffset = new AtomicReference<>();
         Supplier<MySqlSplitReader> splitReaderSupplier =
                 () ->
                         new MySqlSplitReader(
                                 sourceConfig,
                                 readerContext.getIndexOfSubtask(),
                                 mySqlSourceReaderContext,
-                                snapshotHooks);
+                                snapshotHooks,
+                                latestMasterOffset);
         return new MySqlSourceReader<>(
                 splitReaderSupplier,
-                recordEmitterSupplier.get(sourceReaderMetrics, sourceConfig),
+                recordEmitterSupplier.get(sourceReaderMetrics, sourceConfig, latestMasterOffset),
                 readerContext.getConfiguration(),
                 mySqlSourceReaderContext,
                 sourceConfig);
@@ -292,6 +302,9 @@ public class MySqlSource<T>
     @FunctionalInterface
     interface RecordEmitterSupplier<T> extends Serializable {
 
-        MySqlRecordEmitter<T> get(MySqlSourceReaderMetrics metrics, MySqlSourceConfig sourceConfig);
+        MySqlRecordEmitter<T> get(
+                MySqlSourceReaderMetrics metrics,
+                MySqlSourceConfig sourceConfig,
+                AtomicReference<BinlogOffset> latestMasterOffset);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceBuilder.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/MySqlSourceBuilder.java
@@ -313,6 +313,15 @@ public class MySqlSourceBuilder<T> {
     }
 
     /**
+     * The interval in milliseconds to fetch master binlog status for lag metrics. A value of -1
+     * (default) disables the feature.
+     */
+    public MySqlSourceBuilder<T> binlogPositionLagIntervalMs(long intervalMs) {
+        this.configFactory.binlogPositionLagIntervalMs(intervalMs);
+        return this;
+    }
+
+    /**
      * Build the {@link MySqlSource}.
      *
      * @return a MySqlParallelSource with the settings made for this builder.

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfig.java
@@ -73,6 +73,7 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean parseOnLineSchemaChanges;
     public static boolean useLegacyJsonFormat = true;
     private final boolean assignUnboundedChunkFirst;
+    private final long binlogPositionLagIntervalMs;
 
     // --------------------------------------------------------------------------------------------
     // Debezium Configurations
@@ -113,7 +114,8 @@ public class MySqlSourceConfig implements Serializable {
             boolean parseOnLineSchemaChanges,
             boolean treatTinyInt1AsBoolean,
             boolean useLegacyJsonFormat,
-            boolean assignUnboundedChunkFirst) {
+            boolean assignUnboundedChunkFirst,
+            long binlogPositionLagIntervalMs) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
         this.username = checkNotNull(username);
@@ -161,6 +163,7 @@ public class MySqlSourceConfig implements Serializable {
         this.treatTinyInt1AsBoolean = treatTinyInt1AsBoolean;
         this.useLegacyJsonFormat = useLegacyJsonFormat;
         this.assignUnboundedChunkFirst = assignUnboundedChunkFirst;
+        this.binlogPositionLagIntervalMs = binlogPositionLagIntervalMs;
     }
 
     public String getHostname() {
@@ -301,5 +304,13 @@ public class MySqlSourceConfig implements Serializable {
 
     public boolean isTreatTinyInt1AsBoolean() {
         return treatTinyInt1AsBoolean;
+    }
+
+    public boolean isBinlogPositionLagEnabled() {
+        return binlogPositionLagIntervalMs > 0;
+    }
+
+    public long getBinlogPositionLagIntervalMs() {
+        return binlogPositionLagIntervalMs;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceConfigFactory.java
@@ -78,6 +78,8 @@ public class MySqlSourceConfigFactory implements Serializable {
     private boolean treatTinyInt1AsBoolean = true;
     private boolean useLegacyJsonFormat = true;
     private boolean assignUnboundedChunkFirst = false;
+    private long binlogPositionLagIntervalMs =
+            MySqlSourceOptions.BINLOG_POSITION_LAG_INTERVAL_MS.defaultValue();
 
     public MySqlSourceConfigFactory hostname(String hostname) {
         this.hostname = hostname;
@@ -341,6 +343,16 @@ public class MySqlSourceConfigFactory implements Serializable {
         return this;
     }
 
+    /**
+     * The interval in milliseconds to fetch master binlog status for lag metrics. A value of -1
+     * (default) disables the feature. When set to a positive value, the connector periodically
+     * executes SHOW MASTER STATUS at this interval.
+     */
+    public MySqlSourceConfigFactory binlogPositionLagIntervalMs(long intervalMs) {
+        this.binlogPositionLagIntervalMs = intervalMs;
+        return this;
+    }
+
     /** Creates a new {@link MySqlSourceConfig} for the given subtask {@code subtaskId}. */
     public MySqlSourceConfig createConfig(int subtaskId) {
         // hard code server name, because we don't need to distinguish it, docs:
@@ -444,6 +456,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 parseOnLineSchemaChanges,
                 treatTinyInt1AsBoolean,
                 useLegacyJsonFormat,
-                assignUnboundedChunkFirst);
+                assignUnboundedChunkFirst,
+                binlogPositionLagIntervalMs);
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/config/MySqlSourceOptions.java
@@ -292,4 +292,14 @@ public class MySqlSourceOptions {
                     .defaultValue(true)
                     .withDescription(
                             "Whether to assign the unbounded chunks first during snapshot reading phase. This might help reduce the risk of the TaskManager experiencing an out-of-memory (OOM) error when taking a snapshot of the largest unbounded chunk.");
+
+    public static final ConfigOption<Long> BINLOG_POSITION_LAG_INTERVAL_MS =
+            ConfigOptions.key("scan.binlog.position-lag.interval.ms")
+                    .longType()
+                    .defaultValue(-1L)
+                    .withDescription(
+                            "The interval in milliseconds to fetch master binlog status for lag metrics. "
+                                    + "A value of -1 (default) disables the feature. When set to a positive value, "
+                                    + "the connector periodically executes SHOW MASTER STATUS at this interval "
+                                    + "to calculate binlog transaction lag and byte position lag.");
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -25,6 +25,8 @@ import org.apache.flink.runtime.metrics.MetricNames;
 /** A collection class for handling metrics in {@link MySqlSourceReader}. */
 public class MySqlSourceReaderMetrics {
 
+    public static final String CURRENT_BINLOG_TRANSACTION_LAG = "currentBinlogTransactionLag";
+    public static final String CURRENT_BINLOG_BYTE_POSITION_LAG = "currentBinlogBytePositionLag";
     public static final long UNDEFINED = -1;
 
     private final MetricGroup metricGroup;
@@ -35,6 +37,19 @@ public class MySqlSourceReaderMetrics {
      */
     private volatile long fetchDelay = UNDEFINED;
 
+    /**
+     * The binlog transaction lag between current consumed offset and the latest master offset. This
+     * metric is meaningful only in GTID mode. Reports -1 when GTID is not available.
+     */
+    private volatile long binlogTransactionLag = UNDEFINED;
+
+    /**
+     * The binlog byte position lag between current consumed offset and the latest master offset.
+     * Reports exact byte difference for same-file comparison and an estimate for cross-file.
+     * Reports -1 when position information is not available.
+     */
+    private volatile long binlogBytePositionLag = UNDEFINED;
+
     public MySqlSourceReaderMetrics(MetricGroup metricGroup) {
         this.metricGroup = metricGroup;
     }
@@ -44,11 +59,34 @@ public class MySqlSourceReaderMetrics {
                 MetricNames.CURRENT_FETCH_EVENT_TIME_LAG, (Gauge<Long>) this::getFetchDelay);
     }
 
+    public void registerBinlogLagMetrics() {
+        metricGroup.gauge(
+                CURRENT_BINLOG_TRANSACTION_LAG, (Gauge<Long>) this::getBinlogTransactionLag);
+        metricGroup.gauge(
+                CURRENT_BINLOG_BYTE_POSITION_LAG, (Gauge<Long>) this::getBinlogBytePositionLag);
+    }
+
     public long getFetchDelay() {
         return fetchDelay;
     }
 
     public void recordFetchDelay(long fetchDelay) {
         this.fetchDelay = fetchDelay;
+    }
+
+    public long getBinlogTransactionLag() {
+        return binlogTransactionLag;
+    }
+
+    public void recordBinlogTransactionLag(long lag) {
+        this.binlogTransactionLag = lag;
+    }
+
+    public long getBinlogBytePositionLag() {
+        return binlogBytePositionLag;
+    }
+
+    public void recordBinlogBytePositionLag(long lag) {
+        this.binlogBytePositionLag = lag;
     }
 }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitter.java
@@ -23,6 +23,7 @@ import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSplitState;
 import org.apache.flink.cdc.connectors.mysql.source.split.SourceRecords;
+import org.apache.flink.cdc.connectors.mysql.source.utils.BinlogLagCalculator;
 import org.apache.flink.cdc.connectors.mysql.source.utils.RecordUtils;
 import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.cdc.debezium.history.FlinkJsonTableChangeSerializer;
@@ -37,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * The {@link RecordEmitter} implementation for {@link MySqlSourceReader}.
@@ -56,19 +58,28 @@ public class MySqlRecordEmitter<T> implements RecordEmitter<SourceRecords, T, My
     private final boolean includeHeartbeatEvents;
     private final boolean includeTransactionMetadataEvents;
     private final OutputCollector<T> outputCollector;
+    private final AtomicReference<BinlogOffset> latestMasterOffset;
+    private final BinlogLagCalculator lagCalculator = new BinlogLagCalculator();
+    private final long binlogPositionLagIntervalMs;
+
+    private long lastReportBinlogLagTime = 0;
 
     public MySqlRecordEmitter(
             DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
             MySqlSourceReaderMetrics sourceReaderMetrics,
             boolean includeSchemaChanges,
             boolean includeHeartbeatEvents,
-            boolean includeTransactionMetadataEvents) {
+            boolean includeTransactionMetadataEvents,
+            AtomicReference<BinlogOffset> latestMasterOffset,
+            long binlogPositionLagIntervalMs) {
         this.debeziumDeserializationSchema = debeziumDeserializationSchema;
         this.sourceReaderMetrics = sourceReaderMetrics;
         this.includeSchemaChanges = includeSchemaChanges;
         this.includeHeartbeatEvents = includeHeartbeatEvents;
         this.includeTransactionMetadataEvents = includeTransactionMetadataEvents;
         this.outputCollector = new OutputCollector<>();
+        this.latestMasterOffset = latestMasterOffset;
+        this.binlogPositionLagIntervalMs = binlogPositionLagIntervalMs;
     }
 
     @Override
@@ -105,9 +116,11 @@ public class MySqlRecordEmitter<T> implements RecordEmitter<SourceRecords, T, My
         } else if (RecordUtils.isDataChangeRecord(element)) {
             updateStartingOffsetForSplit(splitState, element);
             reportMetrics(element);
+            reportBinlogLag(splitState);
             emitElement(element, output);
         } else if (RecordUtils.isHeartbeatEvent(element)) {
             updateStartingOffsetForSplit(splitState, element);
+            reportBinlogLag(splitState);
             if (includeHeartbeatEvents) {
                 emitElement(element, output);
             }
@@ -149,6 +162,36 @@ public class MySqlRecordEmitter<T> implements RecordEmitter<SourceRecords, T, My
                 sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
             }
         }
+    }
+
+    private void reportBinlogLag(MySqlSplitState splitState) {
+        if (binlogPositionLagIntervalMs <= 0 || !splitState.isBinlogSplitState()) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (now - lastReportBinlogLagTime < binlogPositionLagIntervalMs) {
+            return;
+        }
+        BinlogOffset currentOffset = splitState.asBinlogSplitState().getStartingOffset();
+        BinlogOffset masterOffset = latestMasterOffset.get();
+        if (currentOffset == null || masterOffset == null) {
+            return;
+        }
+        lastReportBinlogLagTime = now;
+        BinlogLagCalculator.LagResult result =
+                lagCalculator.calculateLag(currentOffset, masterOffset);
+        if (result.getTransactionLag() >= 0) {
+            sourceReaderMetrics.recordBinlogTransactionLag(result.getTransactionLag());
+        }
+        if (result.getBytePositionLag() >= 0) {
+            sourceReaderMetrics.recordBinlogBytePositionLag(result.getBytePositionLag());
+        }
+        LOG.debug(
+                "Binlog lag - transaction: {}, bytePosition: {}, current: {}, master: {}",
+                result.getTransactionLag(),
+                result.getBytePositionLag(),
+                currentOffset,
+                masterOffset);
     }
 
     private static class OutputCollector<T> implements Collector<T> {

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSplitReader.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSplitReader.java
@@ -22,6 +22,7 @@ import org.apache.flink.cdc.connectors.mysql.debezium.reader.DebeziumReader;
 import org.apache.flink.cdc.connectors.mysql.debezium.reader.SnapshotSplitReader;
 import org.apache.flink.cdc.connectors.mysql.source.MySqlSource;
 import org.apache.flink.cdc.connectors.mysql.source.config.MySqlSourceConfig;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlBinlogSplit;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlRecords;
 import org.apache.flink.cdc.connectors.mysql.source.split.MySqlSnapshotSplit;
@@ -44,6 +45,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.apache.flink.cdc.connectors.mysql.source.assigners.MySqlBinlogSplitAssigner.BINLOG_SPLIT_ID;
 
@@ -59,6 +61,9 @@ public class MySqlSplitReader implements SplitReader<SourceRecords, MySqlSplit> 
 
     private final SnapshotPhaseHooks snapshotHooks;
 
+    /** Shared reference for the latest master binlog offset, written by BinlogSplitReader. */
+    private final AtomicReference<BinlogOffset> latestMasterOffset;
+
     @Nullable private String currentSplitId;
     @Nullable private DebeziumReader<SourceRecords, MySqlSplit> currentReader;
     @Nullable private SnapshotSplitReader reusedSnapshotReader;
@@ -68,13 +73,15 @@ public class MySqlSplitReader implements SplitReader<SourceRecords, MySqlSplit> 
             MySqlSourceConfig sourceConfig,
             int subtaskId,
             MySqlSourceReaderContext context,
-            SnapshotPhaseHooks snapshotHooks) {
+            SnapshotPhaseHooks snapshotHooks,
+            AtomicReference<BinlogOffset> latestMasterOffset) {
         this.sourceConfig = sourceConfig;
         this.subtaskId = subtaskId;
         this.snapshotSplits = new ArrayDeque<>();
         this.binlogSplits = new ArrayDeque<>(1);
         this.context = context;
         this.snapshotHooks = snapshotHooks;
+        this.latestMasterOffset = latestMasterOffset;
     }
 
     @Override
@@ -232,7 +239,7 @@ public class MySqlSplitReader implements SplitReader<SourceRecords, MySqlSplit> 
 
     private BinlogSplitReader getBinlogSplitReader() {
         if (reusedBinlogReader == null) {
-            reusedBinlogReader = new BinlogSplitReader(sourceConfig, subtaskId);
+            reusedBinlogReader = new BinlogSplitReader(sourceConfig, subtaskId, latestMasterOffset);
         }
         return reusedBinlogReader;
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/BinlogLagCalculator.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/source/utils/BinlogLagCalculator.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.utils;
+
+import org.apache.flink.cdc.common.annotation.Internal;
+import org.apache.flink.cdc.common.annotation.VisibleForTesting;
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
+
+import io.debezium.connector.mysql.GtidSet;
+
+/**
+ * Calculator for binlog lag between the current consumed offset and the latest master offset.
+ * Produces two independent lag values:
+ *
+ * <ul>
+ *   <li>Transaction lag: number of GTID transactions behind (GTID mode only)
+ *   <li>Byte position lag: byte offset difference (file-position mode)
+ * </ul>
+ */
+@Internal
+public class BinlogLagCalculator {
+
+    /** Cached parsed master GtidSet to avoid re-parsing on every calculation. */
+    private String cachedMasterGtidSetStr;
+
+    private GtidSet cachedMasterGtidSet;
+
+    /** Result of a lag calculation containing both transaction and byte position lags. */
+    public static class LagResult {
+        private final long transactionLag;
+        private final long bytePositionLag;
+
+        public LagResult(long transactionLag, long bytePositionLag) {
+            this.transactionLag = transactionLag;
+            this.bytePositionLag = bytePositionLag;
+        }
+
+        /** Transaction lag (GTID-based). Returns -1 when GTID info is unavailable. */
+        public long getTransactionLag() {
+            return transactionLag;
+        }
+
+        /**
+         * Byte position lag (file+position based). Returns -1 when position info is unavailable.
+         */
+        public long getBytePositionLag() {
+            return bytePositionLag;
+        }
+    }
+
+    /**
+     * Calculate binlog lag between current offset and master offset.
+     *
+     * @param current the current consumed binlog offset
+     * @param master the latest master binlog offset
+     * @return a LagResult with independent transaction and byte position lags
+     */
+    public LagResult calculateLag(BinlogOffset current, BinlogOffset master) {
+        long transactionLag = calculateTransactionLag(current, master);
+        long bytePositionLag = calculateBytePositionLag(current, master);
+        return new LagResult(transactionLag, bytePositionLag);
+    }
+
+    private long calculateTransactionLag(BinlogOffset current, BinlogOffset master) {
+        String masterGtidSetStr = master.getGtidSet();
+        String currentGtidSetStr = current.getGtidSet();
+        if (masterGtidSetStr == null
+                || masterGtidSetStr.isEmpty()
+                || currentGtidSetStr == null
+                || currentGtidSetStr.isEmpty()) {
+            return -1L;
+        }
+        if (masterGtidSetStr.equals(currentGtidSetStr)) {
+            return 0L;
+        }
+        // Cache parsed master GtidSet
+        if (!masterGtidSetStr.equals(cachedMasterGtidSetStr)) {
+            cachedMasterGtidSet = new GtidSet(masterGtidSetStr);
+            cachedMasterGtidSetStr = masterGtidSetStr;
+        }
+        GtidSet masterSet = cachedMasterGtidSet;
+        GtidSet currentSet = new GtidSet(currentGtidSetStr);
+        long lag = 0;
+        for (GtidSet.UUIDSet masterUuidSet : masterSet.getUUIDSets()) {
+            long masterMax = getMaxTransactionId(masterUuidSet);
+            GtidSet.UUIDSet currentUuidSet = currentSet.forServerWithId(masterUuidSet.getUUID());
+            if (currentUuidSet == null) {
+                lag += masterMax;
+            } else {
+                long currentMax = getMaxTransactionId(currentUuidSet);
+                lag += Math.max(0, masterMax - currentMax);
+            }
+        }
+        return lag;
+    }
+
+    private long calculateBytePositionLag(BinlogOffset current, BinlogOffset master) {
+        String masterFile = master.getFilename();
+        String currentFile = current.getFilename();
+        if (masterFile == null || currentFile == null) {
+            return -1L;
+        }
+        if (masterFile.equals(currentFile)) {
+            return Math.max(0, master.getPosition() - current.getPosition());
+        }
+        // Cross-file: estimate using file sequence gap
+        try {
+            long masterSeq = extractFileSequence(masterFile);
+            long currentSeq = extractFileSequence(currentFile);
+            if (masterSeq > currentSeq) {
+                // Rough estimate: use 1,000,000 as synthetic weight per file gap.
+                // This is NOT actual byte lag but provides a monotonically decreasing
+                // indicator as the reader catches up.
+                long estimatedLag =
+                        (masterSeq - currentSeq) * 1_000_000L
+                                + master.getPosition()
+                                - current.getPosition();
+                return Math.max(0, estimatedLag);
+            }
+        } catch (NumberFormatException e) {
+            // ignore parse error
+        }
+        return -1L;
+    }
+
+    @VisibleForTesting
+    static long extractFileSequence(String binlogFilename) {
+        // binlog filename format: mysql-bin.000003
+        int dotIndex = binlogFilename.lastIndexOf('.');
+        if (dotIndex >= 0) {
+            return Long.parseLong(binlogFilename.substring(dotIndex + 1));
+        }
+        return 0L;
+    }
+
+    private long getMaxTransactionId(GtidSet.UUIDSet uuidSet) {
+        long max = 0;
+        for (GtidSet.Interval interval : uuidSet.getIntervals()) {
+            max = Math.max(max, interval.getEnd());
+        }
+        return max;
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSource.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSource.java
@@ -101,6 +101,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     final boolean parseOnlineSchemaChanges;
     private final boolean useLegacyJsonFormat;
     private final boolean assignUnboundedChunkFirst;
+    private final long binlogPositionLagIntervalMs;
 
     private final boolean appendOnly;
 
@@ -144,6 +145,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             boolean parseOnlineSchemaChanges,
             boolean useLegacyJsonFormat,
             boolean assignUnboundedChunkFirst,
+            long binlogPositionLagIntervalMs,
             boolean appendOnly) {
         this.physicalSchema = physicalSchema;
         this.port = port;
@@ -177,6 +179,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.skipSnapshotBackFill = skipSnapshotBackFill;
         this.useLegacyJsonFormat = useLegacyJsonFormat;
         this.assignUnboundedChunkFirst = assignUnboundedChunkFirst;
+        this.binlogPositionLagIntervalMs = binlogPositionLagIntervalMs;
         this.appendOnly = appendOnly;
     }
 
@@ -241,6 +244,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .parseOnLineSchemaChanges(parseOnlineSchemaChanges)
                             .useLegacyJsonFormat(useLegacyJsonFormat)
                             .assignUnboundedChunkFirst(assignUnboundedChunkFirst)
+                            .binlogPositionLagIntervalMs(binlogPositionLagIntervalMs)
                             .build();
             return SourceProvider.of(parallelSource);
         } else {
@@ -330,6 +334,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         parseOnlineSchemaChanges,
                         useLegacyJsonFormat,
                         assignUnboundedChunkFirst,
+                        binlogPositionLagIntervalMs,
                         appendOnly);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
@@ -376,6 +381,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 && parseOnlineSchemaChanges == that.parseOnlineSchemaChanges
                 && useLegacyJsonFormat == that.useLegacyJsonFormat
                 && assignUnboundedChunkFirst == that.assignUnboundedChunkFirst
+                && binlogPositionLagIntervalMs == that.binlogPositionLagIntervalMs
                 && Objects.equals(appendOnly, that.appendOnly);
     }
 
@@ -413,6 +419,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 parseOnlineSchemaChanges,
                 useLegacyJsonFormat,
                 assignUnboundedChunkFirst,
+                binlogPositionLagIntervalMs,
                 appendOnly);
     }
 

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/main/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactory.java
@@ -106,6 +106,8 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         boolean useLegacyJsonFormat = config.get(MySqlSourceOptions.USE_LEGACY_JSON_FORMAT);
         boolean assignUnboundedChunkFirst =
                 config.get(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST);
+        long binlogPositionLagIntervalMs =
+                config.get(MySqlSourceOptions.BINLOG_POSITION_LAG_INTERVAL_MS);
 
         boolean appendOnly =
                 config.get(MySqlSourceOptions.SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED);
@@ -156,6 +158,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
                 parseOnLineSchemaChanges,
                 useLegacyJsonFormat,
                 assignUnboundedChunkFirst,
+                binlogPositionLagIntervalMs,
                 appendOnly);
     }
 
@@ -205,6 +208,7 @@ public class MySqlTableSourceFactory implements DynamicTableSourceFactory {
         options.add(MySqlSourceOptions.PARSE_ONLINE_SCHEMA_CHANGES);
         options.add(MySqlSourceOptions.USE_LEGACY_JSON_FORMAT);
         options.add(MySqlSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST);
+        options.add(MySqlSourceOptions.BINLOG_POSITION_LAG_INTERVAL_MS);
         options.add(MySqlSourceOptions.SCAN_READ_CHANGELOG_AS_APPEND_ONLY_ENABLED);
         return options;
     }

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/debezium/reader/BinlogSplitReaderTest.java
@@ -80,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1195,7 +1196,8 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         finishedSplitsInfo.size());
 
         // step-3: test read binlog split
-        BinlogSplitReader binlogReader = new BinlogSplitReader(statefulTaskContext, 0);
+        BinlogSplitReader binlogReader =
+                new BinlogSplitReader(statefulTaskContext, 0, new AtomicReference<>());
         binlogReader.submitSplit(binlogSplit);
 
         List<SourceRecord> sourceRecords =
@@ -1215,7 +1217,8 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
         StatefulTaskContext statefulTaskContext =
                 new StatefulTaskContext(sourceConfig, binaryLogClient, mySqlConnection);
         MySqlBinlogSplit split = createBinlogSplit(sourceConfig);
-        BinlogSplitReader reader = new BinlogSplitReader(statefulTaskContext, 0);
+        BinlogSplitReader reader =
+                new BinlogSplitReader(statefulTaskContext, 0, new AtomicReference<>());
 
         // Mock an exception occurring during stream split reading by setting the error handler
         // and stopping the change event source to test exception handling
@@ -1245,7 +1248,8 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         ? new TestStatefulTaskContext(
                                 sourceConfig, binaryLogClient, mySqlConnection)
                         : new StatefulTaskContext(sourceConfig, binaryLogClient, mySqlConnection),
-                0);
+                0,
+                new AtomicReference<>());
     }
 
     private MySqlBinlogSplit createBinlogSplit(MySqlSourceConfig sourceConfig) throws Exception {
@@ -1397,7 +1401,8 @@ class BinlogSplitReaderTest extends MySqlSourceTestBase {
                         finishedSplitsInfo.size());
 
         // step-3: test read binlog split
-        BinlogSplitReader binlogReader = new BinlogSplitReader(statefulTaskContext, 0);
+        BinlogSplitReader binlogReader =
+                new BinlogSplitReader(statefulTaskContext, 0, new AtomicReference<>());
         binlogReader.submitSplit(binlogSplit);
 
         // step-4: make some binlog events

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitterTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlRecordEmitterTest.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.debezium.config.CommonConnectorConfig.TRANSACTION_TOPIC;
 import static io.debezium.connector.mysql.MySqlConnectorConfig.SERVER_NAME;
@@ -94,7 +95,62 @@ class MySqlRecordEmitterTest {
                 .isEqualByComparingTo(fakeOffset);
     }
 
+    @Test
+    void testBinlogPositionLagMetricIsUpdated() throws Exception {
+        MySqlSourceReaderMetrics metrics =
+                new MySqlSourceReaderMetrics(
+                        UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup());
+        metrics.registerMetrics();
+        metrics.registerBinlogLagMetrics();
+
+        AtomicReference<BinlogOffset> masterOffset =
+                new AtomicReference<>(BinlogOffset.ofBinlogFilePosition("mysql-bin.000001", 10000));
+
+        MySqlRecordEmitter<String> emitter =
+                new MySqlRecordEmitter<>(
+                        new DebeziumDeserializationSchema<String>() {
+                            @Override
+                            public void deserialize(SourceRecord record, Collector<String> out) {
+                                out.collect("record");
+                            }
+
+                            @Override
+                            public TypeInformation<String> getProducedType() {
+                                return TypeInformation.of(String.class);
+                            }
+                        },
+                        metrics,
+                        false,
+                        false,
+                        false,
+                        masterOffset,
+                        10_000L);
+
+        MySqlBinlogSplitState splitState = createBinlogSplitState();
+        splitState.setStartingOffset(BinlogOffset.ofBinlogFilePosition("mysql-bin.000001", 3000));
+
+        // Emit a data change event to trigger reportBinlogLag through the public path
+        SourceRecord dataEvent = createDataChangeEvent("test.table", 3000);
+        TestingReaderOutput<String> readerOutput = new TestingReaderOutput<>();
+        emitter.emitRecord(SourceRecords.fromSingleRecord(dataEvent), readerOutput, splitState);
+
+        Assertions.assertThat(metrics.getBinlogBytePositionLag()).isEqualTo(7000);
+    }
+
     private MySqlRecordEmitter<Void> createRecordEmitter() {
+        return createRecordEmitter(new AtomicReference<>());
+    }
+
+    private MySqlRecordEmitter<Void> createRecordEmitter(
+            AtomicReference<BinlogOffset> latestMasterOffset) {
+        MySqlSourceReaderMetrics metrics =
+                new MySqlSourceReaderMetrics(
+                        UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup());
+        return createRecordEmitter(metrics, latestMasterOffset);
+    }
+
+    private MySqlRecordEmitter<Void> createRecordEmitter(
+            MySqlSourceReaderMetrics metrics, AtomicReference<BinlogOffset> latestMasterOffset) {
         return new MySqlRecordEmitter<>(
                 new DebeziumDeserializationSchema<Void>() {
                     @Override
@@ -107,11 +163,12 @@ class MySqlRecordEmitterTest {
                         return TypeInformation.of(Void.class);
                     }
                 },
-                new MySqlSourceReaderMetrics(
-                        UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()),
+                metrics,
                 false,
                 false,
-                false);
+                false,
+                latestMasterOffset,
+                -1L);
     }
 
     @Test
@@ -375,7 +432,9 @@ class MySqlRecordEmitterTest {
                         UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()),
                 false,
                 false,
-                includeTransactionMetadataEvents);
+                includeTransactionMetadataEvents,
+                new AtomicReference<>(),
+                -1L);
     }
 
     private SourceRecord createTransactionMetadataEvent(

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/reader/MySqlSourceReaderTest.java
@@ -87,6 +87,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -571,7 +572,9 @@ class MySqlSourceReaderTest extends MySqlSourceTestBase {
                                 new MySqlSourceReaderMetrics(readerContext.metricGroup()),
                                 configuration.isIncludeSchemaChanges(),
                                 configuration.isIncludeHeartbeatEvents(),
-                                configuration.isIncludeTransactionMetadataEvents());
+                                configuration.isIncludeTransactionMetadataEvents(),
+                                new AtomicReference<>(),
+                                -1L);
         final MySqlSourceReaderContext mySqlSourceReaderContext =
                 new MySqlSourceReaderContext(readerContext);
         return new MySqlSourceReader<>(
@@ -586,7 +589,8 @@ class MySqlSourceReaderTest extends MySqlSourceTestBase {
             MySqlSourceConfig configuration,
             MySqlSourceReaderContext readerContext,
             SnapshotPhaseHooks snapshotHooks) {
-        return new MySqlSplitReader(configuration, 0, readerContext, snapshotHooks);
+        return new MySqlSplitReader(
+                configuration, 0, readerContext, snapshotHooks, new AtomicReference<>());
     }
 
     private void makeBinlogEventsInOneTransaction(MySqlSourceConfig sourceConfig, String tableId)
@@ -742,7 +746,9 @@ class MySqlSourceReaderTest extends MySqlSourceTestBase {
                     sourceReaderMetrics,
                     includeSchemaChanges,
                     false,
-                    false);
+                    false,
+                    new AtomicReference<>(),
+                    -1L);
             this.debeziumDeserializationSchema = debeziumDeserializationSchema;
             this.sourceReaderMetrics = sourceReaderMetrics;
             this.includeSchemaChanges = includeSchemaChanges;

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/utils/BinlogLagCalculatorTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/source/utils/BinlogLagCalculatorTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.cdc.connectors.mysql.source.utils;
+
+import org.apache.flink.cdc.connectors.mysql.source.offset.BinlogOffset;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link BinlogLagCalculator}. */
+class BinlogLagCalculatorTest {
+
+    private final BinlogLagCalculator calculator = new BinlogLagCalculator();
+
+    // --- GTID mode tests ---
+
+    @Test
+    void testGtidLagWhenFullyCaughtUp() {
+        String gtidSet = "uuid1:1-100";
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofGtidSet(gtidSet), BinlogOffset.ofGtidSet(gtidSet));
+        assertThat(result.getTransactionLag()).isEqualTo(0);
+    }
+
+    @Test
+    void testGtidLagWithSingleUuid() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofGtidSet("uuid1:1-150"),
+                        BinlogOffset.ofGtidSet("uuid1:1-200"));
+        assertThat(result.getTransactionLag()).isEqualTo(50);
+    }
+
+    @Test
+    void testGtidLagWithMultipleUuids() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofGtidSet("uuid1:1-80,uuid2:1-50"),
+                        BinlogOffset.ofGtidSet("uuid1:1-100,uuid2:1-50"));
+        assertThat(result.getTransactionLag()).isEqualTo(20);
+    }
+
+    @Test
+    void testGtidLagWithNewUuidInMaster() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofGtidSet("uuid1:1-100"),
+                        BinlogOffset.ofGtidSet("uuid1:1-100,uuid2:1-30"));
+        assertThat(result.getTransactionLag()).isEqualTo(30);
+    }
+
+    @Test
+    void testGtidLagWithDisjointIntervals() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofGtidSet("uuid1:1-50"),
+                        BinlogOffset.ofGtidSet("uuid1:1-50:100-200"));
+        assertThat(result.getTransactionLag()).isEqualTo(150);
+    }
+
+    @Test
+    void testGtidLagWhenCurrentStartsFromMiddle() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofGtidSet(
+                                "e5f89193-ec81-11ec-8f1c-525400c689b3:1774595494-1775564172"),
+                        BinlogOffset.ofGtidSet(
+                                "e5f89193-ec81-11ec-8f1c-525400c689b3:1-1793121110"));
+        assertThat(result.getTransactionLag()).isEqualTo(17556938);
+    }
+
+    @Test
+    void testSameGtidFallsBackToPositionComparison() {
+        String sameGtid = "c7d9df75-8210-11eb-b9fb-02483243d90e:1-929560837";
+        BinlogOffset current =
+                BinlogOffset.builder()
+                        .setBinlogFilePosition("binlog.000040", 5000)
+                        .setGtidSet(sameGtid)
+                        .build();
+        BinlogOffset master =
+                BinlogOffset.builder()
+                        .setBinlogFilePosition("binlog.000040", 8000)
+                        .setGtidSet(sameGtid)
+                        .build();
+        BinlogLagCalculator.LagResult result = calculator.calculateLag(current, master);
+        assertThat(result.getTransactionLag()).isEqualTo(0);
+        assertThat(result.getBytePositionLag()).isEqualTo(3000);
+    }
+
+    @Test
+    void testSameGtidCurrentAheadOfMaster() {
+        String sameGtid = "c7d9df75-8210-11eb-b9fb-02483243d90e:1-929560837";
+        BinlogOffset current =
+                BinlogOffset.builder()
+                        .setBinlogFilePosition("binlog.000040", 9000)
+                        .setGtidSet(sameGtid)
+                        .build();
+        BinlogOffset master =
+                BinlogOffset.builder()
+                        .setBinlogFilePosition("binlog.000040", 5000)
+                        .setGtidSet(sameGtid)
+                        .build();
+        BinlogLagCalculator.LagResult result = calculator.calculateLag(current, master);
+        assertThat(result.getTransactionLag()).isEqualTo(0);
+        assertThat(result.getBytePositionLag()).isEqualTo(0);
+    }
+
+    // --- Non-GTID mode tests ---
+
+    @Test
+    void testFilePositionLagSameFile() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 1000),
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 5000));
+        assertThat(result.getTransactionLag()).isEqualTo(-1);
+        assertThat(result.getBytePositionLag()).isEqualTo(4000);
+    }
+
+    @Test
+    void testFilePositionLagSameFileCaughtUp() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 5000),
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 5000));
+        assertThat(result.getBytePositionLag()).isEqualTo(0);
+    }
+
+    @Test
+    void testFilePositionLagSameFileNeverNegative() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 5100),
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 5000));
+        assertThat(result.getBytePositionLag()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void testFilePositionLagCrossFile() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000003", 1000),
+                        BinlogOffset.ofBinlogFilePosition("mysql-bin.000005", 2000));
+        assertThat(result.getBytePositionLag()).isEqualTo(2 * 1_000_000L + 2000 - 1000);
+    }
+
+    @Test
+    void testReturnsNonNegativeWhenBothOffsetsAreEarliest() {
+        BinlogLagCalculator.LagResult result =
+                calculator.calculateLag(BinlogOffset.ofEarliest(), BinlogOffset.ofEarliest());
+        assertThat(result.getBytePositionLag()).isGreaterThanOrEqualTo(-1);
+    }
+
+    // --- extractFileSequence tests ---
+
+    @Test
+    void testExtractFileSequence() {
+        assertThat(BinlogLagCalculator.extractFileSequence("mysql-bin.000003")).isEqualTo(3);
+        assertThat(BinlogLagCalculator.extractFileSequence("mysql-bin.000100")).isEqualTo(100);
+    }
+}

--- a/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
+++ b/flink-cdc-connect/flink-cdc-source-connectors/flink-connector-mysql-cdc/src/test/java/org/apache/flink/cdc/connectors/mysql/table/MySqlTableSourceFactoryTest.java
@@ -129,6 +129,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -179,6 +180,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -225,6 +227,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -269,6 +272,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -330,6 +334,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         true,
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource)
                 .isEqualTo(expectedSource)
@@ -389,6 +394,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -431,6 +437,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -474,6 +481,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -518,6 +526,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -560,6 +569,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }
@@ -607,6 +617,7 @@ class MySqlTableSourceFactoryTest {
                         PARSE_ONLINE_SCHEMA_CHANGES.defaultValue(),
                         USE_LEGACY_JSON_FORMAT.defaultValue(),
                         SCAN_INCREMENTAL_SNAPSHOT_UNBOUNDED_CHUNK_FIRST.defaultValue(),
+                        -1L,
                         false);
         expectedSource.producedDataType = SCHEMA_WITH_METADATA.toSourceRowDataType();
         expectedSource.metadataKeys = Arrays.asList("op_ts", "database_name");
@@ -810,6 +821,7 @@ class MySqlTableSourceFactoryTest {
                         true,
                         true,
                         true,
+                        -1L,
                         false);
         Assertions.assertThat(actualSource).isEqualTo(expectedSource);
     }


### PR DESCRIPTION
 ### What is the purpose of the change                                                                                                                                                                                            
                                                                                                                                                                                                                                 
  This PR adds binlog position lag metrics for the MySQL binlog reader, which measure the lag between the current consumed binlog offset and the latest master binlog offset.                                                      
                                                                                                                                                                                                                                 
  Unlike the existing `currentFetchEventTimeLag` metric (which only updates when there are events flowing), these metrics are meaningful even during idle periods — they reflect how far behind the reader is from the MySQL master
   at the position level.                                                                                                                                                                                                        
                                                                                                                                                                                                                                   
  The feature is **opt-in** via `scan.binlog.position-lag.interval.ms`. A value of `-1` (default) disables the feature entirely. When set to a positive value, the connector periodically executes `SHOW MASTER STATUS` at this    
  interval to calculate lag.                                   
                                                                                                                                                                                                                                   
  ### Brief change log                                                                                                                                                                                                             
                                                               
  - Added `BinlogLagCalculator` to compute binlog position lag, producing two independent results: transaction lag (GTID-based) and byte position lag (file+position based).                                                       
  - In `BinlogSplitReader`, conditionally fetch the master's current binlog offset via `SHOW MASTER STATUS` at the configured interval and store it in a shared `AtomicReference<BinlogOffset>`.                                 
  - In `MySqlRecordEmitter`, read the shared master offset and calculate lag against the current consumed offset, then report it via `MySqlSourceReaderMetrics`.                                                                   
  - Registered two new gauge metrics in `MySqlSourceReaderMetrics`:                                                                                                                                                                
    - `currentBinlogTransactionLag`: GTID-based transaction count lag (-1 when GTID is unavailable)                                                                                                                                
    - `currentBinlogBytePositionLag`: byte-level position lag (-1 when position info is unavailable)                                                                                                                               
  - Added configuration option `scan.binlog.position-lag.interval.ms` (default `-1`, disabled) to control the feature and polling frequency.                                                                                       
                                                                                                                                                                                                                                   
  ### Lag calculation strategy                                                                                                                                                                                                     
                                                                                                                                                                                                                                   
  | Mode | Metric | Lag meaning | Calculation |                                                                                                                                                                                    
  |------|--------|-------------|-------------|                                                                                                                                                                                  
  | GTID | `currentBinlogTransactionLag` | Transaction count difference | Sum of (master max txn ID - current max txn ID) per server UUID |                                                                                        
  | File-position (same file) | `currentBinlogBytePositionLag` | Byte offset difference | master position - current position |                                                                                                     
  | File-position (cross file) | `currentBinlogBytePositionLag` | Estimated byte difference | file sequence diff × 1,000,000 + master position - current position |                                                                
                                                                                                                                                                                                                                   
  ### Verifying this change                                                                                                                                                                                                        
                                                                                                                                                                                                                                   
  This change added tests:                                                                                                                                                                                                         
  - `BinlogLagCalculatorTest`: unit tests covering GTID mode (single/multiple UUIDs, disjoint intervals, starts-from-middle, same GTID fallback to position), file-position mode (same file, cross file, edge cases).
  - `MySqlRecordEmitterTest#testBinlogPositionLagMetricIsUpdated`: verifies that the byte position lag metric is updated correctly during record emission through the public API path.                                             
                                                                                                                                                                                                                                   
  ### Does this pull request potentially affect one of the following parts                                                                                                                                                         
                                                                                                                                                                                                                                   
  - Dependencies: no                                                                                                                                                                                                             
  - The public API: yes (new builder method `binlogPositionLagIntervalMs` and config option)
  - The serializers: no                                                                                                                                                                                                            
  - The runtime per-record code path: yes (lightweight gauge update during binlog phase only, disabled by default)                                                                                                                 
  - Anything that affects determine of shard: no                                                                                                                                                                                   
                                                                                                                                                                                                                                   
  ### Documentation                                                                                                                                                                                                                
                                                                                                                                                                                                                                   
  - [x] Does this pull request introduce a new feature? yes — new monitoring metrics and configuration option                                                                                                                      
  - [x] If yes, how is the feature documented? JavaDoc on metric constants; configuration option documented in both English and Chinese user-facing docs (`mysql-cdc.md`). 