### PR TITLE
[FLINK-40512][postgres] Cache typeRegistry to reduce the busy work on inferring schema change event

### DIFF
--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresPipelineRecordEmitter.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/source/reader/PostgresPipelineRecordEmitter.java
@@ -32,6 +32,7 @@ import org.apache.flink.cdc.debezium.DebeziumDeserializationSchema;
 import org.apache.flink.cdc.debezium.event.DebeziumEventDeserializationSchema;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 
+import io.debezium.connector.postgresql.TypeRegistry;
 import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.data.Envelope;
 import io.debezium.relational.Table;
@@ -65,6 +66,8 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
     private final Set<TableId> alreadySendCreateTableTables;
     private final boolean includeDatabaseInTableId;
     private final Map<TableId, CreateTableEvent> createTableEventCache;
+
+    private TypeRegistry typeRegistry;
 
     public PostgresPipelineRecordEmitter(
             DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
@@ -128,7 +131,11 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
         }
         List<SchemaChangeEvent> schemaChangeEvents =
                 inferSchemaChangeEvent(
-                        schemaAfter.id(), schemaBefore, schemaAfter, sourceConfig, postgresDialect);
+                        schemaAfter.id(),
+                        schemaBefore,
+                        schemaAfter,
+                        sourceConfig,
+                        getTypeRegistry());
         LOG.info("Inferred Schema change events: {}", schemaChangeEvents);
         schemaChangeEvents.forEach(
                 schemaChangeEvent -> {
@@ -203,6 +210,15 @@ public class PostgresPipelineRecordEmitter<T> extends PostgresSourceRecordEmitte
                             includeDatabaseInTableId),
                     schema);
         }
+    }
+
+    private TypeRegistry getTypeRegistry() {
+        if (typeRegistry == null) {
+            try (PostgresConnection jdbc = postgresDialect.openJdbcConnection()) {
+                typeRegistry = jdbc.getTypeRegistry();
+            }
+        }
+        return typeRegistry;
     }
 
     private TableId getTableId(SourceRecord dataRecord) {

--- a/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/utils/SchemaChangeUtil.java
+++ b/flink-cdc-connect/flink-cdc-pipeline-connectors/flink-cdc-pipeline-connector-postgres/src/main/java/org/apache/flink/cdc/connectors/postgres/utils/SchemaChangeUtil.java
@@ -25,12 +25,10 @@ import org.apache.flink.cdc.common.event.RenameColumnEvent;
 import org.apache.flink.cdc.common.event.SchemaChangeEvent;
 import org.apache.flink.cdc.common.event.TableId;
 import org.apache.flink.cdc.common.types.DataType;
-import org.apache.flink.cdc.connectors.postgres.source.PostgresDialect;
 import org.apache.flink.cdc.connectors.postgres.source.config.PostgresSourceConfig;
 
 import io.debezium.connector.postgresql.PostgresConnectorConfig;
 import io.debezium.connector.postgresql.TypeRegistry;
-import io.debezium.connector.postgresql.connection.PostgresConnection;
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
 
@@ -83,10 +81,11 @@ public class SchemaChangeUtil {
             @Nullable Table tableBefore,
             Table tableAfter,
             PostgresSourceConfig sourceConfig,
-            PostgresDialect dialect) {
+            TypeRegistry typeRegistry) {
 
         if (tableBefore == null) {
-            return Collections.singletonList(toCreateTableEvent(tableAfter, sourceConfig, dialect));
+            return Collections.singletonList(
+                    toCreateTableEvent(tableAfter, sourceConfig, typeRegistry));
         }
 
         TableId cdcTableId =
@@ -95,23 +94,8 @@ public class SchemaChangeUtil {
                         sourceConfig.getDatabaseList().get(0),
                         sourceConfig.isIncludeDatabaseInTableId());
         PostgresConnectorConfig dbzConfig = sourceConfig.getDbzConnectorConfig();
-
-        try (PostgresConnection connection = dialect.openJdbcConnection()) {
-            TypeRegistry typeRegistry = connection.getTypeRegistry();
-            return inferMinimalSchemaChanges(
-                    cdcTableId,
-                    tableBefore.columns(),
-                    tableAfter.columns(),
-                    dbzConfig,
-                    typeRegistry);
-        }
-    }
-
-    public static CreateTableEvent toCreateTableEvent(
-            Table table, PostgresSourceConfig sourceConfig, PostgresDialect dialect) {
-        try (PostgresConnection connection = dialect.openJdbcConnection()) {
-            return toCreateTableEvent(table, sourceConfig, connection.getTypeRegistry());
-        }
+        return inferMinimalSchemaChanges(
+                cdcTableId, tableBefore.columns(), tableAfter.columns(), dbzConfig, typeRegistry);
     }
 
     private static CreateTableEvent toCreateTableEvent(


### PR DESCRIPTION


<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

  http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

## What is the purpose of this pull request?

Briefly describe the problem this PR fixes or the feature it introduces. Reference Flink JIRA ticket when possible.

## Brief change log

List the key changes in this PR. 

---

## Verifying this change

<!-- Describe how this change can be verified. -->

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change added tests and can be verified as follows:

- *Added/Updated unit tests in `...*`*
- *Added/Updated integration tests in `...*`*
- *Manually tested by ...*

## Documentation

- Does this pull request introduce a new feature? (yes / no)
- If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change the checkbox below to `[X]` followed by the name of the tool, and uncomment the
"Generated-by" line. See the ASF Generative Tooling Guidance for details:
https://www.apache.org/legal/generative-tooling.html

You are responsible for the quality and correctness of every change in this PR
regardless of the tooling used. Low-effort AI-generated PRs will be closed.
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version]
-->
