### PR TITLE
[oracle] Support specific-offset startup mode with SCN for Oracle pipeline source

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/factory/OracleDataSourceFactory.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/factory/OracleDataSourceFactory.java
@@ -33,6 +33,7 @@ import org.apache.flink.cdc.connectors.oracle.source.OracleDataSource;
 import org.apache.flink.cdc.connectors.oracle.source.OracleDataSourceOptions;
 import org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfig;
 import org.apache.flink.cdc.connectors.oracle.source.config.OracleSourceConfigFactory;
+import org.apache.flink.cdc.connectors.oracle.source.meta.offset.RedoLogOffset;
 import org.apache.flink.cdc.connectors.oracle.table.OracleReadableMetaData;
 import org.apache.flink.cdc.connectors.oracle.utils.OracleSchemaUtils;
 import org.apache.flink.table.api.ValidationException;
@@ -40,6 +41,7 @@ import org.apache.flink.table.api.ValidationException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +52,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
 import static org.apache.flink.cdc.connectors.oracle.source.OracleDataSourceOptions.METADATA_LIST;
 import static org.apache.flink.cdc.connectors.oracle.source.OracleDataSourceOptions.SCAN_STARTUP_MODE;
+import static org.apache.flink.cdc.connectors.oracle.source.OracleDataSourceOptions.SCAN_STARTUP_SPECIFIC_OFFSET_SCN;
 import static org.apache.flink.cdc.debezium.table.DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX;
 import static org.apache.flink.cdc.debezium.utils.JdbcUrlUtils.PROPERTIES_PREFIX;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -63,6 +66,7 @@ public class OracleDataSourceFactory implements DataSourceFactory {
     private static final String SCAN_STARTUP_MODE_VALUE_INITIAL = "initial";
     private static final String SCAN_STARTUP_MODE_VALUE_LATEST = "latest-offset";
     private static final String SCAN_STARTUP_MODE_VALUE_SNAPSHOT = "snapshot";
+    private static final String SCAN_STARTUP_MODE_VALUE_SPECIFIC = "specific-offset";
 
     @Override
     public DataSource createDataSource(Context context) {
@@ -204,6 +208,7 @@ public class OracleDataSourceFactory implements DataSourceFactory {
         options.add(OracleDataSourceOptions.LOG_MINING_STRATEGY);
         options.add(OracleDataSourceOptions.DATABASE_CONNECTION_ADAPTER);
         options.add(OracleDataSourceOptions.SCAN_STARTUP_MODE);
+        options.add(OracleDataSourceOptions.SCAN_STARTUP_SPECIFIC_OFFSET_SCN);
         return options;
     }
 
@@ -265,15 +270,30 @@ public class OracleDataSourceFactory implements DataSourceFactory {
                 return StartupOptions.snapshot();
             case SCAN_STARTUP_MODE_VALUE_LATEST:
                 return StartupOptions.latest();
+            case SCAN_STARTUP_MODE_VALUE_SPECIFIC:
+                Long scn = config.get(SCAN_STARTUP_SPECIFIC_OFFSET_SCN);
+                if (scn == null) {
+                    throw new ValidationException(
+                            String.format(
+                                    "Option '%s' is required when '%s' is '%s'.",
+                                    SCAN_STARTUP_SPECIFIC_OFFSET_SCN.key(),
+                                    SCAN_STARTUP_MODE.key(),
+                                    SCAN_STARTUP_MODE_VALUE_SPECIFIC));
+                }
+                Map<String, String> specificOffsetMap = new HashMap<>();
+                specificOffsetMap.put(RedoLogOffset.SCN_KEY, String.valueOf(scn));
+                specificOffsetMap.put(RedoLogOffset.COMMIT_SCN_KEY, String.valueOf(0L));
+                return StartupOptions.specificOffset(specificOffsetMap);
 
             default:
                 throw new ValidationException(
                         String.format(
-                                "Invalid value for option '%s'. Supported values are [%s, %s, %s], but was: %s",
+                                "Invalid value for option '%s'. Supported values are [%s, %s, %s, %s], but was: %s",
                                 SourceOptions.SCAN_STARTUP_MODE.key(),
                                 SCAN_STARTUP_MODE_VALUE_INITIAL,
                                 SCAN_STARTUP_MODE_VALUE_SNAPSHOT,
                                 SCAN_STARTUP_MODE_VALUE_LATEST,
+                                SCAN_STARTUP_MODE_VALUE_SPECIFIC,
                                 modeString));
         }
     }

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleDataSourceOptions.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-oracle/src/main/java/org/apache/flink/cdc/connectors/oracle/source/OracleDataSourceOptions.java
@@ -130,7 +130,15 @@ public class OracleDataSourceOptions {
                     .defaultValue("initial")
                     .withDescription(
                             "Optional startup mode for oracle CDC consumer, valid enumerations are "
-                                    + "\"initial\", \"latest-offset\", \"snapshot\"");
+                                    + "\"initial\", \"latest-offset\", \"snapshot\", \"specific-offset\"");
+
+    public static final ConfigOption<Long> SCAN_STARTUP_SPECIFIC_OFFSET_SCN =
+            ConfigOptions.key("scan.startup.specific-offset.scn")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The specific SCN to start reading redo log from, "
+                                    + "required when 'scan.startup.mode' is 'specific-offset'.");
 
     @Experimental
     public static final ConfigOption<Integer> CHUNK_META_GROUP_SIZE =


### PR DESCRIPTION
## Motivation

The Oracle pipeline connector currently only supports `initial` / `snapshot` / `latest-offset` startup modes, while the MySQL pipeline connector already supports `specific-offset`. For Oracle users who want to skip the full snapshot phase and start incremental (LogMiner redo log) consumption from a known position, there is no way to specify a starting SCN.

Note: the underlying Debezium property `log.mining.start.position.scn` cannot be used as a workaround, because the shaded Debezium dependency in the connector jar does not include that configuration, and passing it through the `debezium.*` prefix is silently ignored.

## Modification

- `OracleDataSourceOptions`: add new option `scan.startup.specific-offset.scn` (Long, no default value)
- `OracleDataSourceFactory`: add `specific-offset` branch in `getStartupOptions()`, which builds `StartupOptions.specificOffset(Map{scn, commit_scn})`. The base framework (`StreamSplitAssigner#createStreamSplit`) already natively consumes SPECIFIC_OFFSETS offsets, so no framework change is needed.

## Usage

```yaml
source:
  type: oracle
  scan.startup.mode: specific-offset
  scan.startup.specific-offset.scn: 2053676
```

## Verification

Verified end-to-end on a real cluster (Flink 1.20.1 YARN session + Oracle 12c LogMiner + Iceberg sink):

- JobManager log confirms the stream split starts exactly at the specified SCN: `Assign split StreamSplit{offset={commit_scn=0, scn=2053676}}`
- Only changes committed after the specified SCN are captured; all pre-existing snapshot rows are correctly skipped