### PR TITLE
[FLINK-40441] Shade HikariCP in pipeline-postgres connector to avoid com.zaxxer conflicts

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/pom.xml
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/pom.xml
@@ -227,6 +227,12 @@ limitations under the License.
                                         org.apache.flink.cdc.connectors.shaded.com.fasterxml
                                     </shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.zaxxer</pattern>
+                                    <shadedPattern>
+                                        org.apache.flink.cdc.connectors.shaded.com.zaxxer
+                                    </shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

## What is the purpose of this pull request?

Add a maven-shade relocation for com.zaxxer (HikariCP) in flink-cdc-pipeline-connector-postgres so the connector uses the unified shaded namespace org.apache.flink.cdc.connectors.shaded.com.zaxxer.

Other connectors already relocate com.zaxxer to avoid HikariCP class conflicts when multiple connectors are bundled together. Postgres connector included HikariCP in its artifact set but omitted the relocation, which can produce runtime conflicts as follows:

```
2026-07-20 14:17:00,145 ERROR org.apache.flink.runtime.entrypoint.ClusterEntrypoint        [] - Fatal error occurred in the cluster entrypoint.
java.util.concurrent.CompletionException: org.apache.flink.client.deployment.application.ApplicationExecutionException: Could not execute application.
    at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292) ~[?:1.8.0_352]
    at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308) ~[?:1.8.0_352]
    at java.util.concurrent.CompletableFuture.uniCompose(CompletableFuture.java:957) ~[?:1.8.0_352]
    at java.util.concurrent.CompletableFuture$UniCompose.tryFire(CompletableFuture.java:940) ~[?:1.8.0_352]
    at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:488) ~[?:1.8.0_352]
    at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1990) ~[?:1.8.0_352]
    at org.apache.flink.client.deployment.application.ApplicationDispatcherBootstrap.runApplicationEntryPoint(ApplicationDispatcherBootstrap.java:337) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.deployment.application.ApplicationDispatcherBootstrap.lambda$runApplicationAsync$2(ApplicationDispatcherBootstrap.java:254) ~[flink-dist-1.20.1.jar:1.20.1]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[?:1.8.0_352]
    at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_352]
    at org.apache.flink.runtime.concurrent.pekko.ActorSystemScheduledExecutorAdapter$ScheduledFutureTask.run(ActorSystemScheduledExecutorAdapter.java:172) ~[?:?]
    at org.apache.flink.runtime.concurrent.ClassLoadingUtils.runWithContextClassLoader(ClassLoadingUtils.java:68) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.runtime.concurrent.ClassLoadingUtils.lambda$withContextClassLoader$0(ClassLoadingUtils.java:41) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.pekko.dispatch.TaskInvocation.run(AbstractDispatcher.scala:59) [flink-rpc-akka1ce3455b-913b-4d52-b0bf-518e598f7860.jar:1.20.1]
    at org.apache.pekko.dispatch.ForkJoinExecutorConfigurator$PekkoForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:61) [flink-rpc-akka1ce3455b-913b-4d52-b0bf-518e598f7860.jar:1.20.1]
    at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289) [?:1.8.0_352]
    at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056) [?:1.8.0_352]
    at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692) [?:1.8.0_352]
    at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:175) [?:1.8.0_352]
Caused by: org.apache.flink.client.deployment.application.ApplicationExecutionException: Could not execute application.
    ... 13 more
Caused by: org.apache.flink.client.program.ProgramInvocationException: The main method caused an error: org.apache.flink.cdc.connectors.shaded.com.zaxxer.hikari.pool.HikariProxyConnection cannot be cast to org.postgresql.core.BaseConnection
    at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:373) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.program.PackagedProgram.invokeInteractiveModeForExecution(PackagedProgram.java:223) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.ClientUtils.executeProgram(ClientUtils.java:113) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.deployment.application.ApplicationDispatcherBootstrap.runApplicationEntryPoint(ApplicationDispatcherBootstrap.java:301) ~[flink-dist-1.20.1.jar:1.20.1]
    ... 12 more
Caused by: java.lang.ClassCastException: org.apache.flink.cdc.connectors.shaded.com.zaxxer.hikari.pool.HikariProxyConnection cannot be cast to org.postgresql.core.BaseConnection
    at io.debezium.connector.postgresql.TypeRegistry.getTypeInfo(TypeRegistry.java:510) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at io.debezium.connector.postgresql.TypeRegistry.access$100(TypeRegistry.java:40) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at io.debezium.connector.postgresql.TypeRegistry$SqlTypeMapper.<init>(TypeRegistry.java:440) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at io.debezium.connector.postgresql.TypeRegistry$SqlTypeMapper.<init>(TypeRegistry.java:410) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at io.debezium.connector.postgresql.TypeRegistry.<init>(TypeRegistry.java:121) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at io.debezium.connector.postgresql.connection.PostgresConnection.<init>(PostgresConnection.java:167) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.connectors.postgres.source.PostgresDialect.openJdbcConnection(PostgresDialect.java:90) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.connectors.postgres.source.PostgresDialect.openJdbcConnection(PostgresDialect.java:101) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.connectors.postgres.utils.PostgresSchemaUtils.listTables(PostgresSchemaUtils.java:76) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.connectors.postgres.factory.PostgresDataSourceFactory.createDataSource(PostgresDataSourceFactory.java:190) ~[flink-cdc-pipeline-connector-postgres-cty-3.4-1.5.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.composer.flink.translator.DataSourceTranslator.createDataSource(DataSourceTranslator.java:101) ~[flink-cdc-dist-3.4.0.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.composer.flink.FlinkPipelineComposer.translate(FlinkPipelineComposer.java:191) ~[flink-cdc-dist-3.4.0.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.composer.flink.FlinkPipelineComposer.compose(FlinkPipelineComposer.java:110) ~[flink-cdc-dist-3.4.0.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.cli.CliExecutor.deployWithComposer(CliExecutor.java:101) ~[flink-cdc-dist-3.4.0.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.cli.CliExecutor.run(CliExecutor.java:79) ~[flink-cdc-dist-3.4.0.jar:cty-3.4-1.5]
    at org.apache.flink.cdc.cli.CliFrontend.main(CliFrontend.java:86) ~[flink-cdc-dist-3.4.0.jar:cty-3.4-1.5]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_352]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_352]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_352]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_352]
    at org.apache.flink.client.program.PackagedProgram.callMainMethod(PackagedProgram.java:356) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.program.PackagedProgram.invokeInteractiveModeForExecution(PackagedProgram.java:223) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.ClientUtils.executeProgram(ClientUtils.java:113) ~[flink-dist-1.20.1.jar:1.20.1]
    at org.apache.flink.client.deployment.application.ApplicationDispatcherBootstrap.runApplicationEntryPoint(ApplicationDispatcherBootstrap.java:301) ~[flink-dist-1.20.1.jar:1.20.1]
    ... 12 more
```


## Brief change log

- Added relocation block for com.zaxxer → org.apache.flink.cdc.connectors.shaded.com.zaxxer in the maven-shade-plugin configuration of flink-cdc-pipeline-connector-postgres/pom.xml.

---

## Verifying this change

- Built pipeline connector packages of pg and mysql
- Run integration scenario with multiple connectors to confirm no HikariCP linkage errors.

Notes: This mirrors shading in other connectors (mysql, oracle, etc.) and is a safe, low-risk packaging change.


## Documentation

- Does this pull request introduce a new feature? (no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
